### PR TITLE
fix: suppress invalid char diagnostic for expression evaluation macros

### DIFF
--- a/.kiro/specs/expression-macro-false-positive/design.md
+++ b/.kiro/specs/expression-macro-false-positive/design.md
@@ -1,0 +1,110 @@
+# Design Document
+
+## Overview
+
+This design addresses a false positive diagnostic where Stata expression evaluation macro syntax like `` `=uchar(65533)' `` is incorrectly flagged as "Invalid character in macro name". The fix adds detection logic to recognize expression evaluation patterns (macros starting with `=`) within local macro reference tokens and suppress the invalid character diagnostic for these valid Stata constructs.
+
+In Stata, the `` `=expr' `` syntax evaluates an expression and substitutes the result as a string. This is a common pattern for inline expression evaluation and is valid Stata syntax.
+
+## Architecture
+
+The fix is localized to the `SemanticAnalyzer` class in `src/analyzer/index.ts`. The existing `detect_undefined_references` method already has several checks to skip invalid character diagnostics for special cases (stored results, nested macros, unbalanced macros). We add a new check for expression evaluation macros.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    detect_undefined_references                   │
+├─────────────────────────────────────────────────────────────────┤
+│  For each MACRO_REF_LOCAL token:                                │
+│    1. Extract macro name content                                │
+│    2. Skip if stored result reference (r/e/c/s)                 │
+│    3. Skip if nested macro reference                            │
+│    4. Skip if unbalanced macro expression                       │
+│    5. NEW: Skip if expression evaluation (starts with =)        │
+│    6. Check for invalid characters → produce diagnostic         │
+│    7. Check for undefined macro → produce warning               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Components and Interfaces
+
+### Modified Component: SemanticAnalyzer
+
+**File:** `src/analyzer/index.ts`
+
+**New Method:**
+
+```typescript
+/**
+ * Check if a local macro content represents an expression evaluation.
+ * Expression evaluation macros use the `=expr' syntax where the content
+ * starts with '=' followed by any valid Stata expression.
+ * 
+ * Examples:
+ * - `=1+2' → content is "=1+2" (arithmetic expression)
+ * - `=uchar(65533)' → content is "=uchar(65533)" (function call)
+ * - `=string(varname)' → content is "=string(varname)" (function call)
+ * - `=`a' + `b'' → content is "=`a' + `b'" (expression with nested macros)
+ * 
+ * @param content The extracted macro name content (without outer delimiters)
+ * @returns true if the content is an expression evaluation (starts with =)
+ */
+private is_expression_evaluation(content: string): boolean {
+    return content.startsWith('=');
+}
+```
+
+**Modified Method:** `detect_undefined_references`
+
+Add a new check before the invalid character check:
+
+```typescript
+// Skip expression evaluation macros - they use `=expr' syntax
+if (macro_name && this.is_expression_evaluation(macro_name)) {
+    continue;
+}
+```
+
+## Data Models
+
+No new data models are required. The fix uses the existing token structure and diagnostic types.
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system—essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Expression Evaluation Macros Are Not Flagged
+
+*For any* local macro reference whose content starts with `=` (expression evaluation syntax), the Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic.
+
+**Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 3.1, 3.2, 3.3, 3.4**
+
+### Property 2: Non-Expression Invalid Characters Are Flagged
+
+*For any* local macro reference that does NOT start with `=` and contains characters outside `[A-Za-z0-9_]` (excluding stored results, nested macros, and unbalanced macros), the Analyzer SHALL produce an "Invalid character in macro name" diagnostic.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+## Error Handling
+
+No new error handling is required. The fix simply adds a condition to skip diagnostic generation for a valid syntax pattern.
+
+## Testing Strategy
+
+### Unit Tests
+
+- Test that `` `=uchar(65533)' `` produces no diagnostic (original bug case)
+- Test that `` `=1+2' `` produces no diagnostic
+- Test that `` `=string(varname)' `` produces no diagnostic
+- Test that `` `foo.bar' `` still produces invalid character diagnostic
+- Test that `` `my var' `` still produces invalid character diagnostic
+
+### Property-Based Tests
+
+Use fast-check to generate:
+1. Random expressions after `=` and verify no invalid character diagnostic
+2. Random invalid macro names (not starting with `=`) and verify diagnostic is produced
+
+**Property Test Configuration:**
+- Minimum 100 iterations per property test
+- Use fast-check library for property-based testing
+- Tag format: **Feature: expression-macro-false-positive, Property N: description**

--- a/.kiro/specs/expression-macro-false-positive/requirements.md
+++ b/.kiro/specs/expression-macro-false-positive/requirements.md
@@ -1,0 +1,48 @@
+# Requirements Document
+
+## Introduction
+
+This document specifies requirements for fixing a false positive diagnostic where Stata expression evaluation macro syntax like `` `=uchar(65533)' `` is incorrectly flagged as "Invalid character in macro name". In Stata, the `` `=expr' `` syntax evaluates an expression and substitutes the result as a string. This is valid Stata syntax that should not produce errors.
+
+## Glossary
+
+- **Local_Macro_Reference**: A Stata local macro reference using backtick-apostrophe syntax: `` `name' ``
+- **Expression_Evaluation_Macro**: A Stata macro reference that evaluates an expression using `` `=expr' `` syntax, where `expr` is any valid Stata expression
+- **Invalid_Macro_Char_Diagnostic**: The diagnostic that reports "Invalid character in macro name" when non-identifier characters are found in a macro reference
+- **Analyzer**: The semantic analysis component that validates macro references and produces diagnostics
+- **Macro_Identifier_Char**: Valid characters for macro names: letters (`A-Za-z`), digits (`0-9`), and underscore (`_`)
+
+## Requirements
+
+### Requirement 1: Recognize Expression Evaluation Macro Syntax
+
+**User Story:** As a Stata developer, I want the LSP to recognize `` `=expr' `` syntax as valid expression evaluation, so that I don't receive false positive diagnostics when using this common Stata pattern.
+
+#### Acceptance Criteria
+
+1. WHEN the Analyzer encounters a local macro reference token starting with `=`, THE Analyzer SHALL recognize it as an expression evaluation macro
+2. WHEN the Analyzer recognizes an expression evaluation macro, THE Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic
+3. WHEN the Analyzer encounters `` `=uchar(65533)' ``, THE Analyzer SHALL NOT produce any diagnostic
+4. WHEN the Analyzer encounters `` `=1+2' ``, THE Analyzer SHALL NOT produce any diagnostic
+5. WHEN the Analyzer encounters `` `=string(varname)' ``, THE Analyzer SHALL NOT produce any diagnostic
+
+### Requirement 2: Preserve Invalid Character Detection for True Macros
+
+**User Story:** As a Stata developer, I want the LSP to continue detecting genuinely invalid macro names, so that I can catch typos and syntax errors.
+
+#### Acceptance Criteria
+
+1. WHEN the Analyzer encounters a local macro reference with invalid characters that is NOT an expression evaluation macro, THE Analyzer SHALL produce an "Invalid character in macro name" diagnostic
+2. WHEN the Analyzer encounters a local macro reference like `` `foo.bar' ``, THE Analyzer SHALL produce an "Invalid character in macro name" diagnostic
+3. WHEN the Analyzer encounters a local macro reference like `` `my var' ``, THE Analyzer SHALL produce an "Invalid character in macro name" diagnostic
+
+### Requirement 3: Handle Complex Expression Evaluation Patterns
+
+**User Story:** As a Stata developer, I want the LSP to handle complex expression evaluation patterns including nested macros and function calls, so that all valid Stata code is accepted.
+
+#### Acceptance Criteria
+
+1. WHEN the Analyzer encounters an expression evaluation macro containing nested local macros like `` `=`varname'' ``, THE Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic
+2. WHEN the Analyzer encounters an expression evaluation macro with function calls like `` `=substr("`str'", 1, 5)' ``, THE Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic
+3. WHEN the Analyzer encounters an expression evaluation macro with operators like `` `=`a' + `b'' ``, THE Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic
+4. WHEN the Analyzer encounters an expression evaluation macro with matrix subscripts like `` `=r(table)[1,1]' ``, THE Analyzer SHALL NOT produce an "Invalid character in macro name" diagnostic

--- a/.kiro/specs/expression-macro-false-positive/tasks.md
+++ b/.kiro/specs/expression-macro-false-positive/tasks.md
@@ -1,0 +1,35 @@
+# Implementation Plan: Expression Macro False Positive Fix
+
+## Overview
+
+This implementation adds detection logic in the analyzer to suppress the "Invalid character in macro name" diagnostic for valid Stata expression evaluation syntax (`` `=expr' ``).
+
+## Tasks
+
+- [x] 1. Implement expression evaluation detection
+  - [x] 1.1 Add `is_expression_evaluation` method to SemanticAnalyzer
+    - Add method that checks if macro content starts with `=`
+    - Include JSDoc documentation with examples
+    - _Requirements: 1.1_
+
+  - [x] 1.2 Add expression evaluation check in `detect_undefined_references`
+    - Add check before invalid character validation
+    - Skip diagnostic generation for expression evaluation macros
+    - _Requirements: 1.2_
+
+- [x] 2. Add property-based tests
+  - [x] 2.1 Write property test for expression evaluation suppression
+    - **Property 1: Expression Evaluation Macros Are Not Flagged**
+    - **Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 3.1, 3.2, 3.3, 3.4**
+
+  - [x] 2.2 Write property test for non-expression invalid character detection
+    - **Property 2: Non-Expression Invalid Characters Are Flagged**
+    - **Validates: Requirements 2.1, 2.2, 2.3**
+
+- [x] 3. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- The fix is localized to `src/analyzer/index.ts`
+- Existing tests for stored results, nested macros, and unbalanced macros should continue to pass

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -2254,6 +2254,11 @@ export class SemanticAnalyzer {
                     continue;
                 }
                 
+                // Skip expression evaluation macros - they use `=expr' syntax
+                if (macro_name && this.is_expression_evaluation(macro_name)) {
+                    continue;
+                }
+                
                 // Check for invalid characters in local macro reference
                 if (macro_name && this.has_invalid_macro_char(macro_name)) {
                     diagnostics.push({
@@ -2411,6 +2416,25 @@ export class SemanticAnalyzer {
      */
     private is_stored_result_reference(content: string): boolean {
         return /^[recs]\(.*\)(\[.*\])?$/.test(content);
+    }
+
+    /**
+     * Check if a local macro content represents an expression evaluation.
+     * Expression evaluation macros use the `=expr' syntax where the content
+     * starts with '=' followed by any valid Stata expression.
+     * 
+     * Examples:
+     * - `=1+2' → content is "=1+2" (arithmetic expression)
+     * - `=uchar(65533)' → content is "=uchar(65533)" (function call)
+     * - `=string(varname)' → content is "=string(varname)" (function call)
+     * - `=`a' + `b'' → content is "=`a' + `b'" (expression with nested macros)
+     * - `=r(table)[1,1]' → content is "=r(table)[1,1]" (matrix subscript)
+     * 
+     * @param content The extracted macro name content (without outer delimiters)
+     * @returns true if the content is an expression evaluation (starts with =)
+     */
+    private is_expression_evaluation(content: string): boolean {
+        return content.startsWith('=');
     }
 
     /**

--- a/tests/property/expression-macro-false-positive.prop.test.ts
+++ b/tests/property/expression-macro-false-positive.prop.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Expression Macro False Positive Property Tests
+ *
+ * Tests that verify expression evaluation macro syntax (`=expr') is correctly
+ * recognized and does NOT produce "Invalid character in macro name" diagnostics.
+ *
+ * Feature: expression-macro-false-positive
+ * Property 1: Expression Evaluation Macros Are Not Flagged
+ * Property 2: Non-Expression Invalid Characters Are Flagged
+ * Validates: Requirements 1.1-1.5, 2.1-2.3, 3.1-3.4
+ */
+
+import { describe, it, beforeEach } from 'bun:test';
+import * as fc from 'fast-check';
+import { DiagnosticsProvider } from '../../src/providers/diagnostics';
+import { StataLSPConfig, StataDiagnosticCode } from '../../src/types';
+import { create_document_state } from './helpers/document-utils';
+import { arbitrary_identifier } from './generators';
+
+describe('Expression Macro False Positive Property Tests', () => {
+  let my_diagnostics_provider: DiagnosticsProvider;
+  let my_config: StataLSPConfig;
+
+  beforeEach(() => {
+    const my_mock_connection = {
+      sendDiagnostics: () => {},
+    } as any;
+
+    my_diagnostics_provider = new DiagnosticsProvider(my_mock_connection);
+
+    my_config = {
+      diagnostics: {
+        enabled: true,
+        severity: {
+          styleWarnings: 'warning',
+          undefinedMacro: 'warning',
+          undefinedVariable: 'warning',
+        },
+        undefinedVariableEnabled: true,
+      },
+      adoPaths: [],
+      completion: {
+        cacheSize: 100,
+        prefixMaxItems: 50,
+      },
+      formatting: {
+        indentSize: 4,
+        indentStyle: 'spaces',
+        lineWidth: 80,
+        preferredCommentStyle: '//',
+        normalizeCommentStyle: false,
+        commentLineWidth: 72,
+      },
+      indexing: {
+        maxFileSizeBytes: 1000000,
+      },
+      indexWorkspace: false,
+      cross_file: {
+        index_workspace: false,
+        max_indexed_files: 100,
+        assume_call_site: 'end',
+        max_backward_depth: 10,
+        max_forward_depth: 10,
+        max_chain_depth: 20,
+        diagnostics: {
+          undefined_symbol: 'warning',
+          out_of_scope: 'warning',
+          missing_file: 'warning',
+          max_depth: 'warning',
+        },
+      },
+    } as StataLSPConfig;
+  });
+
+  /**
+   * Generator for simple Stata expressions (arithmetic, function calls).
+   * Generates expressions that would appear after = in `=expr' syntax.
+   */
+  function arbitrary_simple_expression(): fc.Arbitrary<string> {
+    return fc.oneof(
+      // Arithmetic expressions: 1+2, 3*4, etc.
+      fc.tuple(
+        fc.integer({ min: 1, max: 100 }),
+        fc.constantFrom('+', '-', '*', '/'),
+        fc.integer({ min: 1, max: 100 })
+      ).map(([a, op, b]) => `${a}${op}${b}`),
+      // Function calls: uchar(65533), string(x), etc.
+      fc.tuple(
+        fc.constantFrom('uchar', 'string', 'substr', 'strlen', 'real', 'int', 'round', 'abs', 'sqrt'),
+        fc.oneof(
+          fc.integer({ min: 1, max: 99999 }).map(n => n.toString()),
+          arbitrary_identifier()
+        )
+      ).map(([fn, arg]) => `${fn}(${arg})`),
+      // Simple numbers
+      fc.integer({ min: 1, max: 99999 }).map(n => n.toString()),
+      // Simple identifiers (variable references)
+      arbitrary_identifier()
+    );
+  }
+
+  /**
+   * Generator for complex Stata expressions with nested macros.
+   */
+  function arbitrary_complex_expression(): fc.Arbitrary<string> {
+    return fc.oneof(
+      // Expression with nested local macro: `a' + `b'
+      fc.tuple(arbitrary_identifier(), arbitrary_identifier())
+        .map(([a, b]) => `\`${a}' + \`${b}'`),
+      // Function with nested macro: substr("`str'", 1, 5)
+      fc.tuple(
+        fc.constantFrom('substr', 'strpos', 'strlen'),
+        arbitrary_identifier()
+      ).map(([fn, name]) => `${fn}("\`${name}'", 1, 5)`),
+      // Matrix subscript: r(table)[1,1]
+      fc.constantFrom('r', 'e', 'c', 's')
+        .chain(prefix => fc.tuple(
+          fc.constant(prefix),
+          fc.constantFrom('table', 'N', 'mean', 'sd', 'values')
+        ))
+        .map(([prefix, name]) => `${prefix}(${name})[1,1]`)
+    );
+  }
+
+  /**
+   * Property 1: Expression Evaluation Macros Are Not Flagged
+   *
+   * For any local macro reference whose content starts with `=` (expression
+   * evaluation syntax), the Analyzer SHALL NOT produce an "Invalid character
+   * in macro name" diagnostic.
+   *
+   * Feature: expression-macro-false-positive, Property 1: Expression Evaluation Macros Are Not Flagged
+   * Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5, 3.1, 3.2, 3.3, 3.4
+   */
+  it('should NOT flag expression evaluation macros with simple expressions', async () => {
+    await fc.assert(
+      fc.asyncProperty(arbitrary_simple_expression(), async (my_expr) => {
+        // Create expression evaluation macro: `=expr'
+        const my_expr_macro = `\`=${my_expr}'`;
+        const my_document = `display ${my_expr_macro}`;
+
+        const my_doc_state = create_document_state(my_document);
+        const my_diagnostics = await my_diagnostics_provider.get_diagnostics(
+          my_doc_state,
+          my_config
+        );
+
+        // Filter for INVALID_MACRO_CHAR diagnostics
+        const my_invalid_char_diagnostics = my_diagnostics.filter(
+          (my_diag) => my_diag.code === StataDiagnosticCode.INVALID_MACRO_CHAR
+        );
+
+        // Should NOT have any INVALID_MACRO_CHAR diagnostic
+        return my_invalid_char_diagnostics.length === 0;
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Property 1b: Expression Evaluation Macros with Complex Expressions
+   *
+   * Feature: expression-macro-false-positive, Property 1: Expression Evaluation Macros Are Not Flagged
+   * Validates: Requirements 3.1, 3.2, 3.3, 3.4
+   */
+  it('should NOT flag expression evaluation macros with complex expressions', async () => {
+    await fc.assert(
+      fc.asyncProperty(arbitrary_complex_expression(), async (my_expr) => {
+        // Create expression evaluation macro: `=expr'
+        const my_expr_macro = `\`=${my_expr}'`;
+        const my_document = `display ${my_expr_macro}`;
+
+        const my_doc_state = create_document_state(my_document);
+        const my_diagnostics = await my_diagnostics_provider.get_diagnostics(
+          my_doc_state,
+          my_config
+        );
+
+        // Filter for INVALID_MACRO_CHAR diagnostics
+        const my_invalid_char_diagnostics = my_diagnostics.filter(
+          (my_diag) => my_diag.code === StataDiagnosticCode.INVALID_MACRO_CHAR
+        );
+
+        // Should NOT have any INVALID_MACRO_CHAR diagnostic
+        return my_invalid_char_diagnostics.length === 0;
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  // Invalid characters that are NOT part of nested macro syntax or expression evaluation
+  // Excludes: ` ' $ { } = which have special meanings
+  const the_invalid_chars = ['.', ' ', '@', '#', '!', '%', '^', '&', '*', '(', ')', '-', '[', ']', ':', ';', '<', '>', ',', '?', '/', '\\', '|', '~'];
+
+  /**
+   * Generator for invalid macro names that do NOT start with = and contain
+   * invalid characters.
+   */
+  function arbitrary_invalid_non_expression_macro_name(): fc.Arbitrary<string> {
+    return fc
+      .tuple(
+        arbitrary_identifier(),
+        fc.constantFrom(...the_invalid_chars),
+        arbitrary_identifier()
+      )
+      .map(([my_prefix, my_invalid_char, my_suffix]) => {
+        return `${my_prefix}${my_invalid_char}${my_suffix}`;
+      })
+      // Filter out anything that looks like nested macro syntax or expression evaluation
+      .filter((my_name) => {
+        // No expression evaluation (starts with =)
+        if (my_name.startsWith('=')) return false;
+        // No backticks (nested local macro start)
+        if (my_name.includes('`')) return false;
+        // No apostrophes (nested local macro end)
+        if (my_name.includes("'")) return false;
+        // No ${ (nested braced global start)
+        if (my_name.includes('${')) return false;
+        // No $identifier pattern (nested unbraced global)
+        if (/\$[A-Za-z_][A-Za-z0-9_]*/.test(my_name)) return false;
+        // No stored result patterns
+        if (/^[recs]\(.*\)(\[.*\])?$/.test(my_name)) return false;
+        return true;
+      });
+  }
+
+  /**
+   * Property 2: Non-Expression Invalid Characters Are Flagged
+   *
+   * For any local macro reference that does NOT start with `=` and contains
+   * characters outside [A-Za-z0-9_] (excluding stored results, nested macros,
+   * and unbalanced macros), the Analyzer SHALL produce an "Invalid character
+   * in macro name" diagnostic.
+   *
+   * Feature: expression-macro-false-positive, Property 2: Non-Expression Invalid Characters Are Flagged
+   * Validates: Requirements 2.1, 2.2, 2.3
+   */
+  it('should flag non-expression macros with invalid characters', async () => {
+    await fc.assert(
+      fc.asyncProperty(arbitrary_invalid_non_expression_macro_name(), async (my_invalid_name) => {
+        // Create a local macro reference with invalid characters: `foo.bar'
+        const my_invalid_ref = `\`${my_invalid_name}'`;
+        const my_document = `display ${my_invalid_ref}`;
+
+        const my_doc_state = create_document_state(my_document);
+        const my_diagnostics = await my_diagnostics_provider.get_diagnostics(
+          my_doc_state,
+          my_config
+        );
+
+        // Filter for INVALID_MACRO_CHAR diagnostics
+        const my_invalid_char_diagnostics = my_diagnostics.filter(
+          (my_diag) => my_diag.code === StataDiagnosticCode.INVALID_MACRO_CHAR
+        );
+
+        // Should have at least one INVALID_MACRO_CHAR diagnostic
+        return my_invalid_char_diagnostics.length > 0;
+      }),
+      { numRuns: 100 }
+    );
+  });
+});


### PR DESCRIPTION
Add detection for Stata expression evaluation syntax (`=expr') to prevent false positive 'Invalid character in macro name' diagnostics.

- Add is_expression_evaluation() method to SemanticAnalyzer
- Skip invalid character check when macro content starts with '='
- Add property tests for expression evaluation suppression
- Preserves detection for genuinely invalid macro names

Fixes false positives for patterns like `=uchar(65533)', `=1+2', etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved false positive "Invalid character in macro name" diagnostics for Stata expression evaluation macros (e.g., `=expr`). These macros are now properly recognized and excluded from character validation, while validation for non-expression invalid macro names continues as expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->