### PR TITLE
fix: await pending document processing in outline symbol handler

### DIFF
--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -488,8 +488,12 @@ export function create_references_handler(
  */
 export function create_document_symbol_handler(
     deps: HandlerDependencies
-): (params: DocumentSymbolParams) => DocumentSymbol[] {
-    return (params: DocumentSymbolParams): DocumentSymbol[] => {
+): (params: DocumentSymbolParams) => Promise<DocumentSymbol[]> {
+    return async (params: DocumentSymbolParams): Promise<DocumentSymbol[]> => {
+        // Wait for any pending debounce to complete before reading state
+        await deps.debounce_manager?.wait_for_debounce(params.textDocument.uri);
+        await deps.document_store.wait_for_update(params.textDocument.uri);
+
         const document_state = deps.document_store.get(params.textDocument.uri);
         if (!document_state || !deps.symbol_provider) {
             return [];

--- a/tests/integration/lsp-lifecycle.test.ts
+++ b/tests/integration/lsp-lifecycle.test.ts
@@ -274,11 +274,11 @@ describe('LSP Lifecycle - Handler Factories', () => {
     });
 
     describe('Document Symbol Handler', () => {
-        it('should return empty array when no document found', () => {
+        it('should return empty array when no document found', async () => {
             const deps = create_mock_dependencies();
             const handler = create_document_symbol_handler(deps);
 
-            const result = handler({
+            const result = await handler({
                 textDocument: { uri: 'file:///nonexistent.do' },
             });
 

--- a/tests/property/handler-deps-mutation.prop.test.ts
+++ b/tests/property/handler-deps-mutation.prop.test.ts
@@ -267,7 +267,7 @@ describe('Handler Deps Mutation Property Tests', () => {
                                 create_sentinel(my_key);
                         }
 
-                        const result = handler({
+                        const result = await handler({
                             textDocument: {
                                 uri: 'file:///test.do',
                             },
@@ -707,7 +707,7 @@ describe('Handler Deps Mutation Property Tests', () => {
                             },
                             undefined
                         );
-                        doc_symbol_handler({
+                        await doc_symbol_handler({
                             textDocument: test_params.textDocument,
                         });
                         await formatting_handler({


### PR DESCRIPTION
The document symbol handler was synchronous and didn't wait for pending debounce/document store updates, unlike completion, hover, definition, and references handlers. This caused intermittent 'No symbols found' when VS Code requested outline symbols before the 100ms debounce fired after opening a file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced document symbol request handling with improved synchronization of pending operations, ensuring more reliable and consistent symbol data retrieval for better editor performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->