### PR TITLE
fix(references): remove O(n*m) DoS vulnerability in get_word_at_position

### DIFF
--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -334,22 +334,6 @@ export class ReferencesProvider {
         position: Position
     ): { word: string; range: Range } | null {
         const line = get_line_text(document, position.line);
-        
-        // Check if line exists
-        if (document.line_offsets) {
-            if (position.line >= document.line_offsets.length) return null;
-        } else {
-            if (line === '' && position.line > 0) {
-                let newline_count = 0;
-                for (let i = 0; i < document.content.length; i++) {
-                    if (document.content[i] === '\n') {
-                        newline_count++;
-                    }
-                }
-                if (position.line > newline_count) return null;
-            }
-        }
-        
         const character = position.character;
 
         // Find the start of the word


### PR DESCRIPTION
Remove redundant line existence check that performed a full document scan to count newlines when line_offsets was null. The check was unnecessary since get_line_text already returns '' for non-existent lines, and the word extraction logic naturally returns null when the line is empty.