### PR TITLE
fix: always use each workspace file's own context_ranges for filtering

### DIFF
--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -457,7 +457,7 @@ export class ReferencesProvider {
                     file_data.tokens,
                     uri,
                     search_context,
-                    context_ranges ? file_data.context_ranges : undefined
+                    file_data.context_ranges
                 );
                 for (const my_match of matches) {
                     locations.push({ uri: my_match.uri, range: my_match.range });


### PR DESCRIPTION
Fixes logic error where workspace files only got context_ranges filtering applied if the current document had context_ranges. Each file should use its own context_ranges regardless of the current document's state.

Addresses PR #40 review comment.