### PR TITLE
Add subscript bracket handling in qualifier expressions

### DIFF
--- a/.kiro/specs/subscript-bracket-false-positive/requirements.md
+++ b/.kiro/specs/subscript-bracket-false-positive/requirements.md
@@ -1,0 +1,68 @@
+# Requirements Document
+
+## Introduction
+
+This document specifies the requirements for fixing a false positive diagnostic in the Stata LSP parser. The parser incorrectly flags subscript notation like `total_check[_n-1]` as a stray token when it appears after a comparison expression in `if` or `in` qualifiers. The fix ensures that square bracket subscript expressions are properly tracked in the state machine, similar to how parentheses are handled.
+
+## Glossary
+
+- **Parser**: The `StataParser` class in `src/parser/index.ts` that builds an AST from tokens
+- **Qualifier_Expression**: An expression following `if` or `in` keywords in Stata commands
+- **Subscript_Expression**: A bracket-enclosed expression like `[_n-1]` used to access array elements or observations
+- **State_Machine**: The expression state tracking logic in `parseQualifierExpressionWithStrayDetection()` that detects stray tokens
+- **Stray_Token**: An unexpected token after a comparison expression that likely indicates a syntax error
+- **Bracket_Depth**: A counter tracking nested square bracket levels, analogous to `paren_depth`
+
+## Requirements
+
+### Requirement 1: Subscript Expression Recognition
+
+**User Story:** As a Stata developer, I want subscript notation like `var[_n-1]` to be recognized as valid syntax in if/in qualifiers, so that I don't receive false positive diagnostics.
+
+#### Acceptance Criteria
+
+1. WHEN the Parser encounters a `LBRACKET` token in a qualifier expression, THE State_Machine SHALL increment the Bracket_Depth counter
+2. WHEN the Parser encounters a `RBRACKET` token in a qualifier expression, THE State_Machine SHALL decrement the Bracket_Depth counter
+3. WHEN the Bracket_Depth is greater than zero, THE Parser SHALL NOT emit stray token diagnostics for tokens inside the bracket expression
+4. WHEN a closing bracket `]` is encountered, THE State_Machine SHALL treat the outer level as having seen an operand (transition to AFTER_OPERAND or AFTER_RHS depending on prior state)
+
+### Requirement 2: Subscript Position Support
+
+**User Story:** As a Stata developer, I want subscript notation to work on both sides of comparison operators, so that I can write expressions like `var1[_n] == var2[_n-1]`.
+
+#### Acceptance Criteria
+
+1. WHEN a Subscript_Expression appears on the left-hand side of a comparison, THE Parser SHALL NOT emit stray token diagnostics
+2. WHEN a Subscript_Expression appears on the right-hand side of a comparison, THE Parser SHALL NOT emit stray token diagnostics
+3. WHEN multiple Subscript_Expressions appear in the same condition, THE Parser SHALL handle each independently without false positives
+
+### Requirement 3: Nested Bracket Handling
+
+**User Story:** As a Stata developer, I want nested subscript expressions to be handled correctly, so that complex expressions don't trigger false positives.
+
+#### Acceptance Criteria
+
+1. WHEN nested brackets appear like `matrix[row[i], col]`, THE Parser SHALL track the Bracket_Depth correctly
+2. WHEN brackets are nested inside parentheses like `(var[_n-1])`, THE Parser SHALL handle both depth counters independently
+3. WHEN parentheses are nested inside brackets like `var[func(x)]`, THE Parser SHALL handle both depth counters independently
+
+### Requirement 4: Stray Token Detection Preservation
+
+**User Story:** As a Stata developer, I want actual stray tokens to still be detected, so that I receive helpful diagnostics for genuine syntax errors.
+
+#### Acceptance Criteria
+
+1. WHEN a genuine stray token appears after a comparison (e.g., `if x == y oops`), THE Parser SHALL emit a STRAY_TOKEN_IN_CONDITION diagnostic
+2. WHEN a stray token appears after a subscript expression (e.g., `if var[_n] == 1 oops`), THE Parser SHALL emit a STRAY_TOKEN_IN_CONDITION diagnostic
+3. WHEN an unbalanced bracket appears in a qualifier expression, THE Parser SHALL emit an UNBALANCED_PARENTHESES diagnostic
+
+### Requirement 5: State Machine Consistency
+
+**User Story:** As a maintainer, I want the bracket handling to follow the same patterns as parenthesis handling, so that the code remains consistent and maintainable.
+
+#### Acceptance Criteria
+
+1. THE State_Machine SHALL use a bracket state stack analogous to the existing parenthesis state stack
+2. WHEN entering a bracket expression, THE State_Machine SHALL push a new INITIAL state onto the bracket state stack
+3. WHEN exiting a bracket expression, THE State_Machine SHALL pop the bracket state stack and update the outer state appropriately
+4. THE `isValidAfterComparison()` method SHALL return true for `LBRACKET` tokens (subscript expressions are valid continuations)

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -2737,6 +2737,7 @@ export class StataParser {
   ): string {
     let expression = '';
     let paren_depth = 0;
+    let bracket_depth = 0;  // Track subscript bracket depth
     const start_token = this.peek();
 
     // State machine for stray token detection at each paren level
@@ -2783,13 +2784,25 @@ export class StataParser {
         }
       }
 
+      // Track bracket depth for subscript expressions like var[_n-1]
+      // Brackets don't create new expression contexts like parentheses do,
+      // they just modify the preceding operand
+      if (token.type === 'LBRACKET') {
+        bracket_depth++;
+      } else if (token.type === 'RBRACKET') {
+        bracket_depth--;
+        if (bracket_depth < 0) {
+          bracket_depth = 0;
+        }
+      }
+
       // Handle continuation tokens - skip them and continue parsing
       if (this.skipContinuation()) {
         continue;
       }
 
-      // Stop at top-level terminators
-      if (paren_depth === 0) {
+      // Stop at top-level terminators (only when not inside brackets)
+      if (paren_depth === 0 && bracket_depth === 0) {
         if (token.type === 'STATEMENT_TERMINATOR' || token.type === 'COMMA') {
           break;
         }
@@ -2819,9 +2832,10 @@ export class StataParser {
       // Get current state for this paren level
       const current_state = state_stack[state_stack.length - 1];
 
-      // Stray token and split literal detection - skip if in string context or if this is a delimiter-only STRING
+      // Stray token and split literal detection - skip if in string context, inside brackets, or if this is a delimiter-only STRING
       // We also skip delimiter-only STRING tokens because they are part of the string literal structure
-      if (current_state === 'AFTER_RHS' && token.type !== 'LPAREN' && token.type !== 'RPAREN' && !in_string_context && !is_delimiter_only) {
+      // Skip when inside brackets (bracket_depth > 0) because subscript expressions like var[_n-1] are valid
+      if (current_state === 'AFTER_RHS' && token.type !== 'LPAREN' && token.type !== 'RPAREN' && token.type !== 'LBRACKET' && token.type !== 'RBRACKET' && bracket_depth === 0 && !in_string_context && !is_delimiter_only) {
         // Check for split literal patterns first
         if (prev_token && this.detectSplitLiteral(prev_token, token)) {
           // Split literal diagnostic already emitted by detectSplitLiteral
@@ -2836,7 +2850,9 @@ export class StataParser {
       }
 
       // State transitions based on token type (skip whitespace)
-      if (token.type !== 'WHITESPACE' && token.type !== 'LPAREN' && token.type !== 'RPAREN') {
+      // Also skip state transitions when inside brackets - bracket content is a subscript
+      // expression that doesn't affect the outer expression state
+      if (token.type !== 'WHITESPACE' && token.type !== 'LPAREN' && token.type !== 'RPAREN' && bracket_depth === 0) {
         const current_state_for_transition = state_stack[state_stack.length - 1];
         
         if (token.type === 'OPERATOR') {

--- a/tests/repro_subscript_qualifier.test.ts
+++ b/tests/repro_subscript_qualifier.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'bun:test';
+import { StataParser } from '../src/parser';
+import { StataLexer } from '../src/lexer';
+
+describe('Subscript notation in if-qualifier - Issue reproduction', () => {
+    function parse_and_get_errors(code: string) {
+        const lexer = new StataLexer();
+        const lex_result = lexer.tokenize(code);
+        const parser = new StataParser();
+        const result = parser.parse(lex_result.tokens);
+        return result.errors;
+    }
+
+    it('should NOT flag subscript notation in if-qualifier as stray token', () => {
+        // This is the problematic case from the issue
+        const code = `list month state count total_check ReportsToID category_measure if total_check != total_check[_n-1] & _n != 1`;
+        const errors = parse_and_get_errors(code);
+        
+        // Filter for stray token errors
+        const stray_errors = errors.filter(e => e.message.includes('Unexpected token'));
+        console.log('Errors:', stray_errors.map(e => e.message));
+        
+        expect(stray_errors).toHaveLength(0);
+    });
+
+    it('should NOT flag subscript notation in standalone assert', () => {
+        // This works according to the user
+        const code = `assert total_check == total_check[_n-1] | _n == 1`;
+        const errors = parse_and_get_errors(code);
+        
+        const stray_errors = errors.filter(e => e.message.includes('Unexpected token'));
+        console.log('Errors:', stray_errors.map(e => e.message));
+        
+        expect(stray_errors).toHaveLength(0);
+    });
+
+    it('should NOT flag subscript on LHS of comparison in if-qualifier', () => {
+        const code = `list x if x[_n-1] == 1`;
+        const errors = parse_and_get_errors(code);
+        
+        const stray_errors = errors.filter(e => e.message.includes('Unexpected token'));
+        console.log('Errors:', stray_errors.map(e => e.message));
+        
+        expect(stray_errors).toHaveLength(0);
+    });
+
+    it('should NOT flag subscript on RHS of comparison in if-qualifier', () => {
+        const code = `list x if x == y[_n-1]`;
+        const errors = parse_and_get_errors(code);
+        
+        const stray_errors = errors.filter(e => e.message.includes('Unexpected token'));
+        console.log('Errors:', stray_errors.map(e => e.message));
+        
+        expect(stray_errors).toHaveLength(0);
+    });
+
+    it('should NOT flag _n subscript reference', () => {
+        const code = `gen x = y[_n-1]`;
+        const errors = parse_and_get_errors(code);
+        
+        const stray_errors = errors.filter(e => e.message.includes('Unexpected token'));
+        console.log('Errors:', stray_errors.map(e => e.message));
+        
+        expect(stray_errors).toHaveLength(0);
+    });
+
+    it('should NOT flag subscript with _N (total observations)', () => {
+        const code = `list x if x == y[_N]`;
+        const errors = parse_and_get_errors(code);
+        
+        const stray_errors = errors.filter(e => e.message.includes('Unexpected token'));
+        console.log('Errors:', stray_errors.map(e => e.message));
+        
+        expect(stray_errors).toHaveLength(0);
+    });
+
+    it('should NOT flag subscript with numeric index', () => {
+        const code = `list x if x == y[1]`;
+        const errors = parse_and_get_errors(code);
+        
+        const stray_errors = errors.filter(e => e.message.includes('Unexpected token'));
+        console.log('Errors:', stray_errors.map(e => e.message));
+        
+        expect(stray_errors).toHaveLength(0);
+    });
+
+    it('should NOT flag subscript with expression', () => {
+        const code = `list x if x == y[_n - 5]`;
+        const errors = parse_and_get_errors(code);
+        
+        const stray_errors = errors.filter(e => e.message.includes('Unexpected token'));
+        console.log('Errors:', stray_errors.map(e => e.message));
+        
+        expect(stray_errors).toHaveLength(0);
+    });
+
+    it('should NOT flag multiple subscripts in condition', () => {
+        const code = `list x if x[_n-1] == y[_n-1]`;
+        const errors = parse_and_get_errors(code);
+        
+        const stray_errors = errors.filter(e => e.message.includes('Unexpected token'));
+        console.log('Errors:', stray_errors.map(e => e.message));
+        
+        expect(stray_errors).toHaveLength(0);
+    });
+
+    it('should still detect actual stray tokens after subscript expression', () => {
+        // This should still be flagged - 'oops' is a stray token
+        const code = `list x if x == y[_n-1] oops`;
+        const errors = parse_and_get_errors(code);
+        
+        const stray_errors = errors.filter(e => e.message.includes('Unexpected token'));
+        console.log('Errors:', stray_errors.map(e => e.message));
+        
+        expect(stray_errors).toHaveLength(1);
+        expect(stray_errors[0].message).toContain('oops');
+    });
+});


### PR DESCRIPTION
Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed false-positive stray token diagnostics when using subscript bracket notation in conditional expressions.

* **Documentation**
  * Added requirements documentation for subscript bracket handling in the Stata parser.

* **Tests**
  * Added comprehensive test suite validating subscript notation handling across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->