### PR TITLE
fix(security): use cryptographically secure random bytes for temp fil…

### DIFF
--- a/.kiro/specs/send-to-stata/design.md
+++ b/.kiro/specs/send-to-stata/design.md
@@ -125,7 +125,7 @@ function get_temp_dir(): string;
 
 **Behavior:**
 - Creates files in `os.tmpdir()` (cross-platform)
-- Uses pattern: `stata_send_${timestamp}_${random}.do`
+- Uses pattern: `stata_send_${random_hex}.do` (32 hex chars from cryptographically secure random bytes)
 - Does NOT delete files (Stata needs time to read them)
 - Files accumulate and require periodic manual cleanup
 

--- a/client/src/send-to-stata/temp-file.ts
+++ b/client/src/send-to-stata/temp-file.ts
@@ -11,9 +11,9 @@ const MAX_RETRY_ATTEMPTS = 5;
 
 export async function create_temp_file(content: string): Promise<string> {
     for (let attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt++) {
-        const timestamp = Date.now();
-        const random = crypto.randomInt(0, 1000000);
-        const filename = `stata_send_${timestamp}_${random}.do`;
+        const random_bytes = crypto.randomBytes(16);
+        const random_hex = random_bytes.toString('hex');
+        const filename = `stata_send_${random_hex}.do`;
         const file_path = path.join(get_temp_dir(), filename);
         
         try {

--- a/tests/property/send-to-stata-temp-file.prop.test.ts
+++ b/tests/property/send-to-stata-temp-file.prop.test.ts
@@ -96,8 +96,8 @@ describe('Feature: send-to-stata - Temp File Creation Properties', () => {
         created_files.push(file_path);
 
         const filename = path.basename(file_path);
-        // Pattern: stata_send_${timestamp}_${random}.do
-        const pattern = /^stata_send_\d+_\d+\.do$/;
+        // Pattern: stata_send_${random_hex}.do (32 hex chars from 16 random bytes)
+        const pattern = /^stata_send_[0-9a-f]{32}\.do$/;
         expect(pattern.test(filename)).toBe(true);
     });
 


### PR DESCRIPTION
…e names

Address PR #47 review feedback:
- Replace predictable timestamp+randomInt naming with crypto.randomBytes(16)
- Prevents CWE-377 insecure temporary file vulnerability
- Update property test to match new 32-char hex filename pattern
- Update design doc to reflect new naming scheme

Note: The second review comment about path escaping was not applied as the suggested change (\n instead of \n) would break functionality. The current implementation correctly uses actual newline characters.