### PR TITLE
feat(ci): Add manual trigger to release-build workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -41,7 +41,7 @@ jobs:
       #  3) Replace the SHA below; keep the trailing comment with the major tag (e.g. "# v4").
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
Allow manual triggering of release-build.yml via workflow_dispatch as a fallback when tag push events don't trigger the workflow.

https://claude.ai/code/session_01MP6NXPumu75hwiG9QrBu3g