### PR TITLE
Add auto backward dependency inference

### DIFF
--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -82,13 +82,17 @@ export class DocumentStore {
    * Set all workspace roots for per-document workspace-relative path resolution.
    */
   set_workspace_roots(workspace_roots: string[]): void {
-    this.workspace_roots = Array.from(
-      new Set(
-        workspace_roots.map((my_workspace_root) =>
-          path.resolve(my_workspace_root)
-        )
-      )
-    ).sort((a, b) => a.localeCompare(b));
+    const seen_roots = new Set<string>();
+    const the_normalized_roots: string[] = [];
+    for (const my_workspace_root of workspace_roots) {
+      const normalized_root = path.resolve(my_workspace_root);
+      if (seen_roots.has(normalized_root)) {
+        continue;
+      }
+      seen_roots.add(normalized_root);
+      the_normalized_roots.push(normalized_root);
+    }
+    this.workspace_roots = the_normalized_roots;
   }
 
   /**
@@ -103,7 +107,11 @@ export class DocumentStore {
    * Get the matching workspace root for a document URI.
    */
   get_workspace_root_for_uri(uri: string): string | undefined {
-    return this.get_workspace_root_for_path(URI.parse(uri).fsPath);
+    try {
+      return this.get_workspace_root_for_path(URI.parse(uri).fsPath);
+    } catch {
+      return this.workspace_roots[0];
+    }
   }
 
   private get_workspace_root_for_path(
@@ -136,7 +144,7 @@ export class DocumentStore {
       }
     }
 
-    return matched_workspace_root;
+    return matched_workspace_root ?? this.workspace_roots[0];
   }
 
   /**

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -51,7 +51,7 @@ export class DocumentStore {
   private in_flight_counts: Map<string, number> = new Map();
   private readonly MAX_DOCUMENTS = 50;
   private readonly MAX_TOKEN_BYTES = 100 * 1024 * 1024; // 100MB
-  private workspace_root: string | undefined;
+  private workspace_roots: string[] = [];
   private scope_resolver: ScopeResolver | undefined;
   private disposed: boolean = false;
 
@@ -73,14 +73,70 @@ export class DocumentStore {
    * and for fallback path resolution in forward calls.
    */
   set_workspace_root(workspace_root: string | undefined): void {
-    this.workspace_root = workspace_root;
+    this.set_workspace_roots(
+      workspace_root ? [workspace_root] : []
+    );
   }
 
   /**
-   * Get the current workspace root directory.
+   * Set all workspace roots for per-document workspace-relative path resolution.
+   */
+  set_workspace_roots(workspace_roots: string[]): void {
+    this.workspace_roots = Array.from(
+      new Set(
+        workspace_roots.map((my_workspace_root) =>
+          path.resolve(my_workspace_root)
+        )
+      )
+    ).sort((a, b) => a.localeCompare(b));
+  }
+
+  /**
+   * Get the first configured workspace root directory.
+   * Retained for backward compatibility with older callers.
    */
   get_workspace_root(): string | undefined {
-    return this.workspace_root;
+    return this.workspace_roots[0];
+  }
+
+  /**
+   * Get the matching workspace root for a document URI.
+   */
+  get_workspace_root_for_uri(uri: string): string | undefined {
+    return this.get_workspace_root_for_path(URI.parse(uri).fsPath);
+  }
+
+  private get_workspace_root_for_path(
+    file_path: string
+  ): string | undefined {
+    const normalized_file_path = path.resolve(file_path);
+    let matched_workspace_root: string | undefined;
+
+    for (const my_workspace_root of this.workspace_roots) {
+      const relative_path = path.relative(
+        my_workspace_root,
+        normalized_file_path
+      );
+      const is_within_workspace =
+        relative_path === '' ||
+        (
+          !relative_path.startsWith('..') &&
+          !path.isAbsolute(relative_path)
+        );
+
+      if (!is_within_workspace) {
+        continue;
+      }
+
+      if (
+        !matched_workspace_root ||
+        my_workspace_root.length > matched_workspace_root.length
+      ) {
+        matched_workspace_root = my_workspace_root;
+      }
+    }
+
+    return matched_workspace_root;
   }
 
   /**
@@ -479,6 +535,7 @@ export class DocumentStore {
   ): Promise<DocumentState> {
     const start_time = Date.now();
     this.metrics.parse_count++;
+    const workspace_root = this.get_workspace_root_for_uri(uri);
 
     // Create fresh instances for thread safety (async execution means concurrent calls)
     const lexer = new StataLexer();
@@ -540,7 +597,7 @@ export class DocumentStore {
         // File has its own working directory directive
         resolved_working_directory = this.resolve_working_directory(
           directive_result.working_directory,
-          uri
+          workspace_root
         );
       } else if (directive_result.directives.length > 0 && this.scope_resolver) {
         // File has backward directives but no own working directory
@@ -566,7 +623,7 @@ export class DocumentStore {
         workspace_symbols,
         {
           working_directory: resolved_working_directory,
-          workspace_root: this.workspace_root,
+          workspace_root,
         },
         lex_result.result!.tokens
       )
@@ -864,23 +921,23 @@ export class DocumentStore {
    * - If the resolved directory doesn't exist, return undefined (fallback to script dir)
    * 
    * @param directive - The parsed working directory directive
-   * @param uri - The URI of the script file
+   * @param workspace_root - The matching workspace root for the current document
    * @returns The resolved absolute path, or undefined if resolution fails
    */
   private resolve_working_directory(
     directive: WorkingDirectoryDirective,
-    uri: string
+    workspace_root?: string
   ): string | undefined {
     let resolved_path: string;
 
     if (directive.is_workspace_relative) {
       // Resolve relative to workspace root
-      if (!this.workspace_root) {
+      if (!workspace_root) {
         // No workspace root available - cannot resolve workspace-relative path
         return undefined;
       }
       // resolved_path in directive already has leading slash stripped
-      resolved_path = path.normalize(path.join(this.workspace_root, directive.resolved_path));
+      resolved_path = path.normalize(path.join(workspace_root, directive.resolved_path));
     } else {
       // Resolve relative to script's containing directory
       // The directive parser already resolved this for us

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -19,6 +19,7 @@ import {
     MatrixSymbol,
     Token,
     ContextRange,
+    ForwardCall,
 } from '../types';
 import { StataLexer } from '../lexer';
 import { StataParser } from '../parser';
@@ -41,6 +42,13 @@ export interface IndexedFileData {
     uri: string;
     tokens: Token[];
     context_ranges?: ContextRange[];
+}
+
+export interface IndexedFileUpdate {
+    uri: string;
+    symbols: SymbolTable;
+    directives: Directive[];
+    forward_calls: ForwardCall[];
 }
 
 /**
@@ -68,6 +76,10 @@ export class WorkspaceIndexer {
     private max_indexed_files: number = 1000;
     private max_files_reached = false;
     private version: number = 0;
+    private workspace_root: string | undefined;
+    private on_file_indexed?: (
+        update: IndexedFileUpdate
+    ) => void | Promise<void>;
     
     // Debouncing state for file updates
     private pending_updates: Map<string, NodeJS.Timeout> = new Map();
@@ -86,6 +98,7 @@ export class WorkspaceIndexer {
         }
         this.ado_paths = ado_paths;
         this.cancelled = false;
+        this.workspace_root = workspace_folders[0];
         const start_time = Date.now();
 
         for (const folder of [...workspace_folders, ...this.ado_paths]) {
@@ -227,14 +240,36 @@ export class WorkspaceIndexer {
 
             // Parse directives
             const directive_result = this.directive_parser.parse(content, file_uri);
+            const resolved_working_directory =
+                directive_result.working_directory?.resolved_path;
 
             // Parse and analyze
             const lexResult = this.lexer.tokenize(content);
             const parseResult = this.parser.parse(lexResult.tokens);
             const analyzeResult = this.analyzer.analyze(
                 parseResult.ast,
-                file_uri
+                file_uri,
+                undefined,
+                {
+                    working_directory: resolved_working_directory,
+                    workspace_root: this.workspace_root,
+                },
+                lexResult.tokens
             );
+            const directive_forward_calls: ForwardCall[] =
+                (directive_result.forward_calls ?? []).map((my_directive) => ({
+                    type: my_directive.type,
+                    path: my_directive.path,
+                    raw_path: my_directive.raw_path,
+                    call_site_line: my_directive.call_site_line,
+                    range: my_directive.range,
+                    source: 'directive',
+                    is_static: true,
+                }));
+            const all_forward_calls = [
+                ...analyzeResult.forward_calls,
+                ...directive_forward_calls,
+            ];
 
             // Compute context ranges for embedded language support
             const context_tracker = new ContextTracker();
@@ -250,6 +285,14 @@ export class WorkspaceIndexer {
             });
             this.version++;
             this.metrics.files_indexed++;
+            if (this.on_file_indexed) {
+                await this.on_file_indexed({
+                    uri: file_uri,
+                    symbols: analyzeResult.symbols,
+                    directives: directive_result.directives,
+                    forward_calls: all_forward_calls,
+                });
+            }
         } catch (error) {
             logger.error(`Failed to index file ${file_path}: ${error}`);
             this.metrics.files_skipped++;
@@ -304,6 +347,14 @@ export class WorkspaceIndexer {
         });
         this.version++;
         this.metrics.files_indexed++;
+        if (this.on_file_indexed) {
+            await this.on_file_indexed({
+                uri: file_uri,
+                symbols,
+                directives: [],
+                forward_calls: [],
+            });
+        }
     }
 
 
@@ -466,6 +517,17 @@ export class WorkspaceIndexer {
     }
 
     /**
+     * Register a callback invoked whenever a file is indexed.
+     */
+    set_on_file_indexed(
+        on_file_indexed: (
+            update: IndexedFileUpdate
+        ) => void | Promise<void>
+    ): void {
+        this.on_file_indexed = on_file_indexed;
+    }
+
+    /**
      * Get all indexed files with their tokens.
      * Used by ReferencesProvider for workspace-wide search.
      */
@@ -585,7 +647,11 @@ export class WorkspaceIndexer {
     async get_reachable_symbols(
         file_uri: string,
         scope_resolver: ScopeResolver,
-        cross_file_config?: { assume_call_site?: 'start' | 'end'; max_forward_depth?: number }
+        cross_file_config?: {
+            assume_call_site?: 'start' | 'end';
+            max_forward_depth?: number;
+            backward_dependencies?: 'auto' | 'explicit';
+        }
     ): Promise<SymbolTable> {
         const entry = this.symbol_index.get(file_uri);
         if (!entry) {
@@ -599,8 +665,15 @@ export class WorkspaceIndexer {
             // Only pass config if assume_call_site is explicitly set to avoid
             // overriding the default with undefined
             const resolve_config = cross_file_config?.assume_call_site
-                ? { assume_call_site: cross_file_config.assume_call_site, max_forward_depth: cross_file_config.max_forward_depth }
-                : { max_forward_depth: cross_file_config?.max_forward_depth };
+                ? {
+                    assume_call_site: cross_file_config.assume_call_site,
+                    max_forward_depth: cross_file_config.max_forward_depth,
+                    backward_dependencies: cross_file_config.backward_dependencies,
+                }
+                : {
+                    max_forward_depth: cross_file_config?.max_forward_depth,
+                    backward_dependencies: cross_file_config?.backward_dependencies,
+                };
             const resolved_scope = await scope_resolver.resolve(
                 file_uri,
                 content,

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -20,6 +20,7 @@ import {
     Token,
     ContextRange,
     ForwardCall,
+    WorkingDirectoryDirective,
 } from '../types';
 import { StataLexer } from '../lexer';
 import { StataParser } from '../parser';
@@ -29,7 +30,10 @@ import {
     merge_symbol_tables
 } from '../analyzer';
 import { DirectiveParser } from '../directive-parser';
-import { ScopeResolver } from '../scope-resolver';
+import {
+    ScopeResolver,
+    build_scope_resolver_config
+} from '../scope-resolver';
 import { ContextTracker } from '../context-tracker';
 import { logger } from '../utils/logger';
 import { compute_line_offsets } from '../utils/line-utils';
@@ -76,7 +80,7 @@ export class WorkspaceIndexer {
     private max_indexed_files: number = 1000;
     private max_files_reached = false;
     private version: number = 0;
-    private workspace_root: string | undefined;
+    private workspace_roots: string[] = [];
     private on_file_indexed?: (
         update: IndexedFileUpdate
     ) => void | Promise<void>;
@@ -98,7 +102,9 @@ export class WorkspaceIndexer {
         }
         this.ado_paths = ado_paths;
         this.cancelled = false;
-        this.workspace_root = workspace_folders[0];
+        this.workspace_roots = workspace_folders.map((my_folder) =>
+            path.normalize(my_folder)
+        );
         const start_time = Date.now();
 
         for (const folder of [...workspace_folders, ...this.ado_paths]) {
@@ -231,6 +237,7 @@ export class WorkspaceIndexer {
                 'utf8'
             );
             const file_uri = URI.file(file_path).toString();
+            const workspace_root = this.get_workspace_root_for_file(file_path);
 
             // Handle .mata files differently
             if (file_path.endsWith('.mata')) {
@@ -241,7 +248,10 @@ export class WorkspaceIndexer {
             // Parse directives
             const directive_result = this.directive_parser.parse(content, file_uri);
             const resolved_working_directory =
-                directive_result.working_directory?.resolved_path;
+                this.resolve_working_directory(
+                    directive_result.working_directory,
+                    workspace_root
+                );
 
             // Parse and analyze
             const lexResult = this.lexer.tokenize(content);
@@ -252,7 +262,7 @@ export class WorkspaceIndexer {
                 undefined,
                 {
                     working_directory: resolved_working_directory,
-                    workspace_root: this.workspace_root,
+                    workspace_root: workspace_root,
                 },
                 lexResult.tokens
             );
@@ -662,18 +672,9 @@ export class WorkspaceIndexer {
         try {
             const file_path = URI.parse(file_uri).fsPath;
             const content = await fs.promises.readFile(file_path, 'utf8');
-            // Only pass config if assume_call_site is explicitly set to avoid
-            // overriding the default with undefined
-            const resolve_config = cross_file_config?.assume_call_site
-                ? {
-                    assume_call_site: cross_file_config.assume_call_site,
-                    max_forward_depth: cross_file_config.max_forward_depth,
-                    backward_dependencies: cross_file_config.backward_dependencies,
-                }
-                : {
-                    max_forward_depth: cross_file_config?.max_forward_depth,
-                    backward_dependencies: cross_file_config?.backward_dependencies,
-                };
+            const resolve_config = build_scope_resolver_config(
+                cross_file_config
+            );
             const resolved_scope = await scope_resolver.resolve(
                 file_uri,
                 content,
@@ -687,5 +688,71 @@ export class WorkspaceIndexer {
                 ...entry.symbols,
             };
         }
+    }
+
+    private get_workspace_root_for_file(
+        file_path: string
+    ): string | undefined {
+        const normalized_file_path = path.normalize(file_path);
+        let matched_workspace_root: string | undefined;
+
+        for (const my_workspace_root of this.workspace_roots) {
+            const relative_path = path.relative(
+                my_workspace_root,
+                normalized_file_path
+            );
+            const is_within_workspace =
+                relative_path === '' ||
+                (
+                    !relative_path.startsWith('..') &&
+                    !path.isAbsolute(relative_path)
+                );
+
+            if (!is_within_workspace) {
+                continue;
+            }
+
+            if (
+                !matched_workspace_root ||
+                my_workspace_root.length > matched_workspace_root.length
+            ) {
+                matched_workspace_root = my_workspace_root;
+            }
+        }
+
+        return matched_workspace_root;
+    }
+
+    private resolve_working_directory(
+        directive?: WorkingDirectoryDirective,
+        workspace_root?: string
+    ): string | undefined {
+        if (!directive) {
+            return undefined;
+        }
+
+        let resolved_path = directive.resolved_path;
+
+        if (directive.is_workspace_relative) {
+            if (!workspace_root) {
+                return undefined;
+            }
+            resolved_path = path.normalize(
+                path.join(workspace_root, resolved_path)
+            );
+        }
+
+        try {
+            if (
+                fs.existsSync(resolved_path) &&
+                fs.statSync(resolved_path).isDirectory()
+            ) {
+                return resolved_path;
+            }
+        } catch {
+            return undefined;
+        }
+
+        return undefined;
     }
 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -103,7 +103,7 @@ export class WorkspaceIndexer {
         this.ado_paths = ado_paths;
         this.cancelled = false;
         this.workspace_roots = workspace_folders.map((my_folder) =>
-            path.normalize(my_folder)
+            path.resolve(my_folder)
         );
         const start_time = Date.now();
 
@@ -731,7 +731,7 @@ export class WorkspaceIndexer {
     private get_workspace_root_for_file(
         file_path: string
     ): string | undefined {
-        const normalized_file_path = path.normalize(file_path);
+        const normalized_file_path = path.resolve(file_path);
         let matched_workspace_root: string | undefined;
 
         for (const my_workspace_root of this.workspace_roots) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -295,14 +295,12 @@ export class WorkspaceIndexer {
             });
             this.version++;
             this.metrics.files_indexed++;
-            if (this.on_file_indexed) {
-                await this.on_file_indexed({
-                    uri: file_uri,
-                    symbols: analyzeResult.symbols,
-                    directives: directive_result.directives,
-                    forward_calls: all_forward_calls,
-                });
-            }
+            await this.notify_file_indexed({
+                uri: file_uri,
+                symbols: analyzeResult.symbols,
+                directives: directive_result.directives,
+                forward_calls: all_forward_calls,
+            });
         } catch (error) {
             logger.error(`Failed to index file ${file_path}: ${error}`);
             this.metrics.files_skipped++;
@@ -357,14 +355,12 @@ export class WorkspaceIndexer {
         });
         this.version++;
         this.metrics.files_indexed++;
-        if (this.on_file_indexed) {
-            await this.on_file_indexed({
-                uri: file_uri,
-                symbols,
-                directives: [],
-                forward_calls: [],
-            });
-        }
+        await this.notify_file_indexed({
+            uri: file_uri,
+            symbols,
+            directives: [],
+            forward_calls: [],
+        });
     }
 
 
@@ -535,6 +531,22 @@ export class WorkspaceIndexer {
         ) => void | Promise<void>
     ): void {
         this.on_file_indexed = on_file_indexed;
+    }
+
+    private async notify_file_indexed(
+        update: IndexedFileUpdate
+    ): Promise<void> {
+        if (!this.on_file_indexed) {
+            return;
+        }
+
+        try {
+            await this.on_file_indexed(update);
+        } catch (my_error) {
+            logger.error(
+                `on_file_indexed callback failed for ${update.uri}: ${my_error}`
+            );
+        }
     }
 
     /**

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -516,6 +516,32 @@ export class WorkspaceIndexer {
     }
 
     /**
+     * Reset indexed state so the workspace can be rebuilt from scratch.
+     */
+    reset(): void {
+        this.symbol_index.clear();
+        this.token_index.clear();
+        this.context_ranges_index.clear();
+        this.skipped_files.clear();
+        this.metrics = {
+            files_indexed: 0,
+            files_skipped: 0,
+            total_index_time_ms: 0,
+            avg_file_time_ms: 0,
+        };
+        this.max_files_reached = false;
+        this.cancelled = false;
+        this.version++;
+
+        for (const my_timer of this.pending_updates.values()) {
+            clearTimeout(my_timer);
+        }
+        this.pending_updates.clear();
+        this.update_queue.clear();
+        this.is_processing_queue = false;
+    }
+
+    /**
      * Set the maximum number of files to index.
      */
     set_max_indexed_files(limit: number): void {

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -35,7 +35,10 @@ import {
 import { IContextTracker, LanguageContext } from '../context-tracker/types';
 import { CompletionPrefixCache } from '../utils/lru-cache';
 import { SymbolIndexCache } from '../utils/symbol-index-cache';
-import { ScopeResolver } from '../scope-resolver';
+import {
+    ScopeResolver,
+    build_scope_resolver_config
+} from '../scope-resolver';
 import { merge_symbol_tables } from '../analyzer';
 import { isPathDirective, isFileCommand, hasStataExtension } from '../utils/file-path-utils';
 import { logger } from '../utils/logger';
@@ -921,18 +924,9 @@ export class CompletionProvider {
             let symbols_for_completion: SymbolTable = document.symbols;
 
             if (scope_resolver) {
-                // Only pass config if assume_call_site is explicitly set to avoid
-                // overriding the default with undefined
-                const resolve_config = cross_file_config?.assume_call_site
-                    ? {
-                        assume_call_site: cross_file_config.assume_call_site,
-                        max_forward_depth: cross_file_config.max_forward_depth,
-                        backward_dependencies: cross_file_config.backward_dependencies,
-                    }
-                    : {
-                        max_forward_depth: cross_file_config?.max_forward_depth,
-                        backward_dependencies: cross_file_config?.backward_dependencies,
-                    };
+                const resolve_config = build_scope_resolver_config(
+                    cross_file_config
+                );
                 const temp_scope = await scope_resolver.resolve(
                     document.uri,
                     document.content,

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -859,7 +859,11 @@ export class CompletionProvider {
         trigger_character?: string,
         scope_resolver?: ScopeResolver,
         workspace_symbols?: SymbolTable,
-        cross_file_config?: { assume_call_site?: 'start' | 'end'; max_forward_depth?: number },
+        cross_file_config?: {
+            assume_call_site?: 'start' | 'end';
+            max_forward_depth?: number;
+            backward_dependencies?: 'auto' | 'explicit';
+        },
         forward_scope?: ForwardResolvedScope,
         workspace_version?: number,
         cancellation_token?: CancellationToken
@@ -920,17 +924,24 @@ export class CompletionProvider {
                 // Only pass config if assume_call_site is explicitly set to avoid
                 // overriding the default with undefined
                 const resolve_config = cross_file_config?.assume_call_site
-                    ? { assume_call_site: cross_file_config.assume_call_site, max_forward_depth: cross_file_config.max_forward_depth }
-                    : { max_forward_depth: cross_file_config?.max_forward_depth };
+                    ? {
+                        assume_call_site: cross_file_config.assume_call_site,
+                        max_forward_depth: cross_file_config.max_forward_depth,
+                        backward_dependencies: cross_file_config.backward_dependencies,
+                    }
+                    : {
+                        max_forward_depth: cross_file_config?.max_forward_depth,
+                        backward_dependencies: cross_file_config?.backward_dependencies,
+                    };
                 const temp_scope = await scope_resolver.resolve(
                     document.uri,
                     document.content,
                     resolve_config,
                     cancellation_token
                 );
-                const has_directives = temp_scope.has_directives;
+                const has_parent_scope = temp_scope.chain.length > 1;
 
-                if (has_directives) {
+                if (temp_scope.has_directives || has_parent_scope) {
                     // With directives: use reachable scope chain (precision)
                     resolved_scope = temp_scope;
                     symbols_for_completion = temp_scope.symbols;

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -73,7 +73,11 @@ export class DefinitionProvider {
         context_tracker?: IContextTracker,
         scope_resolver?: ScopeResolver,
         workspace_indexer?: WorkspaceIndexer,
-        cross_file_config?: { assume_call_site?: 'start' | 'end'; max_forward_depth?: number },
+        cross_file_config?: {
+            assume_call_site?: 'start' | 'end';
+            max_forward_depth?: number;
+            backward_dependencies?: 'auto' | 'explicit';
+        },
         cancellation_token?: CancellationToken
     ): Promise<Definition | null> {
         // Check cancellation before starting (Req 5.2)
@@ -190,7 +194,11 @@ export class DefinitionProvider {
         document: DocumentState,
         scope_resolver?: ScopeResolver,
         workspace_indexer?: WorkspaceIndexer,
-        cross_file_config?: { assume_call_site?: 'start' | 'end'; max_forward_depth?: number },
+        cross_file_config?: {
+            assume_call_site?: 'start' | 'end';
+            max_forward_depth?: number;
+            backward_dependencies?: 'auto' | 'explicit';
+        },
         cancellation_token?: CancellationToken
     ): Promise<Definition | null> {
         // Try scope resolver first
@@ -199,8 +207,13 @@ export class DefinitionProvider {
                 ? {
                     assume_call_site: cross_file_config.assume_call_site,
                     max_forward_depth: cross_file_config.max_forward_depth,
+                    backward_dependencies: cross_file_config.backward_dependencies,
                 }
-                : { max_forward_depth: cross_file_config?.max_forward_depth };
+                : {
+                    max_forward_depth: cross_file_config?.max_forward_depth,
+                    backward_dependencies:
+                        cross_file_config?.backward_dependencies,
+                };
             const resolved_scope = await scope_resolver.resolve(
                 document.uri,
                 document.content,
@@ -246,7 +259,11 @@ export class DefinitionProvider {
         workspace_symbols?: SymbolTable,
         scope_resolver?: ScopeResolver,
         workspace_indexer?: WorkspaceIndexer,
-        cross_file_config?: { assume_call_site?: 'start' | 'end'; max_forward_depth?: number },
+        cross_file_config?: {
+            assume_call_site?: 'start' | 'end';
+            max_forward_depth?: number;
+            backward_dependencies?: 'auto' | 'explicit';
+        },
         cancellation_token?: CancellationToken
     ): Promise<Definition | null> {
         // Try scope resolver first
@@ -255,8 +272,13 @@ export class DefinitionProvider {
                 ? {
                     assume_call_site: cross_file_config.assume_call_site,
                     max_forward_depth: cross_file_config.max_forward_depth,
+                    backward_dependencies: cross_file_config.backward_dependencies,
                 }
-                : { max_forward_depth: cross_file_config?.max_forward_depth };
+                : {
+                    max_forward_depth: cross_file_config?.max_forward_depth,
+                    backward_dependencies:
+                        cross_file_config?.backward_dependencies,
+                };
             const resolved_scope = await scope_resolver.resolve(
                 document.uri,
                 document.content,
@@ -284,7 +306,10 @@ export class DefinitionProvider {
 
         // Check workspace indexer
         if (workspace_indexer) {
-            const global_defs = workspace_indexer.find_symbol_definitions(word, 'global');
+            const global_defs = workspace_indexer.find_symbol_definitions(
+                word,
+                'global'
+            );
             if (global_defs.length > 0) {
                 return this.as_locations(global_defs);
             }
@@ -315,7 +340,11 @@ export class DefinitionProvider {
         workspace_symbols?: SymbolTable,
         scope_resolver?: ScopeResolver,
         workspace_indexer?: WorkspaceIndexer,
-        cross_file_config?: { assume_call_site?: 'start' | 'end'; max_forward_depth?: number },
+        cross_file_config?: {
+            assume_call_site?: 'start' | 'end';
+            max_forward_depth?: number;
+            backward_dependencies?: 'auto' | 'explicit';
+        },
         cancellation_token?: CancellationToken
     ): Promise<Definition | null> {
         // Try scope resolver first
@@ -324,8 +353,13 @@ export class DefinitionProvider {
                 ? {
                     assume_call_site: cross_file_config.assume_call_site,
                     max_forward_depth: cross_file_config.max_forward_depth,
+                    backward_dependencies: cross_file_config.backward_dependencies,
                 }
-                : { max_forward_depth: cross_file_config?.max_forward_depth };
+                : {
+                    max_forward_depth: cross_file_config?.max_forward_depth,
+                    backward_dependencies:
+                        cross_file_config?.backward_dependencies,
+                };
             const resolved_scope = await scope_resolver.resolve(
                 document.uri,
                 document.content,
@@ -405,22 +439,34 @@ export class DefinitionProvider {
 
         // Check workspace indexer
         if (workspace_indexer) {
-            const variable_defs = workspace_indexer.find_symbol_definitions(word, 'variable');
+            const variable_defs = workspace_indexer.find_symbol_definitions(
+                word,
+                'variable'
+            );
             if (variable_defs.length > 0) {
                 return this.as_locations(variable_defs);
             }
 
-            const program_defs = workspace_indexer.find_symbol_definitions(word, 'program');
+            const program_defs = workspace_indexer.find_symbol_definitions(
+                word,
+                'program'
+            );
             if (program_defs.length > 0) {
                 return this.as_locations(program_defs);
             }
 
-            const scalar_defs = workspace_indexer.find_symbol_definitions(word, 'scalar');
+            const scalar_defs = workspace_indexer.find_symbol_definitions(
+                word,
+                'scalar'
+            );
             if (scalar_defs.length > 0) {
                 return this.as_locations(scalar_defs);
             }
 
-            const matrix_defs = workspace_indexer.find_symbol_definitions(word, 'matrix');
+            const matrix_defs = workspace_indexer.find_symbol_definitions(
+                word,
+                'matrix'
+            );
             if (matrix_defs.length > 0) {
                 return this.as_locations(matrix_defs);
             }
@@ -475,7 +521,11 @@ export class DefinitionProvider {
         workspace_symbols?: SymbolTable,
         scope_resolver?: ScopeResolver,
         workspace_indexer?: WorkspaceIndexer,
-        cross_file_config?: { assume_call_site?: 'start' | 'end'; max_forward_depth?: number },
+        cross_file_config?: {
+            assume_call_site?: 'start' | 'end';
+            max_forward_depth?: number;
+            backward_dependencies?: 'auto' | 'explicit';
+        },
         cancellation_token?: CancellationToken
     ): Promise<Definition | null> {
         // Use existing helper to determine if reference looks like a macro
@@ -611,7 +661,11 @@ export class DefinitionProvider {
         workspace_symbols?: SymbolTable,
         scope_resolver?: ScopeResolver,
         workspace_indexer?: WorkspaceIndexer,
-        cross_file_config?: { assume_call_site?: 'start' | 'end'; max_forward_depth?: number },
+        cross_file_config?: {
+            assume_call_site?: 'start' | 'end';
+            max_forward_depth?: number;
+            backward_dependencies?: 'auto' | 'explicit';
+        },
         cancellation_token?: CancellationToken
     ): Promise<Definition | null> {
         // Get the word at the cursor position
@@ -630,8 +684,13 @@ export class DefinitionProvider {
                 ? {
                     assume_call_site: cross_file_config.assume_call_site,
                     max_forward_depth: cross_file_config.max_forward_depth,
+                    backward_dependencies: cross_file_config.backward_dependencies,
                 }
-                : { max_forward_depth: cross_file_config?.max_forward_depth };
+                : {
+                    max_forward_depth: cross_file_config?.max_forward_depth,
+                    backward_dependencies:
+                        cross_file_config?.backward_dependencies,
+                };
             const resolved_scope = await scope_resolver.resolve(
                 document.uri,
                 document.content,

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -39,7 +39,10 @@ type MacroDefNodeLike = {
     range: { start: Position; end: Position };
 };
 import { IContextTracker } from '../context-tracker/types';
-import { ScopeResolver } from '../scope-resolver';
+import {
+    ScopeResolver,
+    build_scope_resolver_config
+} from '../scope-resolver';
 import { WorkspaceIndexer } from '../indexer';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -203,17 +206,9 @@ export class DefinitionProvider {
     ): Promise<Definition | null> {
         // Try scope resolver first
         if (scope_resolver) {
-            const resolve_config = cross_file_config?.assume_call_site
-                ? {
-                    assume_call_site: cross_file_config.assume_call_site,
-                    max_forward_depth: cross_file_config.max_forward_depth,
-                    backward_dependencies: cross_file_config.backward_dependencies,
-                }
-                : {
-                    max_forward_depth: cross_file_config?.max_forward_depth,
-                    backward_dependencies:
-                        cross_file_config?.backward_dependencies,
-                };
+            const resolve_config = build_scope_resolver_config(
+                cross_file_config
+            );
             const resolved_scope = await scope_resolver.resolve(
                 document.uri,
                 document.content,
@@ -268,17 +263,9 @@ export class DefinitionProvider {
     ): Promise<Definition | null> {
         // Try scope resolver first
         if (scope_resolver) {
-            const resolve_config = cross_file_config?.assume_call_site
-                ? {
-                    assume_call_site: cross_file_config.assume_call_site,
-                    max_forward_depth: cross_file_config.max_forward_depth,
-                    backward_dependencies: cross_file_config.backward_dependencies,
-                }
-                : {
-                    max_forward_depth: cross_file_config?.max_forward_depth,
-                    backward_dependencies:
-                        cross_file_config?.backward_dependencies,
-                };
+            const resolve_config = build_scope_resolver_config(
+                cross_file_config
+            );
             const resolved_scope = await scope_resolver.resolve(
                 document.uri,
                 document.content,
@@ -678,19 +665,9 @@ export class DefinitionProvider {
 
         // Try scope resolver first if available
         if (scope_resolver) {
-            // Only pass config if assume_call_site is explicitly set to avoid
-            // overriding the default with undefined
-            const resolve_config = cross_file_config?.assume_call_site
-                ? {
-                    assume_call_site: cross_file_config.assume_call_site,
-                    max_forward_depth: cross_file_config.max_forward_depth,
-                    backward_dependencies: cross_file_config.backward_dependencies,
-                }
-                : {
-                    max_forward_depth: cross_file_config?.max_forward_depth,
-                    backward_dependencies:
-                        cross_file_config?.backward_dependencies,
-                };
+            const resolve_config = build_scope_resolver_config(
+                cross_file_config
+            );
             const resolved_scope = await scope_resolver.resolve(
                 document.uri,
                 document.content,

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -336,17 +336,9 @@ export class DefinitionProvider {
     ): Promise<Definition | null> {
         // Try scope resolver first
         if (scope_resolver) {
-            const resolve_config = cross_file_config?.assume_call_site
-                ? {
-                    assume_call_site: cross_file_config.assume_call_site,
-                    max_forward_depth: cross_file_config.max_forward_depth,
-                    backward_dependencies: cross_file_config.backward_dependencies,
-                }
-                : {
-                    max_forward_depth: cross_file_config?.max_forward_depth,
-                    backward_dependencies:
-                        cross_file_config?.backward_dependencies,
-                };
+            const resolve_config = build_scope_resolver_config(
+                cross_file_config
+            );
             const resolved_scope = await scope_resolver.resolve(
                 document.uri,
                 document.content,

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -194,12 +194,14 @@ export class DiagnosticsProvider {
             ? {
                 assume_call_site: config.cross_file.assume_call_site,
                 max_forward_depth: config.cross_file?.max_forward_depth,
+                backward_dependencies: config.cross_file?.backward_dependencies,
                 diagnostics: {
                     max_depth: config.cross_file?.diagnostics?.max_depth,
                 },
             }
             : { 
                 max_forward_depth: config.cross_file?.max_forward_depth,
+                backward_dependencies: config.cross_file?.backward_dependencies,
                 diagnostics: {
                     max_depth: config.cross_file?.diagnostics?.max_depth,
                 },
@@ -210,10 +212,22 @@ export class DiagnosticsProvider {
             resolve_config,
             cancellation_token
         ) : undefined;
+        const defer_auto_backward_diagnostics =
+            !!scope_resolver &&
+            config.cross_file?.backward_dependencies === 'auto' &&
+            !resolved_scope?.has_directives &&
+            !scope_resolver.is_workspace_scan_complete();
         
         for (const my_diagnostic of this.extract_semantic_diagnostics(document)) {
             // Suppress Stata-specific semantic diagnostics in embedded contexts
             if (this.is_in_embedded_context(my_diagnostic.range.start, the_context_ranges)) {
+                continue;
+            }
+            if (
+                defer_auto_backward_diagnostics &&
+                (my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO ||
+                 my_diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE)
+            ) {
                 continue;
             }
             

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -13,7 +13,10 @@ import {
     DirectiveDiagnostic,
     ForwardResolvedScope
 } from '../types';
-import { ScopeResolver } from '../scope-resolver';
+import {
+    ScopeResolver,
+    build_scope_resolver_config
+} from '../scope-resolver';
 import { createHash } from 'crypto';
 import { DocumentDebounceManager } from '../utils/debounce-manager';
 import { get_line_text, get_line_count } from '../utils/line-utils';
@@ -188,24 +191,14 @@ export class DiagnosticsProvider {
 
         // Add semantic diagnostics from cached analyzer results
         // If scope_resolver is provided, check against cross-file scope first
-        // Only pass config if assume_call_site is explicitly set to avoid
-        // overriding the default with undefined
-        const resolve_config = config.cross_file?.assume_call_site
-            ? {
-                assume_call_site: config.cross_file.assume_call_site,
-                max_forward_depth: config.cross_file?.max_forward_depth,
-                backward_dependencies: config.cross_file?.backward_dependencies,
-                diagnostics: {
-                    max_depth: config.cross_file?.diagnostics?.max_depth,
-                },
-            }
-            : { 
-                max_forward_depth: config.cross_file?.max_forward_depth,
-                backward_dependencies: config.cross_file?.backward_dependencies,
-                diagnostics: {
-                    max_depth: config.cross_file?.diagnostics?.max_depth,
-                },
-            };
+        const resolve_config = build_scope_resolver_config({
+            assume_call_site: config.cross_file?.assume_call_site,
+            max_forward_depth: config.cross_file?.max_forward_depth,
+            backward_dependencies: config.cross_file?.backward_dependencies,
+            diagnostics: {
+                max_depth: config.cross_file?.diagnostics?.max_depth,
+            },
+        });
         const resolved_scope = scope_resolver ? await scope_resolver.resolve(
             document.uri,
             document.content,

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -99,7 +99,11 @@ export class HoverProvider {
         position: Position,
         workspace_symbols?: SymbolTable,
         scope_resolver?: ScopeResolver,
-        cross_file_config?: { assume_call_site?: 'start' | 'end'; max_forward_depth?: number },
+        cross_file_config?: {
+            assume_call_site?: 'start' | 'end';
+            max_forward_depth?: number;
+            backward_dependencies?: 'auto' | 'explicit';
+        },
 
         cancellation_token?: CancellationToken,
         workspace_root?: string
@@ -136,8 +140,12 @@ export class HoverProvider {
                 ? {
                     assume_call_site: cross_file_config.assume_call_site,
                     max_forward_depth: cross_file_config.max_forward_depth,
+                    backward_dependencies: cross_file_config.backward_dependencies,
                 }
-                : { max_forward_depth: cross_file_config?.max_forward_depth };
+                : {
+                    max_forward_depth: cross_file_config?.max_forward_depth,
+                    backward_dependencies: cross_file_config?.backward_dependencies,
+                };
             resolved_scope = await scope_resolver.resolve(
                 document.uri,
                 document.content,

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -38,7 +38,10 @@ import {
 } from '../types';
 import { IContextTracker } from '../context-tracker/types';
 import { LanguageContext } from '../context-tracker/types';
-import { ScopeResolver } from '../scope-resolver';
+import {
+    ScopeResolver,
+    build_scope_resolver_config
+} from '../scope-resolver';
 import { get_line_text } from '../utils/line-utils';
 
 /**
@@ -134,18 +137,9 @@ export class HoverProvider {
         // Resolve scope if scope_resolver is provided
         let resolved_scope: ResolvedScope | undefined;
         if (scope_resolver) {
-            // Only pass config if assume_call_site is explicitly set to avoid
-            // overriding the default with undefined
-            const resolve_config = cross_file_config?.assume_call_site
-                ? {
-                    assume_call_site: cross_file_config.assume_call_site,
-                    max_forward_depth: cross_file_config.max_forward_depth,
-                    backward_dependencies: cross_file_config.backward_dependencies,
-                }
-                : {
-                    max_forward_depth: cross_file_config?.max_forward_depth,
-                    backward_dependencies: cross_file_config?.backward_dependencies,
-                };
+            const resolve_config = build_scope_resolver_config(
+                cross_file_config
+            );
             resolved_scope = await scope_resolver.resolve(
                 document.uri,
                 document.content,

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -1984,10 +1984,19 @@ export class ScopeResolver {
                 diagnostics: parse_result.diagnostics,
             });
 
-            // Register backward directive dependencies from cached file
-            // This ensures transitive dependents are discoverable even when
-            // intermediate files are only read from disk (not opened in editor)
-            this.sync_backward_directive_dependencies(actual_uri, parse_result.directives);
+            // Register only explicit backward directive dependencies from cached
+            // files. Auto-synthesized parents are useful when actively resolving
+            // a file, but caching a callee during forward-call traversal should
+            // not pollute the backward-directive dependency graph with inferred
+            // caller edges.
+            const normalized_cached_directives = this.normalize_directives(
+                parse_result.directives,
+                []
+            );
+            this.replace_backward_directive_dependencies(
+                actual_uri,
+                normalized_cached_directives
+            );
 
             // Register forward call relationships from cached file
             // This ensures callee_to_callers map includes relationships from cached files,

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -2488,17 +2488,27 @@ export class ScopeResolver {
     }
 
     /**
-     * Clear all caches.
+     * Clear all scope cache entries while preserving file parse caches and
+     * reverse dependency state.
      */
-    clear_cache(): void {
+    clear_scope_cache(): void {
         const scope_cache_size = this.scope_cache.size;
-        const file_cache_size = this.file_cache.size;
 
         this.scope_cache.clear();
         this.uri_to_cache_keys.clear();
-        this.file_cache.clear();
 
         this.cache_metrics.scope.invalidations += scope_cache_size;
+    }
+
+    /**
+     * Clear all caches.
+     */
+    clear_cache(): void {
+        const file_cache_size = this.file_cache.size;
+
+        this.clear_scope_cache();
+        this.file_cache.clear();
+
         this.cache_metrics.file.invalidations += file_cache_size;
     }
 

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -54,6 +54,7 @@ export function build_scope_resolver_config(
         return {};
     }
 
+
     const resolved_config: Partial<ScopeResolverConfig> = {};
 
     if (config.assume_call_site !== undefined) {
@@ -143,7 +144,7 @@ export class ScopeResolver {
     // Track backward directive dependencies: parent_uri → set of child_uris that depend on it via @lsp-done-by/@lsp-included-by
     private backward_directive_children: Map<string, Set<string>>;
     private content_provider: ContentProvider;
-    private workspace_root: string | undefined;
+    private workspace_roots: string[];
     private workspace_scan_complete: boolean;
 
     constructor(logger?: ScopeResolverLogger, content_provider?: ContentProvider) {
@@ -164,6 +165,7 @@ export class ScopeResolver {
             last_forward_calls: new Map(),
         };
         this.backward_directive_children = new Map();
+        this.workspace_roots = [];
         this.workspace_scan_complete = true;
 
         // Default content provider uses fs
@@ -194,10 +196,39 @@ export class ScopeResolver {
     }
 
     /**
-     * Set the workspace root for resolving workspace-relative working directory paths.
+     * Set a single workspace root for resolving workspace-relative paths.
+     * Retained for backward compatibility with existing callers and tests.
      */
     set_workspace_root(workspace_root: string | undefined): void {
-        this.workspace_root = workspace_root;
+        this.set_workspace_roots(
+            workspace_root ? [workspace_root] : []
+        );
+    }
+
+    /**
+     * Set all workspace roots for per-file workspace-relative path resolution.
+     */
+    set_workspace_roots(workspace_roots: string[]): void {
+        const normalized_roots = Array.from(
+            new Set(
+                workspace_roots.map((my_workspace_root) =>
+                    path.resolve(my_workspace_root)
+                )
+            )
+        ).sort((a, b) => a.localeCompare(b));
+        const roots_unchanged =
+            normalized_roots.length === this.workspace_roots.length &&
+            normalized_roots.every(
+                (my_workspace_root, my_index) =>
+                    my_workspace_root === this.workspace_roots[my_index]
+            );
+
+        if (roots_unchanged) {
+            return;
+        }
+
+        this.workspace_roots = normalized_roots;
+        this.clear_cache();
     }
 
     /**
@@ -212,6 +243,43 @@ export class ScopeResolver {
      */
     is_workspace_scan_complete(): boolean {
         return this.workspace_scan_complete;
+    }
+
+    private get_workspace_root_for_uri(uri: string): string | undefined {
+        return this.get_workspace_root_for_path(URI.parse(uri).fsPath);
+    }
+
+    private get_workspace_root_for_path(
+        file_path: string
+    ): string | undefined {
+        const normalized_file_path = path.resolve(file_path);
+        let matched_workspace_root: string | undefined;
+
+        for (const my_workspace_root of this.workspace_roots) {
+            const relative_path = path.relative(
+                my_workspace_root,
+                normalized_file_path
+            );
+            const is_within_workspace =
+                relative_path === '' ||
+                (
+                    !relative_path.startsWith('..') &&
+                    !path.isAbsolute(relative_path)
+                );
+
+            if (!is_within_workspace) {
+                continue;
+            }
+
+            if (
+                !matched_workspace_root ||
+                my_workspace_root.length > matched_workspace_root.length
+            ) {
+                matched_workspace_root = my_workspace_root;
+            }
+        }
+
+        return matched_workspace_root;
     }
 
     /**
@@ -636,7 +704,8 @@ export class ScopeResolver {
     }
 
     private resolve_working_directory_directive(
-        directive?: WorkingDirectoryDirective
+        directive?: WorkingDirectoryDirective,
+        workspace_root?: string
     ): string | undefined {
         if (!directive) {
             return undefined;
@@ -646,12 +715,12 @@ export class ScopeResolver {
             return directive.resolved_path;
         }
 
-        if (!this.workspace_root) {
+        if (!workspace_root) {
             return undefined;
         }
 
         return path.normalize(
-            path.join(this.workspace_root, directive.resolved_path)
+            path.join(workspace_root, directive.resolved_path)
         );
     }
 
@@ -837,14 +906,14 @@ export class ScopeResolver {
                 normalized_directives,
                 my_config
             );
+        const current_workspace_root = this.get_workspace_root_for_uri(file_uri);
 
         // Register backward directive dependencies for this file
         // Clear old dependencies first, then register new ones
-        this.clear_backward_directive_dependencies(file_uri);
-        for (const my_directive of normalized_directives) {
-            const my_parent_uri = URI.file(my_directive.path).toString();
-            this.register_backward_directive_dependency(file_uri, my_parent_uri);
-        }
+        this.replace_backward_directive_dependencies(
+            file_uri,
+            effective_backward_directives
+        );
 
         // Follow directive chain and get inherited working directory
         const directive_result = await this.follow_directives(
@@ -878,7 +947,8 @@ export class ScopeResolver {
         // We need to parse directives again to get working_directory (parse_file doesn't return it)
         const directive_parse_result = this.directive_parser.parse(file_content, file_uri);
         const own_working_directory = this.resolve_working_directory_directive(
-            directive_parse_result.working_directory
+            directive_parse_result.working_directory,
+            current_workspace_root
         );
 
         // Only use inherited working directory if current file doesn't have its own
@@ -1152,8 +1222,11 @@ export class ScopeResolver {
 
             // If the parent has a working_directory directive, resolve it for inheritance
             if (my_parent_result.working_directory_directive) {
+                const parent_workspace_root =
+                    this.get_workspace_root_for_uri(my_parent_uri);
                 const resolved_path = this.resolve_working_directory_directive(
-                    my_parent_result.working_directory_directive
+                    my_parent_result.working_directory_directive,
+                    parent_workspace_root
                 );
 
                 if (!resolved_path) {
@@ -1513,6 +1586,10 @@ export class ScopeResolver {
                     normalized_parent_directives,
                     config
                 );
+            this.replace_backward_directive_dependencies(
+                my_parent_uri,
+                effective_parent_directives
+            );
             // Record chain length before recursion to strip locals from ancestor entries if needed
             const chain_length_before = chain.length;
             const recursive_result = await this.follow_directives(
@@ -1666,17 +1743,19 @@ export class ScopeResolver {
         const my_directive_result = this.directive_parser.parse(content, uri);
         const my_lex_result = this.lexer.tokenize(content);
         const my_parse_result = this.parser.parse(my_lex_result.tokens);
+        const workspace_root = this.get_workspace_root_for_uri(uri);
 
         // Use file's own working_directory if present, otherwise use inherited
         const effective_working_directory =
             this.resolve_working_directory_directive(
-                my_directive_result.working_directory
+                my_directive_result.working_directory,
+                workspace_root
             ) ?? inherited_working_directory;
 
         // Pass working_directory to analyzer for path resolution in do/run/include commands
         const my_analysis = this.analyzer.analyze(my_parse_result.ast, uri, undefined, {
             working_directory: effective_working_directory,
-            workspace_root: this.workspace_root,
+            workspace_root,
         });
 
         // Combine forward calls from commands and directives
@@ -2685,6 +2764,23 @@ export class ScopeResolver {
     }
 
     /**
+     * Replace all backward directive dependencies recorded for a child file.
+     */
+    private replace_backward_directive_dependencies(
+        child_uri: string,
+        directives: Directive[]
+    ): void {
+        this.clear_backward_directive_dependencies(child_uri);
+        for (const my_directive of directives) {
+            const my_parent_uri = URI.file(my_directive.path).toString();
+            this.register_backward_directive_dependency(
+                child_uri,
+                my_parent_uri
+            );
+        }
+    }
+
+    /**
      * Sync backward directive dependencies for a child file using a set of directives.
      * This is a helper for callers (e.g., DocumentStore) that already parsed directives
      * and want to register dependencies without doing a full scope resolve.
@@ -2692,11 +2788,7 @@ export class ScopeResolver {
     sync_backward_directive_dependencies(child_uri: string, directives: Directive[]): void {
         // Normalize directives to match resolve() behavior (handles done-by + included-by collisions)
         const normalized = this.normalize_directives(directives, []);
-        this.clear_backward_directive_dependencies(child_uri);
-        for (const my_directive of normalized) {
-            const my_parent_uri = URI.file(my_directive.path).toString();
-            this.register_backward_directive_dependency(child_uri, my_parent_uri);
-        }
+        this.replace_backward_directive_dependencies(child_uri, normalized);
     }
 
     /**

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -1238,9 +1238,7 @@ export class ScopeResolver {
                 if (resolved_path) {
                     return resolved_path;
                 }
-                if (!resolved_path) {
-                    this.warn(`discover_working_directory: Cannot resolve workspace-relative path \"${my_parent_result.working_directory_directive.path}\" - no workspace root set`);
-                }
+                this.warn(`discover_working_directory: Cannot resolve workspace-relative path \"${my_parent_result.working_directory_directive.path}\" - no workspace root set`);
             }
 
             const normalized_parent_directives = this.normalize_directives(
@@ -2801,9 +2799,7 @@ export class ScopeResolver {
     sync_backward_directive_dependencies(
         child_uri: string,
         directives: Directive[],
-        config: Partial<ScopeResolverConfig> = {
-            backward_dependencies: 'explicit',
-        }
+        config?: Partial<ScopeResolverConfig>
     ): void {
         // Normalize directives to match resolve() behavior (handles done-by + included-by collisions)
         const normalized = this.normalize_directives(directives, []);

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -44,6 +44,7 @@ const DEFAULT_CONFIG: ScopeResolverConfig = {
     max_backward_depth: 10,
     max_forward_depth: 10,
     max_chain_depth: 20,
+    backward_dependencies: 'auto',
 };
 
 /**
@@ -101,6 +102,7 @@ export class ScopeResolver {
     private backward_directive_children: Map<string, Set<string>>;
     private content_provider: ContentProvider;
     private workspace_root: string | undefined;
+    private workspace_scan_complete: boolean;
 
     constructor(logger?: ScopeResolverLogger, content_provider?: ContentProvider) {
         this.directive_parser = new DirectiveParser();
@@ -120,6 +122,7 @@ export class ScopeResolver {
             last_forward_calls: new Map(),
         };
         this.backward_directive_children = new Map();
+        this.workspace_scan_complete = true;
 
         // Default content provider uses fs
         this.content_provider = content_provider || {
@@ -153,6 +156,20 @@ export class ScopeResolver {
      */
     set_workspace_root(workspace_root: string | undefined): void {
         this.workspace_root = workspace_root;
+    }
+
+    /**
+     * Mark whether the initial workspace scan has completed.
+     */
+    set_workspace_scan_complete(is_complete: boolean): void {
+        this.workspace_scan_complete = is_complete;
+    }
+
+    /**
+     * Check whether the initial workspace scan has completed.
+     */
+    is_workspace_scan_complete(): boolean {
+        return this.workspace_scan_complete;
     }
 
     /**
@@ -479,6 +496,82 @@ export class ScopeResolver {
     }
 
     /**
+     * Determine which backward directives should be followed for resolution.
+     * Explicit directives always win for the current file; auto mode only
+     * synthesizes parents when the file has no explicit backward directives.
+     */
+    private get_effective_backward_directives(
+        current_uri: string,
+        normalized_directives: Directive[],
+        config: ScopeResolverConfig
+    ): Directive[] {
+        if (normalized_directives.length > 0) {
+            return normalized_directives;
+        }
+
+        if (config.backward_dependencies !== 'auto') {
+            return normalized_directives;
+        }
+
+        return this.synthesize_auto_backward_directives(current_uri);
+    }
+
+    /**
+     * Synthesize backward directives from the reverse dependency graph.
+     */
+    private synthesize_auto_backward_directives(current_uri: string): Directive[] {
+        const caller_set = this.reverse_deps.callee_to_callers.get(current_uri);
+        if (!caller_set || caller_set.size === 0) {
+            return [];
+        }
+
+        const inferred_callers = Array.from(caller_set)
+            .map((caller_uri) => {
+                const call_edges = this.get_call_edges(caller_uri, current_uri);
+                if (!call_edges || call_edges.length === 0) {
+                    return undefined;
+                }
+
+                const earliest_edge = call_edges.reduce((min_edge, my_edge) =>
+                    my_edge.call_site_line < min_edge.call_site_line
+                        ? my_edge
+                        : min_edge
+                );
+
+                return {
+                    caller_uri,
+                    earliest_edge,
+                };
+            })
+            .filter((value): value is {
+                caller_uri: string;
+                earliest_edge: CallEdge;
+            } => value !== undefined)
+            .sort((a, b) => {
+                if (a.earliest_edge.call_site_line !== b.earliest_edge.call_site_line) {
+                    return a.earliest_edge.call_site_line -
+                        b.earliest_edge.call_site_line;
+                }
+                return a.caller_uri.localeCompare(b.caller_uri);
+            });
+
+        return inferred_callers.map(({ caller_uri, earliest_edge }, my_index) => {
+            const parent_path = URI.parse(caller_uri).fsPath;
+            return {
+                type: earliest_edge.call_type === 'include'
+                    ? 'included-by'
+                    : 'done-by',
+                path: parent_path,
+                raw_path: parent_path,
+                range: {
+                    start: { line: 0, character: my_index },
+                    end: { line: 0, character: my_index },
+                },
+            };
+        });
+    }
+
+    /**
      * Generate cache key for scope resolution.
      */
     private generate_cache_key(file_uri: string, content: string, config: ScopeResolverConfig): string {
@@ -676,6 +769,12 @@ export class ScopeResolver {
             my_directives,
             the_diagnostics
         );
+        const effective_backward_directives =
+            this.get_effective_backward_directives(
+                file_uri,
+                normalized_directives,
+                my_config
+            );
 
         // Register backward directive dependencies for this file
         // Clear old dependencies first, then register new ones
@@ -687,7 +786,7 @@ export class ScopeResolver {
 
         // Follow directive chain and get inherited working directory
         const directive_result = await this.follow_directives(
-            normalized_directives,
+            effective_backward_directives,
             file_uri,
             visited,
             the_chain,
@@ -1497,6 +1596,7 @@ export class ScopeResolver {
         // Pass working_directory to analyzer for path resolution in do/run/include commands
         const my_analysis = this.analyzer.analyze(my_parse_result.ast, uri, undefined, {
             working_directory: effective_working_directory,
+            workspace_root: this.workspace_root,
         });
 
         // Combine forward calls from commands and directives

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -209,13 +209,16 @@ export class ScopeResolver {
      * Set all workspace roots for per-file workspace-relative path resolution.
      */
     set_workspace_roots(workspace_roots: string[]): void {
-        const normalized_roots = Array.from(
-            new Set(
-                workspace_roots.map((my_workspace_root) =>
-                    path.resolve(my_workspace_root)
-                )
-            )
-        ).sort((a, b) => a.localeCompare(b));
+        const seen_roots = new Set<string>();
+        const normalized_roots: string[] = [];
+        for (const my_workspace_root of workspace_roots) {
+            const normalized_root = path.resolve(my_workspace_root);
+            if (seen_roots.has(normalized_root)) {
+                continue;
+            }
+            seen_roots.add(normalized_root);
+            normalized_roots.push(normalized_root);
+        }
         const roots_unchanged =
             normalized_roots.length === this.workspace_roots.length &&
             normalized_roots.every(
@@ -246,7 +249,11 @@ export class ScopeResolver {
     }
 
     private get_workspace_root_for_uri(uri: string): string | undefined {
-        return this.get_workspace_root_for_path(URI.parse(uri).fsPath);
+        try {
+            return this.get_workspace_root_for_path(URI.parse(uri).fsPath);
+        } catch {
+            return this.workspace_roots[0];
+        }
     }
 
     private get_workspace_root_for_path(
@@ -279,7 +286,7 @@ export class ScopeResolver {
             }
         }
 
-        return matched_workspace_root;
+        return matched_workspace_root ?? this.workspace_roots[0];
     }
 
     /**
@@ -1228,12 +1235,12 @@ export class ScopeResolver {
                     my_parent_result.working_directory_directive,
                     parent_workspace_root
                 );
-
+                if (resolved_path) {
+                    return resolved_path;
+                }
                 if (!resolved_path) {
                     this.warn(`discover_working_directory: Cannot resolve workspace-relative path \"${my_parent_result.working_directory_directive.path}\" - no workspace root set`);
-                    continue;
                 }
-                return resolved_path;
             }
 
             const normalized_parent_directives = this.normalize_directives(
@@ -2587,6 +2594,12 @@ export class ScopeResolver {
 
         this.clear_scope_cache();
         this.file_cache.clear();
+        this.backward_directive_children.clear();
+        this.reverse_deps.caller_to_callees.clear();
+        this.reverse_deps.callee_to_callers.clear();
+        this.reverse_deps.forward_caller_to_callees.clear();
+        this.reverse_deps.interface_hashes.clear();
+        this.reverse_deps.last_forward_calls.clear();
 
         this.cache_metrics.file.invalidations += file_cache_size;
     }
@@ -2785,10 +2798,28 @@ export class ScopeResolver {
      * This is a helper for callers (e.g., DocumentStore) that already parsed directives
      * and want to register dependencies without doing a full scope resolve.
      */
-    sync_backward_directive_dependencies(child_uri: string, directives: Directive[]): void {
+    sync_backward_directive_dependencies(
+        child_uri: string,
+        directives: Directive[],
+        config: Partial<ScopeResolverConfig> = {
+            backward_dependencies: 'explicit',
+        }
+    ): void {
         // Normalize directives to match resolve() behavior (handles done-by + included-by collisions)
         const normalized = this.normalize_directives(directives, []);
-        this.replace_backward_directive_dependencies(child_uri, normalized);
+        const resolved_config: ScopeResolverConfig = {
+            ...DEFAULT_CONFIG,
+            ...build_scope_resolver_config(config),
+        };
+        const effective_directives = this.get_effective_backward_directives(
+            child_uri,
+            normalized,
+            resolved_config
+        );
+        this.replace_backward_directive_dependencies(
+            child_uri,
+            effective_directives
+        );
     }
 
     /**

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -47,6 +47,48 @@ const DEFAULT_CONFIG: ScopeResolverConfig = {
     backward_dependencies: 'auto',
 };
 
+export function build_scope_resolver_config(
+    config?: Partial<ScopeResolverConfig>
+): Partial<ScopeResolverConfig> {
+    if (!config) {
+        return {};
+    }
+
+    const resolved_config: Partial<ScopeResolverConfig> = {};
+
+    if (config.assume_call_site !== undefined) {
+        resolved_config.assume_call_site = config.assume_call_site;
+    }
+    if (config.max_backward_depth !== undefined) {
+        resolved_config.max_backward_depth = config.max_backward_depth;
+    }
+    if (config.max_forward_depth !== undefined) {
+        resolved_config.max_forward_depth = config.max_forward_depth;
+    }
+    if (config.max_chain_depth !== undefined) {
+        resolved_config.max_chain_depth = config.max_chain_depth;
+    }
+    if (config.backward_dependencies !== undefined) {
+        resolved_config.backward_dependencies = config.backward_dependencies;
+    }
+
+    if (config.diagnostics) {
+        const diagnostics: NonNullable<ScopeResolverConfig['diagnostics']> = {};
+        if (config.diagnostics.max_depth !== undefined) {
+            diagnostics.max_depth = config.diagnostics.max_depth;
+        }
+        if (config.diagnostics.call_site_identification !== undefined) {
+            diagnostics.call_site_identification =
+                config.diagnostics.call_site_identification;
+        }
+        if (Object.keys(diagnostics).length > 0) {
+            resolved_config.diagnostics = diagnostics;
+        }
+    }
+
+    return resolved_config;
+}
+
 /**
  * Cache for file parsing results within a single resolution request.
  * Ensures we only read/parse each file once per request.
@@ -593,6 +635,26 @@ export class ScopeResolver {
         return hash.toString(36);
     }
 
+    private resolve_working_directory_directive(
+        directive?: WorkingDirectoryDirective
+    ): string | undefined {
+        if (!directive) {
+            return undefined;
+        }
+
+        if (!directive.is_workspace_relative) {
+            return directive.resolved_path;
+        }
+
+        if (!this.workspace_root) {
+            return undefined;
+        }
+
+        return path.normalize(
+            path.join(this.workspace_root, directive.resolved_path)
+        );
+    }
+
     /**
      * Compute a stable hash of the symbols that would be inherited by a child.
      * The hash targets the 'public interface' (globals, programs, scalars, matrices, variables).
@@ -815,7 +877,9 @@ export class ScopeResolver {
         // Check if current file has its own working directory
         // We need to parse directives again to get working_directory (parse_file doesn't return it)
         const directive_parse_result = this.directive_parser.parse(file_content, file_uri);
-        const own_working_directory = directive_parse_result.working_directory?.resolved_path;
+        const own_working_directory = this.resolve_working_directory_directive(
+            directive_parse_result.working_directory
+        );
 
         // Only use inherited working directory if current file doesn't have its own
         const inherited_working_directory = own_working_directory
@@ -1088,28 +1152,35 @@ export class ScopeResolver {
 
             // If the parent has a working_directory directive, resolve it for inheritance
             if (my_parent_result.working_directory_directive) {
-                let resolved_path = my_parent_result.working_directory_directive.resolved_path;
-                
-                // Handle workspace-relative paths
-                if (my_parent_result.working_directory_directive.is_workspace_relative) {
-                    if (this.workspace_root) {
-                        resolved_path = path.normalize(path.join(this.workspace_root, resolved_path));
-                    } else {
-                        this.warn(`discover_working_directory: Cannot resolve workspace-relative path "${my_parent_result.working_directory_directive.path}" - no workspace root set`);
-                        continue;
-                    }
+                const resolved_path = this.resolve_working_directory_directive(
+                    my_parent_result.working_directory_directive
+                );
+
+                if (!resolved_path) {
+                    this.warn(`discover_working_directory: Cannot resolve workspace-relative path \"${my_parent_result.working_directory_directive.path}\" - no workspace root set`);
+                    continue;
                 }
-                
                 return resolved_path;
             }
 
+            const normalized_parent_directives = this.normalize_directives(
+                my_parent_result.directives,
+                []
+            );
+            const effective_parent_directives =
+                this.get_effective_backward_directives(
+                    my_parent_uri,
+                    normalized_parent_directives,
+                    config
+                );
+
             // Otherwise, recursively search deeper ancestors
-            if (my_parent_result.directives.length > 0) {
+            if (effective_parent_directives.length > 0) {
                 // Mark as visited before recursing
                 visited.add(my_parent_uri);
 
                 const my_deeper_wd = await this.discover_working_directory(
-                    my_parent_result.directives,
+                    effective_parent_directives,
                     visited,
                     depth + 1,
                     config,
@@ -1436,10 +1507,16 @@ export class ScopeResolver {
                 my_parent_result.directives,
                 diagnostics
             );
+            const effective_parent_directives =
+                this.get_effective_backward_directives(
+                    my_parent_uri,
+                    normalized_parent_directives,
+                    config
+                );
             // Record chain length before recursion to strip locals from ancestor entries if needed
             const chain_length_before = chain.length;
             const recursive_result = await this.follow_directives(
-                normalized_parent_directives,
+                effective_parent_directives,
                 my_parent_uri,
                 visited,
                 chain,
@@ -1591,7 +1668,10 @@ export class ScopeResolver {
         const my_parse_result = this.parser.parse(my_lex_result.tokens);
 
         // Use file's own working_directory if present, otherwise use inherited
-        const effective_working_directory = my_directive_result.working_directory?.resolved_path ?? inherited_working_directory;
+        const effective_working_directory =
+            this.resolve_working_directory_directive(
+                my_directive_result.working_directory
+            ) ?? inherited_working_directory;
 
         // Pass working_directory to analyzer for path resolution in do/run/include commands
         const my_analysis = this.analyzer.analyze(my_parse_result.ast, uri, undefined, {

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -214,6 +214,13 @@ export async function create_server(options: ServerOptions): Promise<void> {
     }
 
     /**
+     * Get workspace-level settings without populating per-document caches.
+     */
+    function get_workspace_settings(): Promise<StataLSPConfig> {
+        return get_document_settings('');
+    }
+
+    /**
      * Get priority for a document based on visibility.
      */
     function get_document_priority(uri: string): number {
@@ -435,7 +442,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
         }
 
         document_settings.clear();
-        const settings = await get_document_settings('');
+        const settings = await get_workspace_settings();
 
         if (workspace_indexer) {
             workspace_indexer.configure(settings);
@@ -824,16 +831,18 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 if (!scope_resolver) {
                     return;
                 }
-                const settings = await get_document_settings(update.uri);
+                const workspace_settings = await get_workspace_settings();
                 const resolve_config = build_scope_resolver_config({
-                    assume_call_site: settings.cross_file?.assume_call_site,
+                    assume_call_site:
+                        workspace_settings.cross_file?.assume_call_site,
                     max_backward_depth:
-                        settings.cross_file?.max_backward_depth,
+                        workspace_settings.cross_file?.max_backward_depth,
                     max_forward_depth:
-                        settings.cross_file?.max_forward_depth,
-                    max_chain_depth: settings.cross_file?.max_chain_depth,
+                        workspace_settings.cross_file?.max_forward_depth,
+                    max_chain_depth:
+                        workspace_settings.cross_file?.max_chain_depth,
                     backward_dependencies:
-                        settings.cross_file?.backward_dependencies,
+                        workspace_settings.cross_file?.backward_dependencies,
                 });
 
                 scope_resolver.sync_backward_directive_dependencies(
@@ -863,7 +872,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 schedule_callee_revalidation(
                     affected_callees,
                     update.uri,
-                    settings
+                    workspace_settings
                 );
 
                 if (!interface_changed) {
@@ -880,7 +889,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     schedule_caller_revalidation(
                         caller_uris,
                         update.uri,
-                        settings
+                        workspace_settings
                     );
                 }
 
@@ -892,7 +901,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     schedule_caller_revalidation(
                         backward_children,
                         update.uri,
-                        settings
+                        workspace_settings
                     );
                 }
             });

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -835,12 +835,12 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     if (forward_scope_resolver) {
                         forward_scope_resolver.set_workspace_roots(folder_paths);
                     }
+                    if (scope_resolver) {
+                        scope_resolver.set_workspace_roots(folder_paths);
+                    }
+                    document_store.set_workspace_roots(folder_paths);
 
                     if (folder_paths.length > 0) {
-                        document_store.set_workspace_root(folder_paths[0]);
-                        if (scope_resolver) {
-                            scope_resolver.set_workspace_root(folder_paths[0]);
-                        }
                         const loaded = read_workspace_file_config_from_root(folder_paths[0]);
                         workspace_file_config = loaded.partial_config;
                         if (loaded.error) {
@@ -902,20 +902,16 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 connection.workspace.onDidChangeWorkspaceFolders(async (_event) => {
                     connection.console.log('Workspace folder change event received.');
                     const folders = await connection.workspace.getWorkspaceFolders();
-                    if (folders && folders.length > 0) {
-                        const folder_path = URI.parse(folders[0].uri).fsPath;
-                        if (folder_path) {
-                            document_store.set_workspace_root(folder_path);
-                            if (scope_resolver) {
-                                scope_resolver.set_workspace_root(folder_path);
-                            }
-                        }
-                    } else {
-                        document_store.set_workspace_root(undefined);
-                        if (scope_resolver) {
-                            scope_resolver.set_workspace_root(undefined);
-                        }
+                    const folder_paths = (folders ?? [])
+                        .map((my_folder) => URI.parse(my_folder.uri).fsPath)
+                        .filter((my_path) => my_path !== undefined);
+                    if (forward_scope_resolver) {
+                        forward_scope_resolver.set_workspace_roots(folder_paths);
                     }
+                    if (scope_resolver) {
+                        scope_resolver.set_workspace_roots(folder_paths);
+                    }
+                    document_store.set_workspace_roots(folder_paths);
                 });
             }
         })

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -24,7 +24,7 @@ import { command_database } from './command-database';
 import { StataLSPConfig } from './types';
 import type { DeepPartial } from './utils/workspace-config';
 import { WorkspaceIndexer } from './indexer';
-import { ScopeResolver } from './scope-resolver';
+import { ScopeResolver, build_scope_resolver_config } from './scope-resolver';
 import { ForwardScopeResolver } from './forward-scope-resolver';
 import { DocumentDebounceManager } from './utils/debounce-manager';
 import { validate_comment_formatting_config } from './utils/config-validator';
@@ -412,6 +412,69 @@ export async function create_server(options: ServerOptions): Promise<void> {
         }
     }
 
+    async function refresh_workspace_state(
+        folder_paths: string[]
+    ): Promise<void> {
+        if (forward_scope_resolver) {
+            forward_scope_resolver.set_workspace_roots(folder_paths);
+        }
+        if (scope_resolver) {
+            scope_resolver.set_workspace_roots(folder_paths);
+        }
+        document_store.set_workspace_roots(folder_paths);
+
+        workspace_file_config = undefined;
+        if (folder_paths.length > 0) {
+            const loaded = read_workspace_file_config_from_root(folder_paths[0]);
+            workspace_file_config = loaded.partial_config;
+            if (loaded.error) {
+                connection.console.log(
+                    `Error reading .sight.json: ${loaded.error}`
+                );
+            }
+        }
+
+        document_settings.clear();
+        const settings = await get_document_settings('');
+
+        if (workspace_indexer) {
+            workspace_indexer.configure(settings);
+            workspace_indexer.set_max_indexed_files(
+                settings.cross_file?.max_indexed_files ?? 1000
+            );
+            workspace_indexer.reset();
+        }
+
+        if (!server_capabilities.has_configuration_capability) {
+            global_settings = settings;
+        }
+
+        const enabled = settings.indexWorkspace !== false &&
+            settings.cross_file?.index_workspace !== false;
+        if (scope_resolver) {
+            scope_resolver.set_workspace_scan_complete(!enabled);
+        }
+
+        if (enabled && workspace_indexer) {
+            try {
+                await workspace_indexer.initialize(
+                    folder_paths,
+                    settings.adoPaths || []
+                );
+            } catch (error) {
+                connection.console.error(
+                    `Workspace indexing failed: ${error}`
+                );
+            }
+        }
+
+        if (scope_resolver) {
+            scope_resolver.set_workspace_scan_complete(true);
+            scope_resolver.clear_scope_cache();
+        }
+        revalidate_all_open_documents();
+    }
+
     // Mutable handler dependencies container (Req 4.1, 4.2, 14.1, 14.2).
     // Handlers capture this object by reference, so mutating its properties
     // after provider initialization makes new providers visible to all
@@ -761,10 +824,22 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 if (!scope_resolver) {
                     return;
                 }
+                const settings = await get_document_settings(update.uri);
+                const resolve_config = build_scope_resolver_config({
+                    assume_call_site: settings.cross_file?.assume_call_site,
+                    max_backward_depth:
+                        settings.cross_file?.max_backward_depth,
+                    max_forward_depth:
+                        settings.cross_file?.max_forward_depth,
+                    max_chain_depth: settings.cross_file?.max_chain_depth,
+                    backward_dependencies:
+                        settings.cross_file?.backward_dependencies,
+                });
 
                 scope_resolver.sync_backward_directive_dependencies(
                     update.uri,
-                    update.directives
+                    update.directives,
+                    resolve_config
                 );
                 const { affected_callees, interface_changed } =
                     scope_resolver.update_reverse_dependencies(
@@ -785,12 +860,41 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     return;
                 }
 
-                const settings = await get_document_settings(update.uri);
                 schedule_callee_revalidation(
                     affected_callees,
                     update.uri,
                     settings
                 );
+
+                if (!interface_changed) {
+                    return;
+                }
+
+                scope_resolver.invalidate_file_cache(update.uri, {
+                    preserve_forward_call_relationships: true,
+                });
+
+                const caller_uris =
+                    scope_resolver.get_callers_for_callee(update.uri);
+                if (caller_uris.size > 0) {
+                    schedule_caller_revalidation(
+                        caller_uris,
+                        update.uri,
+                        settings
+                    );
+                }
+
+                const backward_children =
+                    scope_resolver.get_transitive_backward_directive_children(
+                        update.uri
+                    );
+                if (backward_children.size > 0) {
+                    schedule_caller_revalidation(
+                        backward_children,
+                        update.uri,
+                        settings
+                    );
+                }
             });
 
             rename_handler = new RenameHandler(
@@ -827,72 +931,14 @@ export async function create_server(options: ServerOptions): Promise<void> {
             // Initialize workspace indexer
             const workspace_folders_promise = connection.workspace.getWorkspaceFolders();
             workspace_folders_promise.then((folders) => {
-                if (folders && workspace_indexer) {
-                    const folder_paths = folders
-                        .map((f) => URI.parse(f.uri).fsPath)
-                        .filter((p) => p !== undefined);
-
-                    if (forward_scope_resolver) {
-                        forward_scope_resolver.set_workspace_roots(folder_paths);
-                    }
-                    if (scope_resolver) {
-                        scope_resolver.set_workspace_roots(folder_paths);
-                    }
-                    document_store.set_workspace_roots(folder_paths);
-
-                    if (folder_paths.length > 0) {
-                        const loaded = read_workspace_file_config_from_root(folder_paths[0]);
-                        workspace_file_config = loaded.partial_config;
-                        if (loaded.error) {
-                            connection.console.log(`Error reading .sight.json: ${loaded.error}`);
-                        }
-                    }
-
-                    get_document_settings('').then((settings) => {
-                        if (workspace_indexer) {
-                            workspace_indexer.configure(settings);
-                            workspace_indexer.set_max_indexed_files(
-                                settings.cross_file?.max_indexed_files ?? 1000
-                            );
-                        }
-
-                        if (!server_capabilities.has_configuration_capability) {
-                            global_settings = settings;
-                        }
-
-                        const enabled = settings.indexWorkspace !== false &&
-                            settings.cross_file?.index_workspace !== false;
-                        if (scope_resolver) {
-                            scope_resolver.set_workspace_scan_complete(!enabled);
-                        }
-                        if (enabled && workspace_indexer) {
-                            workspace_indexer.initialize(
-                                folder_paths,
-                                settings.adoPaths || []
-                            ).then(() => {
-                                if (scope_resolver) {
-                                    scope_resolver.set_workspace_scan_complete(true);
-                                    // Scope entries cached during the initial scan
-                                    // may be missing auto-inferred parents because
-                                    // the reverse dependency graph was incomplete.
-                                    scope_resolver.clear_scope_cache();
-                                }
-                                revalidate_all_open_documents();
-                            }).catch((error) => {
-                                connection.console.error(
-                                    `Workspace indexing failed: ${error}`
-                                );
-                                if (scope_resolver) {
-                                    scope_resolver.set_workspace_scan_complete(true);
-                                    scope_resolver.clear_scope_cache();
-                                }
-                                revalidate_all_open_documents();
-                            });
-                        } else if (scope_resolver) {
-                            scope_resolver.set_workspace_scan_complete(true);
-                        }
-                    });
-                }
+                const folder_paths = (folders ?? [])
+                    .map((my_folder) => URI.parse(my_folder.uri).fsPath)
+                    .filter((my_path) => my_path !== undefined);
+                refresh_workspace_state(folder_paths).catch((error) => {
+                    connection.console.error(
+                        `Workspace refresh failed: ${error}`
+                    );
+                });
             });
 
             if (server_capabilities.has_configuration_capability) {
@@ -905,13 +951,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     const folder_paths = (folders ?? [])
                         .map((my_folder) => URI.parse(my_folder.uri).fsPath)
                         .filter((my_path) => my_path !== undefined);
-                    if (forward_scope_resolver) {
-                        forward_scope_resolver.set_workspace_roots(folder_paths);
-                    }
-                    if (scope_resolver) {
-                        scope_resolver.set_workspace_roots(folder_paths);
-                    }
-                    document_store.set_workspace_roots(folder_paths);
+                    await refresh_workspace_state(folder_paths);
                 });
             }
         })

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -872,6 +872,10 @@ export async function create_server(options: ServerOptions): Promise<void> {
                             ).then(() => {
                                 if (scope_resolver) {
                                     scope_resolver.set_workspace_scan_complete(true);
+                                    // Scope entries cached during the initial scan
+                                    // may be missing auto-inferred parents because
+                                    // the reverse dependency graph was incomplete.
+                                    scope_resolver.clear_scope_cache();
                                 }
                                 revalidate_all_open_documents();
                             }).catch((error) => {
@@ -880,6 +884,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
                                 );
                                 if (scope_resolver) {
                                     scope_resolver.set_workspace_scan_complete(true);
+                                    scope_resolver.clear_scope_cache();
                                 }
                                 revalidate_all_open_documents();
                             });

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -649,6 +649,22 @@ export async function create_server(options: ServerOptions): Promise<void> {
         );
     }
 
+    function revalidate_all_open_documents(): void {
+        if (diagnostics_provider) {
+            for (const my_doc of documents.all()) {
+                diagnostics_provider.clear_published_version(my_doc.uri);
+            }
+        }
+
+        documents.all().forEach((my_doc) => {
+            validate_text_document(my_doc).catch((err) => {
+                connection.console.error(
+                    `Error validating ${my_doc.uri} after workspace scan: ${err}`
+                );
+            });
+        });
+    }
+
     // Wire initialize handler
     connection.onInitialize(
         create_initialize_handler(
@@ -741,6 +757,41 @@ export async function create_server(options: ServerOptions): Promise<void> {
             });
 
             scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+            workspace_indexer.set_on_file_indexed(async (update) => {
+                if (!scope_resolver) {
+                    return;
+                }
+
+                scope_resolver.sync_backward_directive_dependencies(
+                    update.uri,
+                    update.directives
+                );
+                const { affected_callees, interface_changed } =
+                    scope_resolver.update_reverse_dependencies(
+                        update.uri,
+                        update.forward_calls,
+                        update.symbols
+                    );
+
+                if (!scope_resolver.is_workspace_scan_complete()) {
+                    return;
+                }
+
+                if (affected_callees.size > 0) {
+                    scope_resolver.cascade_invalidate(affected_callees);
+                }
+
+                if (affected_callees.size === 0 && !interface_changed) {
+                    return;
+                }
+
+                const settings = await get_document_settings(update.uri);
+                schedule_callee_revalidation(
+                    affected_callees,
+                    update.uri,
+                    settings
+                );
+            });
 
             rename_handler = new RenameHandler(
                 (file_path: string) => {
@@ -811,8 +862,29 @@ export async function create_server(options: ServerOptions): Promise<void> {
 
                         const enabled = settings.indexWorkspace !== false &&
                             settings.cross_file?.index_workspace !== false;
+                        if (scope_resolver) {
+                            scope_resolver.set_workspace_scan_complete(!enabled);
+                        }
                         if (enabled && workspace_indexer) {
-                            workspace_indexer.initialize(folder_paths, settings.adoPaths || []);
+                            workspace_indexer.initialize(
+                                folder_paths,
+                                settings.adoPaths || []
+                            ).then(() => {
+                                if (scope_resolver) {
+                                    scope_resolver.set_workspace_scan_complete(true);
+                                }
+                                revalidate_all_open_documents();
+                            }).catch((error) => {
+                                connection.console.error(
+                                    `Workspace indexing failed: ${error}`
+                                );
+                                if (scope_resolver) {
+                                    scope_resolver.set_workspace_scan_complete(true);
+                                }
+                                revalidate_all_open_documents();
+                            });
+                        } else if (scope_resolver) {
+                            scope_resolver.set_workspace_scan_complete(true);
                         }
                     });
                 }

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -403,7 +403,9 @@ export function create_hover_handler(
             ? deps.workspace_indexer.get_all_symbols()
             : undefined;
         const config = await deps.get_document_settings(params.textDocument.uri);
-        const workspace_root = deps.document_store.get_workspace_root();
+        const workspace_root = deps.document_store.get_workspace_root_for_uri(
+            params.textDocument.uri
+        );
         return await deps.hover_provider.get_hover(
             document_state,
             params.position,

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -125,6 +125,7 @@ export const DEFAULT_SETTINGS: StataLSPConfig = {
         max_backward_depth: 10,
         max_forward_depth: 10,
         max_chain_depth: 20,
+        backward_dependencies: 'auto',
         max_callee_revalidations: 10,
         diagnostics: {
             out_of_scope: 'information',

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -341,6 +341,7 @@ export function create_completion_handler(
                 {
                     assume_call_site: config.cross_file?.assume_call_site,
                     max_forward_depth: config.cross_file?.max_forward_depth,
+                    backward_dependencies: config.cross_file?.backward_dependencies,
                 },
                 forward_scope,
                 workspace_version,
@@ -411,6 +412,7 @@ export function create_hover_handler(
             {
                 assume_call_site: config.cross_file?.assume_call_site,
                 max_forward_depth: config.cross_file?.max_forward_depth,
+                backward_dependencies: config.cross_file?.backward_dependencies,
             },
             token,
             workspace_root
@@ -450,6 +452,7 @@ export function create_definition_handler(
             {
                 assume_call_site: config.cross_file?.assume_call_site,
                 max_forward_depth: config.cross_file?.max_forward_depth,
+                backward_dependencies: config.cross_file?.backward_dependencies,
             },
             token
         );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -625,6 +625,7 @@ export interface ScopeResolverConfig {
   max_backward_depth: number;      // Limit backward directive chain depth (@lsp-done-by, @lsp-included-by)
   max_forward_depth: number;       // Limit forward-call recursion depth (do/run/include commands)
   max_chain_depth: number;         // Overall limit for combined forward + backward resolution
+  backward_dependencies?: 'auto' | 'explicit';
   diagnostics?: {
     max_depth?: 'error' | 'warning' | 'information' | 'off';
     // Severity for call site identification diagnostics
@@ -658,6 +659,7 @@ export interface CrossFileConfig {
   max_backward_depth: number;      // Limit backward directive chain depth
   max_forward_depth: number;       // Limit forward-call recursion depth  
   max_chain_depth: number;         // Overall limit for combined resolution
+  backward_dependencies: 'auto' | 'explicit';
   max_callee_revalidations?: number;  // Maximum callees to revalidate per caller change (default: 10)
   diagnostics: {
     out_of_scope: 'error' | 'warning' | 'information' | 'off';

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -248,6 +248,12 @@ export function validate_comment_formatting_config(
         if (cross_file.assume_call_site === 'end' || cross_file.assume_call_site === 'start') {
             validated_config.cross_file.assume_call_site = cross_file.assume_call_site;
         }
+        if (
+            cross_file.backward_dependencies === 'auto' ||
+            cross_file.backward_dependencies === 'explicit'
+        ) {
+            validated_config.cross_file.backward_dependencies = cross_file.backward_dependencies;
+        }
 
         if (typeof cross_file.max_backward_depth === 'number' && cross_file.max_backward_depth > 0) {
             validated_config.cross_file.max_backward_depth = cross_file.max_backward_depth;

--- a/src/utils/workspace-config.ts
+++ b/src/utils/workspace-config.ts
@@ -82,6 +82,12 @@ export function map_stata_lsp_json_to_partial_config(raw: unknown): DeepPartial<
         if (cross_file_obj.assumeCallSite === 'end' || cross_file_obj.assumeCallSite === 'start') {
             mapped.cross_file!.assume_call_site = cross_file_obj.assumeCallSite;
         }
+        if (
+            cross_file_obj.backwardDependencies === 'auto' ||
+            cross_file_obj.backwardDependencies === 'explicit'
+        ) {
+            mapped.cross_file!.backward_dependencies = cross_file_obj.backwardDependencies;
+        }
         if (typeof cross_file_obj.maxBackwardDepth === 'number') {
             mapped.cross_file!.max_backward_depth = cross_file_obj.maxBackwardDepth;
         }

--- a/tests/integration/working-directory-inheritance.test.ts
+++ b/tests/integration/working-directory-inheritance.test.ts
@@ -214,6 +214,74 @@ local result \`parent_var'
         });
     });
 
+    describe('Multi-root DocumentStore behavior', () => {
+        it('uses the matching workspace root for workspace-relative @lsp-cd', async () => {
+            const first_root = path.join(test_dir, 'workspace-a');
+            const second_root = path.join(test_dir, 'workspace-b');
+            document_store.set_workspace_roots([first_root, second_root]);
+            scope_resolver.set_workspace_roots([first_root, second_root]);
+
+            write_file('workspace-a/data/load_data.do', '* wrong root');
+            write_file('workspace-b/data/load_data.do', '* right root');
+
+            const child_content = `// @lsp-cd: "/data"
+do "load_data.do"
+`;
+            const child_path = write_file(
+                'workspace-b/scripts/analysis.do',
+                child_content
+            );
+            const child_uri = URI.file(child_path).toString();
+
+            await document_store.open(child_uri, child_content, 1);
+            const document_state = document_store.get(child_uri);
+
+            expect(document_state).toBeDefined();
+            expect(document_state!.working_directory).toBeDefined();
+            expect(document_state!.working_directory).toBe(
+                path.join(second_root, 'data')
+            );
+
+            const load_data_call = document_state!.forward_calls.find(
+                my_call => my_call.raw_path === 'load_data.do'
+            );
+            expect(load_data_call).toBeDefined();
+            expect(load_data_call!.path).toBe(
+                path.join(second_root, 'data', 'load_data.do')
+            );
+        });
+
+        it('uses the matching workspace root for analyzer fallback paths', async () => {
+            const first_root = path.join(test_dir, 'workspace-a');
+            const second_root = path.join(test_dir, 'workspace-b');
+            document_store.set_workspace_roots([first_root, second_root]);
+
+            write_file('workspace-a/shared/load_data.do', '* wrong root');
+            write_file('workspace-b/shared/load_data.do', '* right root');
+
+            const child_content = `do "shared/load_data"
+`;
+            const child_path = write_file(
+                'workspace-b/scripts/analysis.do',
+                child_content
+            );
+            const child_uri = URI.file(child_path).toString();
+
+            await document_store.open(child_uri, child_content, 1);
+            const document_state = document_store.get(child_uri);
+
+            expect(document_state).toBeDefined();
+
+            const load_data_call = document_state!.forward_calls.find(
+                my_call => my_call.raw_path === 'shared/load_data'
+            );
+            expect(load_data_call).toBeDefined();
+            expect(load_data_call!.path).toBe(
+                path.join(second_root, 'shared', 'load_data.do')
+            );
+        });
+    });
+
     describe('Chain Propagation', () => {
         it('should propagate working directory through multi-level chain', async () => {
             // Create chain: root.do -> middle.do -> leaf.do

--- a/tests/property/config-mapping-type-safety.prop.test.ts
+++ b/tests/property/config-mapping-type-safety.prop.test.ts
@@ -27,6 +27,10 @@ describe('Config Mapping Type Safety Property Tests', () => {
                         fc.constant('end' as const),
                         fc.constant('start' as const)
                     ),
+                    backwardDependencies: fc.oneof(
+                        fc.constant('auto' as const),
+                        fc.constant('explicit' as const)
+                    ),
                 }),
                 (my_cross_file_config) => {
                     const my_raw = {
@@ -45,6 +49,9 @@ describe('Config Mapping Type Safety Property Tests', () => {
                     );
                     expect(my_result.cross_file!.assume_call_site).toBe(
                         my_cross_file_config.assumeCallSite
+                    );
+                    expect(my_result.cross_file!.backward_dependencies).toBe(
+                        my_cross_file_config.backwardDependencies
                     );
                 }
             ),
@@ -236,6 +243,13 @@ describe('Config Mapping Type Safety Property Tests', () => {
                         fc.integer(),
                         fc.boolean()
                     ),
+                    backwardDependencies: fc.oneof(
+                        fc.string().filter(
+                            (s) => s !== 'auto' && s !== 'explicit'
+                        ),
+                        fc.integer(),
+                        fc.boolean()
+                    ),
                 }),
                 (my_invalid_types) => {
                     const my_raw = {
@@ -248,6 +262,9 @@ describe('Config Mapping Type Safety Property Tests', () => {
                     expect(my_result.cross_file!.index_workspace).toBeUndefined();
                     expect(my_result.cross_file!.max_indexed_files).toBeUndefined();
                     expect(my_result.cross_file!.assume_call_site).toBeUndefined();
+                    expect(
+                        my_result.cross_file!.backward_dependencies
+                    ).toBeUndefined();
                 }
             ),
             { numRuns: 100 }

--- a/tests/test-config-helper.ts
+++ b/tests/test-config-helper.ts
@@ -16,6 +16,7 @@ export function createTestConfig(overrides: Partial<StataLSPConfig> = {}): Stata
         max_backward_depth: 10,
         max_forward_depth: 10,
         max_chain_depth: 20,
+        backward_dependencies: 'auto',
         max_callee_revalidations: 10,
         assume_call_site: 'end',
         diagnostics: {

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -1118,6 +1118,52 @@ display \`result'
             expect(out_of_scope_diag).toBeDefined();
             expect(out_of_scope_diag?.message).toContain('after the call site');
         });
+
+        it('defers undefined symbol diagnostics while auto backward scan is incomplete', async () => {
+            const document = create_real_document_state(
+                "display `undefined_macro'"
+            );
+            const auto_config = {
+                ...DEFAULT_CONFIG,
+                cross_file: {
+                    index_workspace: true,
+                    max_indexed_files: 1000,
+                    assume_call_site: 'end' as const,
+                    max_backward_depth: 10,
+                    max_forward_depth: 10,
+                    max_chain_depth: 20,
+                    backward_dependencies: 'auto' as const,
+                    diagnostics: {
+                        out_of_scope: 'information' as const,
+                        missing_file: 'warning' as const,
+                        max_depth: 'warning' as const,
+                    },
+                },
+            } as any;
+
+            const mock_scope_resolver = {
+                resolve: async () => ({
+                    symbols: create_empty_symbol_table(),
+                    chain: [],
+                    out_of_scope_symbols: [],
+                    diagnostics: [],
+                    has_directives: false,
+                }),
+                is_workspace_scan_complete: () => false,
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                auto_config,
+                undefined,
+                mock_scope_resolver as any
+            );
+
+            const undefined_macro = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(undefined_macro).toBeUndefined();
+        });
     });
 });
       

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -257,4 +257,19 @@ describe('WorkspaceIndexer', () => {
             path.join(second_data_dir, 'child.do')
         );
     });
+
+    it('should match relative workspace roots against absolute file paths', async () => {
+        const relative_workspace_root = path.relative(
+            process.cwd(),
+            temp_dir
+        );
+
+        await indexer.initialize([relative_workspace_root]);
+
+        expect(
+            (indexer as any).get_workspace_root_for_file(
+                path.join(temp_dir, 'nested', 'file.do')
+            )
+        ).toBe(path.resolve(temp_dir));
+    });
 });

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -191,4 +191,53 @@ describe('WorkspaceIndexer', () => {
             )
         ).toBe(true);
     });
+
+    it('should derive the workspace root from each indexed file', async () => {
+        const the_updates: any[] = [];
+        indexer.set_on_file_indexed((my_update) => {
+            the_updates.push(my_update);
+        });
+
+        const first_workspace_root = path.join(temp_dir, 'ws1');
+        const second_workspace_root = path.join(temp_dir, 'ws2');
+        const first_data_dir = path.join(first_workspace_root, 'data');
+        const second_data_dir = path.join(second_workspace_root, 'data');
+        const second_scripts_dir = path.join(second_workspace_root, 'scripts');
+        fs.mkdirSync(first_workspace_root, { recursive: true });
+        fs.mkdirSync(first_data_dir, { recursive: true });
+        fs.mkdirSync(second_data_dir, { recursive: true });
+        fs.mkdirSync(second_scripts_dir, { recursive: true });
+
+        fs.writeFileSync(
+            path.join(first_data_dir, 'child.do'),
+            'global WRONG_ROOT \"1\"\n',
+        );
+        fs.writeFileSync(
+            path.join(second_data_dir, 'child.do'),
+            'global RIGHT_ROOT \"1\"\n'
+        );
+
+        const caller_path = path.join(second_scripts_dir, 'caller.do');
+        fs.writeFileSync(
+            caller_path,
+            '// @lsp-cd /data\n' +
+            'do \"child.do\"\n'
+        );
+
+        await indexer.initialize([
+            first_workspace_root,
+            second_workspace_root,
+        ]);
+
+        const caller_uri = URI.file(caller_path).toString();
+        const caller_update = the_updates.find(
+            (my_update) => my_update.uri === caller_uri
+        );
+
+        expect(caller_update).toBeDefined();
+        expect(caller_update.forward_calls).toHaveLength(1);
+        expect(caller_update.forward_calls[0].path).toBe(
+            path.join(second_data_dir, 'child.do')
+        );
+    });
 });

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -125,6 +125,23 @@ describe('WorkspaceIndexer', () => {
         expect(metrics.avg_file_time_ms).toBeGreaterThanOrEqual(0);
     });
 
+    it('should keep indexed state when on_file_indexed callback throws', async () => {
+        const file_path = path.join(temp_dir, 'callback-error.do');
+        fs.writeFileSync(file_path, 'program define callback_prog\\nend');
+
+        indexer.set_on_file_indexed(() => {
+            throw new Error('callback failure');
+        });
+
+        await indexer.index_file(file_path);
+
+        const symbols = indexer.get_all_symbols();
+        const metrics = indexer.get_metrics();
+        expect(symbols.programs.has('callback_prog')).toBe(true);
+        expect(metrics.files_indexed).toBe(1);
+        expect(metrics.files_skipped).toBe(0);
+    });
+
     it('should skip files larger than MAX_FILE_SIZE_BYTES', async () => {
         const file_path = path.join(temp_dir, 'large.do');
         // Create a file larger than 10MB

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -127,7 +127,7 @@ describe('WorkspaceIndexer', () => {
 
     it('should keep indexed state when on_file_indexed callback throws', async () => {
         const file_path = path.join(temp_dir, 'callback-error.do');
-        fs.writeFileSync(file_path, 'program define callback_prog\\nend');
+        fs.writeFileSync(file_path, 'program define callback_prog\nend');
 
         indexer.set_on_file_indexed(() => {
             throw new Error('callback failure');

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -154,4 +154,41 @@ describe('WorkspaceIndexer', () => {
         // Should only index once despite 3 schedule calls
         expect(metrics.files_indexed).toBe(1);
     });
+
+    it('should report indexed forward calls with workspace-root-aware paths', async () => {
+        const the_updates: any[] = [];
+        indexer.set_on_file_indexed((my_update) => {
+            the_updates.push(my_update);
+        });
+
+        const data_dir = path.join(temp_dir, 'data');
+        const sub_dir = path.join(temp_dir, 'sub');
+        fs.mkdirSync(data_dir);
+        fs.mkdirSync(sub_dir);
+
+        const child_path = path.join(data_dir, 'child.do');
+        fs.writeFileSync(child_path, 'global CHILD_VAR "1"\n');
+
+        const caller_path = path.join(sub_dir, 'caller.do');
+        fs.writeFileSync(
+            caller_path,
+            'do "data/child.do"\n' +
+            '// @lsp-do: "../data/child.do"\n'
+        );
+
+        await indexer.initialize([temp_dir]);
+
+        const caller_uri = URI.file(caller_path).toString();
+        const caller_update = the_updates.find(
+            (my_update) => my_update.uri === caller_uri
+        );
+
+        expect(caller_update).toBeDefined();
+        expect(caller_update.forward_calls).toHaveLength(2);
+        expect(
+            caller_update.forward_calls.every(
+                (my_call: any) => my_call.path === child_path
+            )
+        ).toBe(true);
+    });
 });

--- a/tests/unit/scope-resolver-auto-backward-dependencies.test.ts
+++ b/tests/unit/scope-resolver-auto-backward-dependencies.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { URI } from 'vscode-uri';
 import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
 
 describe('ScopeResolver auto backward dependencies', () => {
     let temp_dir: string;
@@ -146,6 +147,44 @@ describe('ScopeResolver auto backward dependencies', () => {
         ).toBe(true);
     });
 
+    it('registers synthesized auto parents for transitive child lookups', async () => {
+        const child_path = write_test_file('child.do', 'display $FROM_GRANDPARENT');
+        const parent_content =
+            'do \"child.do\"\n';
+        const parent_path = write_test_file('parent.do', parent_content);
+        const grandparent_content =
+            'global FROM_GRANDPARENT \"1\"\n' +
+            'do \"parent.do\"\n';
+        const grandparent_path = write_test_file(
+            'grandparent.do',
+            grandparent_content
+        );
+
+        seed_forward_calls(parent_path, parent_content);
+        seed_forward_calls(grandparent_path, grandparent_content);
+
+        const child_uri = URI.file(child_path).toString();
+        const parent_uri = URI.file(parent_path).toString();
+        const grandparent_uri = URI.file(grandparent_path).toString();
+
+        await resolver.resolve(
+            child_uri,
+            fs.readFileSync(child_path, 'utf8'),
+            { backward_dependencies: 'auto' }
+        );
+
+        expect(
+            resolver.get_backward_directive_children(parent_uri).has(child_uri)
+        ).toBe(true);
+
+        const transitive_children =
+            resolver.get_transitive_backward_directive_children(
+                grandparent_uri
+            );
+        expect(transitive_children.has(parent_uri)).toBe(true);
+        expect(transitive_children.has(child_uri)).toBe(true);
+    });
+
     it('inherits working directories through multi-hop inferred parents', async () => {
         const data_dir = path.join(temp_dir, 'data');
         fs.mkdirSync(data_dir, { recursive: true });
@@ -174,5 +213,60 @@ describe('ScopeResolver auto backward dependencies', () => {
         );
 
         expect(resolved_scope.inherited_working_directory).toBe(data_dir);
+    });
+
+    it('uses the matching workspace root for workspace-relative working directories', async () => {
+        const first_workspace_root = path.join(temp_dir, 'ws1');
+        const second_workspace_root = path.join(temp_dir, 'ws2');
+        const first_data_dir = path.join(first_workspace_root, 'data');
+        const second_data_dir = path.join(second_workspace_root, 'data');
+        const second_scripts_dir = path.join(second_workspace_root, 'scripts');
+        fs.mkdirSync(first_data_dir, { recursive: true });
+        fs.mkdirSync(second_data_dir, { recursive: true });
+        fs.mkdirSync(second_scripts_dir, { recursive: true });
+
+        fs.writeFileSync(
+            path.join(first_data_dir, 'child.do'),
+            'global WRONG_ROOT \"1\"\n'
+        );
+        fs.writeFileSync(
+            path.join(second_data_dir, 'child.do'),
+            'global RIGHT_ROOT \"1\"\n'
+        );
+
+        const caller_path = path.join(second_scripts_dir, 'caller.do');
+        const caller_content =
+            '// @lsp-cd /data\n' +
+            'do \"child.do\"\n';
+        fs.writeFileSync(caller_path, caller_content);
+
+        const forward_resolver = new ForwardScopeResolver(resolver);
+        resolver.set_forward_scope_resolver(forward_resolver);
+        resolver.set_workspace_roots([
+            first_workspace_root,
+            second_workspace_root,
+        ]);
+        forward_resolver.set_workspace_roots([
+            first_workspace_root,
+            second_workspace_root,
+        ]);
+
+        const caller_uri = URI.file(caller_path).toString();
+        const resolved_scope = await resolver.resolve(caller_uri, caller_content);
+
+        expect(resolved_scope.forward_call_symbols).toHaveLength(1);
+        expect(resolved_scope.forward_call_symbols?.[0]?.callee_uri).toBe(
+            URI.file(path.join(second_data_dir, 'child.do')).toString()
+        );
+        expect(
+            resolved_scope.forward_call_symbols?.[0]?.symbols.globalMacros.has(
+                'RIGHT_ROOT'
+            )
+        ).toBe(true);
+        expect(
+            resolved_scope.forward_call_symbols?.[0]?.symbols.globalMacros.has(
+                'WRONG_ROOT'
+            )
+        ).toBe(false);
     });
 });

--- a/tests/unit/scope-resolver-auto-backward-dependencies.test.ts
+++ b/tests/unit/scope-resolver-auto-backward-dependencies.test.ts
@@ -109,4 +109,70 @@ describe('ScopeResolver auto backward dependencies', () => {
             )
         ).toBe(true);
     });
+
+    it('follows multi-hop inferred parents in auto mode', async () => {
+        const child_path = write_test_file('child.do', 'display $FROM_GRANDPARENT');
+        const parent_content =
+            'do \"child.do\"\n';
+        const parent_path = write_test_file('parent.do', parent_content);
+        const grandparent_content =
+            'global FROM_GRANDPARENT \"1\"\n' +
+            'do \"parent.do\"\n';
+        const grandparent_path = write_test_file(
+            'grandparent.do',
+            grandparent_content
+        );
+
+        seed_forward_calls(parent_path, parent_content);
+        seed_forward_calls(grandparent_path, grandparent_content);
+
+        const child_uri = URI.file(child_path).toString();
+        const resolved_scope = await resolver.resolve(
+            child_uri,
+            fs.readFileSync(child_path, 'utf8'),
+            { backward_dependencies: 'auto' }
+        );
+
+        expect(resolved_scope.symbols.globalMacros.has('FROM_GRANDPARENT')).toBe(true);
+        expect(
+            resolved_scope.chain.some(
+                (my_entry) => my_entry.uri === URI.file(parent_path).toString()
+            )
+        ).toBe(true);
+        expect(
+            resolved_scope.chain.some(
+                (my_entry) => my_entry.uri === URI.file(grandparent_path).toString()
+            )
+        ).toBe(true);
+    });
+
+    it('inherits working directories through multi-hop inferred parents', async () => {
+        const data_dir = path.join(temp_dir, 'data');
+        fs.mkdirSync(data_dir, { recursive: true });
+        const child_path = path.join(data_dir, 'child.do');
+        fs.writeFileSync(child_path, 'display \"hello\"');
+        const parent_content =
+            'do \"child.do\"\n';
+        const parent_path = path.join(data_dir, 'parent.do');
+        fs.writeFileSync(parent_path, parent_content);
+        const grandparent_content =
+            '// @lsp-cd /data\n' +
+            'do \"parent.do\"\n';
+        const grandparent_path = write_test_file(
+            'grandparent.do',
+            grandparent_content
+        );
+
+        seed_forward_calls(parent_path, parent_content);
+        seed_forward_calls(grandparent_path, grandparent_content);
+
+        const child_uri = URI.file(child_path).toString();
+        const resolved_scope = await resolver.resolve(
+            child_uri,
+            fs.readFileSync(child_path, 'utf8'),
+            { backward_dependencies: 'auto' }
+        );
+
+        expect(resolved_scope.inherited_working_directory).toBe(data_dir);
+    });
 });

--- a/tests/unit/scope-resolver-auto-backward-dependencies.test.ts
+++ b/tests/unit/scope-resolver-auto-backward-dependencies.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
+import { ScopeResolver } from '../../src/scope-resolver';
+
+describe('ScopeResolver auto backward dependencies', () => {
+    let temp_dir: string;
+    let resolver: ScopeResolver;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sight-auto-backward-'));
+        resolver = new ScopeResolver();
+        resolver.set_workspace_root(temp_dir);
+    });
+
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    function write_test_file(name: string, content: string): string {
+        const file_path = path.join(temp_dir, name);
+        fs.writeFileSync(file_path, content);
+        return file_path;
+    }
+
+    function seed_forward_calls(file_path: string, content: string): void {
+        const file_uri = URI.file(file_path).toString();
+        const parse_result = (resolver as any).parse_file(file_uri, content);
+        resolver.update_reverse_dependencies(
+            file_uri,
+            parse_result.forward_calls,
+            parse_result.symbols
+        );
+    }
+
+    it('inherits parent scope from indexed forward calls in auto mode', async () => {
+        const child_path = write_test_file('child.do', 'display $AUTO_PARENT');
+        const parent_content =
+            'global AUTO_PARENT "1"\n' +
+            'do "child.do"\n';
+        const parent_path = write_test_file('parent.do', parent_content);
+
+        seed_forward_calls(parent_path, parent_content);
+
+        const child_uri = URI.file(child_path).toString();
+        const resolved_scope = await resolver.resolve(
+            child_uri,
+            fs.readFileSync(child_path, 'utf8'),
+            { backward_dependencies: 'auto' }
+        );
+
+        expect(resolved_scope.has_directives).toBe(false);
+        expect(resolved_scope.chain.length).toBeGreaterThan(1);
+        expect(resolved_scope.symbols.globalMacros.has('AUTO_PARENT')).toBe(true);
+    });
+
+    it('does not infer parent scope in explicit mode', async () => {
+        const child_path = write_test_file('child.do', 'display $AUTO_PARENT');
+        const parent_content =
+            'global AUTO_PARENT "1"\n' +
+            'do "child.do"\n';
+        const parent_path = write_test_file('parent.do', parent_content);
+
+        seed_forward_calls(parent_path, parent_content);
+
+        const child_uri = URI.file(child_path).toString();
+        const resolved_scope = await resolver.resolve(
+            child_uri,
+            fs.readFileSync(child_path, 'utf8'),
+            { backward_dependencies: 'explicit' }
+        );
+
+        expect(resolved_scope.chain).toHaveLength(1);
+        expect(resolved_scope.symbols.globalMacros.has('AUTO_PARENT')).toBe(false);
+    });
+
+    it('prefers explicit backward directives over auto-inferred parents', async () => {
+        const child_content =
+            '// @lsp-done-by "explicit-parent.do"\n' +
+            'display $EXPLICIT_PARENT\n';
+        const child_path = write_test_file('child.do', child_content);
+        const explicit_parent_path = write_test_file(
+            'explicit-parent.do',
+            'global EXPLICIT_PARENT "1"\n'
+        );
+        const auto_parent_content =
+            'global AUTO_PARENT "1"\n' +
+            'do "child.do"\n';
+        const auto_parent_path = write_test_file('auto-parent.do', auto_parent_content);
+
+        seed_forward_calls(auto_parent_path, auto_parent_content);
+
+        const child_uri = URI.file(child_path).toString();
+        const resolved_scope = await resolver.resolve(
+            child_uri,
+            child_content,
+            { backward_dependencies: 'auto' }
+        );
+
+        expect(
+            resolved_scope.symbols.globalMacros.has('EXPLICIT_PARENT')
+        ).toBe(true);
+        expect(resolved_scope.symbols.globalMacros.has('AUTO_PARENT')).toBe(false);
+        expect(
+            resolved_scope.chain.some(
+                (my_entry) => my_entry.uri === URI.file(explicit_parent_path).toString()
+            )
+        ).toBe(true);
+    });
+});

--- a/tests/unit/scope-resolver-auto-backward-dependencies.test.ts
+++ b/tests/unit/scope-resolver-auto-backward-dependencies.test.ts
@@ -77,6 +77,25 @@ describe('ScopeResolver auto backward dependencies', () => {
         expect(resolved_scope.symbols.globalMacros.has('AUTO_PARENT')).toBe(false);
     });
 
+    it('syncs inferred parents when config is omitted', () => {
+        const child_path = write_test_file('child.do', 'display $AUTO_PARENT');
+        const parent_content =
+            'global AUTO_PARENT "1"\n' +
+            'do "child.do"\n';
+        const parent_path = write_test_file('parent.do', parent_content);
+
+        seed_forward_calls(parent_path, parent_content);
+
+        const child_uri = URI.file(child_path).toString();
+        const parent_uri = URI.file(parent_path).toString();
+
+        resolver.sync_backward_directive_dependencies(child_uri, []);
+
+        expect(
+            resolver.get_backward_directive_children(parent_uri).has(child_uri)
+        ).toBe(true);
+    });
+
     it('prefers explicit backward directives over auto-inferred parents', async () => {
         const child_content =
             '// @lsp-done-by "explicit-parent.do"\n' +

--- a/tests/unit/scope-resolver-cache.test.ts
+++ b/tests/unit/scope-resolver-cache.test.ts
@@ -187,6 +187,49 @@ local x = 1
         });
     });
 
+    describe('clear_scope_cache', () => {
+        it('refreshes auto backward scope after reverse dependencies appear', async () => {
+            const child_content = 'display $AUTO_PARENT';
+            const child_path = create_file('child.do', child_content);
+            const child_uri = `file://${child_path}`;
+            const parent_content =
+                'global AUTO_PARENT "1"\n' +
+                'do "child.do"\n';
+            const parent_path = create_file('parent.do', parent_content);
+            const parent_uri = `file://${parent_path}`;
+
+            const first_result = await resolver.resolve(
+                child_uri,
+                child_content,
+                { backward_dependencies: 'auto' }
+            );
+            expect(first_result.symbols.globalMacros.has('AUTO_PARENT')).toBe(
+                false
+            );
+
+            const parse_result = (resolver as any).parse_file(
+                parent_uri,
+                parent_content
+            );
+            resolver.update_reverse_dependencies(
+                parent_uri,
+                parse_result.forward_calls,
+                parse_result.symbols
+            );
+
+            resolver.clear_scope_cache();
+
+            const second_result = await resolver.resolve(
+                child_uri,
+                child_content,
+                { backward_dependencies: 'auto' }
+            );
+            expect(second_result.symbols.globalMacros.has('AUTO_PARENT')).toBe(
+                true
+            );
+        });
+    });
+
     describe('reset_cache_metrics', () => {
         it('should reset all counters without clearing caches', async () => {
             const file_path = create_file('test.do', 'local x = 1');

--- a/tests/unit/scope-resolver-config.test.ts
+++ b/tests/unit/scope-resolver-config.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test';
+import { build_scope_resolver_config } from '../../src/scope-resolver';
+
+describe('build_scope_resolver_config', () => {
+    it('omits undefined top-level keys', () => {
+        const my_config = build_scope_resolver_config({
+            max_forward_depth: 7,
+            backward_dependencies: undefined,
+        });
+
+        expect(my_config).toEqual({
+            max_forward_depth: 7,
+        });
+        expect('backward_dependencies' in my_config).toBe(false);
+    });
+
+    it('omits empty diagnostics objects', () => {
+        const my_config = build_scope_resolver_config({
+            diagnostics: {
+                max_depth: undefined,
+                call_site_identification: undefined,
+            },
+        });
+
+        expect(my_config).toEqual({});
+        expect('diagnostics' in my_config).toBe(false);
+    });
+
+    it('preserves explicitly provided backward dependency mode', () => {
+        const my_config = build_scope_resolver_config({
+            backward_dependencies: 'explicit',
+            diagnostics: {
+                max_depth: 'warning',
+            },
+        });
+
+        expect(my_config).toEqual({
+            backward_dependencies: 'explicit',
+            diagnostics: {
+                max_depth: 'warning',
+            },
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- port `crossFile.backwardDependencies=auto` into Sight config, scope resolution, and diagnostics deferral
- feed indexed forward-call relationships into reverse dependency tracking and revalidate open documents after the initial workspace scan
- add coverage for auto backward inference, indexer callback updates, diagnostics deferral, and config mapping

## Validation
- `bun run typecheck`
- `bun test tests/integration`
- `bun run test`

Co-Authored-By: Oz <oz-agent@warp.dev>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backward-dependency mode ('auto' | 'explicit') with default 'auto' for cross-file resolution
  * Per-file indexing notifications with symbol/directive/forward-call updates; workspace-root-aware resolution and per-file working-directory handling
  * Multi-root workspace support, workspace-scan completion flag, and workspace refresh/revalidation hooks
  * Unified scope-resolver config helper for consistent cross-file options

* **Bug Fixes**
  * Suppress spurious undefined-symbol diagnostics during incomplete workspace scans

* **Tests**
  * Expanded tests for backward-dependencies, indexing, cache/refresh, working-directory inheritance, and deferred diagnostics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->