### PR TITLE
feat(ci): Enable OpenVSX publishing in release workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -125,13 +125,13 @@ jobs:
         env:
           VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
 
-      # - name: Publish to OpenVSX Registry
-      #   if: ${{ inputs.publish_vscode }}
-      #   run: |
-      #     cd client
-      #     npx ovsx publish --pat ${{ secrets.OVSX_TOKEN }}
-      #   env:
-      #     OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
+      - name: Publish to OpenVSX Registry
+        if: ${{ inputs.publish_vscode }}
+        run: |
+          cd client
+          npx ovsx publish --pat ${{ secrets.OVSX_TOKEN }}
+        env:
+          OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
 
       - name: Create GitHub Release
         # Pinned action SHA for supply-chain safety.


### PR DESCRIPTION
Uncomment the OpenVSX Registry publishing step so extensions are automatically published to both VS Code Marketplace and OpenVSX when publish_vscode is enabled.

https://claude.ai/code/session_01MP6NXPumu75hwiG9QrBu3g