### PR TITLE
Revert "Fix context lookup performance regression and flaky property test"

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "sight-client",
   "displayName": "Sight - Stata Language Server",
   "description": "Language support for Stata using LSP",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "publisher": "jbearak",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sight-language-server",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "type": "module",
   "workspaces": [
     "client"
@@ -8,7 +8,7 @@
   "description": "Language Server Protocol implementation for Stata",
   "main": "dist/cli.js",
   "bin": {
-    "sight-language-server": "dist/sight-server.js"
+    "sight-language-server": "dist/cli.js"
   },
   "scripts": {
     "build": "tsc && cp -r src/command-database/caches dist/command-database/ && cd client && npm run compile && npm run copy-server && cd ..",

--- a/src/context-tracker/index.ts
+++ b/src/context-tracker/index.ts
@@ -15,7 +15,6 @@ import { get_line_text, get_line_count, compute_line_offsets } from '../utils/li
  */
 export class ContextTracker implements IContextTracker {
   private context_ranges: ContextRange[] = [];
-  private sorted_ranges_cache: ContextRange[] | null = null;
   private context_stack: LanguageContext[] = [LanguageContext.STATA];
   private document_content: string = '';
   private diagnostics: ContextDiagnostic[] = [];
@@ -42,7 +41,6 @@ export class ContextTracker implements IContextTracker {
     // that can be used to detect context blocks
     
     this.context_ranges = [];
-    this.sorted_ranges_cache = null;
     this.context_stack = [LanguageContext.STATA];
     let my_current_range: Partial<ContextRange> | null = null;
     let my_current_context = LanguageContext.STATA;
@@ -236,9 +234,6 @@ export class ContextTracker implements IContextTracker {
   }
 
   get_all_context_ranges(): ContextRange[] {
-    if (this.sorted_ranges_cache !== null) {
-      return this.sorted_ranges_cache;
-    }
     // Sort ranges by (start.line, start.character) for binary search
     const my_sorted_ranges = [...this.context_ranges].sort(
       (my_a, my_b) => {
@@ -252,9 +247,6 @@ export class ContextTracker implements IContextTracker {
 
     // Debug assertion: verify sorted invariant in development
     this.assert_ranges_sorted(my_sorted_ranges);
-
-    this.sorted_ranges_cache = my_sorted_ranges;
-    return my_sorted_ranges;
 
     return my_sorted_ranges;
   }

--- a/tests/property/context-tracker-validation.prop.test.ts
+++ b/tests/property/context-tracker-validation.prop.test.ts
@@ -18,14 +18,10 @@ describe('Context Tracker Validation Property Tests', () => {
    * Validates: Requirements 3.1, 3.2, 3.3
    */
   it('should accept valid blocks ending with end', () => {
-    // Filter out strings that would be parsed as block terminators
-    const safe_content = fc.string({ minLength: 1, maxLength: 20 }).filter(
-      (s) => !/^(end|mata|python)\b/i.test(s.trim())
-    );
     fc.assert(
       fc.property(
         fc.oneof(fc.constant('mata'), fc.constant('python')),
-        fc.array(safe_content, { minLength: 0, maxLength: 3 }),
+        fc.array(fc.string({ minLength: 1, maxLength: 20 }), { minLength: 0, maxLength: 3 }),
         (block_type, content_lines) => {
           let my_document = `${block_type}\n`;
           for (const my_line of content_lines) {


### PR DESCRIPTION
Reverts jbearak/sight#9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.1.1 across client and main packages
  * Modified CLI binary entry point configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->