### PR TITLE
fix: suppress false positive diagnostics for stored result references

### DIFF
--- a/.kiro/specs/stored-result-reference-false-positive/design.md
+++ b/.kiro/specs/stored-result-reference-false-positive/design.md
@@ -1,0 +1,152 @@
+# Design Document: Stored Result Reference False Positive Fix
+
+## Overview
+
+This design addresses a false positive diagnostic where Stata stored result references like `` `r(values)' `` are incorrectly flagged as "Invalid character in macro name". The fix adds detection logic to recognize stored result function patterns (`r()`, `e()`, `c()`, `s()`) within local macro reference tokens and suppress the invalid character diagnostic for these valid Stata constructs.
+
+## Architecture
+
+The fix is localized to the Analyzer component (`src/analyzer/index.ts`), specifically in the `collect_undefined_macro_diagnostics` method. A new helper method `is_stored_result_reference` will be added to detect stored result patterns before the invalid character check is applied.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Analyzer.collect_undefined_macro_diagnostics │
+├─────────────────────────────────────────────────────────────────┤
+│  For each MACRO_REF_LOCAL token:                                │
+│    1. Extract macro name from `name' format                     │
+│    2. NEW: Check if is_stored_result_reference(name)            │
+│       - If yes: skip invalid char check                         │
+│       - If no: proceed with has_invalid_macro_char check        │
+│    3. Check for undefined macro (existing logic)                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Components and Interfaces
+
+### Modified Component: Analyzer
+
+**File:** `src/analyzer/index.ts`
+
+**New Method:**
+
+```typescript
+/**
+ * Check if a macro reference content represents a stored result reference.
+ * Stored results use patterns: r(name), e(name), c(name), s(name)
+ * Also handles nested macros and matrix subscripts.
+ * 
+ * @param content - The content between backtick and apostrophe (e.g., "r(values)")
+ * @returns true if this is a stored result reference pattern
+ */
+private is_stored_result_reference(content: string): boolean {
+    // Pattern: single lowercase letter (r/e/c/s) followed by parentheses
+    // The content inside parentheses can contain:
+    // - Valid identifier chars [A-Za-z0-9_]
+    // - Nested macro references (backticks and apostrophes)
+    // - Matrix subscripts [...]
+    
+    // Match: r(...), e(...), c(...), s(...)
+    // Case-sensitive: Stata requires lowercase r/e/c/s
+    // Allow anything inside parentheses (nested macros, subscripts)
+    const stored_result_pattern = /^[recs]\(.*\)(\[.*\])?$/;
+    return stored_result_pattern.test(content);
+}
+```
+
+**Modified Method:** `collect_undefined_macro_diagnostics`
+
+```typescript
+if (token.type === 'MACRO_REF_LOCAL') {
+    const macro_name = this.extract_local_macro_name(token.value);
+    
+    // Skip invalid char check for stored result references
+    if (macro_name && this.is_stored_result_reference(macro_name)) {
+        // Stored result references like `r(values)' are valid
+        // Skip both invalid char check and undefined macro check
+        continue;
+    }
+    
+    // Check for invalid characters in local macro reference
+    if (macro_name && this.has_invalid_macro_char(macro_name)) {
+        diagnostics.push({
+            message: 'Invalid character in macro name',
+            range: token.range,
+            code: StataDiagnosticCode.INVALID_MACRO_CHAR,
+            severity: 'error',
+        });
+        continue;
+    }
+    
+    // ... existing undefined macro check
+}
+```
+
+## Data Models
+
+No new data models are required. The fix uses the existing `Token` type and diagnostic structures.
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Stored Result References Are Not Flagged
+
+*For any* stored result function prefix (`r`, `e`, `c`, `s`) and *for any* valid identifier, when wrapped in backtick-apostrophe syntax (e.g., `` `r(identifier)' ``), the Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic.
+
+**Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5**
+
+### Property 2: Non-Stored-Result Invalid Characters Are Flagged
+
+*For any* local macro reference that does NOT match a stored result pattern and contains characters outside `[A-Za-z0-9_]`, the Analyzer SHALL produce an "Invalid character in macro name" diagnostic.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+### Property 3: Nested Macros in Stored Results Are Not Flagged
+
+*For any* stored result reference containing nested macro syntax (backticks and apostrophes within the parentheses), the Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic.
+
+**Validates: Requirements 3.1, 3.2**
+
+### Property 4: Matrix Subscripts in Stored Results Are Not Flagged
+
+*For any* stored result reference followed by matrix subscript syntax (`[...]`), the Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic.
+
+**Validates: Requirements 4.1, 4.2**
+
+## Error Handling
+
+1. **Malformed stored result syntax**: If a reference starts with `r(`, `e(`, `c(`, or `s(` but has unbalanced parentheses, the regex will not match and the reference will be treated as a regular macro reference (potentially flagged for invalid chars).
+
+2. **Case sensitivity**: The stored result pattern is case-sensitive—only lowercase `r()`, `e()`, `c()`, `s()` are valid. Uppercase variants like `R()` will be treated as regular macro references and flagged for invalid characters.
+
+3. **Empty parentheses**: References like `` `r()' `` will match the pattern and not be flagged, which is correct as Stata allows this syntax.
+
+## Testing Strategy
+
+### Property-Based Tests
+
+Use `fast-check` to generate test cases:
+
+1. **Property 1 Test**: Generate random valid identifiers, combine with each stored result prefix, wrap in backtick-apostrophe, analyze, and verify no INVALID_MACRO_CHAR diagnostic.
+
+2. **Property 2 Test**: Generate random strings containing invalid characters (dots, spaces, special chars) that don't match stored result patterns, wrap in backtick-apostrophe, analyze, and verify INVALID_MACRO_CHAR diagnostic is produced.
+
+3. **Property 3 Test**: Generate stored result references with nested macro patterns, analyze, and verify no INVALID_MACRO_CHAR diagnostic.
+
+4. **Property 4 Test**: Generate stored result references with matrix subscript patterns, analyze, and verify no INVALID_MACRO_CHAR diagnostic.
+
+### Unit Tests
+
+Specific examples to verify:
+- `` `r(values)' `` → no diagnostic
+- `` `e(N)' `` → no diagnostic
+- `` `c(current_date)' `` → no diagnostic
+- `` `s(macros)' `` → no diagnostic
+- `` `r(table)[1,1]' `` → no diagnostic
+- `` `foo.bar' `` → INVALID_MACRO_CHAR diagnostic
+- `` `my var' `` → INVALID_MACRO_CHAR diagnostic
+
+### Test Configuration
+
+- Property tests: minimum 100 iterations
+- Tag format: **Feature: stored-result-reference-false-positive, Property N: [property text]**

--- a/.kiro/specs/stored-result-reference-false-positive/requirements.md
+++ b/.kiro/specs/stored-result-reference-false-positive/requirements.md
@@ -1,0 +1,55 @@
+# Requirements Document
+
+## Introduction
+
+This document specifies requirements for fixing a false positive diagnostic where Stata stored result references like `` `r(values)' `` are incorrectly flagged as "Invalid character in macro name". In Stata, stored result functions (`r()`, `e()`, `c()`, `s()`) can be wrapped in backtick-apostrophe syntax for string interpolation, and this is valid Stata syntax that should not produce errors.
+
+## Glossary
+
+- **Stored_Result_Reference**: A Stata expression that accesses stored results from commands, using the pattern `r(name)`, `e(name)`, `c(name)`, or `s(name)` where `name` is the result identifier
+- **Local_Macro_Reference**: A Stata local macro reference using backtick-apostrophe syntax: `` `name' ``
+- **Stored_Result_Function**: One of the four Stata functions that return stored results: `r()` (return values), `e()` (estimation results), `c()` (system constants), `s()` (string scalars)
+- **Invalid_Macro_Char_Diagnostic**: The diagnostic that reports "Invalid character in macro name" when non-identifier characters are found in a macro reference
+- **Analyzer**: The semantic analysis component that validates macro references and produces diagnostics
+
+## Requirements
+
+### Requirement 1: Recognize Stored Result References
+
+**User Story:** As a Stata developer, I want the LSP to recognize stored result references wrapped in backtick-apostrophe syntax, so that I don't receive false positive errors for valid Stata code.
+
+#### Acceptance Criteria
+
+1. WHEN the Analyzer encounters a local macro reference token with content matching the pattern `r(identifier)`, THE Analyzer SHALL recognize it as a stored result reference
+2. WHEN the Analyzer encounters a local macro reference token with content matching the pattern `e(identifier)`, THE Analyzer SHALL recognize it as a stored result reference
+3. WHEN the Analyzer encounters a local macro reference token with content matching the pattern `c(identifier)`, THE Analyzer SHALL recognize it as a stored result reference
+4. WHEN the Analyzer encounters a local macro reference token with content matching the pattern `s(identifier)`, THE Analyzer SHALL recognize it as a stored result reference
+5. WHEN the Analyzer recognizes a stored result reference, THE Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic
+
+### Requirement 2: Preserve Invalid Character Detection for True Macros
+
+**User Story:** As a Stata developer, I want the LSP to continue detecting invalid characters in actual macro names, so that I catch typos and syntax errors.
+
+#### Acceptance Criteria
+
+1. WHEN the Analyzer encounters a local macro reference with invalid characters that is NOT a stored result reference, THE Analyzer SHALL produce an "Invalid character in macro name" diagnostic
+2. WHEN the Analyzer encounters a local macro reference like `` `foo.bar' ``, THE Analyzer SHALL produce an "Invalid character in macro name" diagnostic
+3. WHEN the Analyzer encounters a local macro reference like `` `my var' ``, THE Analyzer SHALL produce an "Invalid character in macro name" diagnostic
+
+### Requirement 3: Handle Nested Stored Result References
+
+**User Story:** As a Stata developer, I want the LSP to handle stored result references that contain macro expansions, so that dynamic stored result access works correctly.
+
+#### Acceptance Criteria
+
+1. WHEN the Analyzer encounters a stored result reference containing a nested macro like `` `r(`varname')' ``, THE Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic
+2. WHEN the Analyzer encounters a stored result reference with a complex identifier like `` `r(mean_`i')' ``, THE Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic
+
+### Requirement 4: Support Stored Result Subscripts
+
+**User Story:** As a Stata developer, I want the LSP to recognize stored result matrix subscripts, so that matrix element access doesn't produce false positives.
+
+#### Acceptance Criteria
+
+1. WHEN the Analyzer encounters a stored result reference with matrix subscripts like `` `r(table)[1,1]' ``, THE Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic
+2. WHEN the Analyzer encounters a stored result reference with variable subscripts like `` `e(b)[1,`i']' ``, THE Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic

--- a/.kiro/specs/stored-result-reference-false-positive/tasks.md
+++ b/.kiro/specs/stored-result-reference-false-positive/tasks.md
@@ -1,0 +1,49 @@
+# Implementation Plan: Stored Result Reference False Positive Fix
+
+## Overview
+
+This implementation adds detection logic to recognize Stata stored result references (`r()`, `e()`, `c()`, `s()`) within local macro reference tokens and suppress the invalid character diagnostic for these valid constructs.
+
+## Tasks
+
+- [x] 1. Add stored result reference detection
+  - [x] 1.1 Add `is_stored_result_reference` helper method to Analyzer
+    - Add new private method in `src/analyzer/index.ts`
+    - Implement regex pattern to match `r(...)`, `e(...)`, `c(...)`, `s(...)` with optional matrix subscripts
+    - Handle nested macro syntax within parentheses
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 3.1, 3.2, 4.1, 4.2_
+
+  - [x] 1.2 Modify `collect_undefined_macro_diagnostics` to skip stored results
+    - Add check for `is_stored_result_reference` before `has_invalid_macro_char` check
+    - Skip both invalid char check and undefined macro check for stored results
+    - _Requirements: 1.5, 2.1_
+
+  - [x] 1.3 Write property test for stored result recognition
+    - **Property 1: Stored Result References Are Not Flagged**
+    - **Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5**
+
+  - [x] 1.4 Write property test for invalid char detection preservation
+    - **Property 2: Non-Stored-Result Invalid Characters Are Flagged**
+    - **Validates: Requirements 2.1, 2.2, 2.3**
+
+- [x] 2. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+  - [x] 2.1 Write property test for nested macros in stored results
+    - **Property 3: Nested Macros in Stored Results Are Not Flagged**
+    - **Validates: Requirements 3.1, 3.2**
+
+  - [x] 2.2 Write property test for matrix subscripts in stored results
+    - **Property 4: Matrix Subscripts in Stored Results Are Not Flagged**
+    - **Validates: Requirements 4.1, 4.2**
+
+- [x] 3. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- All core implementation tasks (1.1, 1.2) are required
+- Each task references specific requirements for traceability
+- The fix is localized to `src/analyzer/index.ts` with minimal changes
+- Property tests use `fast-check` library with minimum 100 iterations

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -2239,6 +2239,11 @@ export class SemanticAnalyzer {
                 // Extract macro name from `name' format
                 const macro_name = this.extract_local_macro_name(token.value);
                 
+                // Skip stored result references like `r(values)' - they are valid Stata syntax
+                if (macro_name && this.is_stored_result_reference(macro_name)) {
+                    continue;
+                }
+                
                 // Check for invalid characters in local macro reference
                 if (macro_name && this.has_invalid_macro_char(macro_name)) {
                     diagnostics.push({
@@ -2294,6 +2299,23 @@ export class SemanticAnalyzer {
      */
     private has_invalid_macro_char(name: string): boolean {
         return !/^[A-Za-z0-9_]*$/.test(name);
+    }
+
+    /**
+     * Check if a string is a stored result reference.
+     * Stored results use the format r(...), e(...), c(...), or s(...)
+     * with optional matrix subscripts [...].
+     * Case-sensitive: only lowercase r/e/c/s are valid.
+     * 
+     * Examples:
+     * - r(values) - return values
+     * - e(N) - estimation results
+     * - c(current_date) - system constants
+     * - s(macros) - string scalars
+     * - r(table)[1,2] - matrix subscript
+     */
+    private is_stored_result_reference(content: string): boolean {
+        return /^[recs]\(.*\)(\[.*\])?$/.test(content);
     }
 
     /**

--- a/tests/property/stored-result-reference-detection.prop.test.ts
+++ b/tests/property/stored-result-reference-detection.prop.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Stored Result Reference Detection Property Tests
+ *
+ * Tests that verify stored result references (r(), e(), c(), s()) wrapped in
+ * backtick-apostrophe syntax are correctly recognized and do not produce
+ * false positive INVALID_MACRO_CHAR diagnostics.
+ *
+ * Feature: stored-result-reference-false-positive
+ */
+
+import { describe, it, beforeEach } from 'bun:test';
+import * as fc from 'fast-check';
+import { DiagnosticsProvider } from '../../src/providers/diagnostics';
+import { StataLSPConfig, StataDiagnosticCode } from '../../src/types';
+import { create_document_state } from './helpers/document-utils';
+import { arbitrary_identifier } from './generators';
+
+describe('Stored Result Reference Detection Property Tests', () => {
+  let my_diagnostics_provider: DiagnosticsProvider;
+  let my_config: StataLSPConfig;
+
+  // Stored result prefixes
+  const the_stored_result_prefixes = ['r', 'e', 'c', 's'];
+
+  beforeEach(() => {
+    // Create a mock connection for diagnostics provider
+    const my_mock_connection = {
+      sendDiagnostics: () => {},
+    } as any;
+
+    my_diagnostics_provider = new DiagnosticsProvider(my_mock_connection);
+
+    // Create default config with diagnostics enabled
+    my_config = {
+      diagnostics: {
+        enabled: true,
+        severity: {
+          styleWarnings: 'warning',
+          undefinedMacro: 'warning',
+          undefinedVariable: 'warning',
+        },
+        undefinedVariableEnabled: true,
+      },
+      adoPaths: [],
+      completion: {
+        cacheSize: 100,
+        prefixMaxItems: 50,
+      },
+      formatting: {
+        indentSize: 4,
+        indentStyle: 'spaces',
+        lineWidth: 80,
+        preferredCommentStyle: '//',
+        normalizeCommentStyle: false,
+        commentLineWidth: 72,
+      },
+      indexing: {
+        maxFileSizeBytes: 1000000,
+      },
+      indexWorkspace: false,
+      cross_file: {
+        index_workspace: false,
+        max_indexed_files: 100,
+        assume_call_site: 'end',
+        max_backward_depth: 10,
+        max_forward_depth: 10,
+        max_chain_depth: 20,
+        diagnostics: {
+          undefined_symbol: 'warning',
+          out_of_scope: 'warning',
+          missing_file: 'warning',
+          max_depth: 'warning',
+        },
+      },
+    } as StataLSPConfig;
+  });
+
+  /**
+   * Property 1: Stored Result References Are Not Flagged
+   *
+   * For any valid identifier combined with a stored result prefix (r, e, c, s),
+   * when wrapped in backtick-apostrophe syntax, no INVALID_MACRO_CHAR diagnostic
+   * should be produced.
+   *
+   * Feature: stored-result-reference-false-positive, Property 1: Stored Result References Are Not Flagged
+   * Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5
+   */
+  it('should not flag stored result references as invalid macro characters', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbitrary_identifier(),
+        fc.constantFrom(...the_stored_result_prefixes),
+        async (my_identifier, my_prefix) => {
+          // Create a stored result reference: `r(identifier)'
+          const my_stored_result_ref = `\`${my_prefix}(${my_identifier})'`;
+
+          // Create a Stata document using the reference
+          const my_document = `display ${my_stored_result_ref}`;
+
+          const my_doc_state = create_document_state(my_document);
+          const my_diagnostics = await my_diagnostics_provider.get_diagnostics(
+            my_doc_state,
+            my_config
+          );
+
+          // Filter for INVALID_MACRO_CHAR diagnostics (code 3010)
+          const my_invalid_char_diagnostics = my_diagnostics.filter(
+            (my_diag) => my_diag.code === StataDiagnosticCode.INVALID_MACRO_CHAR
+          );
+
+          // Should have no INVALID_MACRO_CHAR diagnostics
+          return my_invalid_char_diagnostics.length === 0;
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 2: Non-Stored-Result Invalid Characters Are Flagged
+   *
+   * For any string containing invalid characters (dots, spaces, special chars)
+   * that does not match a stored result pattern, when wrapped in backtick-apostrophe
+   * syntax, an INVALID_MACRO_CHAR diagnostic should be produced.
+   *
+   * Feature: stored-result-reference-false-positive, Property 2: Non-Stored-Result Invalid Characters Are Flagged
+   * Validates: Requirements 2.1, 2.2, 2.3
+   */
+  it('should flag non-stored-result invalid characters', async () => {
+    // Generator for invalid macro names that are NOT stored result patterns
+    const arbitrary_invalid_macro_name = fc
+      .tuple(
+        arbitrary_identifier(),
+        fc.constantFrom('.', ' ', '@', '#', '!', '%', '^', '&'),
+        arbitrary_identifier()
+      )
+      .map(([my_prefix, my_invalid_char, my_suffix]) => {
+        return `${my_prefix}${my_invalid_char}${my_suffix}`;
+      })
+      // Filter out anything that looks like a stored result pattern
+      .filter((my_name) => {
+        return !/^[recs]\(.*\)(\[.*\])?$/.test(my_name);
+      });
+
+    await fc.assert(
+      fc.asyncProperty(arbitrary_invalid_macro_name, async (my_invalid_name) => {
+        // Create a local macro reference with invalid characters: `foo.bar'
+        const my_invalid_ref = `\`${my_invalid_name}'`;
+
+        // Create a Stata document using the reference
+        const my_document = `display ${my_invalid_ref}`;
+
+        const my_doc_state = create_document_state(my_document);
+        const my_diagnostics = await my_diagnostics_provider.get_diagnostics(
+          my_doc_state,
+          my_config
+        );
+
+        // Filter for INVALID_MACRO_CHAR diagnostics (code 3010)
+        const my_invalid_char_diagnostics = my_diagnostics.filter(
+          (my_diag) => my_diag.code === StataDiagnosticCode.INVALID_MACRO_CHAR
+        );
+
+        // Should have at least one INVALID_MACRO_CHAR diagnostic
+        return my_invalid_char_diagnostics.length > 0;
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 3: Nested Macros in Stored Results Are Not Flagged
+   *
+   * For stored result references containing nested macro patterns like
+   * `r(`varname')' or `r(mean_`i')', no INVALID_MACRO_CHAR diagnostic
+   * should be produced.
+   *
+   * Feature: stored-result-reference-false-positive, Property 3: Nested Macros in Stored Results Are Not Flagged
+   * Validates: Requirements 3.1, 3.2
+   */
+  it('should not flag nested macros in stored results', async () => {
+    // Generator for nested macro patterns within stored results
+    const arbitrary_nested_stored_result = fc
+      .tuple(
+        fc.constantFrom(...the_stored_result_prefixes),
+        fc.oneof(
+          // Pattern 1: `r(`varname')' - nested macro as entire identifier
+          arbitrary_identifier().map((my_name) => `\`${my_name}'`),
+          // Pattern 2: `r(mean_`i')' - nested macro as suffix
+          fc
+            .tuple(arbitrary_identifier(), arbitrary_identifier())
+            .map(([my_prefix, my_nested]) => `${my_prefix}_\`${my_nested}'`),
+          // Pattern 3: `r(`prefix'_var)' - nested macro as prefix
+          fc
+            .tuple(arbitrary_identifier(), arbitrary_identifier())
+            .map(([my_nested, my_suffix]) => `\`${my_nested}'_${my_suffix}`)
+        )
+      )
+      .map(([my_prefix, my_inner]) => `\`${my_prefix}(${my_inner})'`);
+
+    await fc.assert(
+      fc.asyncProperty(arbitrary_nested_stored_result, async (my_nested_ref) => {
+        // Create a Stata document using the nested reference
+        const my_document = `display ${my_nested_ref}`;
+
+        const my_doc_state = create_document_state(my_document);
+        const my_diagnostics = await my_diagnostics_provider.get_diagnostics(
+          my_doc_state,
+          my_config
+        );
+
+        // Filter for INVALID_MACRO_CHAR diagnostics (code 3010)
+        const my_invalid_char_diagnostics = my_diagnostics.filter(
+          (my_diag) => my_diag.code === StataDiagnosticCode.INVALID_MACRO_CHAR
+        );
+
+        // Should have no INVALID_MACRO_CHAR diagnostics
+        return my_invalid_char_diagnostics.length === 0;
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 4: Matrix Subscripts in Stored Results Are Not Flagged
+   *
+   * For stored result references with matrix subscripts like `r(table)[1,1]'
+   * or `e(b)[1,`i']', no INVALID_MACRO_CHAR diagnostic should be produced.
+   *
+   * Feature: stored-result-reference-false-positive, Property 4: Matrix Subscripts in Stored Results Are Not Flagged
+   * Validates: Requirements 4.1, 4.2
+   */
+  it('should not flag matrix subscripts in stored results', async () => {
+    // Generator for matrix subscript patterns
+    const arbitrary_subscript = fc.oneof(
+      // Numeric subscripts: [1,1], [2,3]
+      fc
+        .tuple(
+          fc.integer({ min: 1, max: 100 }),
+          fc.integer({ min: 1, max: 100 })
+        )
+        .map(([my_row, my_col]) => `[${my_row},${my_col}]`),
+      // Variable subscripts with macros: [1,`i'], [`j',1]
+      fc
+        .tuple(
+          fc.oneof(
+            fc.integer({ min: 1, max: 100 }).map((my_n) => my_n.toString()),
+            arbitrary_identifier().map((my_name) => `\`${my_name}'`)
+          ),
+          fc.oneof(
+            fc.integer({ min: 1, max: 100 }).map((my_n) => my_n.toString()),
+            arbitrary_identifier().map((my_name) => `\`${my_name}'`)
+          )
+        )
+        .map(([my_row, my_col]) => `[${my_row},${my_col}]`)
+    );
+
+    // Generator for stored results with matrix subscripts
+    const arbitrary_matrix_stored_result = fc
+      .tuple(
+        fc.constantFrom(...the_stored_result_prefixes),
+        arbitrary_identifier(),
+        arbitrary_subscript
+      )
+      .map(
+        ([my_prefix, my_identifier, my_subscript]) =>
+          `\`${my_prefix}(${my_identifier})${my_subscript}'`
+      );
+
+    await fc.assert(
+      fc.asyncProperty(
+        arbitrary_matrix_stored_result,
+        async (my_matrix_ref) => {
+          // Create a Stata document using the matrix reference
+          const my_document = `display ${my_matrix_ref}`;
+
+          const my_doc_state = create_document_state(my_document);
+          const my_diagnostics = await my_diagnostics_provider.get_diagnostics(
+            my_doc_state,
+            my_config
+          );
+
+          // Filter for INVALID_MACRO_CHAR diagnostics (code 3010)
+          const my_invalid_char_diagnostics = my_diagnostics.filter(
+            (my_diag) => my_diag.code === StataDiagnosticCode.INVALID_MACRO_CHAR
+          );
+
+          // Should have no INVALID_MACRO_CHAR diagnostics
+          return my_invalid_char_diagnostics.length === 0;
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});


### PR DESCRIPTION
Add detection logic to recognize Stata stored result references (r(), e(), c(), s()) within local macro reference tokens and suppress the invalid character diagnostic for these valid constructs.

Changes:
- Add is_stored_result_reference() helper method to Analyzer
- Modify check_token_macro_references() to skip stored result patterns
- Add property tests for stored result detection

Stored result references like `r(values)' are valid Stata syntax for accessing return values, estimation results, system constants, and string scalars. The fix also handles nested macros and matrix subscripts.

Closes: stored-result-reference-false-positive spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed false positives where stored result references (r(), e(), c(), s()) wrapped in backtick-apostrophe syntax were incorrectly flagged as invalid macro names. The analyzer now properly recognizes these valid Stata constructs, including nested macros and matrix subscripts, reducing diagnostic noise.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->