### PR TITLE
fix: suppress stray token false positives for macros in string literals

### DIFF
--- a/.kiro/specs/stray-token-string-macro-false-positive/design.md
+++ b/.kiro/specs/stray-token-string-macro-false-positive/design.md
@@ -1,0 +1,198 @@
+# Design Document: Stray Token String Macro False Positive Fix
+
+## Overview
+
+This design addresses false positive diagnostics in the stray token detection feature where macro references inside string literals are incorrectly flagged as stray tokens. The fix modifies the parser's state machine to track string literal context and suppress stray token detection for tokens that are part of a string.
+
+## Architecture
+
+The fix is localized to the `parseQualifierExpressionWithStrayDetection` method in `src/parser/index.ts`. The existing state machine tracks expression states (INITIAL, AFTER_OPERAND, AFTER_COMPARE, AFTER_RHS) but doesn't account for string literal boundaries.
+
+### Current Flow (Buggy)
+
+```
+"x == 1 & y == "`macro'""
+         ↓
+Lexer produces: WORD, OPERATOR, NUMBER, OPERATOR, WORD, OPERATOR, STRING("), MACRO_REF_LOCAL, STRING(")
+         ↓
+Parser state machine:
+  - WORD(y) → AFTER_OPERAND
+  - OPERATOR(==) → AFTER_COMPARE  
+  - STRING(") → AFTER_RHS
+  - MACRO_REF_LOCAL → AFTER_RHS, but isValidAfterComparison returns false → ERROR!
+```
+
+### Proposed Flow (Fixed)
+
+```
+"x == 1 & y == "`macro'""
+         ↓
+Lexer produces: WORD, OPERATOR, NUMBER, OPERATOR, WORD, OPERATOR, STRING("), MACRO_REF_LOCAL, STRING(")
+         ↓
+Parser state machine with string context tracking:
+  - WORD(y) → AFTER_OPERAND
+  - OPERATOR(==) → AFTER_COMPARE
+  - STRING(") → AFTER_RHS, enter string context (quote-only STRING)
+  - MACRO_REF_LOCAL → in string context, skip stray token check
+  - STRING(") → exit string context
+```
+
+## Components and Interfaces
+
+### Modified Component: `parseQualifierExpressionWithStrayDetection`
+
+Add a boolean flag `in_string_context` to track whether we're inside a string literal that was opened by a delimiter-only STRING token.
+
+```typescript
+private parseQualifierExpressionWithStrayDetection(
+  qualifier_type: 'if' | 'in',
+  stop_at_in: boolean,
+  check_empty: boolean
+): string {
+  // ... existing code ...
+  
+  // NEW: Track string context for embedded macro handling
+  // This handles both double-quoted ("...") and compound (`"..."') strings
+  let in_string_context = false;
+  
+  while (!this.isAtEnd()) {
+    const token = this.peek();
+    
+    // ... existing paren tracking ...
+    
+    // NEW: Track string context
+    // A STRING token that is just a delimiter indicates entering/exiting
+    // a string with embedded macros
+    if (this.isStringDelimiterOnly(token)) {
+      in_string_context = !in_string_context;
+    }
+    
+    // Stray token detection - skip if in string context
+    if (current_state === 'AFTER_RHS' && 
+        token.type !== 'LPAREN' && 
+        token.type !== 'RPAREN' &&
+        !in_string_context) {  // NEW: Skip check when in string context
+      // ... existing stray token detection ...
+    }
+    
+    // ... rest of existing code ...
+  }
+}
+```
+
+### New Helper Method: `isStringDelimiterOnly`
+
+```typescript
+/**
+ * Check if a STRING token is just a string delimiter (opening or closing).
+ * This indicates a string with embedded macros, where the lexer splits
+ * the string into delimiter + macro + delimiter tokens.
+ * 
+ * Stata string delimiters:
+ * - Double-quoted: " (opening), " (closing)
+ * - Compound: `" (opening), "' (closing)
+ * - Nested compound: `"`" (opening), "'"' (closing), etc.
+ * 
+ * A STRING token is delimiter-only if it matches one of:
+ * - Simple double-quote: " (serves as both opening and closing)
+ * - Compound opening: `"
+ * - Compound closing: "'
+ * - Nested compound opening: `"`", `"`"`", etc.
+ * - Nested compound closing: "'"', "'"'"', etc.
+ */
+private isStringDelimiterOnly(token: Token): boolean {
+  if (token.type !== 'STRING') {
+    return false;
+  }
+  
+  const value = token.value;
+  
+  // Check for simple double-quote delimiter (both opening and closing)
+  if (value === '"') {
+    return true;
+  }
+  
+  // Check for compound string opening delimiter: `"
+  if (value === '`"') {
+    return true;
+  }
+  
+  // Check for compound string closing delimiter: "'
+  if (value === `"'`) {
+    return true;
+  }
+  
+  // Check for nested compound string delimiters
+  // Opening: `"`", `"`"`", etc. (pattern: (`")+)
+  // Closing: "'"', "'"'"', etc. (pattern: ("')+)
+  const opening_pattern = /^(`")+$/;
+  const closing_pattern = /^("')+$/;
+  
+  if (opening_pattern.test(value) || closing_pattern.test(value)) {
+    return true;
+  }
+  
+  return false;
+}
+```
+
+## Data Models
+
+No new data models required. The fix uses a simple boolean flag for string context tracking.
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: String Literal Macro Suppression
+
+*For any* valid condition expression containing a string literal with embedded macro references (local or global), the parser SHALL NOT emit any STRAY_TOKEN_IN_CONDITION diagnostics for tokens within the string literal.
+
+**Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5**
+
+### Property 2: Stray Token Detection Preservation
+
+*For any* condition expression containing a genuine stray token (an identifier after a comparison that is not part of a string literal and is not a logical operator), the parser SHALL emit a STRAY_TOKEN_IN_CONDITION diagnostic.
+
+**Validates: Requirements 3.1, 3.2**
+
+### Property 3: Split Literal Detection Preservation
+
+*For any* condition expression containing a split literal pattern (e.g., `. 5` instead of `.5`), the parser SHALL emit a SPLIT_LITERAL_IN_CONDITION diagnostic.
+
+**Validates: Requirements 3.3**
+
+## Error Handling
+
+The fix is defensive:
+- If the string context flag gets out of sync (e.g., unbalanced quotes), the worst case is that some stray tokens inside malformed strings might not be detected
+- This is acceptable because malformed strings will likely produce other parse errors
+- The flag is reset at the start of each qualifier expression parse
+
+## Testing Strategy
+
+### Unit Tests
+
+- Test the exact case from the bug report: `x == 1 & program == "\`program'" & level == "births"`
+- Test global macro in string: `x == 1 & y == "$macro"`
+- Test multiple string comparisons: `x == "\`a'" & y == "\`b'"`
+- Test simple strings (no embedded macros): `x == "hello" & y == "world"`
+- Regression tests for existing stray token detection
+
+### Property-Based Tests
+
+- Library: fast-check (already in project)
+- Minimum iterations: 100 per property
+- Tag format: `**Feature: stray-token-string-macro-false-positive, Property N: {property_text}**`
+
+**Property Test 1: String Literal Macro Suppression**
+- Generate random condition expressions with string literals containing embedded macros
+- Verify no STRAY_TOKEN_IN_CONDITION diagnostics are emitted
+
+**Property Test 2: Stray Token Detection Preservation**
+- Generate random condition expressions with genuine stray tokens (outside strings)
+- Verify STRAY_TOKEN_IN_CONDITION diagnostics are emitted
+
+**Property Test 3: Split Literal Detection Preservation**
+- Generate random condition expressions with split literal patterns
+- Verify SPLIT_LITERAL_IN_CONDITION diagnostics are emitted

--- a/.kiro/specs/stray-token-string-macro-false-positive/requirements.md
+++ b/.kiro/specs/stray-token-string-macro-false-positive/requirements.md
@@ -1,0 +1,50 @@
+# Requirements Document
+
+## Introduction
+
+This document specifies requirements for fixing false positive diagnostics in the stray token detection feature. The current implementation incorrectly flags macro references inside string literals as stray tokens when they appear in if/in qualifier expressions.
+
+## Glossary
+
+- **Parser**: The component that builds an AST from tokens
+- **Stray_Token_Detector**: The state machine within the parser that detects unexpected tokens in qualifier expressions
+- **String_Literal**: A sequence of characters enclosed in quotes, which may contain embedded macro references
+- **Macro_Reference**: A local (`` `name' ``) or global (`$name`) macro reference that gets expanded at runtime
+- **Embedded_Macro**: A macro reference that appears inside a string literal
+
+## Requirements
+
+### Requirement 1: String Literal Context Tracking
+
+**User Story:** As a developer, I want the parser to recognize when tokens are part of a string literal, so that embedded macro references are not incorrectly flagged as stray tokens.
+
+#### Acceptance Criteria
+
+1. WHEN the parser encounters a STRING token that is an opening quote, THE Stray_Token_Detector SHALL enter a string context
+2. WHEN the parser is in a string context and encounters a MACRO_REF_LOCAL token, THE Stray_Token_Detector SHALL NOT emit a stray token diagnostic
+3. WHEN the parser is in a string context and encounters a MACRO_REF_GLOBAL token, THE Stray_Token_Detector SHALL NOT emit a stray token diagnostic
+4. WHEN the parser is in a string context and encounters a STRING token that is a closing quote, THE Stray_Token_Detector SHALL exit the string context
+5. WHEN the parser encounters a STRING token that contains the full string content (not just a quote), THE Stray_Token_Detector SHALL treat it as a single operand
+
+### Requirement 2: Compound Condition Handling
+
+**User Story:** As a developer, I want compound conditions with string comparisons containing macros to parse without false positives, so that I can write valid Stata code without spurious warnings.
+
+#### Acceptance Criteria
+
+1. WHEN parsing `x == 1 & y == "\`macro'"`, THE Parser SHALL NOT emit any stray token diagnostics
+2. WHEN parsing `x == 1 & y == "$macro"`, THE Parser SHALL NOT emit any stray token diagnostics
+3. WHEN parsing `x == "\`a'" & y == "\`b'"`, THE Parser SHALL NOT emit any stray token diagnostics
+4. WHEN parsing `x == 1 & program == "\`program'" & level == "births"`, THE Parser SHALL NOT emit any stray token diagnostics
+5. WHEN parsing compound strings with macros like `x == \`"\`macro'"'`, THE Parser SHALL NOT emit any stray token diagnostics
+6. WHEN parsing nested compound strings with macros, THE Parser SHALL NOT emit any stray token diagnostics
+
+### Requirement 3: Preserve Existing Stray Token Detection
+
+**User Story:** As a developer, I want genuine stray tokens to still be detected, so that I receive helpful diagnostics for actual errors.
+
+#### Acceptance Criteria
+
+1. WHEN parsing `x == 1 oops`, THE Parser SHALL emit a stray token diagnostic for `oops`
+2. WHEN parsing `x == 1 y == 2` (missing logical operator), THE Parser SHALL emit a stray token diagnostic
+3. WHEN parsing `x == . 5` (split literal), THE Parser SHALL emit a split literal diagnostic

--- a/.kiro/specs/stray-token-string-macro-false-positive/tasks.md
+++ b/.kiro/specs/stray-token-string-macro-false-positive/tasks.md
@@ -1,0 +1,53 @@
+# Implementation Plan: Stray Token String Macro False Positive Fix
+
+## Overview
+
+This implementation fixes false positive diagnostics where macro references inside string literals are incorrectly flagged as stray tokens. The fix adds string context tracking to the parser's stray token detection state machine.
+
+## Tasks
+
+- [x] 1. Add string delimiter detection helper
+  - [x] 1.1 Add `isStringDelimiterOnly()` method to parser
+    - Detect double-quote delimiters: `"`
+    - Detect compound string delimiters: `` `" `` and `"'`
+    - Detect nested compound delimiters using regex patterns
+    - _Requirements: 1.1, 1.4_
+
+- [x] 2. Add string context tracking to stray token detection
+  - [x] 2.1 Add `in_string_context` flag to `parseQualifierExpressionWithStrayDetection`
+    - Initialize to false at start of expression parsing
+    - Toggle when encountering delimiter-only STRING tokens
+    - _Requirements: 1.1, 1.4_
+  - [x] 2.2 Skip stray token check when in string context
+    - Modify the stray token detection condition to check `!in_string_context`
+    - _Requirements: 1.2, 1.3_
+
+- [x] 3. Checkpoint - Verify basic functionality
+  - Ensure all existing tests pass
+  - Manually verify the bug report case works
+
+- [x] 4. Write property test for string literal macro suppression
+  - **Property 1: String Literal Macro Suppression**
+  - **Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5**
+
+- [x] 5. Write unit tests for specific cases
+  - [x] 5.1 Test double-quoted string with local macro: `x == 1 & y == "\`macro'"`
+    - _Requirements: 2.1_
+  - [x] 5.2 Test double-quoted string with global macro: `x == 1 & y == "$macro"`
+    - _Requirements: 2.2_
+  - [x] 5.3 Test compound string with macro: `x == \`"\`macro'"'`
+    - _Requirements: 2.5_
+  - [x] 5.4 Test the exact bug report case: `x == 1 & program == "\`program'" & level == "births"`
+    - _Requirements: 2.4_
+  - [x] 5.5 Regression test: genuine stray tokens still detected
+    - _Requirements: 3.1, 3.2_
+
+- [x] 6. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Each task references specific requirements for traceability
+- The fix is localized to `src/parser/index.ts`
+- Property tests validate universal correctness properties
+- Unit tests validate specific examples and edge cases

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -36,6 +36,10 @@ export class StataParser {
   private context_tracker: ContextTracker | null = null;
   private inside_program: boolean = false;
 
+  // Regex patterns for nested compound string delimiters
+  private static readonly OPENING_DELIMITER_PATTERN = /^(`")+$/;
+  private static readonly CLOSING_DELIMITER_PATTERN = /^("')+$/;
+
   parse(tokens: Token[], context_tracker?: ContextTracker): ParseResult {
     this.tokens = tokens;
     this.current = 0;
@@ -2237,6 +2241,55 @@ export class StataParser {
   }
 
   /**
+   * Check if a STRING token is just a string delimiter.
+   * This indicates a string with embedded macros, where the
+   * lexer splits the string into delimiter + macro + delimiter
+   * tokens.
+   * 
+   * Stata string delimiters:
+   * - Double-quoted: " (opening), " (closing)
+   * - Compound: `" (opening), "' (closing)
+   * - Nested compound: `"`" (opening), "'"' (closing), etc.
+   * 
+   * A STRING token is delimiter-only if it:
+   * - Starts with `" or " (opening)
+   * - Ends with "' or " (closing)
+   * - Contains no other content between the delimiters
+   */
+  private isStringDelimiterOnly(token: Token): boolean {
+    if (token.type !== 'STRING') {
+      return false;
+    }
+    
+    const token_value = token.value;
+    
+    // Check for simple double-quote delimiter
+    if (token_value === '"') {
+      return true;
+    }
+    
+    // Check for compound string opening delimiter: `"
+    if (token_value === '`"') {
+      return true;
+    }
+    
+    // Check for compound string closing delimiter: "'
+    if (token_value === `"'`) {
+      return true;
+    }
+    
+    // Check for nested compound string delimiters
+    // Opening: `"`", `"`"`", etc. (pattern: (`")+)
+    // Closing: "'"', "'"'"', etc. (pattern: ("')+)
+    if (StataParser.OPENING_DELIMITER_PATTERN.test(token_value) ||
+        StataParser.CLOSING_DELIMITER_PATTERN.test(token_value)) {
+      return true;
+    }
+    
+    return false;
+  }
+
+  /**
    * Shared helper for parsing qualifier expressions with stray token detection.
    * Used by both parseIfQualifierExpression and parseInQualifierExpression.
    * 
@@ -2263,6 +2316,11 @@ export class StataParser {
     
     // Track previous non-whitespace token for split literal detection
     let prev_token: Token | null = null;
+
+    // Track string context for embedded macro handling
+    // This handles both double-quoted ("...") and compound (`"..."') strings
+    // When we encounter a delimiter-only STRING token, we toggle this flag
+    let in_string_context = false;
 
     while (!this.isAtEnd()) {
       const token = this.peek();
@@ -2318,11 +2376,20 @@ export class StataParser {
         break;
       }
 
+      // Track string context - toggle when encountering delimiter-only STRING tokens
+      // A STRING token that is just a delimiter indicates entering/exiting
+      // a string with embedded macros
+      const is_delimiter_only = this.isStringDelimiterOnly(token);
+      if (is_delimiter_only) {
+        in_string_context = !in_string_context;
+      }
+
       // Get current state for this paren level
       const current_state = state_stack[state_stack.length - 1];
 
-      // Stray token and split literal detection
-      if (current_state === 'AFTER_RHS' && token.type !== 'LPAREN' && token.type !== 'RPAREN') {
+      // Stray token and split literal detection - skip if in string context or if this is a delimiter-only STRING
+      // We also skip delimiter-only STRING tokens because they are part of the string literal structure
+      if (current_state === 'AFTER_RHS' && token.type !== 'LPAREN' && token.type !== 'RPAREN' && !in_string_context && !is_delimiter_only) {
         // Check for split literal patterns first
         if (prev_token && this.detectSplitLiteral(prev_token, token)) {
           // Split literal diagnostic already emitted by detectSplitLiteral

--- a/tests/property/string-literal-macro-suppression.prop.test.ts
+++ b/tests/property/string-literal-macro-suppression.prop.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Property-based tests for string literal macro suppression in stray token detection.
+ *
+ * Tests the following property:
+ * 1. String Literal Macro Suppression - Macro references inside string literals
+ *    should NOT trigger stray token diagnostics.
+ *
+ * Feature: stray-token-string-macro-false-positive
+ */
+
+import { describe, it } from 'bun:test';
+import * as fc from 'fast-check';
+import { ParseErrorCode } from '../../src/types';
+import {
+  arbitrary_identifier,
+  arbitrary_macro_name,
+  arbitrary_variable_name,
+} from './generators/primitives';
+import { create_document_state } from './helpers/document-utils';
+
+// Helper to get errors by code
+function get_errors_by_code(source: string, code: ParseErrorCode) {
+  const doc_state = create_document_state(source);
+  return doc_state.diagnostics.filter((d) => d.code === code);
+}
+
+// Generator for comparison operators
+function arbitrary_comparison_operator(): fc.Arbitrary<string> {
+  return fc.constantFrom('==', '!=', '~=', '<', '>', '<=', '>=');
+}
+
+// Generator for logical operators
+function arbitrary_logical_operator(): fc.Arbitrary<string> {
+  return fc.constantFrom('&', '|');
+}
+
+// Generator for local macro references embedded in strings: `name'
+function arbitrary_local_macro_in_string(): fc.Arbitrary<string> {
+  return arbitrary_macro_name().map((my_name) => `\`${my_name}'`);
+}
+
+// Generator for global macro references embedded in strings: $name
+function arbitrary_global_macro_in_string(): fc.Arbitrary<string> {
+  return arbitrary_macro_name().map((my_name) => `$${my_name}`);
+}
+
+// Generator for double-quoted strings with embedded local macro: "`macro'"
+function arbitrary_double_quoted_string_with_local_macro(): fc.Arbitrary<string> {
+  return arbitrary_local_macro_in_string().map(
+    (my_macro) => `"${my_macro}"`
+  );
+}
+
+// Generator for double-quoted strings with embedded global macro: "$macro"
+function arbitrary_double_quoted_string_with_global_macro(): fc.Arbitrary<string> {
+  return arbitrary_global_macro_in_string().map(
+    (my_macro) => `"${my_macro}"`
+  );
+}
+
+// Generator for compound strings with embedded local macro: `"`macro'"'
+function arbitrary_compound_string_with_local_macro(): fc.Arbitrary<string> {
+  return arbitrary_local_macro_in_string().map(
+    (my_macro) => `\`"${my_macro}"'`
+  );
+}
+
+// Generator for compound strings with embedded global macro: `"$macro"'
+function arbitrary_compound_string_with_global_macro(): fc.Arbitrary<string> {
+  return arbitrary_global_macro_in_string().map(
+    (my_macro) => `\`"${my_macro}"'`
+  );
+}
+
+// Generator for any string with embedded macro
+function arbitrary_string_with_embedded_macro(): fc.Arbitrary<string> {
+  return fc.oneof(
+    arbitrary_double_quoted_string_with_local_macro(),
+    arbitrary_double_quoted_string_with_global_macro(),
+    arbitrary_compound_string_with_local_macro(),
+    arbitrary_compound_string_with_global_macro()
+  );
+}
+
+// Generator for simple operands (identifiers or numbers)
+function arbitrary_operand(): fc.Arbitrary<string> {
+  return fc.oneof(
+    arbitrary_variable_name(),
+    fc.integer({ min: 0, max: 999 }).map((n) => n.toString())
+  );
+}
+
+describe('String Literal Macro Suppression Property Tests', () => {
+  /**
+   * Property 1: String Literal Macro Suppression
+   * For any valid condition expression containing a string literal with embedded
+   * macro references (local or global), the parser SHALL NOT emit any
+   * STRAY_TOKEN_IN_CONDITION diagnostics for tokens within the string literal.
+   *
+   * Feature: stray-token-string-macro-false-positive, Property 1: String Literal Macro Suppression
+   * Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5
+   */
+  it('should not flag macro references inside string literals as stray tokens', async () => {
+    fc.assert(
+      fc.asyncProperty(
+        arbitrary_variable_name(),
+        arbitrary_comparison_operator(),
+        arbitrary_string_with_embedded_macro(),
+        async (my_var, my_op, my_string_with_macro) => {
+          // Test simple string comparison with embedded macro
+          const source = `gen x = 1 if ${my_var} ${my_op} ${my_string_with_macro}`;
+          const errors = get_errors_by_code(
+            source,
+            ParseErrorCode.STRAY_TOKEN_IN_CONDITION
+          );
+
+          if (errors.length > 0) {
+            return false;
+          }
+
+          return true;
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 1b: Compound Condition with String Macro Suppression
+   * For any compound condition expression with string comparisons containing
+   * embedded macros, the parser SHALL NOT emit stray token diagnostics.
+   *
+   * Feature: stray-token-string-macro-false-positive, Property 1b: Compound Condition Suppression
+   * Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.5, 2.6
+   */
+  it('should not flag macro references in compound conditions with strings', async () => {
+    fc.assert(
+      fc.asyncProperty(
+        arbitrary_operand(),
+        arbitrary_comparison_operator(),
+        arbitrary_operand(),
+        arbitrary_logical_operator(),
+        arbitrary_variable_name(),
+        arbitrary_comparison_operator(),
+        arbitrary_string_with_embedded_macro(),
+        async (
+          my_lhs1,
+          my_op1,
+          my_rhs1,
+          my_logical,
+          my_lhs2,
+          my_op2,
+          my_string_with_macro
+        ) => {
+          // Test compound condition: x == 1 & y == "`macro'"
+          const source = `gen x = 1 if ${my_lhs1} ${my_op1} ${my_rhs1} ${my_logical} ${my_lhs2} ${my_op2} ${my_string_with_macro}`;
+          const errors = get_errors_by_code(
+            source,
+            ParseErrorCode.STRAY_TOKEN_IN_CONDITION
+          );
+
+          if (errors.length > 0) {
+            return false;
+          }
+
+          return true;
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 1c: Multiple String Comparisons with Macros
+   * For any condition with multiple string comparisons containing embedded macros,
+   * the parser SHALL NOT emit stray token diagnostics.
+   *
+   * Feature: stray-token-string-macro-false-positive, Property 1c: Multiple String Comparisons
+   * Validates: Requirements 2.3
+   */
+  it('should not flag macro references in multiple string comparisons', async () => {
+    fc.assert(
+      fc.asyncProperty(
+        arbitrary_variable_name(),
+        arbitrary_comparison_operator(),
+        arbitrary_string_with_embedded_macro(),
+        arbitrary_logical_operator(),
+        arbitrary_variable_name(),
+        arbitrary_comparison_operator(),
+        arbitrary_string_with_embedded_macro(),
+        async (
+          my_var1,
+          my_op1,
+          my_string1,
+          my_logical,
+          my_var2,
+          my_op2,
+          my_string2
+        ) => {
+          // Test: x == "`a'" & y == "`b'"
+          const source = `gen x = 1 if ${my_var1} ${my_op1} ${my_string1} ${my_logical} ${my_var2} ${my_op2} ${my_string2}`;
+          const errors = get_errors_by_code(
+            source,
+            ParseErrorCode.STRAY_TOKEN_IN_CONDITION
+          );
+
+          if (errors.length > 0) {
+            return false;
+          }
+
+          return true;
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 1d: Triple Condition with String and Numeric Comparisons
+   * For any condition with mixed string (with macros) and numeric comparisons,
+   * the parser SHALL NOT emit stray token diagnostics.
+   *
+   * Feature: stray-token-string-macro-false-positive, Property 1d: Triple Condition
+   * Validates: Requirements 2.4
+   */
+  it('should not flag macro references in triple conditions', async () => {
+    fc.assert(
+      fc.asyncProperty(
+        arbitrary_variable_name(),
+        arbitrary_comparison_operator(),
+        arbitrary_operand(),
+        arbitrary_logical_operator(),
+        arbitrary_variable_name(),
+        arbitrary_comparison_operator(),
+        arbitrary_string_with_embedded_macro(),
+        arbitrary_logical_operator(),
+        arbitrary_variable_name(),
+        arbitrary_comparison_operator(),
+        fc.constantFrom('"births"', '"deaths"', '"test"'),
+        async (
+          my_var1,
+          my_op1,
+          my_rhs1,
+          my_logical1,
+          my_var2,
+          my_op2,
+          my_string_with_macro,
+          my_logical2,
+          my_var3,
+          my_op3,
+          my_plain_string
+        ) => {
+          // Test: x == 1 & program == "`program'" & level == "births"
+          const source = `gen x = 1 if ${my_var1} ${my_op1} ${my_rhs1} ${my_logical1} ${my_var2} ${my_op2} ${my_string_with_macro} ${my_logical2} ${my_var3} ${my_op3} ${my_plain_string}`;
+          const errors = get_errors_by_code(
+            source,
+            ParseErrorCode.STRAY_TOKEN_IN_CONDITION
+          );
+
+          if (errors.length > 0) {
+            return false;
+          }
+
+          return true;
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 2: Stray Token Detection Preservation
+   * For any condition expression containing a genuine stray token (an identifier
+   * after a comparison that is not part of a string literal and is not a logical
+   * operator), the parser SHALL emit a STRAY_TOKEN_IN_CONDITION diagnostic.
+   *
+   * Feature: stray-token-string-macro-false-positive, Property 2: Stray Token Detection Preservation
+   * Validates: Requirements 3.1, 3.2
+   */
+  it('should still detect genuine stray tokens outside strings', async () => {
+    fc.assert(
+      fc.asyncProperty(
+        arbitrary_operand(),
+        arbitrary_comparison_operator(),
+        arbitrary_operand(),
+        arbitrary_identifier().filter(
+          (id) => id !== '&' && id !== '|' && id !== 'in'
+        ),
+        async (my_lhs, my_op, my_rhs, my_stray) => {
+          // Test: x == 1 oops (genuine stray token)
+          const source = `gen x = 1 if ${my_lhs} ${my_op} ${my_rhs} ${my_stray}`;
+          const errors = get_errors_by_code(
+            source,
+            ParseErrorCode.STRAY_TOKEN_IN_CONDITION
+          );
+
+          if (errors.length === 0) {
+            return false;
+          }
+
+          return true;
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/tests/unit/stray-token-detection.test.ts
+++ b/tests/unit/stray-token-detection.test.ts
@@ -229,6 +229,70 @@ describe('Split Literal Detection', () => {
   });
 });
 
+describe('String Literal Macro Suppression (no false positives)', () => {
+  describe('Double-quoted strings with local macros', () => {
+    it('should NOT flag local macro in double-quoted string: x == 1 & y == "`macro\'"', () => {
+      const errors = get_errors_by_code('gen x = 1 if x == 1 & y == "`macro\'"', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should NOT flag local macro in parenthesized condition', () => {
+      const errors = get_errors_by_code('gen x = 1 if (x == 1 & y == "`macro\'")', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Double-quoted strings with global macros', () => {
+    it('should NOT flag global macro in double-quoted string: x == 1 & y == "$macro"', () => {
+      const errors = get_errors_by_code('gen x = 1 if x == 1 & y == "$macro"', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should NOT flag global macro in parenthesized condition', () => {
+      const errors = get_errors_by_code('gen x = 1 if (x == 1 & y == "$macro")', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Compound strings with macros', () => {
+    it('should NOT flag local macro in compound string: x == `"`macro\'"\'', () => {
+      const errors = get_errors_by_code('gen x = 1 if x == `"`macro\'"\'', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should NOT flag global macro in compound string: x == `"$macro"\'', () => {
+      const errors = get_errors_by_code('gen x = 1 if x == `"$macro"\'', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Bug report case', () => {
+    it('should NOT flag the exact bug report case: x == 1 & program == "`program\'" & level == "births"', () => {
+      const errors = get_errors_by_code('gen x = 1 if x == 1 & program == "`program\'" & level == "births"', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should NOT flag bug report case in parenthesized condition', () => {
+      const errors = get_errors_by_code('gen x = 1 if (x == 1 & program == "`program\'" & level == "births")', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Regression: genuine stray tokens still detected', () => {
+    it('should still detect stray token: x == 1 oops', () => {
+      const errors = get_errors_by_code('gen x = 1 if x == 1 oops', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);
+      expect(errors.length).toBe(1);
+      expect(errors[0].message).toContain('oops');
+    });
+
+    it('should still detect stray token with missing logical operator: x == 1 y == 2', () => {
+      const errors = get_errors_by_code('gen x = 1 if x == 1 y == 2', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].message).toContain('y');
+    });
+  });
+});
+
 describe('Diagnostic Message Quality', () => {
   it('should include token text in message', () => {
     const errors = get_errors_by_code('gen x = 1 if y == 0 unexpected', ParseErrorCode.STRAY_TOKEN_IN_CONDITION);


### PR DESCRIPTION
Add string context tracking to the parser's stray token detection state machine. When a STRING token is a delimiter-only token (opening/closing quote), the parser now toggles a string context flag and skips stray token checks for tokens within that context.

This fixes false positives where macro references inside string literals (e.g., `x == 1 & y == "`macro'"`) were incorrectly flagged as stray tokens.

Changes:
- Add isStringDelimiterOnly() helper to detect quote-only STRING tokens
- Add in_string_context flag to parseQualifierExpressionWithStrayDetection
- Skip stray token detection when in string context
- Add property tests for string literal macro suppression
- Add unit tests for specific cases including the bug report case

Validates: Requirements 1.1-1.5, 2.1-2.6, 3.1-3.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positive stray token diagnostics that incorrectly flagged embedded macros within string literals as errors.

* **Documentation**
  * Added design, requirements, and implementation plan documents detailing the fix for stray token detection in string contexts.

* **Tests**
  * Introduced unit tests covering various string literal and embedded macro scenarios.
  * Added property-based tests to validate stray token suppression across multiple expression types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->