### PR TITLE
t3code/713b915d

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,9 +220,9 @@ Completion requests are race-prone against document updates. The `server-handler
 distinct scoping tiers by design: (1) **local macros** — include-chain files
 only (Stata locals don't propagate through `do`/`run`); (2) **global macros,
 programs, scalars, matrices** — dep-graph-reachable files (all do/run/include
-edges), further filtered to files visible at the cursor (backward-directive
-parents and forward-called files whose `do`/`include` sits on or above the
-cursor line); (3) **variables** — entire workspace (dataset columns like
+edges), further filtered to dep-graph-reachable, cursor-visible files, with
+same-name conflicts resolved by effective scope precedence so only the active
+visible symbol's files participate; (3) **variables** — entire workspace (dataset columns like
 `id`, `year`, `analysis_sample` are legitimately shared across unrelated
 analyses). If this looks like a bug: it is not. See
 [docs/find-references.md](docs/find-references.md). Implementation:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,9 +220,11 @@ Completion requests are race-prone against document updates. The `server-handler
 distinct scoping tiers by design: (1) **local macros** — include-chain files
 only (Stata locals don't propagate through `do`/`run`); (2) **global macros,
 programs, scalars, matrices** — dep-graph-reachable files (all do/run/include
-edges); (3) **variables** — entire workspace (dataset columns like `id`,
-`year`, `analysis_sample` are legitimately shared across unrelated analyses).
-If this looks like a bug: it is not. See
+edges), further filtered to files visible at the cursor (backward-directive
+parents and forward-called files whose `do`/`include` sits on or above the
+cursor line); (3) **variables** — entire workspace (dataset columns like
+`id`, `year`, `analysis_sample` are legitimately shared across unrelated
+analyses). If this looks like a bug: it is not. See
 [docs/find-references.md](docs/find-references.md). Implementation:
 `src/providers/references.ts::collect_references`.
 

--- a/docs/find-references.md
+++ b/docs/find-references.md
@@ -22,19 +22,20 @@ type:
 downstream `done-by` boundary stay out of scope even if an older ancestor was
 reached through `included-by`.
 
-**Why global macros and code symbols are dep-graph-scoped *and* call-site
+**Why global macros and code symbols are dep-graph-scoped *and* identity
 filtered:** Same-named programs, scalars, or matrices in unrelated branches
 of the dependency graph are typically coincidental, not shared semantics.
 Pooling them would produce misleading results — for example, jumping
 between two unrelated `helper` programs that happen to share a name. Within
-the dep-graph-reachable set, files reached through forward `do` / `include`
-commands are further filtered to those whose call site precedes the cursor:
-a `do "child.do"` on line 10 doesn't bring `child.do`'s declarations into
-scope at line 5. See issue #129 for the unified "visible at cursor" rule
-that closes this drift across providers. Among those cursor-visible candidates,
-Sight follows effective scope precedence and pools declarations/references only
-from files contributing the active visible symbol instance at the cursor. That
-is why masked same-name definitions in otherwise-visible files are excluded.
+the dep-graph-reachable set, Sight resolves the cursor position to a single
+*active symbol instance* (using effective scope precedence to pick between
+same-name candidates) and then includes every file that could reference
+*that* instance — no matter whether its call site sits before or after the
+cursor in execution order. The cursor line only picks the definition; once
+picked, it's irrelevant to reference discovery. Files that redeclare the
+name with a different identity are excluded, because their declarations are
+separate instances and their in-file references are no longer unambiguously
+to the active definition.
 
 **Why variables are workspace-wide:** Stata dataset columns are legitimately
 shared across unrelated analyses. Column names like `id`, `year`, or

--- a/docs/find-references.md
+++ b/docs/find-references.md
@@ -11,15 +11,16 @@ type:
 | Symbol type | Scope |
 |---|---|
 | **Local macros** | Include-chain files only |
-| **Global macros, programs, scalars, matrices** | Dep-graph-reachable files (do/run/include edges), further filtered to files visible at the cursor — backward-directive parents and forward-called files whose `do`/`include` appears on or above the cursor line |
+| **Global macros, programs, scalars, matrices** | Dep-graph-reachable, cursor-visible files, with same-name conflicts resolved by effective scope precedence so only files contributing the active visible symbol instance at the cursor participate |
 | **Variables** | Entire workspace |
 
 ## Rationale
 
 **Why local macros are narrowest:** Stata only propagates local macros through
 `include`, never through `do` or `run`. A local macro with the same name in a
-`do`-called child is a separate, unrelated macro — pooling those references
-would be misleading.
+`do`-called child is a separate, unrelated macro, and locals stripped by a
+downstream `done-by` boundary stay out of scope even if an older ancestor was
+reached through `included-by`.
 
 **Why global macros and code symbols are dep-graph-scoped *and* call-site
 filtered:** Same-named programs, scalars, or matrices in unrelated branches
@@ -30,7 +31,10 @@ the dep-graph-reachable set, files reached through forward `do` / `include`
 commands are further filtered to those whose call site precedes the cursor:
 a `do "child.do"` on line 10 doesn't bring `child.do`'s declarations into
 scope at line 5. See issue #129 for the unified "visible at cursor" rule
-that closes this drift across providers.
+that closes this drift across providers. Among those cursor-visible candidates,
+Sight follows effective scope precedence and pools declarations/references only
+from files contributing the active visible symbol instance at the cursor. That
+is why masked same-name definitions in otherwise-visible files are excluded.
 
 **Why variables are workspace-wide:** Stata dataset columns are legitimately
 shared across unrelated analyses. Column names like `id`, `year`, or

--- a/docs/find-references.md
+++ b/docs/find-references.md
@@ -11,7 +11,7 @@ type:
 | Symbol type | Scope |
 |---|---|
 | **Local macros** | Include-chain files only |
-| **Global macros, programs, scalars, matrices** | Dep-graph-reachable files (do/run/include edges) |
+| **Global macros, programs, scalars, matrices** | Dep-graph-reachable files (do/run/include edges), further filtered to files visible at the cursor — backward-directive parents and forward-called files whose `do`/`include` appears on or above the cursor line |
 | **Variables** | Entire workspace |
 
 ## Rationale
@@ -21,11 +21,16 @@ type:
 `do`-called child is a separate, unrelated macro — pooling those references
 would be misleading.
 
-**Why global macros and code symbols are dep-graph-scoped:** Same-named
-programs, scalars, or matrices in unrelated branches of the dependency graph
-are typically coincidental, not shared semantics. Pooling them would produce
-misleading results — for example, jumping between two unrelated `helper`
-programs that happen to share a name.
+**Why global macros and code symbols are dep-graph-scoped *and* call-site
+filtered:** Same-named programs, scalars, or matrices in unrelated branches
+of the dependency graph are typically coincidental, not shared semantics.
+Pooling them would produce misleading results — for example, jumping
+between two unrelated `helper` programs that happen to share a name. Within
+the dep-graph-reachable set, files reached through forward `do` / `include`
+commands are further filtered to those whose call site precedes the cursor:
+a `do "child.do"` on line 10 doesn't bring `child.do`'s declarations into
+scope at line 5. See issue #129 for the unified "visible at cursor" rule
+that closes this drift across providers.
 
 **Why variables are workspace-wide:** Stata dataset columns are legitimately
 shared across unrelated analyses. Column names like `id`, `year`, or

--- a/docs/superpowers/specs/2026-04-18-issue-129-unify-visible-at-cursor-design.md
+++ b/docs/superpowers/specs/2026-04-18-issue-129-unify-visible-at-cursor-design.md
@@ -1,0 +1,293 @@
+# Issue #129 — Unify "symbols visible at cursor position" across providers
+
+**Status:** design approved, implementation pending
+**Date:** 2026-04-18
+**GitHub issue:** [#129](https://github.com/jbearak/sight/issues/129)
+**Scope:** full — fix the two latent bugs identified in #129's audit, consolidate the ≈8 duplicated filter sites behind shared pure helpers, and retire the legacy `forward_scope` provider parameter.
+
+## Problem
+
+Issue #129's audit enumerates a rule — "symbols from a forward call are visible only after the call line; backward-directive parents are always visible" — that is implemented ad-hoc across providers. Current state:
+
+- **`completion.ts`** applies the filter in 8 places: one file-local helper `get_visible_forward_call_sites` (lines 63–76) used by four `resolved_scope` paths (1182, 1803, 2173, 2364), plus four inline `call_site.call_line < cursor_line` blocks on a legacy `forward_scope` fallback path (1144–1176, 1751–1801, 2064–2171, 2325–2362).
+- **`hover.ts`** has its own private method `get_visible_forward_call_sites` (475–488) used at six sites.
+- **`diagnostics.ts`** inlines the same filter at 309–315.
+- **`references.ts::classify_word_symbol`** (post-#127) applies the filter correctly at 564–567.
+- **`ForwardScopeResolver.get_symbols_at_line`** (forward-scope-resolver/index.ts:425–448) already merges base + visible-forward-call symbols into a single `SymbolTable`. It is tested (`tests/property/forward-scope-resolution.prop.test.ts`) and unused by any provider.
+
+Two latent defects sit underneath the duplication:
+
+1. **`definition.ts::resolve_non_macro_symbols`** (321–375) consults `resolved_scope.symbols` but never `resolved_scope.forward_call_symbols`. A `WORD` token naming a program/scalar/matrix/variable that is defined in a visible forward-called file does not resolve through the scope resolver. It falls through to `workspace_indexer.find_symbol_definitions`, which has no cursor-ordering filter and can jump to a definition in an unrelated branch. This is the "bigger user impact" variant #127 flagged.
+2. **`references.ts::find_definitions`** (166–240) pools declarations from `workspace_indexer.find_symbol_definitions` restricted to `get_related_uris(document.uri)` — the full dep-graph, with no call-site filter. For non-variable kinds, redeclarations in not-yet-reached forward-called files are pooled into the `includeDeclaration` list.
+
+The duplication has its own cost: any refinement to the rule (e.g., handling edge cases around `#delimit;` statement ordering, or tightening the `<` comparison) must land in ≈8 places or risk drift between providers.
+
+## Goals
+
+- One canonical, tested place where the "visible at cursor" question is answered. All providers consult it.
+- `definition.ts::resolve_non_macro_symbols` returns the correct in-scope location for programs / scalars / matrices / variables defined in visible forward-called files.
+- `find_definitions` restricts non-variable declaration pooling to files that are in-scope at the cursor. Variables stay workspace-wide (dataset-column semantics, matching the three-tier scoping documented in `docs/find-references.md` and `CLAUDE.md`).
+- The runtime-dead legacy `forward_scope: ForwardResolvedScope` parameter is gone from provider method signatures.
+
+## Non-goals
+
+- Changes to `ScopeResolver`'s caching or resolution algorithm.
+- Changes to completion ranking semantics, or the `effective_type === 'include'` rule for local macros in hover/diagnostics.
+- Changes to `collect_references` (the references scanner) or the three-tier model in general.
+- Retiring the `ForwardResolvedScope` type itself — it stays as the return type of `ForwardScopeResolver.resolve`. Only the provider-level `forward_scope` parameter goes.
+- Issue #128's open docs work.
+
+## Architecture
+
+### New primitives
+
+A new module, `src/scope-resolver/visible-symbols.ts`, re-exported through `src/scope-resolver/index.ts`. Three pure, synchronous functions, each accepting `undefined` gracefully so test-only paths don't need to construct a scope:
+
+```ts
+import type { ResolvedScope, ForwardCallSite, SymbolTable } from '../types';
+import { merge_symbol_tables } from '../analyzer';
+
+/**
+ * SymbolTable of all symbols in scope at `cursor_line`. Equivalent to
+ *   resolved_scope.symbols
+ *   ∪ { call_site.symbols : call_site ∈ resolved_scope.forward_call_symbols,
+ *                           call_site.call_line < cursor_line }
+ * with `merge_symbol_tables` overlay semantics (lattermost wins on name
+ * collisions; preserves scope-resolver precedence).
+ *
+ * Returns an empty SymbolTable when `scope` is undefined.
+ */
+export function get_visible_symbols_at(
+    scope: ResolvedScope | undefined,
+    cursor_line: number,
+): SymbolTable;
+
+/**
+ * Forward-call sites visible at `cursor_line` (site.call_line < cursor_line),
+ * preserving array order so ranking-sensitive callers keep current behavior.
+ *
+ * Returns `[]` when `scope` is undefined.
+ */
+export function get_visible_forward_call_sites(
+    scope: ResolvedScope | undefined,
+    cursor_line: number,
+): ForwardCallSite[];
+
+/**
+ * URIs whose symbols contribute to scope at `cursor_line`:
+ *   current_uri
+ *   ∪ { entry.uri : entry ∈ scope.chain }
+ *   ∪ { site.callee_uri : site ∈ get_visible_forward_call_sites(scope, cursor_line) }
+ *
+ * Returns `{ current_uri }` when `scope` is undefined.
+ */
+export function collect_visible_uris(
+    scope: ResolvedScope | undefined,
+    cursor_line: number,
+    current_uri: string,
+): Set<string>;
+```
+
+Returning `SymbolTable` means consumers keep using `.programs.get(name)` / `.variables.get(name)` — zero new query vocabulary. The underlying merge logic is already implemented and tested in `ForwardScopeResolver.get_symbols_at_line`; the latter becomes a thin delegation to `get_visible_symbols_at` so there is exactly one source of truth. Its existing property test (`tests/property/forward-scope-resolution.prop.test.ts:172,176`) continues to cover that path.
+
+### Strict vs. non-strict inequality
+
+All existing sites use `call_site.call_line < cursor_line` (never `≤`). A symbol defined on the same line as the `do` is not yet in scope at the `do` line itself. The new helpers preserve strict `<`.
+
+## Concrete changes
+
+### `src/scope-resolver/visible-symbols.ts` (new)
+
+Contains the three helpers above. `get_visible_symbols_at` is implemented by copying the loop body of `ForwardScopeResolver.get_symbols_at_line`; `get_visible_forward_call_sites` is a one-line filter; `collect_visible_uris` walks `scope.chain` and visible forward sites.
+
+### `src/scope-resolver/index.ts`
+
+Re-export the three new helpers so providers can import them alongside `ScopeResolver`.
+
+### `src/forward-scope-resolver/index.ts`
+
+`get_symbols_at_line` (lines 425–448) stays unchanged. Keeping two independent implementations of the same rule — the instance method here and the pure `get_visible_symbols_at` in the new module — gives the property test below a non-trivial invariant to check: it can compare the two outputs on arbitrary inputs and fail if they drift. Folding one into the other would turn that property test into a tautology.
+
+### `src/providers/definition.ts`
+
+`resolve_non_macro_symbols` (321–375) uses the merged view. Priority order unchanged (variable → program → scalar → matrix), matching the existing WORD-priority for go-to-def.
+
+```ts
+if (scope_resolver) {
+    const resolve_config = build_scope_resolver_config(cross_file_config);
+    const resolved_scope = await scope_resolver.resolve(
+        document.uri, document.content, resolve_config, cancellation_token);
+    const visible = get_visible_symbols_at(resolved_scope, position.line);
+
+    const variable = visible.variables.get(word);
+    if (variable) return { uri: variable.location.uri, range: variable.location.range };
+
+    const program = visible.programs.get(word);
+    if (program) return { uri: program.location.uri, range: program.location.range };
+
+    const scalar = visible.scalars.get(word);
+    if (scalar) return { uri: scalar.location.uri, range: scalar.location.range };
+
+    const matrix = visible.matrices.get(word);
+    if (matrix) return { uri: matrix.location.uri, range: matrix.location.range };
+}
+// Fall through to document.symbols (test-only fallback) and workspace_indexer,
+// unchanged from today.
+```
+
+Consequences:
+
+- Programs/scalars/matrices defined in a visible forward-called file now resolve to that file (the headline bug from the issue).
+- Variables defined in a visible forward-called file resolve in-scope before falling through to the workspace multi-def picker — captures the "if there is a def in scope, that is the def that's relevant for go-to-def" rule.
+- Variables with no in-scope def continue to fall through to `workspace_indexer.find_symbol_definitions(word, 'variable')` and return a `Location[]`. Workspace-wide variable semantics preserved where no in-scope def exists.
+
+The rest of `resolve_non_macro_symbols` (document-symbols fallback at 377–408, workspace-indexer fallback at 411–430, workspace-symbols fallback at 434–465) is unchanged. These paths only execute when `scope_resolver` is absent (test-only) or when the in-scope check misses.
+
+### `src/providers/references.ts`
+
+**`classify_word_symbol`** (540–607): replace the inline `if (my_site.call_line >= cursor_line) continue;` loop with `for (const my_site of get_visible_forward_call_sites(resolved_scope, cursor_line))`. Semantics identical; cleanup only. The workspace-wide variable fallback at 594–604 is unchanged.
+
+**`find_definitions`** (166–240): accepts two new parameters — `resolved_scope: ResolvedScope | undefined` and `cursor_line: number` — threaded through from `get_references`. The workspace-indexer block at 216–237 replaces `get_related_uris` with `collect_visible_uris` for non-variable kinds:
+
+```ts
+if (workspace_indexer) {
+    const ws_type = symbol_type === 'local_macro' ? 'local' :
+                    symbol_type === 'global_macro' ? 'global' : symbol_type;
+    // Variables are dataset columns — pooled workspace-wide across unrelated
+    // modules (see docs/find-references.md). Non-variable kinds are
+    // restricted to files visible at the cursor.
+    const restrict_to_visible = symbol_type !== 'variable';
+    const the_visible_uris = restrict_to_visible
+        ? collect_visible_uris(resolved_scope, cursor_line, document.uri)
+        : null;
+    for (const my_def of workspace_indexer.find_symbol_definitions(symbol_name, ws_type)) {
+        if (my_def.sourceUri === document.uri) continue;
+        if (the_visible_uris && !the_visible_uris.has(my_def.sourceUri)) continue;
+        push({ uri: my_def.location.uri, range: my_def.location.range });
+    }
+}
+```
+
+Behavior after fix:
+
+- For programs / scalars / matrices / local-macro / global-macro, declarations in not-yet-reached forward-called files are dropped from `includeDeclaration`.
+- Variable declarations continue to pool workspace-wide, matching find-references' variable semantics. Not restricted by `the_visible_uris`.
+
+**`get_references`**: gains access to `cursor_line` via the existing `position.line` already in scope and threads it, along with the `resolved_scope` it already resolves for `classify_word_symbol`, into `find_definitions`.
+
+### `src/providers/completion.ts`
+
+- Delete the file-local `get_visible_forward_call_sites` (63–76). Replace with `import { get_visible_forward_call_sites } from '../scope-resolver';`.
+- Delete `forward_scope?: ForwardResolvedScope` from all five method signatures (865, 1080, 1597, 1912, 2285).
+- Delete the four corresponding inline legacy blocks at 1144–1176, 1751–1801, 2064–2171, 2325–2362 (the `if (forward_scope) { … for (const call_site of forward_scope.call_sites) { if (call_site.call_line < cursor_line) …` fallbacks).
+- The helper-using blocks at 1182, 1803, 2173, 2364 remain and become the sole forward-call path.
+- Ranking logic is unchanged — it correctly needs per-site `effective_type` / `parent_uri`.
+
+### `src/providers/hover.ts`
+
+- Delete the private method `get_visible_forward_call_sites` (475–488). Replace call-site calls `this.get_visible_forward_call_sites(resolved_scope, position)` at 531, 623, 705, 792, 1351, 1452 with the shared `get_visible_forward_call_sites(resolved_scope, position.line)` imported from `../scope-resolver`.
+- The `effective_type === 'include'` branches that handle local-macro visibility are unchanged.
+
+### `src/providers/diagnostics.ts`
+
+- Delete `forward_scope?: ForwardResolvedScope` from `get_diagnostics` / `convert_all` signatures (105, 151).
+- Simplify line 301 from `const forward_call_sites = resolved_scope?.forward_call_symbols ?? forward_scope?.call_sites;` to `const forward_call_sites = resolved_scope?.forward_call_symbols ?? [];` (retained only for the code's null-check flow; the loop below swaps to the helper).
+- Rewrite the loop at 309–315 using the shared helper:
+  ```ts
+  for (const call_site of get_visible_forward_call_sites(resolved_scope, diag_line)) {
+      if (this.is_symbol_in_forward_call(
+              symbol_name, call_site.symbols, my_diagnostic.code, call_site.effective_type)) {
+          found_in_forward_call = true;
+          break;
+      }
+  }
+  ```
+- Keep `is_symbol_in_forward_call` (891+) — it's a per-site predicate that uses `effective_type`, not a generic "is in scope" check.
+
+### `src/server-handlers.ts`
+
+- Remove the `let forward_scope = undefined; if (!deps.scope_resolver && deps.forward_scope_resolver && …) forward_scope = await deps.forward_scope_resolver.resolve(…)` block around line 327.
+- Remove the `forward_scope,` argument at 363 (passed to completion/diagnostics).
+- `create_references_handler` threads `cursor_line` from the request position into `get_references` (needed by `find_definitions` now).
+- `deps.forward_scope_resolver` itself stays wired — it is still used internally by `ScopeResolver` and disposed at line 687.
+
+## Test plan
+
+### New unit tests — `tests/unit/scope-resolver/visible-symbols.test.ts`
+
+- `get_visible_symbols_at`:
+  - Undefined scope returns an empty `SymbolTable` (all six Maps empty).
+  - Empty `forward_call_symbols` returns a copy of `scope.symbols`.
+  - One forward site with `call_line < cursor_line` contributes; same site with `call_line >= cursor_line` does not.
+  - `call_line === cursor_line` is excluded (strict `<`).
+  - Two sites defining the same name: lattermost wins (matches merge_symbol_tables overlay semantics).
+- `get_visible_forward_call_sites`:
+  - Undefined scope returns `[]`.
+  - Preserves array order.
+  - Strict `<` boundary.
+- `collect_visible_uris`:
+  - Contains `current_uri` even when `scope` is undefined.
+  - Includes every `chain[*].uri` regardless of cursor line.
+  - Includes `callee_uri` for sites with `call_line < cursor_line` only.
+
+### New property test — `tests/property/visible-symbols.prop.test.ts`
+
+- For arbitrary `(ResolvedScope, line)`: `get_visible_symbols_at(scope, line)` equals `ForwardScopeResolver.get_symbols_at_line(scope.symbols, scope.forward_call_symbols ?? [], line)` (semantic equivalence). Locks the two implementations together so they cannot drift.
+
+### New integration test — `tests/integration/definition-call-site-scope.test.ts`
+
+Mirrors the structure of `tests/integration/find-references-call-site-scope.test.ts` from #127. Uses the same pipeline-wiring helper so `DocumentStore + WorkspaceIndexer + DependencyGraph + ScopeResolver + ForwardScopeResolver` behave as in production.
+
+Scenarios:
+
+1. **Regression — program defined in forward-called file.** `main.do`: `shared_prog\ndo "defs.do"`. `defs.do` defines `shared_prog`. Cursor on line 0. Assert result is null (pre-fix: would have jumped to `defs.do` via workspace fallback).
+2. **Positive — cursor after the `do`.** Same files, cursor on line 2 (after the `do`). Assert result is the location in `defs.do`.
+3. **Variable in-scope preference.** A variable defined only in a visible forward-called file. Cursor after the `do`. Assert result is the single in-scope location — *not* the workspace `Location[]` fallback.
+4. **Variable workspace fallback.** A variable with no in-scope def, defined in an unrelated workspace file. Assert result is the workspace `Location[]`.
+5. **Unrelated branches with same-named program.** `main.do` does `branch_a.do` then `branch_b.do`. Both define `shared_prog`. Cursor after the `do "branch_a.do"` only → resolves to `branch_a.do` alone (not pooled with `branch_b.do`).
+6. **Transitive forward call.** `main.do` does `mid.do` at line 5; `mid.do` does `leaf.do` at line 3; `leaf.do` defines `deep_prog`. Cursor at line 10 in `main.do` → resolves to `leaf.do`. Cursor at line 2 → returns `null` (not yet in scope, and no workspace fallback because no other file in the workspace defines `deep_prog`).
+
+### New integration test — `tests/integration/find-references-declaration-scope.test.ts`
+
+Scenarios:
+
+1. Program declared in not-yet-reached forward-called file: `find-references` with `includeDeclaration: true` does not include that location.
+2. Program declared in a visible forward-called file: `find-references` includes that declaration.
+3. Variable declarations pool workspace-wide regardless of cursor: a variable defined in an unrelated workspace file appears in declarations (keeps the workspace-scoping guarantee explicit as a test).
+4. Variable declaration in a visible forward-called file: appears in declarations (not excluded by any filter).
+
+### Retirement migrations — existing tests
+
+Three files that construct `ForwardResolvedScope` directly need migration:
+
+- **`tests/unit/diagnostics-provider.test.ts`** (798, 817, 835, 853): four scenarios migrated to wire a `ScopeResolver` and assemble a `ResolvedScope` with `forward_call_symbols` populated. A small test helper in `tests/unit/helpers/` that builds a minimal `ResolvedScope` from a `ForwardCallSite[]` keeps the migration concise.
+- **`tests/unit/unify-forward-call-feeds.test.ts`** (122, 210, 275): three scenarios, same migration.
+- **`tests/property/unify-forward-call-feeds.prop.test.ts`** (148, 238): two generators, same migration. The property shape — "warnings suppressed when the symbol is defined in a visible forward-call" — is unchanged; only the entry point moves to the canonical path.
+
+### Updated expectations — existing tests
+
+No semantic changes are expected in hover / completion / diagnostics provider unit tests (the helper swap is structural). Any snapshot or assertion drift indicates a real semantic regression and must be investigated before the PR lands.
+
+## Implementation ordering
+
+A single PR, sequenced so each commit isolates one concern. Every commit must pass `bun run test` and `bun run typecheck`.
+
+1. **Add primitives + their unit and property tests.** `src/scope-resolver/visible-symbols.ts` and tests in isolation — nothing else touches it yet. Export through `src/scope-resolver/index.ts`.
+2. **Migrate `hover.ts`.** Six mechanical call-site swaps; private helper method deleted. Existing hover tests pass unchanged.
+3. **Migrate `completion.ts` + retire legacy parameter.** Delete `forward_scope` from five signatures, delete four inline fallback blocks, swap the file-local helper for the shared import. Existing completion tests pass unchanged.
+4. **Migrate `diagnostics.ts` + retire legacy parameter.** Same pattern. Migrate the three `forward_scope`-using test files in this commit (`tests/unit/diagnostics-provider.test.ts`, `tests/unit/unify-forward-call-feeds.test.ts`, `tests/property/unify-forward-call-feeds.prop.test.ts`).
+5. **Fix `definition.ts::resolve_non_macro_symbols`.** Add `tests/integration/definition-call-site-scope.test.ts` in the same commit (TDD: failing first, then the fix).
+6. **Fix `references.ts::find_definitions`.** Add `tests/integration/find-references-declaration-scope.test.ts` in the same commit (same TDD rhythm).
+7. **Cleanup `references.ts::classify_word_symbol`.** Mechanical helper swap; no behavior change.
+8. **Remove `forward_scope` plumbing from `server-handlers.ts`.** Final cleanup — after all providers are migrated.
+
+## Risks
+
+- **Performance.** `get_visible_symbols_at` allocates six new Maps per call. Typical request path hits it once; `ScopeResolver.resolve` memoization means the underlying `ResolvedScope` is reused across requests on the same buffer. No measured perf concern expected; no benchmark planned.
+- **Silent semantic drift on migration.** The "unify-forward-call-feeds" tests were specifically designed to pin feed-level behavior. After migration they verify the same invariants through the canonical path — if they pass, confidence is high that no semantic regression occurred. If they fail, investigate before landing.
+- **Variable scope regression.** The variable-stays-workspace-wide rule lives in exactly one place today (`find_definitions`'s `restrict_to_related = symbol_type !== 'variable'` at line 225) and will live in exactly one place after (the renamed `restrict_to_visible = symbol_type !== 'variable'`). The new integration test explicitly asserts this semantic so a future refactor cannot silently regress it.
+
+## Related
+
+- Blocker (closed): #127 (narrow fix, spec: `docs/superpowers/specs/2026-04-18-issue-127-classify-call-site-filtering-design.md`).
+- Docs issue (open, unrelated): #128.

--- a/docs/superpowers/specs/2026-04-18-issue-129-unify-visible-at-cursor-design.md
+++ b/docs/superpowers/specs/2026-04-18-issue-129-unify-visible-at-cursor-design.md
@@ -1,9 +1,51 @@
 # Issue #129 — Unify "symbols visible at cursor position" across providers
 
-**Status:** design approved, implementation pending
-**Date:** 2026-04-18
+**Status:** implemented; semantics revised post-landing — see "2026-04-19 addendum" below
+**Date:** 2026-04-18 (original design); 2026-04-19 (addendum)
 **GitHub issue:** [#129](https://github.com/jbearak/sight/issues/129)
 **Scope:** full — fix the two latent bugs identified in #129's audit, consolidate the ≈8 duplicated filter sites behind shared pure helpers, and retire the legacy `forward_scope` provider parameter.
+
+## 2026-04-19 addendum — find-references no longer uses a cursor-line filter
+
+After #129 landed, a user report exposed a gap: find-references on a local macro declared in file A where A has an `include` relationship with file B (either A is `included-by` B, or A `include`s B) returned zero results. The declaration is in scope at the cursor, and the reference site is in the sibling file, but the sibling's URI was excluded by `collect_visible_reference_uris`'s `call_line < cursor_line` filter.
+
+The underlying misconception: the cursor line was being used for two distinct jobs — *picking* the active symbol instance (correct) and *filtering* reference sites (incorrect). Once the active instance is chosen, every file that could reference *that definition* is a legitimate hit, regardless of call-site order relative to the cursor.
+
+### Revised semantics (now in effect)
+
+`collect_visible_reference_uris`:
+
+- The cursor line resolves ambiguity among same-name instances via `get_visible_symbols_at`. That is its *only* role.
+- Every forward call from the current file is walked (not just those with `call_line < cursor_line`).
+- A forward-called file is included when the active instance is visible at its call (either already defined in the current file's pre-call state, or defined by the site itself), *and* the site does not redeclare the name with a different identity. Redeclaring sites are excluded because their in-file references become ambiguous — some may hit the active instance pre-redeclaration, others the shadow post-redeclaration.
+- Chain-entry URIs are added when the parent's post-call state sees the active instance. For `included-by`, that includes the case where the active symbol is declared in the current file itself and reaches back into the parent via include. The pre-fix `entry_visible_symbols` check only modeled the parent's pre-call state, missing this direction.
+
+### What changed in the shipped code vs. the original spec
+
+- The line in the forward-call loop is now `for (const my_site of scope.forward_call_symbols ?? [])` — no cursor-line filter. A separate guard drops sites that redeclare the name with a different identity.
+- The chain-entry check gained an `active_symbol_identity === current_uri` shortcut so parents that reach back into the current file via `included-by` (or `done-by` for non-locals) are added even when the parent's own symbol table does not yet list the symbol.
+
+### What the original spec got right and kept
+
+- The unification — one shared helper, import sites collapsed across `completion.ts`, `hover.ts`, `diagnostics.ts`, `definition.ts`, `references.ts`.
+- The `get_visible_symbols_at` / `get_visible_forward_call_sites` semantics — both still use strict `<` against `cursor_line`, because those functions answer "what is visible at the cursor," which is exactly the right question for *picking* a symbol.
+- `definition.ts::resolve_non_macro_symbols` — go-to-def still uses strict cursor-line visibility (a `do "defs.do"` after the cursor should not resolve the cursor's token).
+- Retirement of the `forward_scope` parameter plumbing.
+
+### What to update when reading the historical design below
+
+Two parts of the original design are superseded:
+
+1. **`find_definitions` behavior after fix** (in "Concrete changes / `src/providers/references.ts`") — the bullet *"declarations in not-yet-reached forward-called files are dropped from `includeDeclaration`"* no longer holds. The current rule is the identity-based one described above.
+2. **Test plan** — the unit test expectation *"Keeps the strict `<` boundary for current-file forward calls"* under `collect_visible_reference_uris`, and the integration-test scenario *"Program declared in not-yet-reached forward-called file: `find-references` does not include that location"* are both obsolete. The first has been flipped in `tests/unit/scope-resolver/visible-symbols.test.ts`; the second expectation in `tests/integration/find-references-declaration-scope.test.ts` still passes only because the test's forward-called file *redeclares* `shared_prog` (different identity), not because of the cursor-line filter.
+
+The `get_visible_symbols_at` / `get_visible_forward_call_sites` sections of the original design are unchanged and remain accurate.
+
+Primary commit: `2f56e0e` ("Find references to locals across include boundaries").
+
+---
+
+## Original design (2026-04-18)
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-04-18-issue-129-unify-visible-at-cursor-design.md
+++ b/docs/superpowers/specs/2026-04-18-issue-129-unify-visible-at-cursor-design.md
@@ -74,17 +74,18 @@ export function get_visible_forward_call_sites(
 ): ForwardCallSite[];
 
 /**
- * URIs whose symbols contribute to scope at `cursor_line`:
- *   current_uri
- *   ∪ { entry.uri : entry ∈ scope.chain }
- *   ∪ { site.callee_uri : site ∈ get_visible_forward_call_sites(scope, cursor_line) }
+ * URIs that should participate in find-references for the given symbol kind.
+ * Includes backward-chain files, retained parent forward callees, and
+ * current-file visible forward callees. Local macros remain include-only
+ * across both backward and forward edges.
  *
  * Returns `{ current_uri }` when `scope` is undefined.
  */
-export function collect_visible_uris(
+export function collect_visible_reference_uris(
     scope: ResolvedScope | undefined,
     cursor_line: number,
     current_uri: string,
+    symbol_type: 'local_macro' | 'global_macro' | 'program' | 'scalar' | 'matrix',
 ): Set<string>;
 ```
 
@@ -98,7 +99,7 @@ All existing sites use `call_site.call_line < cursor_line` (never `≤`). A symb
 
 ### `src/scope-resolver/visible-symbols.ts` (new)
 
-Contains the three helpers above. `get_visible_symbols_at` is implemented by copying the loop body of `ForwardScopeResolver.get_symbols_at_line`; `get_visible_forward_call_sites` is a one-line filter; `collect_visible_uris` walks `scope.chain` and visible forward sites.
+Contains the three helpers above. `get_visible_symbols_at` is implemented by copying the loop body of `ForwardScopeResolver.get_symbols_at_line`; `get_visible_forward_call_sites` is a one-line filter; `collect_visible_reference_uris` walks `scope.chain`, retained parent `forward_call_sites`, and current visible forward sites with an include-only branch for local macros.
 
 ### `src/scope-resolver/index.ts`
 
@@ -147,7 +148,7 @@ The rest of `resolve_non_macro_symbols` (document-symbols fallback at 377–408,
 
 **`classify_word_symbol`** (540–607): replace the inline `if (my_site.call_line >= cursor_line) continue;` loop with `for (const my_site of get_visible_forward_call_sites(resolved_scope, cursor_line))`. Semantics identical; cleanup only. The workspace-wide variable fallback at 594–604 is unchanged.
 
-**`find_definitions`** (166–240): accepts two new parameters — `resolved_scope: ResolvedScope | undefined` and `cursor_line: number` — threaded through from `get_references`. The workspace-indexer block at 216–237 replaces `get_related_uris` with `collect_visible_uris` for non-variable kinds:
+**`find_definitions`** (166–240): accepts two new parameters — `resolved_scope: ResolvedScope | undefined` and `cursor_line: number` — threaded through from `get_references`. The workspace-indexer block at 216–237 replaces `get_related_uris` with `collect_visible_reference_uris` for non-variable kinds:
 
 ```ts
 if (workspace_indexer) {
@@ -158,7 +159,8 @@ if (workspace_indexer) {
     // restricted to files visible at the cursor.
     const restrict_to_visible = symbol_type !== 'variable';
     const the_visible_uris = restrict_to_visible
-        ? collect_visible_uris(resolved_scope, cursor_line, document.uri)
+        ? collect_visible_reference_uris(
+            resolved_scope, cursor_line, document.uri, symbol_type)
         : null;
     for (const my_def of workspace_indexer.find_symbol_definitions(symbol_name, ws_type)) {
         if (my_def.sourceUri === document.uri) continue;
@@ -171,6 +173,7 @@ if (workspace_indexer) {
 Behavior after fix:
 
 - For programs / scalars / matrices / local-macro / global-macro, declarations in not-yet-reached forward-called files are dropped from `includeDeclaration`.
+- Files reachable only through a backward parent's earlier forward calls remain visible to find-references because each `ScopeChainEntry` retains its filtered `forward_call_sites`.
 - Variable declarations continue to pool workspace-wide, matching find-references' variable semantics. Not restricted by `the_visible_uris`.
 
 **`get_references`**: gains access to `cursor_line` via the existing `position.line` already in scope and threads it, along with the `resolved_scope` it already resolves for `classify_word_symbol`, into `find_definitions`.
@@ -225,10 +228,11 @@ Behavior after fix:
   - Undefined scope returns `[]`.
   - Preserves array order.
   - Strict `<` boundary.
-- `collect_visible_uris`:
+- `collect_visible_reference_uris`:
   - Contains `current_uri` even when `scope` is undefined.
-  - Includes every `chain[*].uri` regardless of cursor line.
-  - Includes `callee_uri` for sites with `call_line < cursor_line` only.
+  - For non-local kinds, includes every `chain[*].uri`, every retained parent `forward_call_sites[*].callee_uri`, and every current-file visible `callee_uri`.
+  - For `local_macro`, includes only `included-by` chain entries and only call sites with `effective_type === 'include'`.
+  - Keeps the strict `<` boundary for current-file forward calls.
 
 ### New property test — `tests/property/visible-symbols.prop.test.ts`
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -36,8 +36,11 @@ import { CompletionPrefixCache } from '../utils/lru-cache';
 import { SymbolIndexCache } from '../utils/symbol-index-cache';
 import { ScopeResolver } from '../scope-resolver';
 import { build_scope_resolver_config } from '../scope-resolver';
-import { get_visible_forward_call_sites } from '../scope-resolver';
-import { merge_symbol_tables } from '../analyzer';
+import {
+    get_visible_forward_call_sites,
+    get_visible_symbols_at,
+} from '../scope-resolver';
+import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 import { isPathDirective, isFileCommand, hasStataExtension } from '../utils/file-path-utils';
 import { logger } from '../utils/logger';
 import * as fs from 'fs';
@@ -905,19 +908,36 @@ export class CompletionProvider {
                 );
                 const has_directives = temp_scope.has_directives;
                 const has_auto_parents = temp_scope.has_auto_parents;
+                const visible_forward_overlay =
+                    this.get_annotated_visible_forward_symbols(
+                        temp_scope,
+                        position.line,
+                    );
 
                 if (has_directives || has_auto_parents) {
                     // With directives: use reachable scope chain (precision)
                     resolved_scope = temp_scope;
-                    symbols_for_completion = temp_scope.symbols;
+                    symbols_for_completion = merge_symbol_tables(
+                        get_visible_symbols_at(temp_scope, position.line),
+                        visible_forward_overlay,
+                    );
                 } else if (workspace_symbols) {
                     // No directives: use cached merged symbols (workspace + document)
-                    symbols_for_completion = this.get_merged_symbols(
+                    const merged_workspace_symbols = this.get_merged_symbols(
                         workspace_symbols,
                         document.symbols,
                         document.uri,
                         document.version || 0,
-                        workspace_version || 0
+                        workspace_version || 0,
+                    );
+                    symbols_for_completion = merge_symbol_tables(
+                        merged_workspace_symbols,
+                        visible_forward_overlay,
+                    );
+                } else {
+                    symbols_for_completion = merge_symbol_tables(
+                        document.symbols,
+                        visible_forward_overlay,
                     );
                 }
             } else if (workspace_symbols) {
@@ -1077,19 +1097,15 @@ export class CompletionProvider {
             for (const [name, program] of symbols.programs) {
                 if (prefix === '' || name.toLowerCase().startsWith(prefix.toLowerCase())) {
                     seen_labels.add(name.toLowerCase());
-                    
-                    // Determine scope proximity for ranking
-                    let depth = 0;
-                    let directive_type: 'done-by' | 'included-by' | 'current' = 'current';
-                    if (resolved_scope && program.sourceUri !== document.uri) {
-                        const symbol_info = this.get_symbol_depth(program.sourceUri, resolved_scope);
-                        depth = symbol_info.depth;
-                        directive_type = symbol_info.directive_type;
-                    }
+                    const symbol_info = this.get_completion_symbol_provenance(
+                        program,
+                        document.uri,
+                        resolved_scope,
+                    );
                     
                     const ranking_factors: CompletionRankingFactors = {
-                        scope_depth: depth,
-                        directive_type,
+                        scope_depth: symbol_info.depth,
+                        directive_type: symbol_info.directive_type,
                         symbol_type: 'user-program',
                         alphabetical_order: program.name,
                         parent_uri: program.sourceUri
@@ -1097,9 +1113,8 @@ export class CompletionProvider {
                     
                     // Add source file annotation for cross-file symbols
                     let detail = 'User-defined program';
-                    if (resolved_scope && program.sourceUri !== document.uri) {
-                        const source_path = this.get_relative_path(program.sourceUri);
-                        detail += ` (from ${source_path})`;
+                    if (symbol_info.source_path) {
+                        detail += ` (from ${symbol_info.source_path})`;
                     }
                     
                     the_completions.push({
@@ -1109,40 +1124,6 @@ export class CompletionProvider {
                         documentation: `Defined at ${program.sourceUri}`,
                         sortText: compute_ranking_key(ranking_factors),
                     });
-                }
-            }
-        }
-
-        // Add forward call symbols from resolved_scope (position-aware filtering)
-        // This handles symbols from current file's forward call directives
-        // Programs are visible from both 'do' and 'include' types
-        if (resolved_scope?.forward_call_symbols) {
-            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
-            for (const my_call_site of the_visible_call_sites) {
-                for (const [name, program] of my_call_site.symbols.programs) {
-                    if ((prefix === '' || name.toLowerCase().startsWith(prefix.toLowerCase())) &&
-                        !seen_labels.has(name.toLowerCase())) {
-                        seen_labels.add(name.toLowerCase());
-                        
-                        const ranking_factors: CompletionRankingFactors = {
-                            scope_depth: 1,
-                            directive_type: map_effective_type_to_directive(my_call_site.effective_type),
-                            symbol_type: 'user-program',
-                            alphabetical_order: program.name,
-                            parent_uri: program.sourceUri
-                        };
-                        
-                        const source_path = this.get_relative_path(program.sourceUri);
-                        const detail = `User-defined program (from ${source_path})`;
-                        
-                        the_completions.push({
-                            label: program.name,
-                            kind: CompletionItemKind.Function,
-                            detail,
-                            documentation: `Defined at ${program.sourceUri}`,
-                            sortText: compute_ranking_key(ranking_factors),
-                        });
-                    }
                 }
             }
         }
@@ -1632,29 +1613,15 @@ export class CompletionProvider {
             }
 
             // Determine scope proximity for ranking
-            let depth = 0;
-            let directive_type: 'done-by' | 'included-by' | 'current' = 'current';
-
-            // If a resolved scope is provided, use the scope chain.
-            if (resolved_scope && macro.sourceUri !== document.uri) {
-                const symbol_info = this.get_symbol_depth(macro.sourceUri, resolved_scope);
-                depth = symbol_info.depth;
-                directive_type = symbol_info.directive_type;
-            } else {
-                // Fallback for tests / pre-annotated symbols.
-                const annotated_depth = (macro as any).scope_depth;
-                const annotated_directive = (macro as any).directive_type;
-                if (typeof annotated_depth === 'number') {
-                    depth = annotated_depth;
-                }
-                if (annotated_directive === 'current' || annotated_directive === 'included-by' || annotated_directive === 'done-by') {
-                    directive_type = annotated_directive;
-                }
-            }
+            const symbol_info = this.get_completion_symbol_provenance(
+                macro,
+                document.uri,
+                resolved_scope,
+            );
 
             const ranking_factors: CompletionRankingFactors = {
-                scope_depth: depth,
-                directive_type,
+                scope_depth: symbol_info.depth,
+                directive_type: symbol_info.directive_type,
                 symbol_type: scope === 'local' ? 'local-macro' : 'global-macro',
                 alphabetical_order: name,
                 parent_uri: macro.sourceUri,
@@ -1662,9 +1629,8 @@ export class CompletionProvider {
 
             // Add source file annotation for cross-file symbols
             let detail = `${scope} macro`;
-            if (resolved_scope && macro.sourceUri !== document.uri) {
-                const source_path = this.get_relative_path(macro.sourceUri);
-                detail += ` (from ${source_path})`;
+            if (symbol_info.source_path) {
+                detail += ` (from ${symbol_info.source_path})`;
             }
 
             // Compute newText with optional closing delimiter
@@ -1682,62 +1648,6 @@ export class CompletionProvider {
                 },
             });
             seen_labels.add(name);
-        }
-
-        // Add forward call symbols from resolved_scope (position-aware filtering)
-        // This handles symbols from current file's forward call directives
-        if (resolved_scope?.forward_call_symbols) {
-            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
-            for (const my_call_site of the_visible_call_sites) {
-                // For local macros, only include from 'include' type (not 'do')
-                // For global macros, include from both 'do' and 'include' types
-                if (scope === 'local' && my_call_site.effective_type !== 'include') {
-                    continue;
-                }
-
-                const forward_macros = scope === 'local' 
-                    ? my_call_site.symbols.localMacros 
-                    : my_call_site.symbols.globalMacros;
-                
-                for (const [name, macro] of forward_macros) {
-                    // Case-insensitive prefix match
-                    if (!(prefix === '' || name.toLowerCase().startsWith(prefix_lower))) {
-                        continue;
-                    }
-
-                    // Skip if already added
-                    if (seen_labels.has(name)) {
-                        continue;
-                    }
-
-                    const ranking_factors: CompletionRankingFactors = {
-                        scope_depth: 1,
-                        directive_type: map_effective_type_to_directive(my_call_site.effective_type),
-                        symbol_type: scope === 'local' ? 'local-macro' : 'global-macro',
-                        alphabetical_order: name,
-                        parent_uri: macro.sourceUri,
-                    };
-
-                    const source_path = this.get_relative_path(macro.sourceUri);
-                    const detail = `${scope} macro (from ${source_path})`;
-
-                    // Compute newText with optional closing delimiter
-                    const new_text = name + (needs_closing_delimiter ? closing_char : '');
-
-                    the_completions.push({
-                        label: name,
-                        kind: CompletionItemKind.Variable,
-                        detail,
-                        documentation: macro.value ? `Value: ${macro.value}` : undefined,
-                        sortText: compute_ranking_key(ranking_factors),
-                        textEdit: {
-                            range: replacement_range,
-                            newText: new_text,
-                        },
-                    });
-                    seen_labels.add(name);
-                }
-            }
         }
 
         // Add program arguments if we're inside a program body and looking for local macros.
@@ -1828,18 +1738,15 @@ export class CompletionProvider {
 
         // Variables
         for (const [name, variable] of symbols.variables) {
-            // Determine scope proximity for ranking
-            let depth = 0;
-            let directive_type: 'done-by' | 'included-by' | 'current' = 'current';
-            if (resolved_scope && variable.sourceUri !== document.uri) {
-                const symbol_info = this.get_symbol_depth(variable.sourceUri, resolved_scope);
-                depth = symbol_info.depth;
-                directive_type = symbol_info.directive_type;
-            }
+            const symbol_info = this.get_completion_symbol_provenance(
+                variable,
+                document.uri,
+                resolved_scope,
+            );
 
             const ranking_factors: CompletionRankingFactors = {
-                scope_depth: depth,
-                directive_type,
+                scope_depth: symbol_info.depth,
+                directive_type: symbol_info.directive_type,
                 symbol_type: 'variable',
                 alphabetical_order: name,
                 parent_uri: variable.sourceUri
@@ -1847,9 +1754,8 @@ export class CompletionProvider {
 
             // Add source file annotation for cross-file symbols
             let detail = variable.type ? `${variable.type} variable` : 'Variable';
-            if (resolved_scope && variable.sourceUri !== document.uri) {
-                const source_path = this.get_relative_path(variable.sourceUri);
-                detail += ` (from ${source_path})`;
+            if (symbol_info.source_path) {
+                detail += ` (from ${symbol_info.source_path})`;
             }
 
             the_completions.push({
@@ -1870,26 +1776,23 @@ export class CompletionProvider {
         // Scalars
         const scalars: Map<string, any> = (symbols as any).scalars instanceof Map ? (symbols as any).scalars : new Map();
         for (const [name, scalar] of scalars) {
-            let depth = 0;
-            let directive_type: 'done-by' | 'included-by' | 'current' = 'current';
-            if (resolved_scope && scalar.sourceUri !== document.uri) {
-                const symbol_info = this.get_symbol_depth(scalar.sourceUri, resolved_scope);
-                depth = symbol_info.depth;
-                directive_type = symbol_info.directive_type;
-            }
+            const symbol_info = this.get_completion_symbol_provenance(
+                scalar,
+                document.uri,
+                resolved_scope,
+            );
 
             const ranking_factors: CompletionRankingFactors = {
-                scope_depth: depth,
-                directive_type,
+                scope_depth: symbol_info.depth,
+                directive_type: symbol_info.directive_type,
                 symbol_type: 'scalar',
                 alphabetical_order: name,
                 parent_uri: scalar.sourceUri
             };
 
             let detail = 'Scalar';
-            if (resolved_scope && scalar.sourceUri !== document.uri) {
-                const source_path = this.get_relative_path(scalar.sourceUri);
-                detail += ` (from ${source_path})`;
+            if (symbol_info.source_path) {
+                detail += ` (from ${symbol_info.source_path})`;
             }
 
             the_completions.push({
@@ -1910,26 +1813,23 @@ export class CompletionProvider {
         // Matrices
         const matrices: Map<string, any> = (symbols as any).matrices instanceof Map ? (symbols as any).matrices : new Map();
         for (const [name, matrix] of matrices) {
-            let depth = 0;
-            let directive_type: 'done-by' | 'included-by' | 'current' = 'current';
-            if (resolved_scope && matrix.sourceUri !== document.uri) {
-                const symbol_info = this.get_symbol_depth(matrix.sourceUri, resolved_scope);
-                depth = symbol_info.depth;
-                directive_type = symbol_info.directive_type;
-            }
+            const symbol_info = this.get_completion_symbol_provenance(
+                matrix,
+                document.uri,
+                resolved_scope,
+            );
 
             const ranking_factors: CompletionRankingFactors = {
-                scope_depth: depth,
-                directive_type,
+                scope_depth: symbol_info.depth,
+                directive_type: symbol_info.directive_type,
                 symbol_type: 'matrix',
                 alphabetical_order: name,
                 parent_uri: matrix.sourceUri
             };
 
             let detail = 'Matrix';
-            if (resolved_scope && matrix.sourceUri !== document.uri) {
-                const source_path = this.get_relative_path(matrix.sourceUri);
-                detail += ` (from ${source_path})`;
+            if (symbol_info.source_path) {
+                detail += ` (from ${symbol_info.source_path})`;
             }
 
             the_completions.push({
@@ -1945,111 +1845,6 @@ export class CompletionProvider {
                 filterText: name,
             });
             seen_labels.add(name);
-        }
-
-        // Add forward call symbols from resolved_scope (position-aware filtering)
-        // This handles symbols from current file's forward call directives
-        // Variables, scalars, and matrices are visible from both 'do' and 'include' types
-        if (resolved_scope?.forward_call_symbols) {
-            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
-            for (const my_call_site of the_visible_call_sites) {
-                // Variables
-                for (const [name, variable] of my_call_site.symbols.variables) {
-                    // Skip if already added
-                    if (seen_labels.has(name)) {
-                        continue;
-                    }
-
-                    const ranking_factors: CompletionRankingFactors = {
-                        scope_depth: 1,
-                        directive_type: map_effective_type_to_directive(my_call_site.effective_type),
-                        symbol_type: 'variable',
-                        alphabetical_order: name,
-                        parent_uri: variable.sourceUri
-                    };
-
-                    const source_path = this.get_relative_path(variable.sourceUri);
-                    const detail = variable.type ? `${variable.type} variable (from ${source_path})` : `Variable (from ${source_path})`;
-
-                    the_completions.push({
-                        label: name,
-                        kind: CompletionItemKind.Field,
-                        detail,
-                        documentation: variable.label || `Created via ${variable.source}`,
-                        sortText: compute_ranking_key(ranking_factors),
-                        textEdit: {
-                            range: replacement_range,
-                            newText: name,
-                        },
-                        filterText: name,
-                    });
-                    seen_labels.add(name);
-                }
-
-                // Scalars
-                for (const [name, scalar] of my_call_site.symbols.scalars) {
-                    if (seen_labels.has(name)) {
-                        continue;
-                    }
-
-                    const ranking_factors: CompletionRankingFactors = {
-                        scope_depth: 1,
-                        directive_type: map_effective_type_to_directive(my_call_site.effective_type),
-                        symbol_type: 'scalar',
-                        alphabetical_order: name,
-                        parent_uri: scalar.sourceUri
-                    };
-
-                    const source_path = this.get_relative_path(scalar.sourceUri);
-                    const detail = `Scalar (from ${source_path})`;
-
-                    the_completions.push({
-                        label: name,
-                        kind: CompletionItemKind.Constant,
-                        detail,
-                        documentation: `Defined at ${scalar.sourceUri}`,
-                        sortText: compute_ranking_key(ranking_factors),
-                        textEdit: {
-                            range: replacement_range,
-                            newText: name,
-                        },
-                        filterText: name,
-                    });
-                    seen_labels.add(name);
-                }
-
-                // Matrices
-                for (const [name, matrix] of my_call_site.symbols.matrices) {
-                    if (seen_labels.has(name)) {
-                        continue;
-                    }
-
-                    const ranking_factors: CompletionRankingFactors = {
-                        scope_depth: 1,
-                        directive_type: map_effective_type_to_directive(my_call_site.effective_type),
-                        symbol_type: 'matrix',
-                        alphabetical_order: name,
-                        parent_uri: matrix.sourceUri
-                    };
-
-                    const source_path = this.get_relative_path(matrix.sourceUri);
-                    const detail = `Matrix (from ${source_path})`;
-
-                    the_completions.push({
-                        label: name,
-                        kind: CompletionItemKind.Struct,
-                        detail,
-                        documentation: `Defined at ${matrix.sourceUri}`,
-                        sortText: compute_ranking_key(ranking_factors),
-                        textEdit: {
-                            range: replacement_range,
-                            newText: name,
-                        },
-                        filterText: name,
-                    });
-                    seen_labels.add(name);
-                }
-            }
         }
 
         return the_completions;
@@ -2068,18 +1863,15 @@ export class CompletionProvider {
         const seen_labels = new Set<string>();
 
         for (const [name, program] of symbols.programs) {
-            // Determine scope proximity for ranking
-            let depth = 0;
-            let directive_type: 'done-by' | 'included-by' | 'current' = 'current';
-            if (resolved_scope && program.sourceUri !== document.uri) {
-                const symbol_info = this.get_symbol_depth(program.sourceUri, resolved_scope);
-                depth = symbol_info.depth;
-                directive_type = symbol_info.directive_type;
-            }
+            const symbol_info = this.get_completion_symbol_provenance(
+                program,
+                document.uri,
+                resolved_scope,
+            );
             
             const ranking_factors: CompletionRankingFactors = {
-                scope_depth: depth,
-                directive_type,
+                scope_depth: symbol_info.depth,
+                directive_type: symbol_info.directive_type,
                 symbol_type: 'user-program',
                 alphabetical_order: program.name,
                 parent_uri: program.sourceUri
@@ -2087,9 +1879,8 @@ export class CompletionProvider {
             
             // Add source file annotation for cross-file symbols
             let detail = 'User-defined program';
-            if (resolved_scope && program.sourceUri !== document.uri) {
-                const source_path = this.get_relative_path(program.sourceUri);
-                detail += ` (from ${source_path})`;
+            if (symbol_info.source_path) {
+                detail += ` (from ${symbol_info.source_path})`;
             }
             
             the_completions.push({
@@ -2100,41 +1891,6 @@ export class CompletionProvider {
                 sortText: compute_ranking_key(ranking_factors),
             });
             seen_labels.add(name);
-        }
-
-        // Add forward call symbols from resolved_scope (position-aware filtering)
-        // This handles symbols from current file's forward call directives
-        // Programs are visible from both 'do' and 'include' types
-        if (resolved_scope?.forward_call_symbols) {
-            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
-            for (const my_call_site of the_visible_call_sites) {
-                for (const [name, program] of my_call_site.symbols.programs) {
-                    // Skip if already added
-                    if (seen_labels.has(name)) {
-                        continue;
-                    }
-
-                    const ranking_factors: CompletionRankingFactors = {
-                        scope_depth: 1,
-                        directive_type: map_effective_type_to_directive(my_call_site.effective_type),
-                        symbol_type: 'user-program',
-                        alphabetical_order: program.name,
-                        parent_uri: program.sourceUri
-                    };
-
-                    const source_path = this.get_relative_path(program.sourceUri);
-                    const detail = `User-defined program (from ${source_path})`;
-
-                    the_completions.push({
-                        label: program.name,
-                        kind: CompletionItemKind.Function,
-                        detail,
-                        documentation: `Defined at ${program.sourceUri}`,
-                        sortText: compute_ranking_key(ranking_factors),
-                    });
-                    seen_labels.add(name);
-                }
-            }
         }
 
         return the_completions;
@@ -2869,6 +2625,125 @@ export class CompletionProvider {
         return {
             kind: 'markdown',
             value: my_doc,
+        };
+    }
+
+    private annotate_symbol_map<T extends object>(
+        symbols: Map<string, T>,
+        scope_depth: number,
+        directive_type: 'done-by' | 'included-by' | 'current',
+    ): Map<string, T> {
+        return new Map(
+            Array.from(symbols.entries()).map(([name, symbol]) => [
+                name,
+                {
+                    ...symbol,
+                    scope_depth,
+                    directive_type,
+                } as T,
+            ]),
+        );
+    }
+
+    private get_annotated_visible_forward_symbols(
+        resolved_scope: ResolvedScope | undefined,
+        cursor_line: number,
+    ): SymbolTable {
+        let the_result = create_empty_symbol_table();
+
+        for (const my_call_site of get_visible_forward_call_sites(
+            resolved_scope,
+            cursor_line,
+        )) {
+            const directive_type = map_effective_type_to_directive(
+                my_call_site.effective_type,
+            );
+            const annotated_symbols: SymbolTable = {
+                programs: this.annotate_symbol_map(
+                    my_call_site.symbols.programs,
+                    1,
+                    directive_type,
+                ),
+                localMacros: my_call_site.effective_type === 'include'
+                    ? this.annotate_symbol_map(
+                        my_call_site.symbols.localMacros,
+                        1,
+                        directive_type,
+                    )
+                    : new Map(),
+                globalMacros: this.annotate_symbol_map(
+                    my_call_site.symbols.globalMacros,
+                    1,
+                    directive_type,
+                ),
+                variables: this.annotate_symbol_map(
+                    my_call_site.symbols.variables,
+                    1,
+                    directive_type,
+                ),
+                scalars: this.annotate_symbol_map(
+                    my_call_site.symbols.scalars,
+                    1,
+                    directive_type,
+                ),
+                matrices: this.annotate_symbol_map(
+                    my_call_site.symbols.matrices,
+                    1,
+                    directive_type,
+                ),
+            };
+
+            the_result = merge_symbol_tables(the_result, annotated_symbols);
+        }
+
+        return the_result;
+    }
+
+    private get_completion_symbol_provenance(
+        symbol: { sourceUri: string },
+        document_uri: string,
+        resolved_scope?: ResolvedScope,
+    ): {
+        depth: number;
+        directive_type: 'done-by' | 'included-by' | 'current';
+        source_path?: string;
+    } {
+        let depth = 0;
+        let directive_type: 'done-by' | 'included-by' | 'current' = 'current';
+        let show_source = false;
+
+        const annotated_depth = (symbol as any).scope_depth;
+        const annotated_directive = (symbol as any).directive_type;
+
+        if (resolved_scope && symbol.sourceUri !== document_uri) {
+            const symbol_info = this.get_symbol_depth(symbol.sourceUri, resolved_scope);
+            depth = symbol_info.depth;
+            directive_type = symbol_info.directive_type;
+            show_source = true;
+        }
+
+        if (
+            typeof annotated_depth === 'number' &&
+            (depth === 0 || depth === 999 || !resolved_scope)
+        ) {
+            depth = annotated_depth;
+        }
+
+        if (
+            annotated_directive === 'current' ||
+            annotated_directive === 'included-by' ||
+            annotated_directive === 'done-by'
+        ) {
+            directive_type = annotated_directive;
+            show_source = symbol.sourceUri !== document_uri;
+        }
+
+        return {
+            depth,
+            directive_type,
+            source_path: show_source && symbol.sourceUri !== document_uri
+                ? this.get_relative_path(symbol.sourceUri)
+                : undefined,
         };
     }
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -29,7 +29,6 @@ import {
     ProgramSignature,
     ProgramNode,
     ProgramSymbol,
-    ForwardCallSite,
     ScopeResolverConfig,
 } from '../types';
 import { IContextTracker, LanguageContext } from '../context-tracker/types';

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -916,9 +916,14 @@ export class CompletionProvider {
                     );
 
                 if (has_directives || has_auto_parents) {
-                    // With directives: use reachable scope chain (precision)
+                    // With directives: use reachable scope chain (precision).
+                    // get_visible_symbols_at already resolves forward calls
+                    // with correct precedence; re-merging visible_forward_overlay
+                    // would let forward symbols win a second time. Instead, copy
+                    // annotations only onto entries whose winner is the forward-
+                    // call version.
                     resolved_scope = temp_scope;
-                    symbols_for_completion = merge_symbol_tables(
+                    symbols_for_completion = this.copy_forward_annotations(
                         get_visible_symbols_at(temp_scope, position.line),
                         visible_forward_overlay,
                     );
@@ -2646,6 +2651,58 @@ export class CompletionProvider {
         );
     }
 
+    /**
+     * Apply annotations from `annotated_overlay` onto entries in `visible`
+     * whose winning `sourceUri` matches. `get_visible_symbols_at` already
+     * resolves forward-call precedence, so we must NOT re-merge the overlay on
+     * top — that would let forward-call symbols win a second time. Instead we
+     * keep the visible map as-is and only copy `scope_depth` / `directive_type`
+     * onto the entries where the forward-call version was the winner.
+     * Produces new wrapper objects; never mutates shared symbols.
+     */
+    private copy_forward_annotations(
+        visible: SymbolTable,
+        annotated_overlay: SymbolTable,
+    ): SymbolTable {
+        type AnnotatedLike = {
+            sourceUri?: string;
+            scope_depth?: number;
+            directive_type?: 'done-by' | 'included-by' | 'current';
+        };
+        const copy_kind = <T extends { sourceUri?: string }>(
+            visible_map: Map<string, T>,
+            overlay_map: Map<string, T>,
+        ): Map<string, T> => {
+            const the_result = new Map<string, T>();
+            for (const [my_name, my_symbol] of visible_map) {
+                const overlay_symbol = overlay_map.get(my_name) as T & AnnotatedLike | undefined;
+                if (
+                    overlay_symbol &&
+                    overlay_symbol.sourceUri === my_symbol.sourceUri &&
+                    (overlay_symbol.scope_depth !== undefined ||
+                        overlay_symbol.directive_type !== undefined)
+                ) {
+                    the_result.set(my_name, {
+                        ...my_symbol,
+                        scope_depth: overlay_symbol.scope_depth,
+                        directive_type: overlay_symbol.directive_type,
+                    } as T);
+                } else {
+                    the_result.set(my_name, my_symbol);
+                }
+            }
+            return the_result;
+        };
+        return {
+            programs: copy_kind(visible.programs, annotated_overlay.programs),
+            localMacros: copy_kind(visible.localMacros, annotated_overlay.localMacros),
+            globalMacros: copy_kind(visible.globalMacros, annotated_overlay.globalMacros),
+            variables: copy_kind(visible.variables, annotated_overlay.variables),
+            scalars: copy_kind(visible.scalars, annotated_overlay.scalars),
+            matrices: copy_kind(visible.matrices, annotated_overlay.matrices),
+        };
+    }
+
     private get_annotated_visible_forward_symbols(
         resolved_scope: ResolvedScope | undefined,
         cursor_line: number,
@@ -2666,6 +2723,7 @@ export class CompletionProvider {
                 my_call_site.symbols,
                 current_file_symbols,
                 my_call_site.call_line,
+                cursor_line,
             );
             const annotated_symbols: SymbolTable = {
                 programs: this.annotate_symbol_map(

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -39,6 +39,7 @@ import { build_scope_resolver_config } from '../scope-resolver';
 import {
     get_visible_forward_call_sites,
     get_visible_symbols_at,
+    filter_forward_site_symbols,
 } from '../scope-resolver';
 import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 import { isPathDirective, isFileCommand, hasStataExtension } from '../utils/file-path-utils';
@@ -2650,6 +2651,9 @@ export class CompletionProvider {
         cursor_line: number,
     ): SymbolTable {
         let the_result = create_empty_symbol_table();
+        const current_file_symbols = resolved_scope && resolved_scope.chain.length > 0
+            ? resolved_scope.chain[0].symbols
+            : undefined;
 
         for (const my_call_site of get_visible_forward_call_sites(
             resolved_scope,
@@ -2658,36 +2662,41 @@ export class CompletionProvider {
             const directive_type = map_effective_type_to_directive(
                 my_call_site.effective_type,
             );
+            const filtered_site_symbols = filter_forward_site_symbols(
+                my_call_site.symbols,
+                current_file_symbols,
+                my_call_site.call_line,
+            );
             const annotated_symbols: SymbolTable = {
                 programs: this.annotate_symbol_map(
-                    my_call_site.symbols.programs,
+                    filtered_site_symbols.programs,
                     1,
                     directive_type,
                 ),
                 localMacros: my_call_site.effective_type === 'include'
                     ? this.annotate_symbol_map(
-                        my_call_site.symbols.localMacros,
+                        filtered_site_symbols.localMacros,
                         1,
                         directive_type,
                     )
                     : new Map(),
                 globalMacros: this.annotate_symbol_map(
-                    my_call_site.symbols.globalMacros,
+                    filtered_site_symbols.globalMacros,
                     1,
                     directive_type,
                 ),
                 variables: this.annotate_symbol_map(
-                    my_call_site.symbols.variables,
+                    filtered_site_symbols.variables,
                     1,
                     directive_type,
                 ),
                 scalars: this.annotate_symbol_map(
-                    my_call_site.symbols.scalars,
+                    filtered_site_symbols.scalars,
                     1,
                     directive_type,
                 ),
                 matrices: this.annotate_symbol_map(
-                    my_call_site.symbols.matrices,
+                    filtered_site_symbols.matrices,
                     1,
                     directive_type,
                 ),

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -1084,7 +1084,13 @@ export class CompletionProvider {
             return [];
         }
         
-        const cache_context = 'command';
+        // Include cursor line in cache context because the caller passes
+        // `symbols` that were computed via get_visible_symbols_at(...,
+        // position.line) and a visible_forward_overlay scoped to the same
+        // line. Without the line in the key, completions from one cursor
+        // position could be served for another position on the same document
+        // version, producing stale/mis-scoped results.
+        const cache_context = `command:${position.line}`;
         const document_version = document.version || 0;
 
         // Check cache first

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -29,7 +29,6 @@ import {
     ProgramSignature,
     ProgramNode,
     ProgramSymbol,
-    ForwardResolvedScope,
     ForwardCallSite,
     ScopeResolverConfig,
 } from '../types';
@@ -38,6 +37,7 @@ import { CompletionPrefixCache } from '../utils/lru-cache';
 import { SymbolIndexCache } from '../utils/symbol-index-cache';
 import { ScopeResolver } from '../scope-resolver';
 import { build_scope_resolver_config } from '../scope-resolver';
+import { get_visible_forward_call_sites } from '../scope-resolver';
 import { merge_symbol_tables } from '../analyzer';
 import { isPathDirective, isFileCommand, hasStataExtension } from '../utils/file-path-utils';
 import { logger } from '../utils/logger';
@@ -51,29 +51,6 @@ import {
     MacroCompletionContext
 } from './completion/macro-completion';
 import { get_line_text, get_line_count } from '../utils/line-utils';
-
-/**
- * Get visible forward call symbols at a given position.
- * Symbols from forward calls are only visible AFTER the call site line.
- *
- * @param resolved_scope - The resolved scope containing forward_call_symbols
- * @param position - The cursor position
- * @returns Array of ForwardCallSite objects that are visible at the position
- */
-function get_visible_forward_call_sites(
-    resolved_scope: ResolvedScope | undefined,
-    position: Position
-): ForwardCallSite[] {
-    if (!resolved_scope?.forward_call_symbols) {
-        return [];
-    }
-
-    // Filter to only include call sites where cursor is AFTER the call line
-    // Symbols become visible after the call site line (cursor_line > call_line)
-    return resolved_scope.forward_call_symbols.filter(
-        call_site => position.line > call_site.call_line
-    );
-}
 
 /**
  * Map ForwardCallSite.effective_type to directive_type for ranking.
@@ -850,7 +827,6 @@ export class CompletionProvider {
      * @param scope_resolver - Optional scope resolver for cross-file awareness
      * @param workspace_symbols - Optional workspace-wide symbol table
      * @param cross_file_config - Optional cross-file config for scope resolution
-     * @param forward_scope - Optional forward-resolved scope for forward calls
      * @param workspace_version - Optional workspace version for cache validation
      * @param cancellation_token - Optional cancellation token
      * @returns Array of completion items
@@ -862,7 +838,6 @@ export class CompletionProvider {
         scope_resolver?: ScopeResolver,
         workspace_symbols?: SymbolTable,
         cross_file_config?: Partial<ScopeResolverConfig>,
-        forward_scope?: ForwardResolvedScope,
         workspace_version?: number,
         cancellation_token?: CancellationToken,
         graph_version?: number
@@ -987,8 +962,7 @@ export class CompletionProvider {
                         document,
                         position,
                         symbols_for_completion,
-                        resolved_scope,
-                        forward_scope
+                        resolved_scope
                     );
                     the_completions.push(...macro_completions);
                     return the_completions;
@@ -1007,7 +981,7 @@ export class CompletionProvider {
                     if (my_current_context !== LanguageContext.STATA) {
                         return [];
                     }
-                    return this.get_command_completions(document, position, symbols_for_completion, resolved_scope, forward_scope);
+                    return this.get_command_completions(document, position, symbols_for_completion, resolved_scope);
 
                 case 'option':
                     // Suppress option completions in embedded language contexts
@@ -1018,21 +992,21 @@ export class CompletionProvider {
 
                 case 'macro':
                     // Always provide macro completions (macros work in all contexts)
-                    return this.get_macro_completions(context as any, document, position, symbols_for_completion, resolved_scope, forward_scope);
+                    return this.get_macro_completions(context as any, document, position, symbols_for_completion, resolved_scope);
 
                 case 'variable':
                     // Suppress variable completions in embedded language contexts
                     if (my_current_context !== LanguageContext.STATA) {
                         return [];
                     }
-                    return this.get_variable_completions(document, position, symbols_for_completion, resolved_scope, forward_scope);
+                    return this.get_variable_completions(document, position, symbols_for_completion, resolved_scope);
 
                 case 'program':
                     // Suppress program completions in embedded language contexts
                     if (my_current_context !== LanguageContext.STATA) {
                         return [];
                     }
-                    return this.get_program_completions(document, position, symbols_for_completion, resolved_scope, forward_scope);
+                    return this.get_program_completions(document, position, symbols_for_completion, resolved_scope);
 
                 case 'directive_path':
                     // File path completions for directives (e.g., @lsp-done-by:)
@@ -1076,8 +1050,7 @@ export class CompletionProvider {
         document: DocumentState,
         position: Position,
         symbols: SymbolTable,
-        resolved_scope?: ResolvedScope,
-        forward_scope?: ForwardResolvedScope
+        resolved_scope?: ResolvedScope
     ): CompletionItem[] {
         const prefix = this.get_word_at_position(document, position);
         
@@ -1141,48 +1114,14 @@ export class CompletionProvider {
             }
         }
 
-        // Add forward scope symbols (from forward_scope parameter - legacy path)
-        if (forward_scope) {
-            const cursor_line = position.line;
-            for (const call_site of forward_scope.call_sites) {
-                if (call_site.call_line < cursor_line) {
-                    for (const [name, program] of call_site.symbols.programs) {
-                        if ((prefix === '' || name.toLowerCase().startsWith(prefix.toLowerCase())) && 
-                            !seen_labels.has(name.toLowerCase())) {
-                            seen_labels.add(name.toLowerCase());
-                            
-                            const ranking_factors: CompletionRankingFactors = {
-                                scope_depth: 1,
-                                directive_type: map_effective_type_to_directive(call_site.effective_type),
-                                symbol_type: 'user-program',
-                                alphabetical_order: program.name,
-                                parent_uri: program.sourceUri
-                            };
-                            
-                            const source_path = this.get_relative_path(program.sourceUri);
-                            const detail = `User-defined program (from ${source_path})`;
-                            
-                            the_completions.push({
-                                label: program.name,
-                                kind: CompletionItemKind.Function,
-                                detail,
-                                documentation: `Defined at ${program.sourceUri}`,
-                                sortText: compute_ranking_key(ranking_factors),
-                            });
-                        }
-                    }
-                }
-            }
-        }
-
         // Add forward call symbols from resolved_scope (position-aware filtering)
         // This handles symbols from current file's forward call directives
         // Programs are visible from both 'do' and 'include' types
         if (resolved_scope?.forward_call_symbols) {
-            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position);
+            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
             for (const my_call_site of the_visible_call_sites) {
                 for (const [name, program] of my_call_site.symbols.programs) {
-                    if ((prefix === '' || name.toLowerCase().startsWith(prefix.toLowerCase())) && 
+                    if ((prefix === '' || name.toLowerCase().startsWith(prefix.toLowerCase())) &&
                         !seen_labels.has(name.toLowerCase())) {
                         seen_labels.add(name.toLowerCase());
                         
@@ -1585,7 +1524,6 @@ export class CompletionProvider {
      * @param document - The document state
      * @param position - The cursor position for prefix extraction
      * @param resolved_scope - Optional resolved scope for cross-file symbols
-     * @param forward_scope - Optional forward-resolved scope for forward calls
      * @returns Array of completion items filtered by prefix and sorted alphabetically
      */
     private get_macro_completions(
@@ -1593,8 +1531,7 @@ export class CompletionProvider {
         document: DocumentState,
         position: Position,
         symbols: SymbolTable,
-        resolved_scope?: ResolvedScope,
-        forward_scope?: ForwardResolvedScope
+        resolved_scope?: ResolvedScope
     ): CompletionItem[] {
         // Use context.form to determine scope and delimiter behavior
         const scope = context.scope;
@@ -1748,59 +1685,10 @@ export class CompletionProvider {
             seen_labels.add(name);
         }
 
-        // Add forward scope symbols (from forward_scope parameter - legacy path)
-        if (forward_scope) {
-            const cursor_line = position.line;
-            for (const call_site of forward_scope.call_sites) {
-                if (call_site.call_line < cursor_line) {
-                    const forward_macros = scope === 'local' ? call_site.symbols.localMacros : call_site.symbols.globalMacros;
-                    
-                    for (const [name, macro] of forward_macros) {
-                        // Case-insensitive prefix match
-                        if (!(prefix === '' || name.toLowerCase().startsWith(prefix_lower))) {
-                            continue;
-                        }
-
-                        // Skip if already added
-                        if (seen_labels.has(name)) {
-                            continue;
-                        }
-
-                        const ranking_factors: CompletionRankingFactors = {
-                            scope_depth: 1,
-                            directive_type: map_effective_type_to_directive(call_site.effective_type),
-                            symbol_type: scope === 'local' ? 'local-macro' : 'global-macro',
-                            alphabetical_order: name,
-                            parent_uri: macro.sourceUri,
-                        };
-
-                        const source_path = this.get_relative_path(macro.sourceUri);
-                        const detail = `${scope} macro (from ${source_path})`;
-
-                        // Compute newText with optional closing delimiter
-                        const new_text = name + (needs_closing_delimiter ? closing_char : '');
-
-                        the_completions.push({
-                            label: name,
-                            kind: CompletionItemKind.Variable,
-                            detail,
-                            documentation: macro.value ? `Value: ${macro.value}` : undefined,
-                            sortText: compute_ranking_key(ranking_factors),
-                            textEdit: {
-                                range: replacement_range,
-                                newText: new_text,
-                            },
-                        });
-                        seen_labels.add(name);
-                    }
-                }
-            }
-        }
-
         // Add forward call symbols from resolved_scope (position-aware filtering)
         // This handles symbols from current file's forward call directives
         if (resolved_scope?.forward_call_symbols) {
-            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position);
+            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
             for (const my_call_site of the_visible_call_sites) {
                 // For local macros, only include from 'include' type (not 'do')
                 // For global macros, include from both 'do' and 'include' types
@@ -1908,8 +1796,7 @@ export class CompletionProvider {
         document: DocumentState,
         position: Position,
         symbols: SymbolTable,
-        resolved_scope?: ResolvedScope,
-        forward_scope?: ForwardResolvedScope
+        resolved_scope?: ResolvedScope
     ): CompletionItem[] {
         const the_completions: CompletionItem[] = [];
         const seen_labels = new Set<string>();
@@ -2061,116 +1948,11 @@ export class CompletionProvider {
             seen_labels.add(name);
         }
 
-        // Add forward scope symbols
-        if (forward_scope) {
-            const cursor_line = position.line;
-            for (const call_site of forward_scope.call_sites) {
-                if (call_site.call_line < cursor_line) {
-                    // Variables
-                    for (const [name, variable] of call_site.symbols.variables) {
-                        // Skip if already added
-                        if (seen_labels.has(name)) {
-                            continue;
-                        }
-
-                        const ranking_factors: CompletionRankingFactors = {
-                            scope_depth: 1,
-                            directive_type: map_effective_type_to_directive(call_site.effective_type),
-                            symbol_type: 'variable',
-                            alphabetical_order: name,
-                            parent_uri: variable.sourceUri
-                        };
-
-                        const source_path = this.get_relative_path(variable.sourceUri);
-                        const detail = variable.type ? `${variable.type} variable (from ${source_path})` : `Variable (from ${source_path})`;
-
-                        the_completions.push({
-                            label: name,
-                            kind: CompletionItemKind.Field,
-                            detail,
-                            documentation: variable.label || `Created via ${variable.source}`,
-                            sortText: compute_ranking_key(ranking_factors),
-                            textEdit: {
-                                range: replacement_range,
-                                newText: name,
-                            },
-                            filterText: name,
-                        });
-                        seen_labels.add(name);
-                    }
-
-                    // Scalars
-                    for (const [name, scalar] of call_site.symbols.scalars) {
-                        if (seen_labels.has(name)) {
-                            continue;
-                        }
-
-                        const ranking_factors: CompletionRankingFactors = {
-                            scope_depth: 1,
-                            directive_type: map_effective_type_to_directive(call_site.effective_type),
-                            symbol_type: 'scalar',
-                            alphabetical_order: name,
-                            parent_uri: scalar.sourceUri
-                        };
-
-                        const source_path = this.get_relative_path(scalar.sourceUri);
-                        const detail = `Scalar (from ${source_path})`;
-
-                        the_completions.push({
-                            label: name,
-                            kind: CompletionItemKind.Constant,
-                            detail,
-                            documentation: `Defined at ${scalar.sourceUri}`,
-                            sortText: compute_ranking_key(ranking_factors),
-                            textEdit: {
-                                range: replacement_range,
-                                newText: name,
-                            },
-                            filterText: name,
-                        });
-                        seen_labels.add(name);
-                    }
-
-                    // Matrices
-                    for (const [name, matrix] of call_site.symbols.matrices) {
-                        if (seen_labels.has(name)) {
-                            continue;
-                        }
-
-                        const ranking_factors: CompletionRankingFactors = {
-                            scope_depth: 1,
-                            directive_type: map_effective_type_to_directive(call_site.effective_type),
-                            symbol_type: 'matrix',
-                            alphabetical_order: name,
-                            parent_uri: matrix.sourceUri
-                        };
-
-                        const source_path = this.get_relative_path(matrix.sourceUri);
-                        const detail = `Matrix (from ${source_path})`;
-
-                        the_completions.push({
-                            label: name,
-                            kind: CompletionItemKind.Struct,
-                            detail,
-                            documentation: `Defined at ${matrix.sourceUri}`,
-                            sortText: compute_ranking_key(ranking_factors),
-                            textEdit: {
-                                range: replacement_range,
-                                newText: name,
-                            },
-                            filterText: name,
-                        });
-                        seen_labels.add(name);
-                    }
-                }
-            }
-        }
-
         // Add forward call symbols from resolved_scope (position-aware filtering)
         // This handles symbols from current file's forward call directives
         // Variables, scalars, and matrices are visible from both 'do' and 'include' types
         if (resolved_scope?.forward_call_symbols) {
-            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position);
+            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
             for (const my_call_site of the_visible_call_sites) {
                 // Variables
                 for (const [name, variable] of my_call_site.symbols.variables) {
@@ -2281,8 +2063,7 @@ export class CompletionProvider {
         document: DocumentState,
         position: Position,
         symbols: SymbolTable,
-        resolved_scope?: ResolvedScope,
-        forward_scope?: ForwardResolvedScope
+        resolved_scope?: ResolvedScope
     ): CompletionItem[] {
         const the_completions: CompletionItem[] = [];
         const seen_labels = new Set<string>();
@@ -2322,46 +2103,11 @@ export class CompletionProvider {
             seen_labels.add(name);
         }
 
-        // Add forward scope symbols (from forward_scope parameter - legacy path)
-        if (forward_scope) {
-            const cursor_line = position.line;
-            for (const call_site of forward_scope.call_sites) {
-                if (call_site.call_line < cursor_line) {
-                    for (const [name, program] of call_site.symbols.programs) {
-                        // Skip if already added
-                        if (seen_labels.has(name)) {
-                            continue;
-                        }
-
-                        const ranking_factors: CompletionRankingFactors = {
-                            scope_depth: 1,
-                            directive_type: map_effective_type_to_directive(call_site.effective_type),
-                            symbol_type: 'user-program',
-                            alphabetical_order: program.name,
-                            parent_uri: program.sourceUri
-                        };
-
-                        const source_path = this.get_relative_path(program.sourceUri);
-                        const detail = `User-defined program (from ${source_path})`;
-
-                        the_completions.push({
-                            label: program.name,
-                            kind: CompletionItemKind.Function,
-                            detail,
-                            documentation: `Defined at ${program.sourceUri}`,
-                            sortText: compute_ranking_key(ranking_factors),
-                        });
-                        seen_labels.add(name);
-                    }
-                }
-            }
-        }
-
         // Add forward call symbols from resolved_scope (position-aware filtering)
         // This handles symbols from current file's forward call directives
         // Programs are visible from both 'do' and 'include' types
         if (resolved_scope?.forward_call_symbols) {
-            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position);
+            const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
             for (const my_call_site of the_visible_call_sites) {
                 for (const [name, program] of my_call_site.symbols.programs) {
                     // Skip if already added

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -2721,8 +2721,13 @@ export class CompletionProvider {
         let directive_type: 'done-by' | 'included-by' | 'current' = 'current';
         let show_source = false;
 
-        const annotated_depth = (symbol as any).scope_depth;
-        const annotated_directive = (symbol as any).directive_type;
+        // Narrow type for annotated symbols with optional metadata
+        type AnnotatedSymbol = {
+            sourceUri: string;
+            scope_depth?: number;
+            directive_type?: 'current' | 'included-by' | 'done-by';
+        };
+        const annotated = symbol as AnnotatedSymbol;
 
         if (resolved_scope && symbol.sourceUri !== document_uri) {
             const symbol_info = this.get_symbol_depth(symbol.sourceUri, resolved_scope);
@@ -2732,18 +2737,18 @@ export class CompletionProvider {
         }
 
         if (
-            typeof annotated_depth === 'number' &&
+            typeof annotated.scope_depth === 'number' &&
             (depth === 0 || depth === 999 || !resolved_scope)
         ) {
-            depth = annotated_depth;
+            depth = annotated.scope_depth;
         }
 
         if (
-            annotated_directive === 'current' ||
-            annotated_directive === 'included-by' ||
-            annotated_directive === 'done-by'
+            annotated.directive_type === 'current' ||
+            annotated.directive_type === 'included-by' ||
+            annotated.directive_type === 'done-by'
         ) {
-            directive_type = annotated_directive;
+            directive_type = annotated.directive_type;
             show_source = symbol.sourceUri !== document_uri;
         }
 

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -136,7 +136,8 @@ export class DefinitionProvider {
                     scope_resolver,
                     workspace_indexer,
                     cross_file_config,
-                    cancellation_token
+                    cancellation_token,
+                    position
                 );
             }
             
@@ -161,7 +162,8 @@ export class DefinitionProvider {
                         scope_resolver,
                         workspace_indexer,
                         cross_file_config,
-                        cancellation_token
+                        cancellation_token,
+                        position
                     );
                 }
 
@@ -211,7 +213,8 @@ export class DefinitionProvider {
         scope_resolver?: ScopeResolver,
         workspace_indexer?: WorkspaceIndexer,
         cross_file_config?: Partial<ScopeResolverConfig>,
-        cancellation_token?: CancellationToken
+        cancellation_token?: CancellationToken,
+        position?: Position
     ): Promise<Definition | null> {
         // Try scope resolver first
         if (scope_resolver) {
@@ -229,6 +232,24 @@ export class DefinitionProvider {
                     uri: local_macro.location.uri,
                     range: local_macro.location.range,
                 };
+            }
+
+            // Check forward-call symbols brought in by `include` before the
+            // cursor. Without this, a local macro pulled in by a forward
+            // `include` falls through to the workspace indexer, which returns
+            // every like-named local in the workspace.
+            if (position && resolved_scope.forward_call_symbols) {
+                for (const my_call_site of resolved_scope.forward_call_symbols) {
+                    if (position.line <= my_call_site.call_line) continue;
+                    if (my_call_site.effective_type !== 'include') continue;
+                    const forward_local = my_call_site.symbols.localMacros.get(word);
+                    if (forward_local) {
+                        return {
+                            uri: forward_local.location.uri,
+                            range: forward_local.location.range,
+                        };
+                    }
+                }
             }
         }
 
@@ -504,7 +525,8 @@ export class DefinitionProvider {
                 scope_resolver,
                 workspace_indexer,
                 cross_file_config,
-                cancellation_token
+                cancellation_token,
+                position
             );
         }
         

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -41,7 +41,7 @@ type MacroDefNodeLike = {
     range: { start: Position; end: Position };
 };
 import { IContextTracker } from '../context-tracker/types';
-import { ScopeResolver, build_scope_resolver_config } from '../scope-resolver';
+import { ScopeResolver, build_scope_resolver_config, get_visible_symbols_at } from '../scope-resolver';
 import { WorkspaceIndexer } from '../indexer';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -178,6 +178,7 @@ export class DefinitionProvider {
                 return await this.resolve_non_macro_symbols(
                     word,
                     document,
+                    position,
                     workspace_symbols,
                     scope_resolver,
                     workspace_indexer,
@@ -321,6 +322,7 @@ export class DefinitionProvider {
     private async resolve_non_macro_symbols(
         word: string,
         document: DocumentState,
+        position: Position,
         workspace_symbols?: SymbolTable,
         scope_resolver?: ScopeResolver,
         workspace_indexer?: WorkspaceIndexer,
@@ -336,18 +338,18 @@ export class DefinitionProvider {
                 resolve_config,
                 cancellation_token
             );
+            const visible = get_visible_symbols_at(resolved_scope, position.line);
 
-            // Check variables first (highest priority for WORD tokens)
-            const variable = resolved_scope.symbols.variables.get(word);
+            // Priority: variable → program → scalar → matrix (matches pre-fix order).
+            const variable = visible.variables.get(word);
             if (variable) {
                 return {
                     uri: variable.location.uri,
                     range: variable.location.range,
                 };
             }
-            
-            // Check programs
-            const program = resolved_scope.symbols.programs.get(word);
+
+            const program = visible.programs.get(word);
             if (program) {
                 return {
                     uri: program.location.uri,
@@ -355,8 +357,7 @@ export class DefinitionProvider {
                 };
             }
 
-            // Check scalars
-            const scalar = resolved_scope.symbols.scalars.get(word);
+            const scalar = visible.scalars.get(word);
             if (scalar) {
                 return {
                     uri: scalar.location.uri,
@@ -364,8 +365,7 @@ export class DefinitionProvider {
                 };
             }
 
-            // Check matrices
-            const matrix = resolved_scope.symbols.matrices.get(word);
+            const matrix = visible.matrices.get(word);
             if (matrix) {
                 return {
                     uri: matrix.location.uri,
@@ -535,6 +535,7 @@ export class DefinitionProvider {
         return await this.resolve_non_macro_symbols(
             word,
             document,
+            position,
             workspace_symbols,
             scope_resolver,
             workspace_indexer,

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -10,10 +10,9 @@ import {
     StataLSPConfig,
     SymbolTable,
     ResolvedScope,
-    DirectiveDiagnostic,
-    ForwardResolvedScope
+    DirectiveDiagnostic
 } from '../types';
-import { ScopeResolver, build_scope_resolver_config } from '../scope-resolver';
+import { ScopeResolver, build_scope_resolver_config, get_visible_forward_call_sites } from '../scope-resolver';
 import { createHash } from 'crypto';
 import { DocumentDebounceManager } from '../utils/debounce-manager';
 import { get_line_text, get_line_count } from '../utils/line-utils';
@@ -101,8 +100,7 @@ export class DiagnosticsProvider {
         config: StataLSPConfig,
         workspace_symbols?: SymbolTable,
         scope_resolver?: ScopeResolver,
-        cancellation_token?: CancellationToken,
-        forward_scope?: ForwardResolvedScope
+        cancellation_token?: CancellationToken
     ): Promise<{ diagnostics: Diagnostic[]; pending: boolean }> {
         // Version gating: only publish if this is the latest version
         const current_published = this.published_versions.get(document.uri);
@@ -123,7 +121,7 @@ export class DiagnosticsProvider {
         const is_pending = this.debounce_manager?.is_pending(document.uri) ?? false;
 
         // Collect all diagnostics (reuse cached results from DocumentStore)
-        const the_diagnostics = await this.get_diagnostics(document, config, workspace_symbols, scope_resolver, cancellation_token, forward_scope);
+        const the_diagnostics = await this.get_diagnostics(document, config, workspace_symbols, scope_resolver, cancellation_token);
 
         // Publish diagnostics
         this.connection.sendDiagnostics({
@@ -147,8 +145,7 @@ export class DiagnosticsProvider {
         config: StataLSPConfig,
         workspace_symbols?: SymbolTable,
         scope_resolver?: ScopeResolver,
-        cancellation_token?: CancellationToken,
-        forward_scope?: ForwardResolvedScope
+        cancellation_token?: CancellationToken
     ): Promise<Diagnostic[]> {
         // Generate config hash for cache key
         const config_hash = this.compute_config_hash(config);
@@ -296,25 +293,24 @@ export class DiagnosticsProvider {
                 }
             }
             
-            // Check if this is an undefined symbol that's defined in forward-call symbols
-            // Use resolved_scope.forward_call_symbols as primary source, fall back to forward_scope.call_sites
-            const forward_call_sites = resolved_scope?.forward_call_symbols ?? forward_scope?.call_sites;
-            if (forward_call_sites && 
+            // Check if this is an undefined symbol that's defined in a forward-called
+            // file visible at this diagnostic's line. Uses the shared helper.
+            if (resolved_scope &&
                 (my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO ||
                  my_diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE)) {
                 const symbol_name = this.extract_symbol_name_from_diagnostic(my_diagnostic);
                 if (symbol_name) {
                     const diag_line = my_diagnostic.range.start.line;
                     let found_in_forward_call = false;
-                    for (const call_site of forward_call_sites) {
-                        if (call_site.call_line < diag_line &&
-                            this.is_symbol_in_forward_call(symbol_name, call_site.symbols, my_diagnostic.code, call_site.effective_type)) {
+                    for (const call_site of get_visible_forward_call_sites(resolved_scope, diag_line)) {
+                        if (this.is_symbol_in_forward_call(
+                                symbol_name, call_site.symbols, my_diagnostic.code, call_site.effective_type)) {
                             found_in_forward_call = true;
                             break;
                         }
                     }
                     if (found_in_forward_call) {
-                        continue; // Skip - symbol is defined in forward-called file before this line
+                        continue;
                     }
                 }
             }
@@ -355,16 +351,6 @@ export class DiagnosticsProvider {
         if (resolved_scope) {
             for (const my_directive_diag of resolved_scope.diagnostics) {
                 const converted = this.convert_directive_diagnostic(my_directive_diag, config);
-                if (converted) {
-                    the_diagnostics.push(converted);
-                }
-            }
-        }
-
-        // Add forward-scope diagnostics (missing file, max depth, cycle)
-        if (forward_scope) {
-            for (const my_forward_diag of forward_scope.diagnostics) {
-                const converted = this.convert_directive_diagnostic(my_forward_diag, config);
                 if (converted) {
                     the_diagnostics.push(converted);
                 }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -466,6 +466,29 @@ export class HoverProvider {
     }
 
     /**
+     * Safely get visible symbols from a resolved scope, guarding against partial stubs.
+     * Returns resolved_scope.symbols when chain is missing/undefined or when position is falsy,
+     * otherwise delegates to get_visible_symbols_at for proper position filtering.
+     *
+     * @param resolved_scope - The resolved scope (may be a partial stub)
+     * @param position - Optional cursor position for forward call symbol filtering
+     */
+    private safe_visible_symbols(
+        resolved_scope: ResolvedScope | undefined,
+        position?: Position
+    ): SymbolTable | undefined {
+        if (!resolved_scope) {
+            return undefined;
+        }
+        // For partial stubs without chain, or when position is undefined, use symbols directly
+        if (!resolved_scope.chain || !position) {
+            return resolved_scope.symbols;
+        }
+        // Otherwise use position-aware filtering
+        return get_visible_symbols_at(resolved_scope, position.line);
+    }
+
+    /**
      * Get hover info for a local macro only.
      * Checks resolved scope, forward call symbols (with position filtering), and document symbols.
      *
@@ -483,10 +506,8 @@ export class HoverProvider {
         position?: Position
     ): MarkupContent | null {
         // Check resolved scope first if available
-        if (resolved_scope) {
-            const local_macro_symbols = position
-                ? get_visible_symbols_at(resolved_scope, position.line)
-                : resolved_scope.symbols;
+        const local_macro_symbols = this.safe_visible_symbols(resolved_scope, position);
+        if (local_macro_symbols) {
             const local_macro = local_macro_symbols.localMacros.get(word);
             if (local_macro) {
                 const source_link = this.format_source_link(local_macro.sourceUri, document.uri, workspace_root);
@@ -550,10 +571,8 @@ export class HoverProvider {
         position?: Position
     ): MarkupContent | null {
         // Check resolved scope first if available
-        if (resolved_scope) {
-            const global_macro_symbols = position
-                ? get_visible_symbols_at(resolved_scope, position.line)
-                : resolved_scope.symbols;
+        const global_macro_symbols = this.safe_visible_symbols(resolved_scope, position);
+        if (global_macro_symbols) {
             const global_macro = global_macro_symbols.globalMacros.get(word);
             if (global_macro) {
                 const source_link = this.format_source_link(global_macro.sourceUri, document.uri, workspace_root);
@@ -617,10 +636,8 @@ export class HoverProvider {
         position?: Position
     ): MarkupContent | null {
         // 1. Check resolved_scope first (highest precedence)
-        if (resolved_scope) {
-            const scalar_symbols = position
-                ? get_visible_symbols_at(resolved_scope, position.line)
-                : resolved_scope.symbols;
+        const scalar_symbols = this.safe_visible_symbols(resolved_scope, position);
+        if (scalar_symbols) {
             const scalar = scalar_symbols.scalars.get(word);
             if (scalar) {
                 const source_link = this.format_source_link(scalar.sourceUri, document.uri, workspace_root);
@@ -688,10 +705,8 @@ export class HoverProvider {
         position?: Position
     ): MarkupContent | null {
         // 1. Check resolved_scope first (highest precedence)
-        if (resolved_scope) {
-            const matrix_symbols = position
-                ? get_visible_symbols_at(resolved_scope, position.line)
-                : resolved_scope.symbols;
+        const matrix_symbols = this.safe_visible_symbols(resolved_scope, position);
+        if (matrix_symbols) {
             const matrix = matrix_symbols.matrices.get(word);
             if (matrix) {
                 const source_link = this.format_source_link(matrix.sourceUri, document.uri, workspace_root);
@@ -1238,10 +1253,8 @@ export class HoverProvider {
         position?: Position
     ): MarkupContent | null {
         // Check resolved scope first if available
-        if (resolved_scope) {
-            const program_symbols = position
-                ? get_visible_symbols_at(resolved_scope, position.line)
-                : resolved_scope.symbols;
+        const program_symbols = this.safe_visible_symbols(resolved_scope, position);
+        if (program_symbols) {
             const program = program_symbols.programs.get(word);
             if (program) {
                 return this.get_hover_for_user_program(
@@ -1335,10 +1348,8 @@ export class HoverProvider {
         position?: Position
     ): MarkupContent | null {
         // 1. Check resolved_scope first (highest precedence)
-        if (resolved_scope) {
-            const variable_symbols = position
-                ? get_visible_symbols_at(resolved_scope, position.line)
-                : resolved_scope.symbols;
+        const variable_symbols = this.safe_visible_symbols(resolved_scope, position);
+        if (variable_symbols) {
             const variable = variable_symbols.variables.get(word);
             if (variable) {
                 return this.format_variable_hover(variable, document.uri, workspace_root);

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -41,7 +41,7 @@ import { IContextTracker } from '../context-tracker/types';
 import { LanguageContext } from '../context-tracker/types';
 import { ScopeResolver } from '../scope-resolver';
 import { build_scope_resolver_config } from '../scope-resolver';
-import { get_visible_forward_call_sites } from '../scope-resolver';
+import { get_visible_symbols_at } from '../scope-resolver';
 import { get_line_text } from '../utils/line-utils';
 import { is_cursor_in_comment } from '../utils/comment-utils';
 
@@ -484,7 +484,10 @@ export class HoverProvider {
     ): MarkupContent | null {
         // Check resolved scope first if available
         if (resolved_scope) {
-            const local_macro = resolved_scope.symbols.localMacros.get(word);
+            const local_macro_symbols = position
+                ? get_visible_symbols_at(resolved_scope, position.line)
+                : resolved_scope.symbols;
+            const local_macro = local_macro_symbols.localMacros.get(word);
             if (local_macro) {
                 const source_link = this.format_source_link(local_macro.sourceUri, document.uri, workspace_root);
                 const line_info = local_macro.definition_line !== undefined ? `, line ${local_macro.definition_line + 1}` : '';
@@ -501,34 +504,6 @@ export class HoverProvider {
                     kind: MarkupKind.Markdown,
                     value: `**Local Macro:** \`${word}\`${source_info}${expansion_text}`,
                 };
-            }
-
-            // Check forward call symbols with position filtering
-            // Only include symbols where cursor line > call_line (visible AFTER call site)
-            if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
-                for (const my_call_site of the_visible_call_sites) {
-                    // For 'include' type, local macros are visible; for 'do' type, they are not
-                    if (my_call_site.effective_type === 'include') {
-                        const forward_local_macro = my_call_site.symbols.localMacros.get(word);
-                        if (forward_local_macro) {
-                            const source_link = this.format_source_link(forward_local_macro.sourceUri, document.uri, workspace_root);
-                            const line_info = forward_local_macro.definition_line !== undefined ? `, line ${forward_local_macro.definition_line + 1}` : '';
-                            const source_info = source_link
-                                ? `\n\nSource: ${source_link}${line_info}`
-                                : `\n\nDefined at: this file${line_info}`;
-                            const expansion_text = forward_local_macro.value
-                                ? (forward_local_macro.value.includes('\n')
-                                    ? `\n\nExpansion:\n\`\`\`\n${forward_local_macro.value}\n\`\`\``
-                                    : `\n\nExpansion: \`${forward_local_macro.value}\``)
-                                : '';
-                            return {
-                                kind: MarkupKind.Markdown,
-                                value: `**Local Macro:** \`${word}\`${source_info}${expansion_text}`,
-                            };
-                        }
-                    }
-                }
             }
         }
 
@@ -576,7 +551,10 @@ export class HoverProvider {
     ): MarkupContent | null {
         // Check resolved scope first if available
         if (resolved_scope) {
-            const global_macro = resolved_scope.symbols.globalMacros.get(word);
+            const global_macro_symbols = position
+                ? get_visible_symbols_at(resolved_scope, position.line)
+                : resolved_scope.symbols;
+            const global_macro = global_macro_symbols.globalMacros.get(word);
             if (global_macro) {
                 const source_link = this.format_source_link(global_macro.sourceUri, document.uri, workspace_root);
                 const line_info = global_macro.definition_line !== undefined ? `, line ${global_macro.definition_line + 1}` : '';
@@ -593,31 +571,6 @@ export class HoverProvider {
                     kind: MarkupKind.Markdown,
                     value: `**Global Macro:** \`${word}\`${source_info}${expansion_text}`,
                 };
-            }
-
-            // Check forward call symbols with position filtering
-            // Global macros are visible from both 'do' and 'include' types
-            if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
-                for (const my_call_site of the_visible_call_sites) {
-                    const forward_global_macro = my_call_site.symbols.globalMacros.get(word);
-                    if (forward_global_macro) {
-                        const source_link = this.format_source_link(forward_global_macro.sourceUri, document.uri, workspace_root);
-                        const line_info = forward_global_macro.definition_line !== undefined ? `, line ${forward_global_macro.definition_line + 1}` : '';
-                        const source_info = source_link
-                            ? `\n\nSource: ${source_link}${line_info}`
-                            : `\n\nDefined at: this file${line_info}`;
-                        const expansion_text = forward_global_macro.value
-                            ? (forward_global_macro.value.includes('\n')
-                                ? `\n\nExpansion:\n\`\`\`\n${forward_global_macro.value}\n\`\`\``
-                                : `\n\nExpansion: \`${forward_global_macro.value}\``)
-                            : '';
-                        return {
-                            kind: MarkupKind.Markdown,
-                            value: `**Global Macro:** \`${word}\`${source_info}${expansion_text}`,
-                        };
-                    }
-                }
             }
         }
 
@@ -665,7 +618,10 @@ export class HoverProvider {
     ): MarkupContent | null {
         // 1. Check resolved_scope first (highest precedence)
         if (resolved_scope) {
-            const scalar = resolved_scope.symbols.scalars.get(word);
+            const scalar_symbols = position
+                ? get_visible_symbols_at(resolved_scope, position.line)
+                : resolved_scope.symbols;
+            const scalar = scalar_symbols.scalars.get(word);
             if (scalar) {
                 const source_link = this.format_source_link(scalar.sourceUri, document.uri, workspace_root);
                 const line_info = scalar.definition_line !== undefined ? `, line ${scalar.definition_line + 1}` : '';
@@ -676,25 +632,6 @@ export class HoverProvider {
                     kind: MarkupKind.Markdown,
                     value: `**Scalar:** \`${word}\`${source_info}`,
                 };
-            }
-
-            // Check forward call symbols with position filtering
-            if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
-                for (const my_call_site of the_visible_call_sites) {
-                    const forward_scalar = my_call_site.symbols.scalars.get(word);
-                    if (forward_scalar) {
-                        const source_link = this.format_source_link(forward_scalar.sourceUri, document.uri, workspace_root);
-                        const line_info = forward_scalar.definition_line !== undefined ? `, line ${forward_scalar.definition_line + 1}` : '';
-                        const source_info = source_link
-                            ? `\n\nSource: ${source_link}${line_info}`
-                            : `\n\nDefined at: this file${line_info}`;
-                        return {
-                            kind: MarkupKind.Markdown,
-                            value: `**Scalar:** \`${word}\`${source_info}`,
-                        };
-                    }
-                }
             }
         }
 
@@ -752,7 +689,10 @@ export class HoverProvider {
     ): MarkupContent | null {
         // 1. Check resolved_scope first (highest precedence)
         if (resolved_scope) {
-            const matrix = resolved_scope.symbols.matrices.get(word);
+            const matrix_symbols = position
+                ? get_visible_symbols_at(resolved_scope, position.line)
+                : resolved_scope.symbols;
+            const matrix = matrix_symbols.matrices.get(word);
             if (matrix) {
                 const source_link = this.format_source_link(matrix.sourceUri, document.uri, workspace_root);
                 const line_info = matrix.definition_line !== undefined ? `, line ${matrix.definition_line + 1}` : '';
@@ -763,25 +703,6 @@ export class HoverProvider {
                     kind: MarkupKind.Markdown,
                     value: `**Matrix:** \`${word}\`${source_info}`,
                 };
-            }
-
-            // Check forward call symbols with position filtering
-            if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
-                for (const my_call_site of the_visible_call_sites) {
-                    const forward_matrix = my_call_site.symbols.matrices.get(word);
-                    if (forward_matrix) {
-                        const source_link = this.format_source_link(forward_matrix.sourceUri, document.uri, workspace_root);
-                        const line_info = forward_matrix.definition_line !== undefined ? `, line ${forward_matrix.definition_line + 1}` : '';
-                        const source_info = source_link
-                            ? `\n\nSource: ${source_link}${line_info}`
-                            : `\n\nDefined at: this file${line_info}`;
-                        return {
-                            kind: MarkupKind.Markdown,
-                            value: `**Matrix:** \`${word}\`${source_info}`,
-                        };
-                    }
-                }
             }
         }
 
@@ -1318,21 +1239,17 @@ export class HoverProvider {
     ): MarkupContent | null {
         // Check resolved scope first if available
         if (resolved_scope) {
-            const program = resolved_scope.symbols.programs.get(word);
+            const program_symbols = position
+                ? get_visible_symbols_at(resolved_scope, position.line)
+                : resolved_scope.symbols;
+            const program = program_symbols.programs.get(word);
             if (program) {
-                return this.get_hover_for_user_program(program.name, resolved_scope.symbols, document.uri, workspace_root);
-            }
-
-            // Check forward call symbols with position filtering
-            // Programs are visible from both 'do' and 'include' types
-            if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
-                for (const my_call_site of the_visible_call_sites) {
-                    const forward_program = my_call_site.symbols.programs.get(word);
-                    if (forward_program) {
-                        return this.get_hover_for_user_program(forward_program.name, my_call_site.symbols, document.uri, workspace_root);
-                    }
-                }
+                return this.get_hover_for_user_program(
+                    program.name,
+                    program_symbols,
+                    document.uri,
+                    workspace_root,
+                );
             }
         }
 
@@ -1419,21 +1336,12 @@ export class HoverProvider {
     ): MarkupContent | null {
         // 1. Check resolved_scope first (highest precedence)
         if (resolved_scope) {
-            const variable = resolved_scope.symbols.variables.get(word);
+            const variable_symbols = position
+                ? get_visible_symbols_at(resolved_scope, position.line)
+                : resolved_scope.symbols;
+            const variable = variable_symbols.variables.get(word);
             if (variable) {
                 return this.format_variable_hover(variable, document.uri, workspace_root);
-            }
-
-            // Check forward call symbols with position filtering
-            // Variables are visible from both 'do' and 'include' types
-            if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
-                for (const my_call_site of the_visible_call_sites) {
-                    const forward_variable = my_call_site.symbols.variables.get(word);
-                    if (forward_variable) {
-                        return this.format_variable_hover(forward_variable, document.uri, workspace_root);
-                    }
-                }
             }
         }
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -41,6 +41,7 @@ import { IContextTracker } from '../context-tracker/types';
 import { LanguageContext } from '../context-tracker/types';
 import { ScopeResolver } from '../scope-resolver';
 import { build_scope_resolver_config } from '../scope-resolver';
+import { get_visible_forward_call_sites } from '../scope-resolver';
 import { get_line_text } from '../utils/line-utils';
 import { is_cursor_in_comment } from '../utils/comment-utils';
 
@@ -465,29 +466,6 @@ export class HoverProvider {
     }
 
     /**
-     * Get visible forward call symbols at a given position.
-     * Symbols from forward calls are only visible AFTER the call site line.
-     *
-     * @param resolved_scope - The resolved scope containing forward_call_symbols
-     * @param position - The cursor position
-     * @returns Array of ForwardCallSite objects that are visible at the position
-     */
-    private get_visible_forward_call_sites(
-        resolved_scope: ResolvedScope | undefined,
-        position: Position
-    ): import('../types').ForwardCallSite[] {
-        if (!resolved_scope?.forward_call_symbols) {
-            return [];
-        }
-
-        // Filter to only include call sites where cursor is AFTER the call line
-        // Symbols become visible after the call site line (cursor_line > call_line)
-        return resolved_scope.forward_call_symbols.filter(
-            call_site => position.line > call_site.call_line
-        );
-    }
-
-    /**
      * Get hover info for a local macro only.
      * Checks resolved scope, forward call symbols (with position filtering), and document symbols.
      *
@@ -528,7 +506,7 @@ export class HoverProvider {
             // Check forward call symbols with position filtering
             // Only include symbols where cursor line > call_line (visible AFTER call site)
             if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = this.get_visible_forward_call_sites(resolved_scope, position);
+                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
                 for (const my_call_site of the_visible_call_sites) {
                     // For 'include' type, local macros are visible; for 'do' type, they are not
                     if (my_call_site.effective_type === 'include') {
@@ -620,7 +598,7 @@ export class HoverProvider {
             // Check forward call symbols with position filtering
             // Global macros are visible from both 'do' and 'include' types
             if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = this.get_visible_forward_call_sites(resolved_scope, position);
+                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
                 for (const my_call_site of the_visible_call_sites) {
                     const forward_global_macro = my_call_site.symbols.globalMacros.get(word);
                     if (forward_global_macro) {
@@ -702,7 +680,7 @@ export class HoverProvider {
 
             // Check forward call symbols with position filtering
             if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = this.get_visible_forward_call_sites(resolved_scope, position);
+                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
                 for (const my_call_site of the_visible_call_sites) {
                     const forward_scalar = my_call_site.symbols.scalars.get(word);
                     if (forward_scalar) {
@@ -789,7 +767,7 @@ export class HoverProvider {
 
             // Check forward call symbols with position filtering
             if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = this.get_visible_forward_call_sites(resolved_scope, position);
+                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
                 for (const my_call_site of the_visible_call_sites) {
                     const forward_matrix = my_call_site.symbols.matrices.get(word);
                     if (forward_matrix) {
@@ -1348,7 +1326,7 @@ export class HoverProvider {
             // Check forward call symbols with position filtering
             // Programs are visible from both 'do' and 'include' types
             if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = this.get_visible_forward_call_sites(resolved_scope, position);
+                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
                 for (const my_call_site of the_visible_call_sites) {
                     const forward_program = my_call_site.symbols.programs.get(word);
                     if (forward_program) {
@@ -1449,7 +1427,7 @@ export class HoverProvider {
             // Check forward call symbols with position filtering
             // Variables are visible from both 'do' and 'include' types
             if (position && resolved_scope.forward_call_symbols) {
-                const the_visible_call_sites = this.get_visible_forward_call_sites(resolved_scope, position);
+                const the_visible_call_sites = get_visible_forward_call_sites(resolved_scope, position.line);
                 for (const my_call_site of the_visible_call_sites) {
                     const forward_variable = my_call_site.symbols.variables.get(word);
                     if (forward_variable) {

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -589,11 +589,7 @@ export class ReferencesProvider {
             //    matrix.
             let best_forward_type: 'program' | 'scalar' | 'matrix' | null = null;
             let best_forward_priority = -1;
-            for (const my_site of resolved_scope.forward_call_symbols ?? []) {
-                if (my_site.call_line >= cursor_line) {
-                    continue;
-                }
-
+            for (const my_site of get_visible_forward_call_sites(resolved_scope, cursor_line)) {
                 let site_type: 'program' | 'scalar' | 'matrix' | null = null;
                 let site_priority = -1;
                 if (my_site.symbols.programs.has(word)) {

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -20,7 +20,7 @@ import type { IContextTracker } from '../context-tracker/types';
 import type { ScopeResolver } from '../scope-resolver';
 import {
     build_scope_resolver_config,
-    collect_visible_uris,
+    collect_visible_reference_uris,
     get_visible_forward_call_sites,
 } from '../scope-resolver';
 import type { ScopeResolverConfig, ResolvedScope } from '../types';
@@ -236,8 +236,20 @@ export class ReferencesProvider {
             let the_allowed_uris: Set<string> | null = null;
             if (symbol_type !== 'variable') {
                 the_allowed_uris = (resolved_scope !== undefined && cursor_line !== undefined)
-                    ? collect_visible_uris(resolved_scope, cursor_line, document.uri)
-                    : workspace_indexer.get_related_uris(document.uri);
+                    ? collect_visible_reference_uris(
+                        resolved_scope,
+                        cursor_line,
+                        document.uri,
+                        symbol_type,
+                    )
+                    : (
+                        symbol_type === 'local_macro'
+                            ? workspace_indexer.get_related_uris(
+                                document.uri,
+                                { include_only: true }
+                            )
+                            : workspace_indexer.get_related_uris(document.uri)
+                    );
             }
             // Skip entries from the current document's URI: the on-disk
             // index can lag unsaved buffer edits, and document.symbols
@@ -801,11 +813,6 @@ export class ReferencesProvider {
         let the_related: Set<string>;
         if (!workspace_indexer) {
             the_related = new Set<string>([document.uri]);
-        } else if (symbol_type === 'local_macro') {
-            the_related = workspace_indexer.get_related_uris(
-                document.uri,
-                { include_only: true }
-            );
         } else if (
             restrict_to_related &&
             resolved_scope !== undefined &&
@@ -815,12 +822,22 @@ export class ReferencesProvider {
             // visible at the cursor so redeclarations in not-yet-reached
             // forward-called files don't leak into references. See issue
             // #129.
-            the_related = collect_visible_uris(resolved_scope, cursor_line, document.uri);
+            the_related = collect_visible_reference_uris(
+                resolved_scope,
+                cursor_line,
+                document.uri,
+                symbol_type,
+            );
         } else {
             // Fallback path (test-only setups without a scope_resolver, or
             // variable lookups that fall through before this point): keep
             // the pre-fix behavior so those setups don't regress.
-            the_related = workspace_indexer.get_related_uris(document.uri);
+            the_related = symbol_type === 'local_macro'
+                ? workspace_indexer.get_related_uris(
+                    document.uri,
+                    { include_only: true }
+                )
+                : workspace_indexer.get_related_uris(document.uri);
         }
 
         // Check cancellation before workspace scan (Req 5.3)

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -18,8 +18,12 @@ import { get_line_text } from '../utils/line-utils';
 import type { WorkspaceIndexer } from '../indexer';
 import type { IContextTracker } from '../context-tracker/types';
 import type { ScopeResolver } from '../scope-resolver';
-import { build_scope_resolver_config } from '../scope-resolver';
-import type { ScopeResolverConfig } from '../types';
+import {
+    build_scope_resolver_config,
+    collect_visible_uris,
+    get_visible_forward_call_sites,
+} from '../scope-resolver';
+import type { ScopeResolverConfig, ResolvedScope } from '../types';
 
 export interface ReferenceSearchContext {
     symbol_name: string;
@@ -167,7 +171,9 @@ export class ReferencesProvider {
         document: DocumentState,
         symbol_name: string,
         symbol_type: 'local_macro' | 'global_macro' | 'program' | 'variable' | 'scalar' | 'matrix',
-        workspace_indexer?: WorkspaceIndexer
+        workspace_indexer?: WorkspaceIndexer,
+        resolved_scope?: ResolvedScope,
+        cursor_line?: number,
     ): Location[] {
         const locations: Location[] = [];
         const seen = new Set<string>();
@@ -218,20 +224,24 @@ export class ReferencesProvider {
                 symbol_type === 'local_macro' ? 'local' :
                 symbol_type === 'global_macro' ? 'global' :
                 symbol_type;
-            // Variables are dataset columns — we include cross-module
-            // definitions. All other symbol kinds are restricted to files
-            // reachable via the dependency graph; see collect_references for
-            // the full rationale.
-            const restrict_to_related = symbol_type !== 'variable';
-            const the_related = restrict_to_related
-                ? workspace_indexer.get_related_uris(document.uri)
+            // Variables are dataset columns — we pool cross-module declarations
+            // workspace-wide (see docs/find-references.md). All other kinds are
+            // restricted to files visible at the cursor: the current file,
+            // backward directive parents, and forward-called files whose
+            // `do`/`include` sits above the cursor line. When `cursor_line` is
+            // undefined (test-only setups without a resolved scope) the URI
+            // filter is skipped so the test fixture still sees cross-file
+            // definitions.
+            const restrict_to_visible = symbol_type !== 'variable';
+            const the_visible_uris = restrict_to_visible && cursor_line !== undefined
+                ? collect_visible_uris(resolved_scope, cursor_line, document.uri)
                 : null;
             // Skip entries from the current document's URI: the on-disk
             // index can lag unsaved buffer edits, and document.symbols
             // already holds the authoritative fresh declaration.
             for (const my_def of workspace_indexer.find_symbol_definitions(symbol_name, ws_type)) {
                 if (my_def.sourceUri === document.uri) continue;
-                if (the_related && !the_related.has(my_def.sourceUri)) continue;
+                if (the_visible_uris && !the_visible_uris.has(my_def.sourceUri)) continue;
                 push({ uri: my_def.location.uri, range: my_def.location.range });
             }
         }
@@ -292,6 +302,19 @@ export class ReferencesProvider {
             return [];
         }
 
+        // Resolve the scope once here (cached by ScopeResolver) so
+        // find_definitions can apply the call-site filter to declarations
+        // pooled from the workspace indexer. See issue #129.
+        const resolve_config = build_scope_resolver_config(cross_file_config);
+        const resolved_scope = this.scope_resolver
+            ? await this.scope_resolver.resolve(
+                document.uri,
+                document.content,
+                resolve_config,
+                cancellation_token
+            )
+            : undefined;
+
         return this.collect_references(
             document,
             identified_symbol.name,
@@ -299,7 +322,9 @@ export class ReferencesProvider {
             context.includeDeclaration,
             workspace_indexer,
             document.context_ranges,
-            cancellation_token
+            cancellation_token,
+            resolved_scope,
+            position.line,
         );
     }
 
@@ -682,6 +707,19 @@ export class ReferencesProvider {
             return [];
         }
 
+        // Resolve the scope once so find_definitions can apply the
+        // call-site filter to non-variable declarations pooled from the
+        // workspace indexer. See issue #129.
+        const resolve_config = build_scope_resolver_config(cross_file_config);
+        const resolved_scope = this.scope_resolver
+            ? await this.scope_resolver.resolve(
+                document.uri,
+                document.content,
+                resolve_config,
+                cancellation_token
+            )
+            : undefined;
+
         return this.collect_references(
             document,
             identified_symbol.name,
@@ -689,7 +727,9 @@ export class ReferencesProvider {
             context.includeDeclaration,
             workspace_indexer,
             undefined, // No context_ranges filtering for macros (they work across all contexts)
-            cancellation_token
+            cancellation_token,
+            resolved_scope,
+            position.line,
         );
     }
 
@@ -703,7 +743,9 @@ export class ReferencesProvider {
         include_declaration: boolean,
         workspace_indexer?: WorkspaceIndexer,
         context_ranges?: ContextRange[],
-        cancellation_token?: CancellationToken
+        cancellation_token?: CancellationToken,
+        resolved_scope?: ResolvedScope,
+        cursor_line?: number,
     ): Promise<Location[]> {
         const search_context: ReferenceSearchContext = {
             symbol_name,
@@ -716,7 +758,9 @@ export class ReferencesProvider {
             document,
             symbol_name,
             symbol_type,
-            workspace_indexer
+            workspace_indexer,
+            resolved_scope,
+            cursor_line,
         );
 
         // Search current document
@@ -741,20 +785,44 @@ export class ReferencesProvider {
         // we scan the full workspace. Every other symbol kind (programs,
         // scalars, matrices, macros) is a code-level symbol where cross-module
         // name collisions are almost always coincidental, so we restrict the
-        // scan to dep-graph-reachable files.
+        // scan to files visible at the cursor — backward chain + forward
+        // calls that sit above the cursor line. (Issue #129 aligns the scan
+        // path with the call-site filter already applied to find_definitions:
+        // a redeclaration in a not-yet-reached forward-called file must not
+        // surface as a cross-reference either.)
         //
         // Local macros are narrower still: Stata only propagates locals
         // through `include` chains, never through `do` or `run`. A local
         // with the same name in a `do`-called child is a different macro,
-        // so the reachable set is restricted to include-only edges.
+        // so the reachable set is restricted to include-only edges; here we
+        // keep that narrower backward path via `get_related_uris`, which
+        // understands `include_only`.
         // See docs/find-references.md for the rationale behind this three-tier model.
         const restrict_to_related = symbol_type !== 'variable';
-        const the_related = workspace_indexer
-            ? workspace_indexer.get_related_uris(
+        let the_related: Set<string>;
+        if (!workspace_indexer) {
+            the_related = new Set<string>([document.uri]);
+        } else if (symbol_type === 'local_macro') {
+            the_related = workspace_indexer.get_related_uris(
                 document.uri,
-                symbol_type === 'local_macro' ? { include_only: true } : undefined
-            )
-            : new Set<string>([document.uri]);
+                { include_only: true }
+            );
+        } else if (
+            restrict_to_related &&
+            resolved_scope !== undefined &&
+            cursor_line !== undefined
+        ) {
+            // Scope-resolver path (production): filter the scan to files
+            // visible at the cursor so redeclarations in not-yet-reached
+            // forward-called files don't leak into references. See issue
+            // #129.
+            the_related = collect_visible_uris(resolved_scope, cursor_line, document.uri);
+        } else {
+            // Fallback path (test-only setups without a scope_resolver, or
+            // variable lookups that fall through before this point): keep
+            // the pre-fix behavior so those setups don't regress.
+            the_related = workspace_indexer.get_related_uris(document.uri);
+        }
 
         // Check cancellation before workspace scan (Req 5.3)
         if (cancellation_token?.isCancellationRequested) {

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -228,20 +228,23 @@ export class ReferencesProvider {
             // workspace-wide (see docs/find-references.md). All other kinds are
             // restricted to files visible at the cursor: the current file,
             // backward directive parents, and forward-called files whose
-            // `do`/`include` sits above the cursor line. When `cursor_line` is
-            // undefined (test-only setups without a resolved scope) the URI
-            // filter is skipped so the test fixture still sees cross-file
-            // definitions.
-            const restrict_to_visible = symbol_type !== 'variable';
-            const the_visible_uris = restrict_to_visible && cursor_line !== undefined
-                ? collect_visible_uris(resolved_scope, cursor_line, document.uri)
-                : null;
+            // `do`/`include` sits above the cursor line. When `resolved_scope`
+            // or `cursor_line` is missing (test-only setups without a scope
+            // resolver wired), fall back to the pre-fix dep-graph-reachable
+            // set so the broader declaration-pooling behavior is preserved —
+            // matching collect_references's symmetric fallback below.
+            let the_allowed_uris: Set<string> | null = null;
+            if (symbol_type !== 'variable') {
+                the_allowed_uris = (resolved_scope !== undefined && cursor_line !== undefined)
+                    ? collect_visible_uris(resolved_scope, cursor_line, document.uri)
+                    : workspace_indexer.get_related_uris(document.uri);
+            }
             // Skip entries from the current document's URI: the on-disk
             // index can lag unsaved buffer edits, and document.symbols
             // already holds the authoritative fresh declaration.
             for (const my_def of workspace_indexer.find_symbol_definitions(symbol_name, ws_type)) {
                 if (my_def.sourceUri === document.uri) continue;
-                if (the_visible_uris && !the_visible_uris.has(my_def.sourceUri)) continue;
+                if (the_allowed_uris && !the_allowed_uris.has(my_def.sourceUri)) continue;
                 push({ uri: my_def.location.uri, range: my_def.location.range });
             }
         }

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -226,13 +226,16 @@ export class ReferencesProvider {
                 symbol_type;
             // Variables are dataset columns — we pool cross-module declarations
             // workspace-wide (see docs/find-references.md). All other kinds are
-            // restricted to files visible at the cursor: the current file,
-            // backward directive parents, and forward-called files whose
-            // `do`/`include` sits above the cursor line. When `resolved_scope`
-            // or `cursor_line` is missing (test-only setups without a scope
-            // resolver wired), fall back to the pre-fix dep-graph-reachable
-            // set so the broader declaration-pooling behavior is preserved —
-            // matching collect_references's symmetric fallback below.
+            // restricted to dep-graph-reachable candidates that are visible at
+            // the cursor, with same-name conflicts resolved by effective scope
+            // precedence. In production we therefore pool declarations only
+            // from files contributing the active visible symbol instance at the
+            // cursor; masked redeclarations in otherwise-visible files are
+            // intentionally excluded. When `resolved_scope` or `cursor_line`
+            // is missing (test-only setups without a scope resolver wired),
+            // fall back to the pre-fix dep-graph-reachable set so the broader
+            // declaration-pooling behavior is preserved — matching
+            // collect_references's symmetric fallback below.
             let the_allowed_uris: Set<string> | null = null;
             if (symbol_type !== 'variable') {
                 the_allowed_uris = (resolved_scope !== undefined && cursor_line !== undefined)
@@ -241,6 +244,7 @@ export class ReferencesProvider {
                         cursor_line,
                         document.uri,
                         symbol_type,
+                        symbol_name,
                     )
                     : (
                         symbol_type === 'local_macro'
@@ -796,11 +800,11 @@ export class ReferencesProvider {
         // we scan the full workspace. Every other symbol kind (programs,
         // scalars, matrices, macros) is a code-level symbol where cross-module
         // name collisions are almost always coincidental, so we restrict the
-        // scan to files visible at the cursor — backward chain + forward
-        // calls that sit above the cursor line. (Issue #129 aligns the scan
-        // path with the call-site filter already applied to find_definitions:
-        // a redeclaration in a not-yet-reached forward-called file must not
-        // surface as a cross-reference either.)
+        // scan to dep-graph-reachable files that are visible at the cursor,
+        // then narrow further to the active visible symbol instance selected
+        // by precedence. (Issue #129 aligns the scan path with the
+        // declaration-pooling rules: a masked redeclaration in an
+        // otherwise-visible file must not surface as a cross-reference.)
         //
         // Local macros are narrower still: Stata only propagates locals
         // through `include` chains, never through `do` or `run`. A local
@@ -819,14 +823,15 @@ export class ReferencesProvider {
             cursor_line !== undefined
         ) {
             // Scope-resolver path (production): filter the scan to files
-            // visible at the cursor so redeclarations in not-yet-reached
-            // forward-called files don't leak into references. See issue
-            // #129.
+            // contributing the active visible symbol instance at the cursor so
+            // not-yet-reached or masked same-name definitions don't leak into
+            // references. See issue #129.
             the_related = collect_visible_reference_uris(
                 resolved_scope,
                 cursor_line,
                 document.uri,
                 symbol_type,
+                symbol_name,
             );
         } else {
             // Fallback path (test-only setups without a scope_resolver, or

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -44,6 +44,7 @@ export {
     get_visible_symbols_at,
     get_visible_forward_call_sites,
     collect_visible_reference_uris,
+    filter_forward_site_symbols,
 } from './visible-symbols';
 
 const DEFAULT_CONFIG: ScopeResolverConfig = {

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -40,6 +40,12 @@ import { logger } from '../utils/logger';
 import { get_line_text, get_line_count, compute_line_offsets } from '../utils/line-utils';
 import { get_workspace_root_for_uri } from '../utils/workspace-roots';
 
+export {
+    get_visible_symbols_at,
+    get_visible_forward_call_sites,
+    collect_visible_uris,
+} from './visible-symbols';
+
 const DEFAULT_CONFIG: ScopeResolverConfig = {
     assume_call_site: 'end',
     max_backward_depth: 10,

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -43,7 +43,7 @@ import { get_workspace_root_for_uri } from '../utils/workspace-roots';
 export {
     get_visible_symbols_at,
     get_visible_forward_call_sites,
-    collect_visible_uris,
+    collect_visible_reference_uris,
 } from './visible-symbols';
 
 const DEFAULT_CONFIG: ScopeResolverConfig = {
@@ -962,10 +962,14 @@ export class ScopeResolver {
         config: ScopeResolverConfig,
         visited: Set<string>,
         token?: CancellationToken
-    ): Promise<{ symbols: SymbolTable; diagnostics: DirectiveDiagnostic[] }> {
+    ): Promise<{ symbols: SymbolTable; diagnostics: DirectiveDiagnostic[]; call_sites: import('../types').ForwardCallSite[] }> {
         // If no forward scope resolver is set, return empty results
         if (!this.forward_scope_resolver) {
-            return { symbols: create_empty_symbol_table(), diagnostics: [] };
+            return {
+                symbols: create_empty_symbol_table(),
+                diagnostics: [],
+                call_sites: [],
+            };
         }
 
         // Filter forward calls to only those before the call site
@@ -975,7 +979,11 @@ export class ScopeResolver {
         );
 
         if (calls_before_site.length === 0) {
-            return { symbols: create_empty_symbol_table(), diagnostics: [] };
+            return {
+                symbols: create_empty_symbol_table(),
+                diagnostics: [],
+                call_sites: [],
+            };
         }
 
         // Compute effective call type based on backward directive type
@@ -996,6 +1004,7 @@ export class ScopeResolver {
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
                     severity: 'warning',
                 }],
+                call_sites: [],
             };
         }
 
@@ -1024,6 +1033,7 @@ export class ScopeResolver {
         return {
             symbols: forward_result.symbols,
             diagnostics: the_diagnostics,
+            call_sites: forward_result.call_sites,
         };
     }
 
@@ -1535,6 +1545,9 @@ export class ScopeResolver {
                 directive_type: my_directive.type,
                 call_site_line: my_call_site_line,
                 symbols: my_merged_symbols,
+                forward_call_sites: forward_result.call_sites.length > 0
+                    ? forward_result.call_sites
+                    : undefined,
                 depth,
                 directive_order: my_directive_order,
                 sort_key: my_sort_key,

--- a/src/scope-resolver/visible-symbols.ts
+++ b/src/scope-resolver/visible-symbols.ts
@@ -8,7 +8,12 @@
  * construct a scope object.
  */
 
-import type { ResolvedScope, ForwardCallSite, SymbolTable } from '../types';
+import type {
+    ResolvedScope,
+    ForwardCallSite,
+    ScopeChainEntry,
+    SymbolTable,
+} from '../types';
 import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 
 /**
@@ -63,29 +68,69 @@ export function get_visible_forward_call_sites(
     );
 }
 
+type ReferenceScopedSymbolType =
+    | 'local_macro'
+    | 'global_macro'
+    | 'program'
+    | 'scalar'
+    | 'matrix';
+
+function should_include_entry_for_references(
+    entry: ScopeChainEntry,
+    symbol_type: ReferenceScopedSymbolType,
+): boolean {
+    if (symbol_type !== 'local_macro') {
+        return true;
+    }
+    return entry.directive_type === 'included-by';
+}
+
+function should_include_call_site_for_references(
+    site: ForwardCallSite,
+    symbol_type: ReferenceScopedSymbolType,
+): boolean {
+    if (symbol_type !== 'local_macro') {
+        return true;
+    }
+    return site.effective_type === 'include';
+}
+
 /**
- * URIs whose symbols contribute to scope at `cursor_line`:
- *   current_uri
- *   ∪ { entry.uri : entry ∈ scope.chain }
- *   ∪ { site.callee_uri : site ∈ get_visible_forward_call_sites(scope, cursor_line) }
+ * URIs that should participate in find-references for the given symbol kind.
+ * This includes backward-chain files, retained parent forward callees, and
+ * current-file visible forward callees, with local macros restricted to
+ * include-only edges.
  *
  * Returns a Set containing just `current_uri` when `scope` is undefined.
  */
-export function collect_visible_uris(
+export function collect_visible_reference_uris(
     scope: ResolvedScope | undefined,
     cursor_line: number,
     current_uri: string,
+    symbol_type: ReferenceScopedSymbolType,
 ): Set<string> {
-    const the_result = new Set<string>();
-    the_result.add(current_uri);
+    const the_result = new Set<string>([current_uri]);
     if (!scope) {
         return the_result;
     }
+
     for (const my_entry of scope.chain) {
-        the_result.add(my_entry.uri);
+        if (should_include_entry_for_references(my_entry, symbol_type)) {
+            the_result.add(my_entry.uri);
+        }
+
+        for (const my_site of my_entry.forward_call_sites ?? []) {
+            if (should_include_call_site_for_references(my_site, symbol_type)) {
+                the_result.add(my_site.callee_uri);
+            }
+        }
     }
+
     for (const my_site of get_visible_forward_call_sites(scope, cursor_line)) {
-        the_result.add(my_site.callee_uri);
+        if (should_include_call_site_for_references(my_site, symbol_type)) {
+            the_result.add(my_site.callee_uri);
+        }
     }
+
     return the_result;
 }

--- a/src/scope-resolver/visible-symbols.ts
+++ b/src/scope-resolver/visible-symbols.ts
@@ -270,6 +270,30 @@ export function collect_visible_reference_uris(
         return the_result;
     }
 
+    // The cursor is only used to pick which definition the user clicked
+    // "through" (when the same name has multiple visible instances). Once
+    // that active instance is chosen, every file that could reference *that
+    // definition* is a legitimate find-references hit — regardless of whether
+    // its call site sits before or after the cursor in execution order. So
+    // the forward-call loops below walk every forward call, not just those
+    // before the cursor.
+    //
+    // A file that redeclares the same name with a different identity is
+    // excluded: its declaration introduces a separate instance, and its
+    // in-file references are ambiguous at best (some may hit the active
+    // instance pre-redeclaration, others the shadow post-redeclaration).
+    // Conservatively, we don't pool such files — this matches the narrow
+    // precedence rule the existing tests pin down.
+    const site_redeclares_with_different_identity = (site: ForwardCallSite): boolean => {
+        const site_symbol = get_reference_symbol_from_table(
+            site.symbols,
+            symbol_type,
+            symbol_name,
+        );
+        if (!site_symbol) return false;
+        return get_reference_symbol_identity(site_symbol) !== active_symbol_identity;
+    };
+
     for (const my_entry of scope.chain) {
         let entry_visible_symbols = clone_symbol_table(my_entry.symbols);
 
@@ -288,6 +312,7 @@ export function collect_visible_reference_uris(
             );
             if (
                 can_reference_forward_site(symbol_type, my_site) &&
+                !site_redeclares_with_different_identity(my_site) &&
                 (symbol_visible_before_site || site_defines_active_symbol)
             ) {
                 the_result.add(my_site.callee_uri);
@@ -298,21 +323,30 @@ export function collect_visible_reference_uris(
             );
         }
 
-        if (
-            can_reference_chain_entry(symbol_type, my_entry.directive_type) &&
+        // `entry_visible_symbols` reflects the parent's state *before* it
+        // calls the current file. If the active symbol is declared in the
+        // current file, the parent's *post-call* state reaches back and sees
+        // it (subject to the directive's propagation rules — locals only
+        // cross `included-by`, not `done-by`). That post-call view never
+        // appears in the chain entry's symbols, so handle it explicitly.
+        const chain_entry_references_active =
             symbol_table_matches_active_reference(
                 entry_visible_symbols,
                 symbol_type,
                 symbol_name,
                 active_symbol_identity,
-            )
+            ) ||
+            active_symbol_identity === current_uri;
+        if (
+            can_reference_chain_entry(symbol_type, my_entry.directive_type) &&
+            chain_entry_references_active
         ) {
             the_result.add(my_entry.uri);
         }
     }
 
     let current_visible_symbols = clone_symbol_table(scope.symbols);
-    for (const my_site of get_visible_forward_call_sites(scope, cursor_line)) {
+    for (const my_site of scope.forward_call_symbols ?? []) {
         const symbol_visible_before_site = symbol_table_matches_active_reference(
             current_visible_symbols,
             symbol_type,
@@ -327,6 +361,7 @@ export function collect_visible_reference_uris(
         );
         if (
             can_reference_forward_site(symbol_type, my_site) &&
+            !site_redeclares_with_different_identity(my_site) &&
             (symbol_visible_before_site || site_defines_active_symbol)
         ) {
             the_result.add(my_site.callee_uri);

--- a/src/scope-resolver/visible-symbols.ts
+++ b/src/scope-resolver/visible-symbols.ts
@@ -28,51 +28,60 @@ type AnySymbol =
     | VariableSymbol;
 
 /**
- * Latest line at which `symbol` is defined in its source file. For macros this
- * considers additional_definitions (subsequent same-name assignments); for
- * other symbols only the primary definition line is available.
+ * True iff `symbol` has any definition (primary or additional) whose line falls
+ * in the half-open window `(after_line, up_to_line]`. The window models "was
+ * this name redefined strictly after the forward call ran, and at-or-before the
+ * cursor we're resolving?" Primary lines come from `location.range.start.line`;
+ * additional lines come from `additional_definitions` (macros only).
  */
-function get_latest_definition_line(symbol: AnySymbol): number {
-    let the_line = symbol.location.range.start.line;
+function has_definition_in_window(
+    symbol: AnySymbol,
+    after_line: number,
+    up_to_line: number,
+): boolean {
+    const primary_line = symbol.location.range.start.line;
+    if (primary_line > after_line && primary_line <= up_to_line) {
+        return true;
+    }
     if ('additional_definitions' in symbol && symbol.additional_definitions) {
         for (const my_extra of symbol.additional_definitions) {
-            if (my_extra.line > the_line) {
-                the_line = my_extra.line;
+            if (my_extra.line > after_line && my_extra.line <= up_to_line) {
+                return true;
             }
         }
     }
-    return the_line;
+    return false;
 }
 
 /**
- * True when the current file has a same-name definition at a line at or before
- * `call_line` — i.e., the current file defines this name before/at the forward
- * call line, so the current file should win per Stata's last-assignment-wins
- * execution order. Definitions after the call line do NOT override the forward
- * call symbol.
+ * True when the current file has a same-name definition in `(call_line,
+ * cursor_line]` — i.e., strictly after the forward call executed and at-or-
+ * before the cursor. Per Stata's last-assignment-wins execution order, such a
+ * definition shadows the forward-call symbol. Definitions before the call are
+ * overwritten by the include; definitions after the cursor haven't run yet.
  */
-function current_file_overrides_forward_call<T extends AnySymbol>(
+function current_file_shadows_forward_site<T extends AnySymbol>(
     current_file_map: Map<string, T> | undefined,
     name: string,
     call_line: number,
+    cursor_line: number,
 ): boolean {
     if (!current_file_map) return false;
     const my_existing = current_file_map.get(name);
     if (!my_existing) return false;
-    return get_latest_definition_line(my_existing) <= call_line;
+    return has_definition_in_window(my_existing, call_line, cursor_line);
 }
 
 /**
- * Drop entries from `site_symbols` that are shadowed by an earlier current-file
- * definition. A name is dropped when `current_file_symbols` has a same-name
- * definition at a line at or before `call_line` (the line at which this forward
- * call executes). Exported so CompletionProvider can apply the same filter when
- * building its annotated forward-symbol overlay.
+ * Drop entries from `site_symbols` that are shadowed by a current-file
+ * definition in `(call_line, cursor_line]`. Exported so CompletionProvider can
+ * apply the same filter when building its annotated forward-symbol overlay.
  */
 export function filter_forward_site_symbols(
     site_symbols: SymbolTable,
     current_file_symbols: SymbolTable | undefined,
     call_line: number,
+    cursor_line: number,
 ): SymbolTable {
     if (!current_file_symbols) return site_symbols;
     const filter_map = <T extends AnySymbol>(
@@ -81,7 +90,12 @@ export function filter_forward_site_symbols(
     ): Map<string, T> => {
         const the_kept = new Map<string, T>();
         for (const [my_name, my_symbol] of the_site_map) {
-            if (!current_file_overrides_forward_call(the_current_map, my_name, call_line)) {
+            if (!current_file_shadows_forward_site(
+                the_current_map,
+                my_name,
+                call_line,
+                cursor_line,
+            )) {
                 the_kept.set(my_name, my_symbol);
             }
         }
@@ -101,9 +115,10 @@ export function filter_forward_site_symbols(
  * SymbolTable of every symbol in scope at `cursor_line`. Starts from
  * `resolved_scope.symbols` (parent chain + current file) and overlays each
  * forward-call site whose `call_line < cursor_line` with merge_symbol_tables
- * last-wins semantics — except that a current-file definition at a line at or
- * before a call's `call_line` is preserved, so earlier current-file definitions
- * shadow forward-call results (matches Stata's sequential execution semantics).
+ * last-wins semantics — except that a current-file definition in the window
+ * `(call_line, cursor_line]` is preserved, so current-file redefinitions that
+ * happen after the call but at-or-before the cursor shadow the forward-call
+ * result (matches Stata's sequential execution semantics).
  *
  * Returns an empty SymbolTable when `scope` is undefined.
  */
@@ -131,6 +146,7 @@ export function get_visible_symbols_at(
                 my_site.symbols,
                 current_file_symbols,
                 my_site.call_line,
+                cursor_line,
             );
             result = merge_symbol_tables(result, filtered);
         }

--- a/src/scope-resolver/visible-symbols.ts
+++ b/src/scope-resolver/visible-symbols.ts
@@ -11,8 +11,11 @@
 import type {
     ResolvedScope,
     ForwardCallSite,
-    ScopeChainEntry,
     SymbolTable,
+    ProgramSymbol,
+    MacroSymbol,
+    ScalarSymbol,
+    MatrixSymbol,
 } from '../types';
 import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 
@@ -75,19 +78,72 @@ type ReferenceScopedSymbolType =
     | 'scalar'
     | 'matrix';
 
-function should_include_entry_for_references(
-    entry: ScopeChainEntry,
+type ReferenceScopedSymbol =
+    | ProgramSymbol
+    | MacroSymbol
+    | ScalarSymbol
+    | MatrixSymbol;
+
+function get_reference_symbol_from_table(
+    symbols: SymbolTable,
     symbol_type: ReferenceScopedSymbolType,
+    symbol_name: string,
+): ReferenceScopedSymbol | undefined {
+    switch (symbol_type) {
+        case 'local_macro':
+            return symbols.localMacros.get(symbol_name);
+        case 'global_macro':
+            return symbols.globalMacros.get(symbol_name);
+        case 'program':
+            return symbols.programs.get(symbol_name);
+        case 'scalar':
+            return symbols.scalars.get(symbol_name);
+        case 'matrix':
+            return symbols.matrices.get(symbol_name);
+    }
+}
+
+function get_reference_symbol_identity(
+    symbol: ReferenceScopedSymbol | undefined,
+): string | undefined {
+    return symbol?.sourceUri ?? symbol?.location.uri;
+}
+
+function symbol_table_matches_active_reference(
+    symbols: SymbolTable,
+    symbol_type: ReferenceScopedSymbolType,
+    symbol_name: string,
+    active_symbol_identity: string,
+): boolean {
+    return get_reference_symbol_identity(
+        get_reference_symbol_from_table(symbols, symbol_type, symbol_name),
+    ) === active_symbol_identity;
+}
+
+function clone_symbol_table(symbols: SymbolTable): SymbolTable {
+    return {
+        programs: new Map(symbols.programs),
+        localMacros: new Map(symbols.localMacros),
+        globalMacros: new Map(symbols.globalMacros),
+        variables: new Map(symbols.variables),
+        scalars: new Map(symbols.scalars),
+        matrices: new Map(symbols.matrices),
+    };
+}
+
+function can_reference_chain_entry(
+    symbol_type: ReferenceScopedSymbolType,
+    directive_type: 'done-by' | 'included-by',
 ): boolean {
     if (symbol_type !== 'local_macro') {
         return true;
     }
-    return entry.directive_type === 'included-by';
+    return directive_type === 'included-by';
 }
 
-function should_include_call_site_for_references(
-    site: ForwardCallSite,
+function can_reference_forward_site(
     symbol_type: ReferenceScopedSymbolType,
+    site: ForwardCallSite,
 ): boolean {
     if (symbol_type !== 'local_macro') {
         return true;
@@ -96,10 +152,15 @@ function should_include_call_site_for_references(
 }
 
 /**
- * URIs that should participate in find-references for the given symbol kind.
- * This includes backward-chain files, retained parent forward callees, and
- * current-file visible forward callees, with local macros restricted to
- * include-only edges.
+ * URIs that should participate in find-references for the queried `(type,
+ * name)`. The helper first resolves the active visible symbol instance at the
+ * cursor via get_visible_symbols_at(), then keeps only related files whose
+ * visible scope resolves that same name to the winning instance.
+ *
+ * This is precedence-aware, excludes masked same-name definitions from
+ * otherwise-visible files, still includes sibling/parent contexts that can see
+ * the winning symbol without defining it locally, and respects stripped-local
+ * behavior implicitly by consulting the merged visible symbol table.
  *
  * Returns a Set containing just `current_uri` when `scope` is undefined.
  */
@@ -108,28 +169,86 @@ export function collect_visible_reference_uris(
     cursor_line: number,
     current_uri: string,
     symbol_type: ReferenceScopedSymbolType,
+    symbol_name: string,
 ): Set<string> {
     const the_result = new Set<string>([current_uri]);
     if (!scope) {
         return the_result;
     }
 
+    const visible_symbols = get_visible_symbols_at(scope, cursor_line);
+    const active_symbol_identity = get_reference_symbol_identity(
+        get_reference_symbol_from_table(visible_symbols, symbol_type, symbol_name),
+    );
+    if (!active_symbol_identity) {
+        return the_result;
+    }
+
     for (const my_entry of scope.chain) {
-        if (should_include_entry_for_references(my_entry, symbol_type)) {
-            the_result.add(my_entry.uri);
-        }
+        let entry_visible_symbols = clone_symbol_table(my_entry.symbols);
 
         for (const my_site of my_entry.forward_call_sites ?? []) {
-            if (should_include_call_site_for_references(my_site, symbol_type)) {
+            const symbol_visible_before_site = symbol_table_matches_active_reference(
+                entry_visible_symbols,
+                symbol_type,
+                symbol_name,
+                active_symbol_identity,
+            );
+            const site_defines_active_symbol = symbol_table_matches_active_reference(
+                my_site.symbols,
+                symbol_type,
+                symbol_name,
+                active_symbol_identity,
+            );
+            if (
+                can_reference_forward_site(symbol_type, my_site) &&
+                (symbol_visible_before_site || site_defines_active_symbol)
+            ) {
                 the_result.add(my_site.callee_uri);
             }
+            entry_visible_symbols = merge_symbol_tables(
+                entry_visible_symbols,
+                my_site.symbols,
+            );
+        }
+
+        if (
+            can_reference_chain_entry(symbol_type, my_entry.directive_type) &&
+            symbol_table_matches_active_reference(
+                entry_visible_symbols,
+                symbol_type,
+                symbol_name,
+                active_symbol_identity,
+            )
+        ) {
+            the_result.add(my_entry.uri);
         }
     }
 
+    let current_visible_symbols = clone_symbol_table(scope.symbols);
     for (const my_site of get_visible_forward_call_sites(scope, cursor_line)) {
-        if (should_include_call_site_for_references(my_site, symbol_type)) {
+        const symbol_visible_before_site = symbol_table_matches_active_reference(
+            current_visible_symbols,
+            symbol_type,
+            symbol_name,
+            active_symbol_identity,
+        );
+        const site_defines_active_symbol = symbol_table_matches_active_reference(
+            my_site.symbols,
+            symbol_type,
+            symbol_name,
+            active_symbol_identity,
+        );
+        if (
+            can_reference_forward_site(symbol_type, my_site) &&
+            (symbol_visible_before_site || site_defines_active_symbol)
+        ) {
             the_result.add(my_site.callee_uri);
         }
+        current_visible_symbols = merge_symbol_tables(
+            current_visible_symbols,
+            my_site.symbols,
+        );
     }
 
     return the_result;

--- a/src/scope-resolver/visible-symbols.ts
+++ b/src/scope-resolver/visible-symbols.ts
@@ -16,16 +16,94 @@ import type {
     MacroSymbol,
     ScalarSymbol,
     MatrixSymbol,
+    VariableSymbol,
 } from '../types';
 import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 
+type AnySymbol =
+    | ProgramSymbol
+    | MacroSymbol
+    | ScalarSymbol
+    | MatrixSymbol
+    | VariableSymbol;
+
 /**
- * SymbolTable of every symbol in scope at `cursor_line`. Equivalent to
- *   resolved_scope.symbols
- *   ∪ { call_site.symbols : call_site ∈ resolved_scope.forward_call_symbols,
- *                           call_site.call_line < cursor_line }
- * applied with merge_symbol_tables overlay semantics (lattermost overlay
- * wins on name collisions; matches scope-resolver precedence).
+ * Latest line at which `symbol` is defined in its source file. For macros this
+ * considers additional_definitions (subsequent same-name assignments); for
+ * other symbols only the primary definition line is available.
+ */
+function get_latest_definition_line(symbol: AnySymbol): number {
+    let the_line = symbol.location.range.start.line;
+    if ('additional_definitions' in symbol && symbol.additional_definitions) {
+        for (const my_extra of symbol.additional_definitions) {
+            if (my_extra.line > the_line) {
+                the_line = my_extra.line;
+            }
+        }
+    }
+    return the_line;
+}
+
+/**
+ * True when the current file has a same-name definition at a line strictly
+ * greater than `call_line` — i.e., the current file redefines this name after
+ * the forward call, so the current file should win per Stata's
+ * last-assignment-wins execution order.
+ */
+function current_file_overrides_forward_call<T extends AnySymbol>(
+    current_file_map: Map<string, T> | undefined,
+    name: string,
+    call_line: number,
+): boolean {
+    if (!current_file_map) return false;
+    const my_existing = current_file_map.get(name);
+    if (!my_existing) return false;
+    return get_latest_definition_line(my_existing) > call_line;
+}
+
+/**
+ * Drop entries from `site_symbols` that are shadowed by a later current-file
+ * definition. A name is dropped when `current_file_symbols` has a same-name
+ * definition at a line strictly greater than `call_line` (the line at which
+ * this forward call executes). Exported so CompletionProvider can apply the
+ * same filter when building its annotated forward-symbol overlay.
+ */
+export function filter_forward_site_symbols(
+    site_symbols: SymbolTable,
+    current_file_symbols: SymbolTable | undefined,
+    call_line: number,
+): SymbolTable {
+    if (!current_file_symbols) return site_symbols;
+    const filter_map = <T extends AnySymbol>(
+        the_site_map: Map<string, T>,
+        the_current_map: Map<string, T>,
+    ): Map<string, T> => {
+        const the_kept = new Map<string, T>();
+        for (const [my_name, my_symbol] of the_site_map) {
+            if (!current_file_overrides_forward_call(the_current_map, my_name, call_line)) {
+                the_kept.set(my_name, my_symbol);
+            }
+        }
+        return the_kept;
+    };
+    return {
+        programs: filter_map(site_symbols.programs, current_file_symbols.programs),
+        localMacros: filter_map(site_symbols.localMacros, current_file_symbols.localMacros),
+        globalMacros: filter_map(site_symbols.globalMacros, current_file_symbols.globalMacros),
+        variables: filter_map(site_symbols.variables, current_file_symbols.variables),
+        scalars: filter_map(site_symbols.scalars, current_file_symbols.scalars),
+        matrices: filter_map(site_symbols.matrices, current_file_symbols.matrices),
+    };
+}
+
+/**
+ * SymbolTable of every symbol in scope at `cursor_line`. Starts from
+ * `resolved_scope.symbols` (parent chain + current file) and overlays each
+ * forward-call site whose `call_line < cursor_line` with merge_symbol_tables
+ * last-wins semantics — except that a current-file definition at a line
+ * greater than a call's `call_line` is preserved, so later current-file
+ * redefinitions shadow earlier forward-call results (matches Stata's
+ * sequential execution semantics).
  *
  * Returns an empty SymbolTable when `scope` is undefined.
  */
@@ -44,9 +122,17 @@ export function get_visible_symbols_at(
         scalars: new Map(scope.symbols.scalars),
         matrices: new Map(scope.symbols.matrices),
     };
+    const current_file_symbols = scope.chain.length > 0
+        ? scope.chain[0].symbols
+        : undefined;
     for (const my_site of scope.forward_call_symbols ?? []) {
         if (my_site.call_line < cursor_line) {
-            result = merge_symbol_tables(result, my_site.symbols);
+            const filtered = filter_forward_site_symbols(
+                my_site.symbols,
+                current_file_symbols,
+                my_site.call_line,
+            );
+            result = merge_symbol_tables(result, filtered);
         }
     }
     return result;

--- a/src/scope-resolver/visible-symbols.ts
+++ b/src/scope-resolver/visible-symbols.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure helpers for asking "what is in scope at a cursor line?" against a
+ * ResolvedScope. Providers import these to avoid duplicating the
+ * `call_site.call_line < cursor_line` filter across ≈8 sites.
+ *
+ * All three functions are pure, synchronous, and accept `undefined` for
+ * convenience so test-only paths without a ScopeResolver don't need to
+ * construct a scope object.
+ */
+
+import type { ResolvedScope, ForwardCallSite, SymbolTable } from '../types';
+import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
+
+/**
+ * SymbolTable of every symbol in scope at `cursor_line`. Equivalent to
+ *   resolved_scope.symbols
+ *   ∪ { call_site.symbols : call_site ∈ resolved_scope.forward_call_symbols,
+ *                           call_site.call_line < cursor_line }
+ * applied with merge_symbol_tables overlay semantics (lattermost overlay
+ * wins on name collisions; matches scope-resolver precedence).
+ *
+ * Returns an empty SymbolTable when `scope` is undefined.
+ */
+export function get_visible_symbols_at(
+    scope: ResolvedScope | undefined,
+    cursor_line: number,
+): SymbolTable {
+    if (!scope) {
+        return create_empty_symbol_table();
+    }
+    let result: SymbolTable = {
+        programs: new Map(scope.symbols.programs),
+        localMacros: new Map(scope.symbols.localMacros),
+        globalMacros: new Map(scope.symbols.globalMacros),
+        variables: new Map(scope.symbols.variables),
+        scalars: new Map(scope.symbols.scalars),
+        matrices: new Map(scope.symbols.matrices),
+    };
+    for (const my_site of scope.forward_call_symbols ?? []) {
+        if (my_site.call_line < cursor_line) {
+            result = merge_symbol_tables(result, my_site.symbols);
+        }
+    }
+    return result;
+}
+
+/**
+ * Forward-call sites whose symbols are visible at `cursor_line`
+ * (site.call_line < cursor_line). Preserves array order so
+ * ranking-sensitive callers keep their current behavior.
+ *
+ * Returns `[]` when `scope` is undefined or has no forward_call_symbols.
+ */
+export function get_visible_forward_call_sites(
+    scope: ResolvedScope | undefined,
+    cursor_line: number,
+): ForwardCallSite[] {
+    if (!scope?.forward_call_symbols) {
+        return [];
+    }
+    return scope.forward_call_symbols.filter(
+        my_site => my_site.call_line < cursor_line,
+    );
+}
+
+/**
+ * URIs whose symbols contribute to scope at `cursor_line`:
+ *   current_uri
+ *   ∪ { entry.uri : entry ∈ scope.chain }
+ *   ∪ { site.callee_uri : site ∈ get_visible_forward_call_sites(scope, cursor_line) }
+ *
+ * Returns a Set containing just `current_uri` when `scope` is undefined.
+ */
+export function collect_visible_uris(
+    scope: ResolvedScope | undefined,
+    cursor_line: number,
+    current_uri: string,
+): Set<string> {
+    const the_result = new Set<string>();
+    the_result.add(current_uri);
+    if (!scope) {
+        return the_result;
+    }
+    for (const my_entry of scope.chain) {
+        the_result.add(my_entry.uri);
+    }
+    for (const my_site of get_visible_forward_call_sites(scope, cursor_line)) {
+        the_result.add(my_site.callee_uri);
+    }
+    return the_result;
+}

--- a/src/scope-resolver/visible-symbols.ts
+++ b/src/scope-resolver/visible-symbols.ts
@@ -45,10 +45,11 @@ function get_latest_definition_line(symbol: AnySymbol): number {
 }
 
 /**
- * True when the current file has a same-name definition at a line strictly
- * greater than `call_line` — i.e., the current file redefines this name after
- * the forward call, so the current file should win per Stata's
- * last-assignment-wins execution order.
+ * True when the current file has a same-name definition at a line at or before
+ * `call_line` — i.e., the current file defines this name before/at the forward
+ * call line, so the current file should win per Stata's last-assignment-wins
+ * execution order. Definitions after the call line do NOT override the forward
+ * call symbol.
  */
 function current_file_overrides_forward_call<T extends AnySymbol>(
     current_file_map: Map<string, T> | undefined,
@@ -58,15 +59,15 @@ function current_file_overrides_forward_call<T extends AnySymbol>(
     if (!current_file_map) return false;
     const my_existing = current_file_map.get(name);
     if (!my_existing) return false;
-    return get_latest_definition_line(my_existing) > call_line;
+    return get_latest_definition_line(my_existing) <= call_line;
 }
 
 /**
- * Drop entries from `site_symbols` that are shadowed by a later current-file
+ * Drop entries from `site_symbols` that are shadowed by an earlier current-file
  * definition. A name is dropped when `current_file_symbols` has a same-name
- * definition at a line strictly greater than `call_line` (the line at which
- * this forward call executes). Exported so CompletionProvider can apply the
- * same filter when building its annotated forward-symbol overlay.
+ * definition at a line at or before `call_line` (the line at which this forward
+ * call executes). Exported so CompletionProvider can apply the same filter when
+ * building its annotated forward-symbol overlay.
  */
 export function filter_forward_site_symbols(
     site_symbols: SymbolTable,
@@ -100,10 +101,9 @@ export function filter_forward_site_symbols(
  * SymbolTable of every symbol in scope at `cursor_line`. Starts from
  * `resolved_scope.symbols` (parent chain + current file) and overlays each
  * forward-call site whose `call_line < cursor_line` with merge_symbol_tables
- * last-wins semantics — except that a current-file definition at a line
- * greater than a call's `call_line` is preserved, so later current-file
- * redefinitions shadow earlier forward-call results (matches Stata's
- * sequential execution semantics).
+ * last-wins semantics — except that a current-file definition at a line at or
+ * before a call's `call_line` is preserved, so earlier current-file definitions
+ * shadow forward-call results (matches Stata's sequential execution semantics).
  *
  * Returns an empty SymbolTable when `scope` is undefined.
  */
@@ -122,7 +122,7 @@ export function get_visible_symbols_at(
         scalars: new Map(scope.symbols.scalars),
         matrices: new Map(scope.symbols.matrices),
     };
-    const current_file_symbols = scope.chain.length > 0
+    const current_file_symbols = scope.chain && scope.chain.length > 0
         ? scope.chain[0].symbols
         : undefined;
     for (const my_site of scope.forward_call_symbols ?? []) {

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -747,36 +747,12 @@ export async function create_server(options: ServerOptions): Promise<void> {
                         ? workspace_indexer.get_all_symbols()
                         : undefined;
 
-                    let forward_scope = undefined;
-                    // Skip forward_scope computation when scope_resolver is available —
-                    // ScopeResolver.resolve() already calls ForwardScopeResolver internally
-                    if (!scope_resolver && forward_scope_resolver && document_state.forward_calls.length > 0) {
-                        const max_depth = settings.cross_file?.max_forward_depth ?? 10;
-                        forward_scope = await forward_scope_resolver.resolve(
-                            document_state.uri,
-                            document_state.forward_calls,
-                            'include',
-                            {
-                                visited: new Map(),
-                                effective_call_type: 'include',
-                                depth: 0,
-                                diagnostics: [],
-                                working_directory: document_state.working_directory,
-                                call_chain: [],
-                            },
-                            undefined,
-                            undefined,
-                            { max_forward_depth: max_depth }
-                        );
-                    }
-
                     const result = await diagnostics_provider.publish_diagnostics(
                         document_state,
                         settings,
                         diag_workspace_symbols,
                         scope_resolver || undefined,
-                        undefined,
-                        forward_scope
+                        undefined
                     );
 
                     if (result.pending) {

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -303,7 +303,6 @@ export function create_completion_handler(
                     undefined,
                     undefined,
                     undefined,
-                    undefined,
                     token
                 );
                 // Return as CompletionList with isIncomplete=true to force VS Code
@@ -360,7 +359,6 @@ export function create_completion_handler(
                     backward_dependencies: config.cross_file?.backward_dependencies,
                     max_forward_depth: config.cross_file?.max_forward_depth,
                 },
-                forward_scope,
                 workspace_version,
                 token,
                 graph_version

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -320,31 +320,7 @@ export function create_completion_handler(
                 ? deps.workspace_indexer.get_version()
                 : 0;
             const config = await deps.get_document_settings(params.textDocument.uri);
-            
-            // Compute forward scope only when scope_resolver is NOT available (fallback path)
-            // When scope_resolver is available, it internally calls ForwardScopeResolver.resolve()
-            let forward_scope = undefined;
-            if (!deps.scope_resolver && deps.forward_scope_resolver && document_state.forward_calls.length > 0) {
-                // Apply per-request max_forward_depth from user config
-                const max_depth = config.cross_file?.max_forward_depth ?? 10;
-                forward_scope = await deps.forward_scope_resolver.resolve(
-                    document_state.uri,
-                    document_state.forward_calls,
-                    'include',
-                    {
-                        visited: new Map(),
-                        effective_call_type: 'include',
-                        depth: 0,
-                        diagnostics: [],
-                        working_directory: document_state.working_directory,
-                        call_chain: [],
-                    },
-                    undefined,
-                    token,
-                    { max_forward_depth: max_depth }
-                );
-            }
-            
+
             const graph_version = deps.dependency_graph
                 ? deps.dependency_graph.get_version()
                 : undefined;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -598,6 +598,7 @@ export interface ScopeChainEntry {
   directive_type: 'done-by' | 'included-by';
   call_site_line: number;          // Line in parent where call occurs
   symbols: SymbolTable;            // Symbols from this file
+  forward_call_sites?: ForwardCallSite[];  // Parent forward calls visible before the child call site
   depth: number;                   // Distance from current file (0 = current)
   // Order of the directive in the referencing file header.
   // Larger means it appeared later in the header ("lattermost" wins at same depth).

--- a/tests/integration/definition-call-site-scope.test.ts
+++ b/tests/integration/definition-call-site-scope.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Integration tests for issue #129: definition.ts::resolve_non_macro_symbols
+ * must consult forward-call symbols visible at the cursor line, and it
+ * must prefer in-scope variable definitions over workspace-wide fallbacks.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { DefinitionProvider } from '../../src/providers/definition';
+import { DocumentStore } from '../../src/document-store';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { join } from 'path';
+import { writeFileSync, mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { URI } from 'vscode-uri';
+
+function build_pipeline() {
+    const the_indexer = new WorkspaceIndexer();
+    const the_dep_graph = new DependencyGraph();
+    the_indexer.set_dependency_graph(the_dep_graph);
+    const the_scope_resolver = new ScopeResolver();
+    the_scope_resolver.set_dependency_graph(the_dep_graph);
+    const the_forward_resolver = new ForwardScopeResolver(the_scope_resolver, {
+        max_forward_depth: 10,
+    });
+    the_scope_resolver.set_forward_scope_resolver(the_forward_resolver);
+    const the_definition_provider = new DefinitionProvider();
+    const the_document_store = new DocumentStore();
+    return {
+        indexer: the_indexer,
+        scope_resolver: the_scope_resolver,
+        forward_scope_resolver: the_forward_resolver,
+        definition_provider: the_definition_provider,
+        document_store: the_document_store,
+        dependency_graph: the_dep_graph,
+    };
+}
+
+describe('Go-to-Definition - call-site scope filtering (issue #129)', () => {
+    let test_temp_dir: string;
+    let pipeline: ReturnType<typeof build_pipeline>;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'def-scope-'));
+        pipeline = build_pipeline();
+    });
+
+    afterEach(() => {
+        try { pipeline?.scope_resolver?.dispose(); } catch {}
+        try { pipeline?.forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('falls through to workspace fallback when forward-called file is not yet visible', async () => {
+        // Sanity regression test: cursor is on line 0, before the do "defs.do"
+        // on line 1. The in-scope check misses (defs.do is not yet visible),
+        // so control falls through to the workspace-indexer fallback, which
+        // correctly returns defs.do's program definition as a workspace-wide
+        // match. This is the specified behavior — the fix only tightens the
+        // *in-scope* lookup; the workspace fallback is intentionally unchanged
+        // (see spec "Concrete changes / src/providers/definition.ts").
+        // The meaningful call-site filtering gain is exercised by the
+        // 'isolates unrelated branches' scenario below.
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `shared_prog\ndo "defs.do"\n`;
+        writeFileSync(main_path, main_content);
+
+        const defs_path = join(test_temp_dir, 'defs.do');
+        writeFileSync(defs_path, `program define shared_prog\nend\n`);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const cursor_char = main_content.split('\n')[0].indexOf('shared_prog') + 3;
+        const result = await pipeline.definition_provider.get_definition(
+            document_state,
+            { line: 0, character: cursor_char },
+            undefined,
+            document_state.context_tracker,
+            pipeline.scope_resolver,
+            pipeline.indexer,
+        );
+
+        const defs_uri = URI.file(defs_path).toString();
+        expect(result).not.toBeNull();
+        const locations = Array.isArray(result) ? result : [result!];
+        expect(locations.some(loc => loc.uri === defs_uri)).toBe(true);
+    });
+
+    it('resolves a program to a visible forward-called file', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `do "defs.do"\nshared_prog\n`;
+        writeFileSync(main_path, main_content);
+
+        const defs_path = join(test_temp_dir, 'defs.do');
+        writeFileSync(defs_path, `program define shared_prog\nend\n`);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const cursor_char = main_content.split('\n')[1].indexOf('shared_prog') + 3;
+        const result = await pipeline.definition_provider.get_definition(
+            document_state,
+            { line: 1, character: cursor_char },
+            undefined,
+            document_state.context_tracker,
+            pipeline.scope_resolver,
+            pipeline.indexer,
+        );
+
+        const defs_uri = URI.file(defs_path).toString();
+        expect(result).not.toBeNull();
+        const locations = Array.isArray(result) ? result : [result!];
+        expect(locations.some(loc => loc.uri === defs_uri)).toBe(true);
+    });
+
+    it('prefers an in-scope variable definition over a workspace-wide fallback', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `do "uses_var.do"\n`;
+        writeFileSync(main_path, main_content);
+
+        const uses_var_path = join(test_temp_dir, 'uses_var.do');
+        const uses_var_content = `gen my_var = 1\nlist my_var\n`;
+        writeFileSync(uses_var_path, uses_var_content);
+
+        const unrelated_path = join(test_temp_dir, 'unrelated.do');
+        writeFileSync(unrelated_path, `gen my_var = 99\n`);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const uses_var_uri = URI.file(uses_var_path).toString();
+        await pipeline.document_store.open(uses_var_uri, uses_var_content, 1);
+        const document_state = pipeline.document_store.get(uses_var_uri)!;
+
+        const cursor_char = uses_var_content.split('\n')[1].indexOf('my_var') + 2;
+        const result = await pipeline.definition_provider.get_definition(
+            document_state,
+            { line: 1, character: cursor_char },
+            undefined,
+            document_state.context_tracker,
+            pipeline.scope_resolver,
+            pipeline.indexer,
+        );
+
+        expect(result).not.toBeNull();
+        const locations = Array.isArray(result) ? result : [result!];
+        expect(locations.some(loc => loc.uri === uses_var_uri && loc.range.start.line === 0)).toBe(true);
+        const unrelated_uri = URI.file(unrelated_path).toString();
+        expect(locations.every(loc => loc.uri !== unrelated_uri)).toBe(true);
+    });
+
+    it('falls back to the workspace-wide Location[] when no in-scope variable def exists', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `list my_var\n`;
+        writeFileSync(main_path, main_content);
+
+        const unrelated_path = join(test_temp_dir, 'unrelated.do');
+        writeFileSync(unrelated_path, `gen my_var = 1\n`);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const cursor_char = main_content.split('\n')[0].indexOf('my_var') + 2;
+        const result = await pipeline.definition_provider.get_definition(
+            document_state,
+            { line: 0, character: cursor_char },
+            undefined,
+            document_state.context_tracker,
+            pipeline.scope_resolver,
+            pipeline.indexer,
+        );
+
+        const unrelated_uri = URI.file(unrelated_path).toString();
+        expect(result).not.toBeNull();
+        const locations = Array.isArray(result) ? result : [result!];
+        expect(locations.some(loc => loc.uri === unrelated_uri)).toBe(true);
+    });
+
+    it('isolates unrelated branches with same-named programs', async () => {
+        writeFileSync(join(test_temp_dir, 'branch_a.do'), `program define shared_prog\nend\n`);
+        writeFileSync(join(test_temp_dir, 'branch_b.do'), `program define shared_prog\nend\n`);
+
+        const caller_path = join(test_temp_dir, 'caller.do');
+        const caller_content = `do "branch_a.do"\nshared_prog\n`;
+        writeFileSync(caller_path, caller_content);
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const caller_uri = URI.file(caller_path).toString();
+        await pipeline.document_store.open(caller_uri, caller_content, 1);
+        const document_state = pipeline.document_store.get(caller_uri)!;
+
+        const cursor_char = caller_content.split('\n')[1].indexOf('shared_prog') + 3;
+        const result = await pipeline.definition_provider.get_definition(
+            document_state,
+            { line: 1, character: cursor_char },
+            undefined,
+            document_state.context_tracker,
+            pipeline.scope_resolver,
+            pipeline.indexer,
+        );
+
+        const branch_a_uri = URI.file(join(test_temp_dir, 'branch_a.do')).toString();
+        const branch_b_uri = URI.file(join(test_temp_dir, 'branch_b.do')).toString();
+        expect(result).not.toBeNull();
+        const locations = Array.isArray(result) ? result : [result!];
+        expect(locations.some(loc => loc.uri === branch_a_uri)).toBe(true);
+        expect(locations.every(loc => loc.uri !== branch_b_uri)).toBe(true);
+    });
+
+    it('resolves transitively through nested forward calls', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content =
+            `* line 0\n* line 1\n* line 2\n* line 3\n* line 4\n` +
+            `do "mid.do"\n* line 6\n* line 7\n* line 8\n* line 9\ndeep_prog\n`;
+        writeFileSync(main_path, main_content);
+
+        const mid_path = join(test_temp_dir, 'mid.do');
+        const mid_content = `* line 0\n* line 1\n* line 2\ndo "leaf.do"\n`;
+        writeFileSync(mid_path, mid_content);
+
+        const leaf_path = join(test_temp_dir, 'leaf.do');
+        writeFileSync(leaf_path, `program define deep_prog\nend\n`);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const cursor_char = main_content.split('\n')[10].indexOf('deep_prog') + 3;
+        const result = await pipeline.definition_provider.get_definition(
+            document_state,
+            { line: 10, character: cursor_char },
+            undefined,
+            document_state.context_tracker,
+            pipeline.scope_resolver,
+            pipeline.indexer,
+        );
+
+        const leaf_uri = URI.file(leaf_path).toString();
+        expect(result).not.toBeNull();
+        const locations = Array.isArray(result) ? result : [result!];
+        expect(locations.some(loc => loc.uri === leaf_uri)).toBe(true);
+    });
+});

--- a/tests/integration/definition-call-site-scope.test.ts
+++ b/tests/integration/definition-call-site-scope.test.ts
@@ -125,24 +125,29 @@ describe('Go-to-Definition - call-site scope filtering (issue #129)', () => {
     });
 
     it('prefers an in-scope variable definition over a workspace-wide fallback', async () => {
+        // The cursor sits in main.do, which has no local `gen my_var`. The
+        // only in-scope definition comes from defs.do via the forward
+        // `do "defs.do"` call, so this exercises the scope_resolver branch
+        // in resolve_non_macro_symbols (not the document.symbols
+        // short-circuit). unrelated.do also defines `my_var` but has no
+        // dep-graph edge to main.do, so it must not appear in the result.
         const main_path = join(test_temp_dir, 'main.do');
-        const main_content = `do "uses_var.do"\n`;
+        const main_content = `do "defs.do"\nlist my_var\n`;
         writeFileSync(main_path, main_content);
 
-        const uses_var_path = join(test_temp_dir, 'uses_var.do');
-        const uses_var_content = `gen my_var = 1\nlist my_var\n`;
-        writeFileSync(uses_var_path, uses_var_content);
+        const defs_path = join(test_temp_dir, 'defs.do');
+        writeFileSync(defs_path, `gen my_var = 1\n`);
 
         const unrelated_path = join(test_temp_dir, 'unrelated.do');
         writeFileSync(unrelated_path, `gen my_var = 99\n`);
 
         await pipeline.indexer.initialize([test_temp_dir]);
 
-        const uses_var_uri = URI.file(uses_var_path).toString();
-        await pipeline.document_store.open(uses_var_uri, uses_var_content, 1);
-        const document_state = pipeline.document_store.get(uses_var_uri)!;
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
 
-        const cursor_char = uses_var_content.split('\n')[1].indexOf('my_var') + 2;
+        const cursor_char = main_content.split('\n')[1].indexOf('my_var') + 2;
         const result = await pipeline.definition_provider.get_definition(
             document_state,
             { line: 1, character: cursor_char },
@@ -152,10 +157,13 @@ describe('Go-to-Definition - call-site scope filtering (issue #129)', () => {
             pipeline.indexer,
         );
 
+        // Should return the in-scope def from defs.do as a single Location
+        // (not a Location[] fan-out including unrelated.do).
+        const defs_uri = URI.file(defs_path).toString();
+        const unrelated_uri = URI.file(unrelated_path).toString();
         expect(result).not.toBeNull();
         const locations = Array.isArray(result) ? result : [result!];
-        expect(locations.some(loc => loc.uri === uses_var_uri && loc.range.start.line === 0)).toBe(true);
-        const unrelated_uri = URI.file(unrelated_path).toString();
+        expect(locations.some(loc => loc.uri === defs_uri && loc.range.start.line === 0)).toBe(true);
         expect(locations.every(loc => loc.uri !== unrelated_uri)).toBe(true);
     });
 

--- a/tests/integration/definition-forward-include.test.ts
+++ b/tests/integration/definition-forward-include.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Go-to-definition should prefer a forward include's callee when the current
+ * file brings the macro into scope via `include`, even if another unrelated
+ * file in the workspace also defines a local with the same name.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { DefinitionProvider } from '../../src/providers/definition';
+import { DocumentStore } from '../../src/document-store';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { join } from 'path';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { URI } from 'vscode-uri';
+
+describe('Definition — forward include brings macro into scope', () => {
+    const test_temp_dir = join(process.cwd(), 'temp_definition_forward_include');
+    let indexer: WorkspaceIndexer;
+    let definition_provider: DefinitionProvider;
+    let document_store: DocumentStore;
+    let scope_resolver: ScopeResolver;
+    let forward_scope_resolver: ForwardScopeResolver;
+
+    beforeEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+        mkdirSync(test_temp_dir);
+
+        indexer = new WorkspaceIndexer();
+        definition_provider = new DefinitionProvider();
+        document_store = new DocumentStore();
+        scope_resolver = new ScopeResolver();
+        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+    });
+
+    afterAll(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('navigates to the included file, not to an unrelated same-name local in the workspace', async () => {
+        // 1.do includes 2.do, then references `fruit'.
+        const file_1_path = join(test_temp_dir, '1.do');
+        const file_1_content = 'include 2.do\ndi "`fruit\'"';
+        writeFileSync(file_1_path, file_1_content);
+
+        // 2.do defines local fruit — this is the real definition.
+        const file_2_path = join(test_temp_dir, '2.do');
+        const file_2_content = 'local fruit apple';
+        writeFileSync(file_2_path, file_2_content);
+
+        // A workspace neighbor that ALSO defines a local named `fruit`.
+        // Historically the workspace-indexer fallback returned this too, which
+        // produced a multi-result peek instead of a direct jump to 2.do.
+        const callee_path = join(test_temp_dir, 'callee.do');
+        const callee_content =
+            '// @lsp-included-by: caller.do\nlocal fruit apple\n';
+        writeFileSync(callee_path, callee_content);
+
+        const caller_path = join(test_temp_dir, 'caller.do');
+        writeFileSync(
+            caller_path,
+            'local espresso double\ninclude callee.do\ndi "`fruit\'"'
+        );
+
+        await indexer.initialize([test_temp_dir]);
+
+        const file_1_uri = URI.file(file_1_path).toString();
+        await document_store.open(file_1_uri, file_1_content, 1);
+        const document_state = document_store.get(file_1_uri)!;
+
+        // Cursor on `fruit' on line 1 (0-indexed) of 1.do — the backtick is
+        // at col 5 inside `di "`fruit'"`, so the identifier starts at col 6.
+        const definition = await definition_provider.get_definition(
+            document_state,
+            { line: 1, character: 7 },
+            indexer.get_all_symbols(),
+            undefined,
+            scope_resolver,
+            indexer
+        );
+
+        expect(definition).not.toBeNull();
+        // Should be a single location, pointing at 2.do.
+        expect(Array.isArray(definition)).toBe(false);
+        const def_uri = Array.isArray(definition)
+            ? definition[0].uri
+            : (definition as { uri: string }).uri;
+        expect(def_uri).toContain('2.do');
+        expect(def_uri).not.toContain('callee.do');
+    });
+});

--- a/tests/integration/find-references-call-site-scope.test.ts
+++ b/tests/integration/find-references-call-site-scope.test.ts
@@ -337,6 +337,51 @@ describe('Find References - call-site scope filtering (issue #127)', () => {
         expect(before_has_leaf).toBe(false);
     });
 
+    it('scans references visible only through a backward parent forward call', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content =
+            `do "defs.do"\n` +
+            `do "helper.do"\n` +
+            `do "child.do"\n`;
+        writeFileSync(main_path, main_content);
+
+        const defs_path = join(test_temp_dir, 'defs.do');
+        writeFileSync(defs_path, `program define deep_prog\nend\n`);
+
+        const helper_path = join(test_temp_dir, 'helper.do');
+        const helper_content =
+            `capture noisily deep_prog\n` +
+            `deep_prog\n`;
+        writeFileSync(helper_path, helper_content);
+
+        const child_path = join(test_temp_dir, 'child.do');
+        const child_content = `* @lsp-done-by: "main.do"\n\ndeep_prog\n`;
+        writeFileSync(child_path, child_content);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const child_uri = URI.file(child_path).toString();
+        await pipeline.document_store.open(child_uri, child_content, 1);
+        const document_state = pipeline.document_store.get(child_uri)!;
+
+        const cursor_char = child_content
+            .split('\n')[2]
+            .indexOf('deep_prog') + 3;
+
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 2, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker
+        );
+
+        const defs_uri = URI.file(defs_path).toString();
+        const helper_uri = URI.file(helper_path).toString();
+        expect(locations.some(loc => loc.uri === defs_uri)).toBe(true);
+        expect(locations.some(loc => loc.uri === helper_uri && loc.range.start.line === 1)).toBe(true);
+    });
+
     it('keeps pre-fix behavior when ReferencesProvider is constructed without a scope_resolver', async () => {
         // The fallback path is intended only for test-only setups that
         // construct `new ReferencesProvider()`. Production always wires a

--- a/tests/integration/find-references-declaration-scope.test.ts
+++ b/tests/integration/find-references-declaration-scope.test.ts
@@ -111,6 +111,93 @@ describe('find-references — declaration call-site scope (issue #129)', () => {
         expect(locations.some(loc => loc.uri === defs_uri)).toBe(true);
     });
 
+    it('includes a declaration inherited through a parent forward call', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `do "leaf.do"\ndo "child.do"\n`;
+        writeFileSync(main_path, main_content);
+
+        const leaf_path = join(test_temp_dir, 'leaf.do');
+        writeFileSync(leaf_path, `program define deep_prog\nend\n`);
+
+        const child_path = join(test_temp_dir, 'child.do');
+        const child_content = `* @lsp-done-by: "main.do"\n\ndeep_prog\n`;
+        writeFileSync(child_path, child_content);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const child_uri = URI.file(child_path).toString();
+        await pipeline.document_store.open(child_uri, child_content, 1);
+        const document_state = pipeline.document_store.get(child_uri)!;
+
+        const cursor_char = child_content.split('\n')[2].indexOf('deep_prog') + 3;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 2, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker,
+        );
+
+        const leaf_uri = URI.file(leaf_path).toString();
+        expect(locations.some(loc => loc.uri === leaf_uri)).toBe(true);
+    });
+
+    it('does not pool local macros through done-by', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `local shared 1\ndo "child.do"\n`;
+        writeFileSync(main_path, main_content);
+
+        const child_path = join(test_temp_dir, 'child.do');
+        const child_content = `* @lsp-done-by: "main.do"\n\ndisplay \`shared'\n`;
+        writeFileSync(child_path, child_content);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const child_uri = URI.file(child_path).toString();
+        await pipeline.document_store.open(child_uri, child_content, 1);
+        const document_state = pipeline.document_store.get(child_uri)!;
+
+        const cursor_char = child_content.split('\n')[2].indexOf('shared') + 2;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 2, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker,
+        );
+
+        const main_uri = URI.file(main_path).toString();
+        expect(locations.every(loc => loc.uri !== main_uri)).toBe(true);
+    });
+
+    it('pools local macros through included-by', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `local shared 1\ninclude "child.do"\n`;
+        writeFileSync(main_path, main_content);
+
+        const child_path = join(test_temp_dir, 'child.do');
+        const child_content = `* @lsp-included-by: "main.do"\n\ndisplay \`shared'\n`;
+        writeFileSync(child_path, child_content);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const child_uri = URI.file(child_path).toString();
+        await pipeline.document_store.open(child_uri, child_content, 1);
+        const document_state = pipeline.document_store.get(child_uri)!;
+
+        const cursor_char = child_content.split('\n')[2].indexOf('shared') + 2;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 2, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker,
+        );
+
+        const main_uri = URI.file(main_path).toString();
+        expect(locations.some(loc => loc.uri === main_uri && loc.range.start.line === 0)).toBe(true);
+    });
+
     it('pools variable declarations workspace-wide regardless of cursor position', async () => {
         const main_path = join(test_temp_dir, 'main.do');
         const main_content = `gen my_var = 1\nlist my_var\n`;

--- a/tests/integration/find-references-declaration-scope.test.ts
+++ b/tests/integration/find-references-declaration-scope.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Integration tests for issue #129: references.ts::find_definitions must
+ * respect call-site order for non-variable kinds but keep variables
+ * workspace-wide (dataset-column semantics).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { ReferencesProvider } from '../../src/providers/references';
+import { DocumentStore } from '../../src/document-store';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { join } from 'path';
+import { writeFileSync, mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { URI } from 'vscode-uri';
+
+function build_pipeline() {
+    const the_indexer = new WorkspaceIndexer();
+    const the_dep_graph = new DependencyGraph();
+    the_indexer.set_dependency_graph(the_dep_graph);
+    const the_scope_resolver = new ScopeResolver();
+    the_scope_resolver.set_dependency_graph(the_dep_graph);
+    const the_forward_resolver = new ForwardScopeResolver(the_scope_resolver, {
+        max_forward_depth: 10,
+    });
+    the_scope_resolver.set_forward_scope_resolver(the_forward_resolver);
+    const the_refs_provider = new ReferencesProvider(the_scope_resolver);
+    const the_document_store = new DocumentStore();
+    return {
+        indexer: the_indexer,
+        scope_resolver: the_scope_resolver,
+        forward_scope_resolver: the_forward_resolver,
+        references_provider: the_refs_provider,
+        document_store: the_document_store,
+        dependency_graph: the_dep_graph,
+    };
+}
+
+describe('find-references — declaration call-site scope (issue #129)', () => {
+    let test_temp_dir: string;
+    let pipeline: ReturnType<typeof build_pipeline>;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'find-refs-decl-scope-'));
+        pipeline = build_pipeline();
+    });
+
+    afterEach(() => {
+        try { pipeline?.scope_resolver?.dispose(); } catch {}
+        try { pipeline?.forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('excludes a program declared in a not-yet-reached forward-called file', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `program define shared_prog\nend\nshared_prog\ndo "branch_b.do"\n`;
+        writeFileSync(main_path, main_content);
+
+        writeFileSync(join(test_temp_dir, 'branch_b.do'), `program define shared_prog\nend\n`);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        // Cursor on `shared_prog` at line 2 (before `do "branch_b.do"` on line 3).
+        const cursor_char = main_content.split('\n')[2].indexOf('shared_prog') + 3;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 2, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker,
+        );
+
+        const branch_b_uri = URI.file(join(test_temp_dir, 'branch_b.do')).toString();
+        expect(locations.every(loc => loc.uri !== branch_b_uri)).toBe(true);
+        // Sanity: main's own declaration must be included.
+        expect(locations.some(loc => loc.uri === main_uri && loc.range.start.line === 0)).toBe(true);
+    });
+
+    it('includes a program declared in a visible forward-called file', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `do "defs.do"\nshared_prog\n`;
+        writeFileSync(main_path, main_content);
+
+        const defs_path = join(test_temp_dir, 'defs.do');
+        writeFileSync(defs_path, `program define shared_prog\nend\n`);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const cursor_char = main_content.split('\n')[1].indexOf('shared_prog') + 3;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 1, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker,
+        );
+
+        const defs_uri = URI.file(defs_path).toString();
+        expect(locations.some(loc => loc.uri === defs_uri)).toBe(true);
+    });
+
+    it('pools variable declarations workspace-wide regardless of cursor position', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `gen my_var = 1\nlist my_var\n`;
+        writeFileSync(main_path, main_content);
+
+        const unrelated_path = join(test_temp_dir, 'unrelated.do');
+        writeFileSync(unrelated_path, `gen my_var = 99\n`);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const cursor_char = main_content.split('\n')[1].indexOf('my_var') + 2;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 1, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker,
+        );
+
+        const unrelated_uri = URI.file(unrelated_path).toString();
+        expect(locations.some(loc => loc.uri === unrelated_uri)).toBe(true);
+    });
+
+    it('includes a variable declaration in a visible forward-called file', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = `do "uses_var.do"\nlist my_var\n`;
+        writeFileSync(main_path, main_content);
+
+        const uses_var_path = join(test_temp_dir, 'uses_var.do');
+        writeFileSync(uses_var_path, `gen my_var = 1\n`);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const cursor_char = main_content.split('\n')[1].indexOf('my_var') + 2;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 1, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker,
+        );
+
+        const uses_var_uri = URI.file(uses_var_path).toString();
+        expect(locations.some(loc => loc.uri === uses_var_uri)).toBe(true);
+    });
+});

--- a/tests/integration/find-references-declaration-scope.test.ts
+++ b/tests/integration/find-references-declaration-scope.test.ts
@@ -142,6 +142,80 @@ describe('find-references — declaration call-site scope (issue #129)', () => {
         expect(locations.some(loc => loc.uri === leaf_uri)).toBe(true);
     });
 
+    it('excludes a masked same-name backward parent from declarations and references', async () => {
+        const earlier_parent_path = join(test_temp_dir, 'earlier_parent.do');
+        writeFileSync(earlier_parent_path, `program define shared_prog\nend\n`);
+
+        const later_parent_path = join(test_temp_dir, 'later_parent.do');
+        writeFileSync(later_parent_path, `program define shared_prog\nend\n`);
+
+        const child_path = join(test_temp_dir, 'child.do');
+        const child_content =
+            `* @lsp-done-by: "earlier_parent.do"\n` +
+            `* @lsp-done-by: "later_parent.do"\n\n` +
+            `shared_prog\n`;
+        writeFileSync(child_path, child_content);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const child_uri = URI.file(child_path).toString();
+        await pipeline.document_store.open(child_uri, child_content, 1);
+        const document_state = pipeline.document_store.get(child_uri)!;
+
+        const cursor_char = child_content.split('\n')[3].indexOf('shared_prog') + 3;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 3, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker,
+        );
+
+        const earlier_parent_uri = URI.file(earlier_parent_path).toString();
+        const later_parent_uri = URI.file(later_parent_path).toString();
+
+        expect(locations.some(loc => loc.uri === later_parent_uri)).toBe(true);
+        expect(locations.every(loc => loc.uri !== earlier_parent_uri)).toBe(true);
+        expect(locations.some(loc => loc.uri === child_uri && loc.range.start.line === 3)).toBe(true);
+    });
+
+    it('excludes a masked same-name visible forward callee from declarations and references', async () => {
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content =
+            `do "earlier.do"\n` +
+            `do "later.do"\n` +
+            `shared_prog\n`;
+        writeFileSync(main_path, main_content);
+
+        const earlier_path = join(test_temp_dir, 'earlier.do');
+        writeFileSync(earlier_path, `program define shared_prog\nend\n`);
+
+        const later_path = join(test_temp_dir, 'later.do');
+        writeFileSync(later_path, `program define shared_prog\nend\n`);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const cursor_char = main_content.split('\n')[2].indexOf('shared_prog') + 3;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 2, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker,
+        );
+
+        const earlier_uri = URI.file(earlier_path).toString();
+        const later_uri = URI.file(later_path).toString();
+
+        expect(locations.some(loc => loc.uri === later_uri)).toBe(true);
+        expect(locations.every(loc => loc.uri !== earlier_uri)).toBe(true);
+        expect(locations.some(loc => loc.uri === main_uri && loc.range.start.line === 2)).toBe(true);
+    });
+
     it('does not pool local macros through done-by', async () => {
         const main_path = join(test_temp_dir, 'main.do');
         const main_content = `local shared 1\ndo "child.do"\n`;
@@ -196,6 +270,43 @@ describe('find-references — declaration call-site scope (issue #129)', () => {
 
         const main_uri = URI.file(main_path).toString();
         expect(locations.some(loc => loc.uri === main_uri && loc.range.start.line === 0)).toBe(true);
+    });
+
+    it('does not leak a local macro from an included ancestor across a downstream done-by boundary', async () => {
+        const grand_path = join(test_temp_dir, 'grand.do');
+        const grand_content = `local shared 1\ninclude "parent.do"\n`;
+        writeFileSync(grand_path, grand_content);
+
+        const parent_path = join(test_temp_dir, 'parent.do');
+        const parent_content =
+            `* @lsp-included-by: "grand.do"\n` +
+            `do "child.do"\n`;
+        writeFileSync(parent_path, parent_content);
+
+        const child_path = join(test_temp_dir, 'child.do');
+        const child_content =
+            `* @lsp-done-by: "parent.do"\n\n` +
+            `display \`shared'\n`;
+        writeFileSync(child_path, child_content);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const child_uri = URI.file(child_path).toString();
+        await pipeline.document_store.open(child_uri, child_content, 1);
+        const document_state = pipeline.document_store.get(child_uri)!;
+
+        const cursor_char = child_content.split('\n')[2].indexOf('shared') + 2;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 2, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker,
+        );
+
+        const grand_uri = URI.file(grand_path).toString();
+        expect(locations.every(loc => loc.uri !== grand_uri)).toBe(true);
+        expect(locations.some(loc => loc.uri === child_uri && loc.range.start.line === 2)).toBe(true);
     });
 
     it('pools variable declarations workspace-wide regardless of cursor position', async () => {

--- a/tests/integration/find-references-include-locals.test.ts
+++ b/tests/integration/find-references-include-locals.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Find References bug: local macros crossing `include` boundaries.
+ *
+ * Reproduces two scenarios:
+ *   1. Cursor on a local defined in a file that is `include`-d by another
+ *      file (via `@lsp-included-by`). The reference in the including file
+ *      (after the include) must be found.
+ *   2. Cursor on a local defined in a file that `include`s another file.
+ *      The reference inside the included file must be found.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { ReferencesProvider } from '../../src/providers/references';
+import { DocumentStore } from '../../src/document-store';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { join } from 'path';
+import { writeFileSync, mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { URI } from 'vscode-uri';
+
+function build_pipeline() {
+    const the_indexer = new WorkspaceIndexer();
+    const the_dep_graph = new DependencyGraph();
+    the_indexer.set_dependency_graph(the_dep_graph);
+
+    const the_scope_resolver = new ScopeResolver();
+    the_scope_resolver.set_dependency_graph(the_dep_graph);
+
+    const the_forward_resolver = new ForwardScopeResolver(the_scope_resolver, {
+        max_forward_depth: 10,
+    });
+    the_scope_resolver.set_forward_scope_resolver(the_forward_resolver);
+
+    const the_references_provider = new ReferencesProvider(the_scope_resolver);
+    const the_document_store = new DocumentStore();
+
+    return {
+        indexer: the_indexer,
+        scope_resolver: the_scope_resolver,
+        forward_scope_resolver: the_forward_resolver,
+        references_provider: the_references_provider,
+        document_store: the_document_store,
+        dependency_graph: the_dep_graph,
+    };
+}
+
+describe('Find References - locals across include boundary', () => {
+    let test_temp_dir: string;
+    let pipeline: ReturnType<typeof build_pipeline>;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'find-refs-include-'));
+        pipeline = build_pipeline();
+    });
+
+    afterEach(() => {
+        try {
+            pipeline?.scope_resolver?.dispose();
+        } catch {}
+        try {
+            pipeline?.forward_scope_resolver?.dispose();
+        } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('finds parent reference to a local defined in the included child (cursor on child declaration)', async () => {
+        // callee.do declares `local fruit`; caller.do includes callee.do,
+        // then references `` `fruit' ``. Cursor is on `fruit` at its
+        // declaration in callee.do — we expect a hit in caller.do.
+        const caller_path = join(test_temp_dir, 'caller.do');
+        const caller_content =
+            `local espresso double\n` +
+            `include callee.do\n` +
+            `di "\`fruit'"\n`;
+        writeFileSync(caller_path, caller_content);
+
+        const callee_path = join(test_temp_dir, 'callee.do');
+        const callee_content =
+            `// @lsp-included-by: caller.do\n` +
+            `local fruit apple\n` +
+            `di "\`espresso'"\n`;
+        writeFileSync(callee_path, callee_content);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const callee_uri = URI.file(callee_path).toString();
+        await pipeline.document_store.open(callee_uri, callee_content, 1);
+        const document_state = pipeline.document_store.get(callee_uri)!;
+
+        // Cursor on `fruit` in `local fruit apple` — line 1 (0-indexed).
+        const decl_line = 1;
+        const name_char = callee_content
+            .split('\n')[decl_line]
+            .indexOf('fruit') + 1;
+
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: decl_line, character: name_char },
+            { includeDeclaration: false },
+            pipeline.indexer,
+            document_state.context_tracker
+        );
+
+        const caller_uri = URI.file(caller_path).toString();
+        const has_caller_ref = locations.some(
+            loc => loc.uri === caller_uri && loc.range.start.line === 2
+        );
+        expect(has_caller_ref).toBe(true);
+    });
+
+    it('finds child reference to a local defined in the including parent (cursor on parent declaration)', async () => {
+        // caller.do declares `local espresso`; includes callee.do, which
+        // references `` `espresso' ``. Cursor is on `espresso` at its
+        // declaration in caller.do — we expect a hit in callee.do.
+        const caller_path = join(test_temp_dir, 'caller.do');
+        const caller_content =
+            `local espresso double\n` +
+            `include callee.do\n` +
+            `di "\`fruit'"\n`;
+        writeFileSync(caller_path, caller_content);
+
+        const callee_path = join(test_temp_dir, 'callee.do');
+        const callee_content =
+            `// @lsp-included-by: caller.do\n` +
+            `local fruit apple\n` +
+            `di "\`espresso'"\n`;
+        writeFileSync(callee_path, callee_content);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const caller_uri = URI.file(caller_path).toString();
+        await pipeline.document_store.open(caller_uri, caller_content, 1);
+        const document_state = pipeline.document_store.get(caller_uri)!;
+
+        // Cursor on `espresso` in `local espresso double` — line 0.
+        const decl_line = 0;
+        const name_char = caller_content
+            .split('\n')[decl_line]
+            .indexOf('espresso') + 1;
+
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: decl_line, character: name_char },
+            { includeDeclaration: false },
+            pipeline.indexer,
+            document_state.context_tracker
+        );
+
+        const callee_uri = URI.file(callee_path).toString();
+        const has_callee_ref = locations.some(
+            loc => loc.uri === callee_uri && loc.range.start.line === 2
+        );
+        expect(has_callee_ref).toBe(true);
+    });
+});

--- a/tests/integration/hover-completion-forward-precedence.test.ts
+++ b/tests/integration/hover-completion-forward-precedence.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { join } from 'path';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { URI } from 'vscode-uri';
+import { HoverProvider } from '../../src/providers/hover';
+import { CompletionProvider } from '../../src/providers/completion';
+import { DocumentStore } from '../../src/document-store';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { CommandDatabase } from '../../src/command-database';
+import { create_empty_symbol_table } from '../../src/analyzer';
+import type { SymbolTable } from '../../src/types';
+
+function build_pipeline() {
+    const the_command_db = new CommandDatabase();
+    const the_scope_resolver = new ScopeResolver();
+    const the_forward_scope_resolver = new ForwardScopeResolver(
+        the_scope_resolver,
+        { max_forward_depth: 10 },
+    );
+    the_scope_resolver.set_forward_scope_resolver(the_forward_scope_resolver);
+
+    return {
+        command_db: the_command_db,
+        hover_provider: new HoverProvider(the_command_db),
+        completion_provider: new CompletionProvider(the_command_db),
+        document_store: new DocumentStore(),
+        scope_resolver: the_scope_resolver,
+        forward_scope_resolver: the_forward_scope_resolver,
+    };
+}
+
+describe('hover/completion forward-call precedence', () => {
+    let test_temp_dir: string;
+    let pipeline: ReturnType<typeof build_pipeline>;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(
+            join(tmpdir(), 'hover-completion-forward-precedence-'),
+        );
+        pipeline = build_pipeline();
+    });
+
+    afterEach(() => {
+        try { pipeline?.scope_resolver?.dispose(); } catch {}
+        try { pipeline?.forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('hover resolves a same-name program to the later visible forward callee', async () => {
+        const first_path = join(test_temp_dir, 'first.do');
+        writeFileSync(first_path, 'program define shared_prog\nend\n');
+
+        const second_path = join(test_temp_dir, 'second.do');
+        writeFileSync(second_path, 'program define shared_prog\nend\n');
+
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content =
+            'do "first.do"\n' +
+            'do "second.do"\n' +
+            'shared_prog\n';
+        writeFileSync(main_path, main_content);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const hover = await pipeline.hover_provider.get_hover(
+            document_state,
+            {
+                line: 2,
+                character: main_content.split('\n')[2].indexOf('shared_prog') + 3,
+            },
+            undefined,
+            pipeline.scope_resolver,
+        );
+
+        expect(hover).toBeDefined();
+        const content = hover?.contents as { kind: string; value: string };
+        expect(content.value).toContain('Program');
+        expect(content.value).toContain('shared_prog');
+        expect(content.value).toContain('second.do');
+        expect(content.value).not.toContain('first.do');
+    });
+
+    it('hover resolves a same-name global macro to the later visible forward callee', async () => {
+        const first_path = join(test_temp_dir, 'first.do');
+        writeFileSync(first_path, 'global SHARED "from_first"\n');
+
+        const second_path = join(test_temp_dir, 'second.do');
+        writeFileSync(second_path, 'global SHARED "from_second"\n');
+
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content =
+            'do "first.do"\n' +
+            'do "second.do"\n' +
+            'display "$SHARED"\n';
+        writeFileSync(main_path, main_content);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const hover = await pipeline.hover_provider.get_hover(
+            document_state,
+            {
+                line: 2,
+                character: main_content.split('\n')[2].indexOf('SHARED') + 2,
+            },
+            undefined,
+            pipeline.scope_resolver,
+        );
+
+        expect(hover).toBeDefined();
+        const content = hover?.contents as { kind: string; value: string };
+        expect(content.value).toContain('Global Macro');
+        expect(content.value).toContain('SHARED');
+        expect(content.value).toContain('from_second');
+        expect(content.value).toContain('second.do');
+        expect(content.value).not.toContain('from_first');
+    });
+
+    it('completion resolves a same-name program to the later visible forward callee', async () => {
+        const first_path = join(test_temp_dir, 'first.do');
+        writeFileSync(first_path, 'program define shared_prog\nend\n');
+
+        const second_path = join(test_temp_dir, 'second.do');
+        writeFileSync(second_path, 'program define shared_prog\nend\n');
+
+        const workspace_uri = URI.file(join(test_temp_dir, 'workspace.do')).toString();
+        const workspace_symbols: SymbolTable = {
+            ...create_empty_symbol_table(),
+            programs: new Map([[
+                'shared_prog',
+                {
+                    name: 'shared_prog',
+                    location: {
+                        uri: workspace_uri,
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 11 },
+                        },
+                    },
+                    sourceUri: workspace_uri,
+                },
+            ]]),
+        };
+
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content =
+            'do "first.do"\n' +
+            'do "second.do"\n' +
+            'sha\n';
+        writeFileSync(main_path, main_content);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const completions = await pipeline.completion_provider.get_completions(
+            document_state,
+            { line: 2, character: 3 },
+            undefined,
+            pipeline.scope_resolver,
+            workspace_symbols,
+        );
+
+        const shared_prog = completions.find(item => item.label === 'shared_prog');
+        expect(shared_prog).toBeDefined();
+        expect(shared_prog?.detail).toContain('second.do');
+        expect(String(shared_prog?.documentation)).toContain('second.do');
+    });
+
+    it('completion resolves a same-name global macro to the later visible forward callee', async () => {
+        const first_path = join(test_temp_dir, 'first.do');
+        writeFileSync(first_path, 'global SHARED "from_first"\n');
+
+        const second_path = join(test_temp_dir, 'second.do');
+        writeFileSync(second_path, 'global SHARED "from_second"\n');
+
+        const workspace_uri = URI.file(join(test_temp_dir, 'workspace.do')).toString();
+        const workspace_symbols: SymbolTable = {
+            ...create_empty_symbol_table(),
+            globalMacros: new Map([[
+                'SHARED',
+                {
+                    name: 'SHARED',
+                    scope: 'global',
+                    location: {
+                        uri: workspace_uri,
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 6 },
+                        },
+                    },
+                    sourceUri: workspace_uri,
+                    value: 'workspace_value',
+                },
+            ]]),
+        };
+
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content =
+            'do "first.do"\n' +
+            'do "second.do"\n' +
+            'display $S\n';
+        writeFileSync(main_path, main_content);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const completions = await pipeline.completion_provider.get_completions(
+            document_state,
+            { line: 2, character: main_content.split('\n')[2].length },
+            undefined,
+            pipeline.scope_resolver,
+            workspace_symbols,
+        );
+
+        const shared = completions.find(item => item.label === 'SHARED');
+        expect(shared).toBeDefined();
+        expect(shared?.detail).toContain('second.do');
+        expect(String(shared?.documentation)).toContain('from_second');
+    });
+});

--- a/tests/integration/hover-completion-forward-precedence.test.ts
+++ b/tests/integration/hover-completion-forward-precedence.test.ts
@@ -174,6 +174,71 @@ describe('hover/completion forward-call precedence', () => {
         expect(String(shared_prog?.documentation)).toContain('second.do');
     });
 
+    it('hover keeps current-file local redefined after forward include', async () => {
+        const child_path = join(test_temp_dir, 'child.do');
+        writeFileSync(child_path, 'local a 2\n');
+
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content =
+            'local a 1\n' +
+            'include "child.do"\n' +
+            'local a 3\n' +
+            'display `a\'\n';
+        writeFileSync(main_path, main_content);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const hover = await pipeline.hover_provider.get_hover(
+            document_state,
+            {
+                line: 3,
+                character: main_content.split('\n')[3].indexOf('`a') + 1,
+            },
+            undefined,
+            pipeline.scope_resolver,
+        );
+
+        expect(hover).toBeDefined();
+        const content = hover?.contents as { kind: string; value: string };
+        expect(content.value).toContain('Local Macro');
+        expect(content.value).toContain('`a`');
+        // Source should be the current file (main.do), not the forward callee.
+        expect(content.value).toContain('this file');
+        expect(content.value).not.toContain('child.do');
+    });
+
+    it('completion keeps current-file local redefined after forward include', async () => {
+        const child_path = join(test_temp_dir, 'child.do');
+        writeFileSync(child_path, 'local a "from_child"\n');
+
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content =
+            'local a "from_main_early"\n' +
+            'include "child.do"\n' +
+            'local a "from_main_late"\n' +
+            'display "`a\'"\n';
+        writeFileSync(main_path, main_content);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const completions = await pipeline.completion_provider.get_completions(
+            document_state,
+            { line: 3, character: main_content.split('\n')[3].indexOf('`a') + 1 },
+            undefined,
+            pipeline.scope_resolver,
+        );
+
+        const macro_a = completions.find(item => item.label === 'a');
+        expect(macro_a).toBeDefined();
+        // Documentation should reflect the current-file definition, not the
+        // forward callee's. (Docs embed the macro's expansion value.)
+        expect(String(macro_a?.documentation)).not.toContain('from_child');
+    });
+
     it('completion resolves a same-name global macro to the later visible forward callee', async () => {
         const first_path = join(test_temp_dir, 'first.do');
         writeFileSync(first_path, 'global SHARED "from_first"\n');

--- a/tests/integration/hover-completion-forward-precedence.test.ts
+++ b/tests/integration/hover-completion-forward-precedence.test.ts
@@ -43,8 +43,16 @@ describe('hover/completion forward-call precedence', () => {
     });
 
     afterEach(() => {
-        try { pipeline?.scope_resolver?.dispose(); } catch {}
-        try { pipeline?.forward_scope_resolver?.dispose(); } catch {}
+        try {
+            pipeline?.scope_resolver?.dispose();
+        } catch {
+            // ignore errors during teardown
+        }
+        try {
+            pipeline?.forward_scope_resolver?.dispose();
+        } catch {
+            // ignore errors during teardown
+        }
         if (existsSync(test_temp_dir)) {
             rmSync(test_temp_dir, { recursive: true, force: true });
         }

--- a/tests/integration/hover-completion-forward-precedence.test.ts
+++ b/tests/integration/hover-completion-forward-precedence.test.ts
@@ -239,6 +239,47 @@ describe('hover/completion forward-call precedence', () => {
         expect(String(macro_a?.documentation)).not.toContain('from_child');
     });
 
+    it('completion keeps current-file macro when directives route through get_visible_symbols_at', async () => {
+        // Exercises the has_directives branch in CompletionProvider.get_completions:
+        // get_visible_symbols_at already resolves forward-call precedence, so the
+        // completion provider must NOT re-overlay the annotated forward symbols
+        // on top (that would make forward-call values win a second time).
+        const parent_path = join(test_temp_dir, 'parent.do');
+        writeFileSync(parent_path, '* parent file\n');
+
+        const child_path = join(test_temp_dir, 'child.do');
+        writeFileSync(child_path, 'local a "from_child"\n');
+
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content =
+            '// @lsp-done-by: "parent.do"\n' +
+            'local a "from_main_early"\n' +
+            'include "child.do"\n' +
+            'local a "from_main_late"\n' +
+            'display "`a\'"\n';
+        writeFileSync(main_path, main_content);
+
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        const document_state = pipeline.document_store.get(main_uri)!;
+
+        const completions = await pipeline.completion_provider.get_completions(
+            document_state,
+            { line: 4, character: main_content.split('\n')[4].indexOf('`a') + 1 },
+            undefined,
+            pipeline.scope_resolver,
+        );
+
+        const macro_a = completions.find(item => item.label === 'a');
+        expect(macro_a).toBeDefined();
+        // Without the fix, the double-overlay lets the forward-call version
+        // win again and the doc shows "from_child". After the fix, the
+        // current file's definition wins; the completion item embeds the
+        // primary `local a` expansion (matching the sibling workspace test).
+        expect(String(macro_a?.documentation)).not.toContain('from_child');
+        expect(String(macro_a?.documentation)).toContain('from_main_early');
+    });
+
     it('completion resolves a same-name global macro to the later visible forward callee', async () => {
         const first_path = join(test_temp_dir, 'first.do');
         writeFileSync(first_path, 'global SHARED "from_first"\n');

--- a/tests/property/unify-forward-call-feeds.prop.test.ts
+++ b/tests/property/unify-forward-call-feeds.prop.test.ts
@@ -13,7 +13,8 @@ import { StataLexer } from '../../src/lexer';
 import { StataParser } from '../../src/parser';
 import { SemanticAnalyzer, create_empty_symbol_table } from '../../src/analyzer';
 import { ContextTracker } from '../../src/context-tracker';
-import { DocumentState, StataDiagnosticCode, ForwardCallSite, StataLSPConfig, ForwardResolvedScope } from '../../src/types';
+import { DocumentState, StataDiagnosticCode, ForwardCallSite, StataLSPConfig, ResolvedScope } from '../../src/types';
+import { ScopeResolver } from '../../src/scope-resolver';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -37,6 +38,17 @@ const DEFAULT_CONFIG: StataLSPConfig = {
 
 function create_mock_connection() {
     return { sendDiagnostics: () => {} };
+}
+
+/**
+ * Wire a stub ScopeResolver whose .resolve() returns the provided
+ * ResolvedScope. Used to feed canned forward_call_symbols to
+ * DiagnosticsProvider without standing up a full resolver.
+ */
+function make_stub_scope_resolver(resolved_scope: ResolvedScope): ScopeResolver {
+    const the_stub = new ScopeResolver();
+    (the_stub as any).resolve = async () => resolved_scope;
+    return the_stub;
 }
 
 function create_document_state(content: string, uri: string): DocumentState {
@@ -144,10 +156,16 @@ describe('Feature: unify-forward-call-feeds', () => {
                         const caller_uri = URI.file(caller_path).toString();
                         const doc_state = create_document_state(caller_content, caller_uri);
 
-                        // Create forward_scope with the symbol
-                        const forward_scope: ForwardResolvedScope = {
+                        // Build a ResolvedScope carrying forward_call_symbols
+                        // and wire it through a stub ScopeResolver.
+                        const resolved_scope: ResolvedScope = {
+                            chain: [],
                             symbols: create_empty_symbol_table(),
-                            call_sites: [{
+                            out_of_scope_symbols: [],
+                            diagnostics: [],
+                            has_directives: false,
+                            has_auto_parents: false,
+                            forward_call_symbols: [{
                                 callee_uri: URI.file(callee_path).toString(),
                                 call_line: call_line,
                                 symbols: {
@@ -160,17 +178,14 @@ describe('Feature: unify-forward-call-feeds', () => {
                                 },
                                 effective_type: 'do' as const,
                             }] as ForwardCallSite[],
-                            diagnostics: [],
                         };
 
-                        // Get diagnostics with forward_scope (no scope_resolver)
+                        const stub_resolver = make_stub_scope_resolver(resolved_scope);
                         const diagnostics = await provider.get_diagnostics(
                             doc_state,
                             DEFAULT_CONFIG,
                             undefined,
-                            undefined,
-                            undefined,
-                            forward_scope
+                            stub_resolver
                         );
 
                         const has_undefined_warning = diagnostics.some(d => 
@@ -219,7 +234,7 @@ describe('Feature: unify-forward-call-feeds', () => {
                         const caller_uri = URI.file(caller_path).toString();
                         const doc_state = create_document_state(caller_content, caller_uri);
 
-                        // Create forward_scope with the symbol
+                        // Build symbols for the forward-call site
                         const symbols = create_empty_symbol_table();
                         if (is_local) {
                             symbols.localMacros.set(symbol_name, {
@@ -235,24 +250,27 @@ describe('Feature: unify-forward-call-feeds', () => {
                             });
                         }
 
-                        const forward_scope: ForwardResolvedScope = {
+                        const resolved_scope: ResolvedScope = {
+                            chain: [],
                             symbols: create_empty_symbol_table(),
-                            call_sites: [{
+                            out_of_scope_symbols: [],
+                            diagnostics: [],
+                            has_directives: false,
+                            has_auto_parents: false,
+                            forward_call_symbols: [{
                                 callee_uri: URI.file(callee_path).toString(),
                                 call_line: 0,
                                 symbols,
                                 effective_type,
                             }] as ForwardCallSite[],
-                            diagnostics: [],
                         };
 
+                        const stub_resolver = make_stub_scope_resolver(resolved_scope);
                         const diagnostics = await provider.get_diagnostics(
                             doc_state,
                             DEFAULT_CONFIG,
                             undefined,
-                            undefined,
-                            undefined,
-                            forward_scope
+                            stub_resolver
                         );
 
                         const has_undefined_warning = diagnostics.some(d => 

--- a/tests/property/visible-symbols.prop.test.ts
+++ b/tests/property/visible-symbols.prop.test.ts
@@ -19,7 +19,6 @@ function make_program(name: string, uri: string): ProgramSymbol {
         name,
         location: { uri, range: { start: { line: 0, character: 0 }, end: { line: 0, character: name.length } } },
         sourceUri: uri,
-        definition_line: 0,
     };
 }
 
@@ -55,7 +54,7 @@ describe('get_visible_symbols_at equivalence with ForwardScopeResolver.get_symbo
                 fc.array(arb_program_site, { maxLength: 8 }),
                 fc.integer({ min: 0, max: 60 }),
                 (raw_sites, cursor_line) => {
-                    const sites: ForwardCallSite[] = raw_sites.map((rs, i) => ({
+                    const sites: ForwardCallSite[] = raw_sites.map(rs => ({
                         callee_uri: rs.callee_uri,
                         call_line: rs.call_line,
                         symbols: {

--- a/tests/property/visible-symbols.prop.test.ts
+++ b/tests/property/visible-symbols.prop.test.ts
@@ -12,7 +12,29 @@ import { get_visible_symbols_at } from '../../src/scope-resolver/visible-symbols
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
 import { ScopeResolver } from '../../src/scope-resolver';
 import { create_empty_symbol_table } from '../../src/analyzer';
-import type { ForwardCallSite, ResolvedScope, SymbolTable, ProgramSymbol } from '../../src/types';
+import type {
+    ForwardCallSite,
+    MacroSymbol,
+    MatrixSymbol,
+    ProgramSymbol,
+    ResolvedScope,
+    ScalarSymbol,
+    SymbolTable,
+    VariableSymbol,
+} from '../../src/types';
+
+// Small pool of names so same-name collisions actually occur across sites —
+// this exercises the lattermost-wins overlay rule under fuzzing.
+const NAME_POOL = ['alpha', 'beta', 'gamma'] as const;
+const arb_name = fc.constantFrom(...NAME_POOL);
+const arb_kind = fc.constantFrom(
+    'programs',
+    'localMacros',
+    'globalMacros',
+    'variables',
+    'scalars',
+    'matrices',
+) satisfies fc.Arbitrary<keyof SymbolTable>;
 
 function make_program(name: string, uri: string): ProgramSymbol {
     return {
@@ -22,14 +44,75 @@ function make_program(name: string, uri: string): ProgramSymbol {
     };
 }
 
+function make_macro(name: string, uri: string, scope: 'local' | 'global'): MacroSymbol {
+    return {
+        name,
+        scope,
+        location: { uri, range: { start: { line: 0, character: 0 }, end: { line: 0, character: name.length } } },
+        sourceUri: uri,
+    };
+}
+
+function make_variable(name: string, uri: string): VariableSymbol {
+    return {
+        name,
+        location: { uri, range: { start: { line: 0, character: 0 }, end: { line: 0, character: name.length } } },
+        sourceUri: uri,
+        source: 'gen',
+    };
+}
+
+function make_scalar(name: string, uri: string): ScalarSymbol {
+    return {
+        name,
+        location: { uri, range: { start: { line: 0, character: 0 }, end: { line: 0, character: name.length } } },
+        sourceUri: uri,
+    };
+}
+
+function make_matrix(name: string, uri: string): MatrixSymbol {
+    return {
+        name,
+        location: { uri, range: { start: { line: 0, character: 0 }, end: { line: 0, character: name.length } } },
+        sourceUri: uri,
+    };
+}
+
+/**
+ * Build a fresh SymbolTable with one symbol of the given kind at (name, uri).
+ */
+function make_symbol_table(kind: keyof SymbolTable, name: string, uri: string): SymbolTable {
+    const the_table = create_empty_symbol_table();
+    switch (kind) {
+        case 'programs': the_table.programs.set(name, make_program(name, uri)); break;
+        case 'localMacros': the_table.localMacros.set(name, make_macro(name, uri, 'local')); break;
+        case 'globalMacros': the_table.globalMacros.set(name, make_macro(name, uri, 'global')); break;
+        case 'variables': the_table.variables.set(name, make_variable(name, uri)); break;
+        case 'scalars': the_table.scalars.set(name, make_scalar(name, uri)); break;
+        case 'matrices': the_table.matrices.set(name, make_matrix(name, uri)); break;
+    }
+    return the_table;
+}
+
+/**
+ * Strong equivalence: same size, same keys, and — for keys that match —
+ * the symbols agree on `location.uri`. This is what catches base-wins vs.
+ * overlay-wins drift: if a helper returned the earlier-applied symbol
+ * instead of the lattermost, the URI would differ even when the key set
+ * matches.
+ */
 function symbol_tables_agree(a: SymbolTable, b: SymbolTable): boolean {
-    const keys: Array<keyof SymbolTable> = [
+    const the_kinds: Array<keyof SymbolTable> = [
         'programs', 'localMacros', 'globalMacros', 'variables', 'scalars', 'matrices',
     ];
-    for (const k of keys) {
-        if (a[k].size !== b[k].size) return false;
-        for (const [name, _] of a[k]) {
-            if (!b[k].has(name)) return false;
+    for (const my_kind of the_kinds) {
+        const a_map = a[my_kind] as Map<string, { location: { uri: string } }>;
+        const b_map = b[my_kind] as Map<string, { location: { uri: string } }>;
+        if (a_map.size !== b_map.size) return false;
+        for (const [name, a_sym] of a_map) {
+            const b_sym = b_map.get(name);
+            if (!b_sym) return false;
+            if (a_sym.location.uri !== b_sym.location.uri) return false;
         }
     }
     return true;
@@ -42,27 +125,26 @@ describe('get_visible_symbols_at equivalence with ForwardScopeResolver.get_symbo
         forward_resolver = new ForwardScopeResolver(new ScopeResolver());
     });
 
-    test('agrees on arbitrary (base, sites, line) inputs', () => {
-        const arb_program_site = fc.record({
-            callee_uri: fc.string({ minLength: 1 }).map(s => `file:///${s}.do`),
+    test('agrees on arbitrary (base, sites, line) inputs across all six symbol kinds', () => {
+        // Each site carries one symbol of one kind at a single (name, uri).
+        // Drawing names from a small pool forces frequent collisions across
+        // sites so lattermost-wins has something to decide.
+        const arb_site_shape = fc.record({
+            callee_uri: fc.integer({ min: 0, max: 4 }).map(n => `file:///callee${n}.do`),
             call_line: fc.integer({ min: 0, max: 50 }),
-            program_names: fc.array(fc.string({ minLength: 1, maxLength: 12 }), { maxLength: 5 }),
+            kind: arb_kind,
+            symbol_name: arb_name,
         });
 
         fc.assert(
             fc.property(
-                fc.array(arb_program_site, { maxLength: 8 }),
+                fc.array(arb_site_shape, { maxLength: 10 }),
                 fc.integer({ min: 0, max: 60 }),
                 (raw_sites, cursor_line) => {
                     const sites: ForwardCallSite[] = raw_sites.map(rs => ({
                         callee_uri: rs.callee_uri,
                         call_line: rs.call_line,
-                        symbols: {
-                            ...create_empty_symbol_table(),
-                            programs: new Map(
-                                rs.program_names.map(n => [n, make_program(n, rs.callee_uri)]),
-                            ),
-                        },
+                        symbols: make_symbol_table(rs.kind, rs.symbol_name, rs.callee_uri),
                         effective_type: 'do' as const,
                     }));
                     const base_symbols = create_empty_symbol_table();
@@ -88,7 +170,7 @@ describe('get_visible_symbols_at equivalence with ForwardScopeResolver.get_symbo
                     expect(symbol_tables_agree(via_helper, via_method)).toBe(true);
                 },
             ),
-            { numRuns: 100 },
+            { numRuns: 200 },
         );
     });
 });

--- a/tests/property/visible-symbols.prop.test.ts
+++ b/tests/property/visible-symbols.prop.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Property test: get_visible_symbols_at must agree with
+ * ForwardScopeResolver.get_symbols_at_line on arbitrary inputs.
+ *
+ * Keeping two independent implementations of the same rule and testing
+ * them against each other means the pair cannot silently drift.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import * as fc from 'fast-check';
+import { get_visible_symbols_at } from '../../src/scope-resolver/visible-symbols';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { create_empty_symbol_table } from '../../src/analyzer';
+import type { ForwardCallSite, ResolvedScope, SymbolTable, ProgramSymbol } from '../../src/types';
+
+function make_program(name: string, uri: string): ProgramSymbol {
+    return {
+        name,
+        location: { uri, range: { start: { line: 0, character: 0 }, end: { line: 0, character: name.length } } },
+        sourceUri: uri,
+        definition_line: 0,
+    };
+}
+
+function symbol_tables_agree(a: SymbolTable, b: SymbolTable): boolean {
+    const keys: Array<keyof SymbolTable> = [
+        'programs', 'localMacros', 'globalMacros', 'variables', 'scalars', 'matrices',
+    ];
+    for (const k of keys) {
+        if (a[k].size !== b[k].size) return false;
+        for (const [name, _] of a[k]) {
+            if (!b[k].has(name)) return false;
+        }
+    }
+    return true;
+}
+
+describe('get_visible_symbols_at equivalence with ForwardScopeResolver.get_symbols_at_line', () => {
+    let forward_resolver: ForwardScopeResolver;
+
+    beforeEach(() => {
+        forward_resolver = new ForwardScopeResolver(new ScopeResolver());
+    });
+
+    test('agrees on arbitrary (base, sites, line) inputs', () => {
+        const arb_program_site = fc.record({
+            callee_uri: fc.string({ minLength: 1 }).map(s => `file:///${s}.do`),
+            call_line: fc.integer({ min: 0, max: 50 }),
+            program_names: fc.array(fc.string({ minLength: 1, maxLength: 12 }), { maxLength: 5 }),
+        });
+
+        fc.assert(
+            fc.property(
+                fc.array(arb_program_site, { maxLength: 8 }),
+                fc.integer({ min: 0, max: 60 }),
+                (raw_sites, cursor_line) => {
+                    const sites: ForwardCallSite[] = raw_sites.map((rs, i) => ({
+                        callee_uri: rs.callee_uri,
+                        call_line: rs.call_line,
+                        symbols: {
+                            ...create_empty_symbol_table(),
+                            programs: new Map(
+                                rs.program_names.map(n => [n, make_program(n, rs.callee_uri)]),
+                            ),
+                        },
+                        effective_type: 'do' as const,
+                    }));
+                    const base_symbols = create_empty_symbol_table();
+
+                    const via_helper = get_visible_symbols_at(
+                        {
+                            chain: [],
+                            symbols: base_symbols,
+                            out_of_scope_symbols: [],
+                            diagnostics: [],
+                            has_directives: false,
+                            has_auto_parents: false,
+                            forward_call_symbols: sites,
+                        } as ResolvedScope,
+                        cursor_line,
+                    );
+                    const via_method = forward_resolver.get_symbols_at_line(
+                        base_symbols,
+                        sites,
+                        cursor_line,
+                    );
+
+                    expect(symbol_tables_agree(via_helper, via_method)).toBe(true);
+                },
+            ),
+            { numRuns: 100 },
+        );
+    });
+});

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -2,13 +2,25 @@ import { init_tracker_from_source } from '../test-context-helper';
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { DiagnosticsProvider } from '../../src/providers/diagnostics';
 import { DocumentState } from '../../src/document-store';
-import { StataLSPConfig, StataDiagnosticCode, LexerErrorCode, ParseErrorCode, ForwardResolvedScope } from '../../src/types';
+import { StataLSPConfig, StataDiagnosticCode, LexerErrorCode, ParseErrorCode, ResolvedScope } from '../../src/types';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { ContextTracker } from '../../src/context-tracker';
 import { StataLexer } from '../../src/lexer';
 import { StataParser } from '../../src/parser';
 import { SemanticAnalyzer } from '../../src/analyzer';
 import { create_empty_symbol_table } from '../../src/analyzer';
+import { ScopeResolver } from '../../src/scope-resolver';
+
+/**
+ * Wire a stub ScopeResolver whose .resolve() returns the provided
+ * ResolvedScope. Used to exercise forward-call symbol filtering and
+ * directive-diagnostic emission without standing up a full resolver.
+ */
+function make_stub_scope_resolver(resolved_scope: ResolvedScope): ScopeResolver {
+    const the_stub = new ScopeResolver();
+    (the_stub as any).resolve = async () => resolved_scope;
+    return the_stub;
+}
 
 // Mock connection for testing
 function create_mock_connection() {
@@ -795,17 +807,21 @@ display \`result'
     describe('forward-scope diagnostics', () => {
         it('should include forward-scope diagnostics for missing file', async () => {
             const document = create_document_state('do "missing.do"\n');
-            const forward_scope: ForwardResolvedScope = {
+            const resolved_scope: ResolvedScope = {
+                chain: [],
                 symbols: create_empty_symbol_table(),
-                call_sites: [],
+                out_of_scope_symbols: [],
                 diagnostics: [{
                     message: 'Cannot read file: missing.do',
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 15 } },
                     severity: 'warning',
                 }],
+                has_directives: false,
+                has_auto_parents: false,
             };
-            const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG, undefined, undefined, undefined, forward_scope);
-            
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
+            const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG, undefined, stub_resolver);
+
             const missing_file_diag = the_diagnostics.find(d => d.message.includes('Cannot read file'));
             expect(missing_file_diag).toBeDefined();
             // Default severity for missing_file is Information when not configured
@@ -814,17 +830,21 @@ display \`result'
 
         it('should include forward-scope diagnostics for max depth exceeded', async () => {
             const document = create_document_state('do "deep.do"\n');
-            const forward_scope: ForwardResolvedScope = {
+            const resolved_scope: ResolvedScope = {
+                chain: [],
                 symbols: create_empty_symbol_table(),
-                call_sites: [],
+                out_of_scope_symbols: [],
                 diagnostics: [{
                     message: 'Maximum forward depth (10) exceeded',
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 12 } },
                     severity: 'warning',
                 }],
+                has_directives: false,
+                has_auto_parents: false,
             };
-            const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG, undefined, undefined, undefined, forward_scope);
-            
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
+            const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG, undefined, stub_resolver);
+
             const max_depth_diag = the_diagnostics.find(d => d.message.includes('Maximum forward depth'));
             expect(max_depth_diag).toBeDefined();
             expect(max_depth_diag?.severity).toBe(DiagnosticSeverity.Warning);
@@ -832,17 +852,21 @@ display \`result'
 
         it('should include forward-scope diagnostics for circular dependency', async () => {
             const document = create_document_state('do "cycle.do"\n');
-            const forward_scope: ForwardResolvedScope = {
+            const resolved_scope: ResolvedScope = {
+                chain: [],
                 symbols: create_empty_symbol_table(),
-                call_sites: [],
+                out_of_scope_symbols: [],
                 diagnostics: [{
                     message: 'Circular dependency detected: cycle.do',
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 13 } },
                     severity: 'warning',
                 }],
+                has_directives: false,
+                has_auto_parents: false,
             };
-            const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG, undefined, undefined, undefined, forward_scope);
-            
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
+            const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG, undefined, stub_resolver);
+
             const cycle_diag = the_diagnostics.find(d => d.message.includes('Circular dependency'));
             expect(cycle_diag).toBeDefined();
             expect(cycle_diag?.severity).toBe(DiagnosticSeverity.Warning);
@@ -850,16 +874,20 @@ display \`result'
 
         it('should respect missing_file config for forward-scope diagnostics', async () => {
             const document = create_document_state('do "missing.do"\n');
-            const forward_scope: ForwardResolvedScope = {
+            const resolved_scope: ResolvedScope = {
+                chain: [],
                 symbols: create_empty_symbol_table(),
-                call_sites: [],
+                out_of_scope_symbols: [],
                 diagnostics: [{
                     message: 'Cannot read file: missing.do',
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 15 } },
                     severity: 'warning',
                 }],
+                has_directives: false,
+                has_auto_parents: false,
             };
-            
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
+
             // Test with missing_file: 'off'
             const off_config = {
                 ...DEFAULT_CONFIG,
@@ -869,7 +897,7 @@ display \`result'
                     },
                 },
             };
-            const off_diagnostics = await provider.get_diagnostics(document, off_config, undefined, undefined, undefined, forward_scope);
+            const off_diagnostics = await provider.get_diagnostics(document, off_config, undefined, stub_resolver);
             const off_missing = off_diagnostics.find(d => d.message.includes('Cannot read file'));
             expect(off_missing).toBeUndefined();
         });

--- a/tests/unit/providers/completion-cache.test.ts
+++ b/tests/unit/providers/completion-cache.test.ts
@@ -68,7 +68,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 mock_workspace_symbols,
                 undefined,
-                undefined,
                 workspace_version
             );
 
@@ -82,7 +81,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 undefined,
                 mock_workspace_symbols,
-                undefined,
                 undefined,
                 workspace_version
             );
@@ -104,7 +102,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 mock_workspace_symbols,
                 undefined,
-                undefined,
                 workspace_version
             );
 
@@ -114,7 +111,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 undefined,
                 mock_workspace_symbols,
-                undefined,
                 undefined,
                 workspace_version
             );
@@ -137,7 +133,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 mock_workspace_symbols,
                 undefined,
-                undefined,
                 workspace_version
             );
 
@@ -151,7 +146,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 undefined,
                 mock_workspace_symbols,
-                undefined,
                 undefined,
                 workspace_version
             );
@@ -174,7 +168,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 mock_workspace_symbols,
                 undefined,
-                undefined,
                 1
             );
 
@@ -187,7 +180,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 undefined,
                 mock_workspace_symbols,
-                undefined,
                 undefined,
                 2
             );
@@ -214,7 +206,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 mock_workspace_symbols,
                 undefined,
-                undefined,
                 workspace_version
             );
 
@@ -233,7 +224,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 mock_workspace_symbols,
                 undefined,
-                undefined,
                 workspace_version
             );
 
@@ -246,7 +236,6 @@ describe('CompletionProvider Cache', () => {
                 undefined,
                 undefined,
                 mock_workspace_symbols,
-                undefined,
                 undefined,
                 workspace_version
             );
@@ -276,7 +265,6 @@ describe('CompletionProvider Cache', () => {
                 '`',  // Trigger local macro completion
                 undefined,
                 conflicting_workspace,
-                undefined,
                 undefined,
                 workspace_version
             );

--- a/tests/unit/scope-resolver/visible-symbols.test.ts
+++ b/tests/unit/scope-resolver/visible-symbols.test.ts
@@ -16,7 +16,6 @@ const make_program = (name: string, uri: string): ProgramSymbol => ({
     name,
     location: { uri, range: { start: { line: 0, character: 0 }, end: { line: 0, character: name.length } } },
     sourceUri: uri,
-    definition_line: 0,
 });
 
 const empty_scope: ResolvedScope = {

--- a/tests/unit/scope-resolver/visible-symbols.test.ts
+++ b/tests/unit/scope-resolver/visible-symbols.test.ts
@@ -1,0 +1,212 @@
+import { describe, test, expect } from 'bun:test';
+import {
+    get_visible_symbols_at,
+    get_visible_forward_call_sites,
+    collect_visible_uris,
+} from '../../../src/scope-resolver/visible-symbols';
+import { create_empty_symbol_table } from '../../../src/analyzer';
+import type {
+    ResolvedScope,
+    ForwardCallSite,
+    ProgramSymbol,
+    ScopeChainEntry,
+} from '../../../src/types';
+
+const make_program = (name: string, uri: string): ProgramSymbol => ({
+    name,
+    location: { uri, range: { start: { line: 0, character: 0 }, end: { line: 0, character: name.length } } },
+    sourceUri: uri,
+    definition_line: 0,
+});
+
+const empty_scope: ResolvedScope = {
+    chain: [],
+    symbols: create_empty_symbol_table(),
+    out_of_scope_symbols: [],
+    diagnostics: [],
+    has_directives: false,
+    has_auto_parents: false,
+};
+
+describe('get_visible_symbols_at', () => {
+    test('returns an empty SymbolTable when scope is undefined', () => {
+        const the_result = get_visible_symbols_at(undefined, 0);
+        expect(the_result.programs.size).toBe(0);
+        expect(the_result.localMacros.size).toBe(0);
+        expect(the_result.globalMacros.size).toBe(0);
+        expect(the_result.variables.size).toBe(0);
+        expect(the_result.scalars.size).toBe(0);
+        expect(the_result.matrices.size).toBe(0);
+    });
+
+    test('returns scope.symbols verbatim when forward_call_symbols is empty', () => {
+        const my_base: ResolvedScope = {
+            ...empty_scope,
+            symbols: {
+                ...create_empty_symbol_table(),
+                programs: new Map([['base_prog', make_program('base_prog', 'file:///a.do')]]),
+            },
+        };
+        const the_result = get_visible_symbols_at(my_base, 100);
+        expect(the_result.programs.has('base_prog')).toBe(true);
+    });
+
+    test('includes a forward-call site symbol when call_line < cursor_line', () => {
+        const my_site: ForwardCallSite = {
+            callee_uri: 'file:///callee.do',
+            call_line: 5,
+            symbols: {
+                ...create_empty_symbol_table(),
+                programs: new Map([['fwd_prog', make_program('fwd_prog', 'file:///callee.do')]]),
+            },
+            effective_type: 'do',
+        };
+        const my_scope: ResolvedScope = { ...empty_scope, forward_call_symbols: [my_site] };
+        const at_six = get_visible_symbols_at(my_scope, 6);
+        expect(at_six.programs.has('fwd_prog')).toBe(true);
+    });
+
+    test('excludes a forward-call site symbol when call_line >= cursor_line (strict <)', () => {
+        const my_site: ForwardCallSite = {
+            callee_uri: 'file:///callee.do',
+            call_line: 5,
+            symbols: {
+                ...create_empty_symbol_table(),
+                programs: new Map([['fwd_prog', make_program('fwd_prog', 'file:///callee.do')]]),
+            },
+            effective_type: 'do',
+        };
+        const my_scope: ResolvedScope = { ...empty_scope, forward_call_symbols: [my_site] };
+        const at_five = get_visible_symbols_at(my_scope, 5);
+        expect(at_five.programs.has('fwd_prog')).toBe(false);
+        const at_four = get_visible_symbols_at(my_scope, 4);
+        expect(at_four.programs.has('fwd_prog')).toBe(false);
+    });
+
+    test('lattermost overlay wins on name collision', () => {
+        const site_a_prog = make_program('shared_prog', 'file:///a.do');
+        const site_b_prog = make_program('shared_prog', 'file:///b.do');
+        const site_a: ForwardCallSite = {
+            callee_uri: 'file:///a.do',
+            call_line: 1,
+            symbols: {
+                ...create_empty_symbol_table(),
+                programs: new Map([['shared_prog', site_a_prog]]),
+            },
+            effective_type: 'do',
+        };
+        const site_b: ForwardCallSite = {
+            callee_uri: 'file:///b.do',
+            call_line: 2,
+            symbols: {
+                ...create_empty_symbol_table(),
+                programs: new Map([['shared_prog', site_b_prog]]),
+            },
+            effective_type: 'do',
+        };
+        const my_scope: ResolvedScope = { ...empty_scope, forward_call_symbols: [site_a, site_b] };
+        const the_result = get_visible_symbols_at(my_scope, 10);
+        expect(the_result.programs.get('shared_prog')?.location.uri).toBe('file:///b.do');
+    });
+});
+
+describe('get_visible_forward_call_sites', () => {
+    test('returns [] when scope is undefined', () => {
+        expect(get_visible_forward_call_sites(undefined, 0)).toEqual([]);
+    });
+
+    test('returns [] when forward_call_symbols is undefined', () => {
+        expect(get_visible_forward_call_sites(empty_scope, 0)).toEqual([]);
+    });
+
+    test('preserves input array order for visible sites', () => {
+        const site_early: ForwardCallSite = {
+            callee_uri: 'file:///early.do',
+            call_line: 1,
+            symbols: create_empty_symbol_table(),
+            effective_type: 'do',
+        };
+        const site_later: ForwardCallSite = {
+            callee_uri: 'file:///later.do',
+            call_line: 3,
+            symbols: create_empty_symbol_table(),
+            effective_type: 'do',
+        };
+        const my_scope: ResolvedScope = {
+            ...empty_scope,
+            forward_call_symbols: [site_early, site_later],
+        };
+        const the_result = get_visible_forward_call_sites(my_scope, 10);
+        expect(the_result.map(s => s.callee_uri)).toEqual(['file:///early.do', 'file:///later.do']);
+    });
+
+    test('strict < boundary: call_line === cursor_line is excluded', () => {
+        const my_site: ForwardCallSite = {
+            callee_uri: 'file:///boundary.do',
+            call_line: 5,
+            symbols: create_empty_symbol_table(),
+            effective_type: 'do',
+        };
+        const my_scope: ResolvedScope = { ...empty_scope, forward_call_symbols: [my_site] };
+        expect(get_visible_forward_call_sites(my_scope, 5)).toEqual([]);
+        expect(get_visible_forward_call_sites(my_scope, 6)).toHaveLength(1);
+    });
+});
+
+describe('collect_visible_uris', () => {
+    test('returns a Set containing just current_uri when scope is undefined', () => {
+        const the_result = collect_visible_uris(undefined, 0, 'file:///current.do');
+        expect(the_result.size).toBe(1);
+        expect(the_result.has('file:///current.do')).toBe(true);
+    });
+
+    test('includes every chain[*].uri regardless of cursor_line', () => {
+        const chain_entries: ScopeChainEntry[] = [
+            {
+                uri: 'file:///parent1.do',
+                directive_type: 'done-by',
+                call_site_line: 0,
+                symbols: create_empty_symbol_table(),
+                depth: 1,
+                directive_order: 0,
+                sort_key: 'a',
+            },
+            {
+                uri: 'file:///parent2.do',
+                directive_type: 'included-by',
+                call_site_line: 0,
+                symbols: create_empty_symbol_table(),
+                depth: 2,
+                directive_order: 1,
+                sort_key: 'b',
+            },
+        ];
+        const my_scope: ResolvedScope = { ...empty_scope, chain: chain_entries };
+        const the_result = collect_visible_uris(my_scope, 0, 'file:///current.do');
+        expect(the_result.has('file:///current.do')).toBe(true);
+        expect(the_result.has('file:///parent1.do')).toBe(true);
+        expect(the_result.has('file:///parent2.do')).toBe(true);
+    });
+
+    test('includes callee_uri only for sites with call_line < cursor_line', () => {
+        const site_visible: ForwardCallSite = {
+            callee_uri: 'file:///visible.do',
+            call_line: 1,
+            symbols: create_empty_symbol_table(),
+            effective_type: 'do',
+        };
+        const site_hidden: ForwardCallSite = {
+            callee_uri: 'file:///hidden.do',
+            call_line: 10,
+            symbols: create_empty_symbol_table(),
+            effective_type: 'do',
+        };
+        const my_scope: ResolvedScope = {
+            ...empty_scope,
+            forward_call_symbols: [site_visible, site_hidden],
+        };
+        const the_result = collect_visible_uris(my_scope, 5, 'file:///current.do');
+        expect(the_result.has('file:///visible.do')).toBe(true);
+        expect(the_result.has('file:///hidden.do')).toBe(false);
+    });
+});

--- a/tests/unit/scope-resolver/visible-symbols.test.ts
+++ b/tests/unit/scope-resolver/visible-symbols.test.ts
@@ -2,18 +2,26 @@ import { describe, test, expect } from 'bun:test';
 import {
     get_visible_symbols_at,
     get_visible_forward_call_sites,
-    collect_visible_uris,
+    collect_visible_reference_uris,
 } from '../../../src/scope-resolver/visible-symbols';
 import { create_empty_symbol_table } from '../../../src/analyzer';
 import type {
     ResolvedScope,
     ForwardCallSite,
     ProgramSymbol,
+    MacroSymbol,
     ScopeChainEntry,
 } from '../../../src/types';
 
 const make_program = (name: string, uri: string): ProgramSymbol => ({
     name,
+    location: { uri, range: { start: { line: 0, character: 0 }, end: { line: 0, character: name.length } } },
+    sourceUri: uri,
+});
+
+const make_local_macro = (name: string, uri: string): MacroSymbol => ({
+    name,
+    scope: 'local',
     location: { uri, range: { start: { line: 0, character: 0 }, end: { line: 0, character: name.length } } },
     sourceUri: uri,
 });
@@ -152,20 +160,31 @@ describe('get_visible_forward_call_sites', () => {
     });
 });
 
-describe('collect_visible_uris', () => {
+describe('collect_visible_reference_uris', () => {
     test('returns a Set containing just current_uri when scope is undefined', () => {
-        const the_result = collect_visible_uris(undefined, 0, 'file:///current.do');
+        const the_result = collect_visible_reference_uris(
+            undefined,
+            0,
+            'file:///current.do',
+            'program',
+        );
         expect(the_result.size).toBe(1);
         expect(the_result.has('file:///current.do')).toBe(true);
     });
 
-    test('includes every chain[*].uri regardless of cursor_line', () => {
+    test('includes chain URIs, retained parent forward callees, and current visible callees for non-local kinds', () => {
         const chain_entries: ScopeChainEntry[] = [
             {
                 uri: 'file:///parent1.do',
                 directive_type: 'done-by',
                 call_site_line: 0,
                 symbols: create_empty_symbol_table(),
+                forward_call_sites: [{
+                    callee_uri: 'file:///parent1-callee.do',
+                    call_line: 0,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'do',
+                }],
                 depth: 1,
                 directive_order: 0,
                 sort_key: 'a',
@@ -175,37 +194,117 @@ describe('collect_visible_uris', () => {
                 directive_type: 'included-by',
                 call_site_line: 0,
                 symbols: create_empty_symbol_table(),
+                forward_call_sites: [{
+                    callee_uri: 'file:///parent2-callee.do',
+                    call_line: 0,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'include',
+                }],
                 depth: 2,
                 directive_order: 1,
                 sort_key: 'b',
             },
         ];
-        const my_scope: ResolvedScope = { ...empty_scope, chain: chain_entries };
-        const the_result = collect_visible_uris(my_scope, 0, 'file:///current.do');
+        const my_scope: ResolvedScope = {
+            ...empty_scope,
+            chain: chain_entries,
+            forward_call_symbols: [
+                {
+                    callee_uri: 'file:///current-visible.do',
+                    call_line: 1,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'do',
+                },
+                {
+                    callee_uri: 'file:///current-hidden.do',
+                    call_line: 10,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'include',
+                },
+            ],
+        };
+        const the_result = collect_visible_reference_uris(
+            my_scope,
+            5,
+            'file:///current.do',
+            'program',
+        );
         expect(the_result.has('file:///current.do')).toBe(true);
         expect(the_result.has('file:///parent1.do')).toBe(true);
         expect(the_result.has('file:///parent2.do')).toBe(true);
+        expect(the_result.has('file:///parent1-callee.do')).toBe(true);
+        expect(the_result.has('file:///parent2-callee.do')).toBe(true);
+        expect(the_result.has('file:///current-visible.do')).toBe(true);
+        expect(the_result.has('file:///current-hidden.do')).toBe(false);
     });
 
-    test('includes callee_uri only for sites with call_line < cursor_line', () => {
-        const site_visible: ForwardCallSite = {
-            callee_uri: 'file:///visible.do',
+    test('keeps local macros include-only across backward and forward edges', () => {
+        const parent_visible_local = make_local_macro('shared', 'file:///parent-include.do');
+        const parent_hidden_local = make_local_macro('shared', 'file:///parent-do.do');
+        const visible_include_site: ForwardCallSite = {
+            callee_uri: 'file:///visible-include.do',
             call_line: 1,
-            symbols: create_empty_symbol_table(),
-            effective_type: 'do',
+            symbols: {
+                ...create_empty_symbol_table(),
+                localMacros: new Map([['shared', parent_visible_local]]),
+            },
+            effective_type: 'include',
         };
-        const site_hidden: ForwardCallSite = {
-            callee_uri: 'file:///hidden.do',
-            call_line: 10,
-            symbols: create_empty_symbol_table(),
+        const visible_do_site: ForwardCallSite = {
+            callee_uri: 'file:///visible-do.do',
+            call_line: 1,
+            symbols: {
+                ...create_empty_symbol_table(),
+                localMacros: new Map([['shared', parent_hidden_local]]),
+            },
             effective_type: 'do',
         };
         const my_scope: ResolvedScope = {
             ...empty_scope,
-            forward_call_symbols: [site_visible, site_hidden],
+            chain: [
+                {
+                    uri: 'file:///done-parent.do',
+                    directive_type: 'done-by',
+                    call_site_line: 0,
+                    symbols: create_empty_symbol_table(),
+                    forward_call_sites: [visible_do_site],
+                    depth: 1,
+                    directive_order: 0,
+                    sort_key: 'a',
+                },
+                {
+                    uri: 'file:///included-parent.do',
+                    directive_type: 'included-by',
+                    call_site_line: 0,
+                    symbols: create_empty_symbol_table(),
+                    forward_call_sites: [visible_include_site, visible_do_site],
+                    depth: 2,
+                    directive_order: 1,
+                    sort_key: 'b',
+                },
+            ],
+            forward_call_symbols: [
+                visible_include_site,
+                visible_do_site,
+                {
+                    callee_uri: 'file:///same-line.do',
+                    call_line: 5,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'include',
+                },
+            ],
         };
-        const the_result = collect_visible_uris(my_scope, 5, 'file:///current.do');
-        expect(the_result.has('file:///visible.do')).toBe(true);
-        expect(the_result.has('file:///hidden.do')).toBe(false);
+        const the_result = collect_visible_reference_uris(
+            my_scope,
+            5,
+            'file:///current.do',
+            'local_macro',
+        );
+        expect(the_result.has('file:///current.do')).toBe(true);
+        expect(the_result.has('file:///done-parent.do')).toBe(false);
+        expect(the_result.has('file:///included-parent.do')).toBe(true);
+        expect(the_result.has('file:///visible-include.do')).toBe(true);
+        expect(the_result.has('file:///visible-do.do')).toBe(false);
+        expect(the_result.has('file:///same-line.do')).toBe(false);
     });
 });

--- a/tests/unit/scope-resolver/visible-symbols.test.ts
+++ b/tests/unit/scope-resolver/visible-symbols.test.ts
@@ -117,6 +117,127 @@ describe('get_visible_symbols_at', () => {
     });
 });
 
+describe('get_visible_symbols_at — current-file shadowing window (call_line, cursor_line]', () => {
+    // A scope where the current file sits at chain[0] (matching the
+    // ScopeResolver's real-world construction) so the shadowing predicate sees
+    // current-file symbols via scope.chain[0].symbols.
+    const current_uri = 'file:///current.do';
+    const callee_uri = 'file:///callee.do';
+
+    const macro_at_lines = (name: string, uri: string, primary: number, extras: number[] = []): MacroSymbol => ({
+        name,
+        scope: 'local',
+        location: { uri, range: { start: { line: primary, character: 0 }, end: { line: primary, character: name.length } } },
+        sourceUri: uri,
+        additional_definitions: extras.length
+            ? extras.map(line => ({ line, character: 0 }))
+            : undefined,
+    });
+
+    const build_scope = (
+        current_symbol: MacroSymbol | undefined,
+        site: ForwardCallSite,
+    ): ResolvedScope => {
+        const current_symbols = current_symbol
+            ? {
+                ...create_empty_symbol_table(),
+                localMacros: new Map([[current_symbol.name, current_symbol]]),
+            }
+            : create_empty_symbol_table();
+        const current_chain_entry: ScopeChainEntry = {
+            uri: current_uri,
+            directive_type: 'included-by',
+            call_site_line: Number.MAX_SAFE_INTEGER,
+            symbols: current_symbols,
+            depth: 0,
+            directive_order: Number.MAX_SAFE_INTEGER,
+            sort_key: `current:${current_uri}`,
+        };
+        return {
+            chain: [current_chain_entry],
+            symbols: current_symbols,
+            out_of_scope_symbols: [],
+            diagnostics: [],
+            has_directives: false,
+            has_auto_parents: false,
+            forward_call_symbols: [site],
+        };
+    };
+
+    const callee_site = (call_line: number): ForwardCallSite => ({
+        callee_uri,
+        call_line,
+        symbols: {
+            ...create_empty_symbol_table(),
+            localMacros: new Map([['shared', macro_at_lines('shared', callee_uri, 0)]]),
+        },
+        effective_type: 'include',
+    });
+
+    test('def before call (line 0), call at 5, cursor at 10 → forward wins', () => {
+        const my_scope = build_scope(
+            macro_at_lines('shared', current_uri, 0),
+            callee_site(5),
+        );
+        const the_result = get_visible_symbols_at(my_scope, 10);
+        expect(the_result.localMacros.get('shared')?.sourceUri).toBe(callee_uri);
+    });
+
+    test('def before call AND redefinition in window (lines 0 + 7), call at 5, cursor at 10 → current wins', () => {
+        const my_scope = build_scope(
+            macro_at_lines('shared', current_uri, 0, [7]),
+            callee_site(5),
+        );
+        const the_result = get_visible_symbols_at(my_scope, 10);
+        expect(the_result.localMacros.get('shared')?.sourceUri).toBe(current_uri);
+    });
+
+    test('def at line 7 only, call at 5, cursor at 6 → forward wins (future def not yet visible)', () => {
+        const my_scope = build_scope(
+            macro_at_lines('shared', current_uri, 7),
+            callee_site(5),
+        );
+        const the_result = get_visible_symbols_at(my_scope, 6);
+        expect(the_result.localMacros.get('shared')?.sourceUri).toBe(callee_uri);
+    });
+
+    test('boundary: def === call_line → forward wins (strict >)', () => {
+        const my_scope = build_scope(
+            macro_at_lines('shared', current_uri, 5),
+            callee_site(5),
+        );
+        const the_result = get_visible_symbols_at(my_scope, 10);
+        expect(the_result.localMacros.get('shared')?.sourceUri).toBe(callee_uri);
+    });
+
+    test('boundary: def === cursor_line → current wins (non-strict <=)', () => {
+        const my_scope = build_scope(
+            macro_at_lines('shared', current_uri, 10),
+            callee_site(5),
+        );
+        const the_result = get_visible_symbols_at(my_scope, 10);
+        expect(the_result.localMacros.get('shared')?.sourceUri).toBe(current_uri);
+    });
+
+    test('primary before call, additional_definitions[0] in window → current wins', () => {
+        const my_scope = build_scope(
+            macro_at_lines('shared', current_uri, 0, [7]),
+            callee_site(5),
+        );
+        const the_result = get_visible_symbols_at(my_scope, 10);
+        expect(the_result.localMacros.get('shared')?.sourceUri).toBe(current_uri);
+    });
+
+    test('primary before call, additional_definitions[0] after cursor → forward wins', () => {
+        const my_scope = build_scope(
+            macro_at_lines('shared', current_uri, 0, [12]),
+            callee_site(5),
+        );
+        const the_result = get_visible_symbols_at(my_scope, 10);
+        expect(the_result.localMacros.get('shared')?.sourceUri).toBe(callee_uri);
+    });
+});
+
 describe('get_visible_forward_call_sites', () => {
     test('returns [] when scope is undefined', () => {
         expect(get_visible_forward_call_sites(undefined, 0)).toEqual([]);

--- a/tests/unit/scope-resolver/visible-symbols.test.ts
+++ b/tests/unit/scope-resolver/visible-symbols.test.ts
@@ -167,22 +167,40 @@ describe('collect_visible_reference_uris', () => {
             0,
             'file:///current.do',
             'program',
+            'shared_prog',
         );
         expect(the_result.size).toBe(1);
         expect(the_result.has('file:///current.do')).toBe(true);
     });
 
-    test('includes chain URIs, retained parent forward callees, and current visible callees for non-local kinds', () => {
+    test('includes only URIs contributing the active visible symbol instance', () => {
+        const parent1_prog = make_program('shared_prog', 'file:///parent1.do');
+        const parent2_prog = make_program('shared_prog', 'file:///parent2.do');
+        const parent1_callee_prog = make_program(
+            'shared_prog',
+            'file:///parent1-callee.do',
+        );
+        const parent2_callee_prog = make_program(
+            'shared_prog',
+            'file:///parent2-callee.do',
+        );
+        const visible_prog = make_program('shared_prog', 'file:///current-visible.do');
         const chain_entries: ScopeChainEntry[] = [
             {
                 uri: 'file:///parent1.do',
                 directive_type: 'done-by',
                 call_site_line: 0,
-                symbols: create_empty_symbol_table(),
+                symbols: {
+                    ...create_empty_symbol_table(),
+                    programs: new Map([['shared_prog', parent1_prog]]),
+                },
                 forward_call_sites: [{
                     callee_uri: 'file:///parent1-callee.do',
                     call_line: 0,
-                    symbols: create_empty_symbol_table(),
+                    symbols: {
+                        ...create_empty_symbol_table(),
+                        programs: new Map([['shared_prog', parent1_callee_prog]]),
+                    },
                     effective_type: 'do',
                 }],
                 depth: 1,
@@ -193,11 +211,17 @@ describe('collect_visible_reference_uris', () => {
                 uri: 'file:///parent2.do',
                 directive_type: 'included-by',
                 call_site_line: 0,
-                symbols: create_empty_symbol_table(),
+                symbols: {
+                    ...create_empty_symbol_table(),
+                    programs: new Map([['shared_prog', parent2_prog]]),
+                },
                 forward_call_sites: [{
                     callee_uri: 'file:///parent2-callee.do',
                     call_line: 0,
-                    symbols: create_empty_symbol_table(),
+                    symbols: {
+                        ...create_empty_symbol_table(),
+                        programs: new Map([['shared_prog', parent2_callee_prog]]),
+                    },
                     effective_type: 'include',
                 }],
                 depth: 2,
@@ -212,7 +236,10 @@ describe('collect_visible_reference_uris', () => {
                 {
                     callee_uri: 'file:///current-visible.do',
                     call_line: 1,
-                    symbols: create_empty_symbol_table(),
+                    symbols: {
+                        ...create_empty_symbol_table(),
+                        programs: new Map([['shared_prog', visible_prog]]),
+                    },
                     effective_type: 'do',
                 },
                 {
@@ -228,19 +255,107 @@ describe('collect_visible_reference_uris', () => {
             5,
             'file:///current.do',
             'program',
+            'shared_prog',
         );
         expect(the_result.has('file:///current.do')).toBe(true);
-        expect(the_result.has('file:///parent1.do')).toBe(true);
-        expect(the_result.has('file:///parent2.do')).toBe(true);
-        expect(the_result.has('file:///parent1-callee.do')).toBe(true);
-        expect(the_result.has('file:///parent2-callee.do')).toBe(true);
+        expect(the_result.has('file:///parent1.do')).toBe(false);
+        expect(the_result.has('file:///parent2.do')).toBe(false);
+        expect(the_result.has('file:///parent1-callee.do')).toBe(false);
+        expect(the_result.has('file:///parent2-callee.do')).toBe(false);
         expect(the_result.has('file:///current-visible.do')).toBe(true);
         expect(the_result.has('file:///current-hidden.do')).toBe(false);
     });
 
+    test('excludes an earlier same-depth backward parent when a later winner masks it', () => {
+        const earlier_prog = make_program('shared_prog', 'file:///earlier-parent.do');
+        const later_prog = make_program('shared_prog', 'file:///later-parent.do');
+        const my_scope: ResolvedScope = {
+            ...empty_scope,
+            symbols: {
+                ...create_empty_symbol_table(),
+                programs: new Map([['shared_prog', later_prog]]),
+            },
+            chain: [
+                {
+                    uri: 'file:///earlier-parent.do',
+                    directive_type: 'done-by',
+                    call_site_line: 0,
+                    symbols: {
+                        ...create_empty_symbol_table(),
+                        programs: new Map([['shared_prog', earlier_prog]]),
+                    },
+                    forward_call_sites: [],
+                    depth: 1,
+                    directive_order: 0,
+                    sort_key: 'a',
+                },
+                {
+                    uri: 'file:///later-parent.do',
+                    directive_type: 'done-by',
+                    call_site_line: 0,
+                    symbols: {
+                        ...create_empty_symbol_table(),
+                        programs: new Map([['shared_prog', later_prog]]),
+                    },
+                    forward_call_sites: [],
+                    depth: 1,
+                    directive_order: 1,
+                    sort_key: 'b',
+                },
+            ],
+        };
+        const the_result = collect_visible_reference_uris(
+            my_scope,
+            5,
+            'file:///current.do',
+            'program',
+            'shared_prog',
+        );
+        expect(the_result.has('file:///current.do')).toBe(true);
+        expect(the_result.has('file:///earlier-parent.do')).toBe(false);
+        expect(the_result.has('file:///later-parent.do')).toBe(true);
+    });
+
+    test('excludes an earlier visible forward callee when a later winner masks it', () => {
+        const earlier_prog = make_program('shared_prog', 'file:///earlier.do');
+        const later_prog = make_program('shared_prog', 'file:///later.do');
+        const my_scope: ResolvedScope = {
+            ...empty_scope,
+            forward_call_symbols: [
+                {
+                    callee_uri: 'file:///earlier.do',
+                    call_line: 1,
+                    symbols: {
+                        ...create_empty_symbol_table(),
+                        programs: new Map([['shared_prog', earlier_prog]]),
+                    },
+                    effective_type: 'do',
+                },
+                {
+                    callee_uri: 'file:///later.do',
+                    call_line: 2,
+                    symbols: {
+                        ...create_empty_symbol_table(),
+                        programs: new Map([['shared_prog', later_prog]]),
+                    },
+                    effective_type: 'do',
+                },
+            ],
+        };
+        const the_result = collect_visible_reference_uris(
+            my_scope,
+            5,
+            'file:///current.do',
+            'program',
+            'shared_prog',
+        );
+        expect(the_result.has('file:///current.do')).toBe(true);
+        expect(the_result.has('file:///earlier.do')).toBe(false);
+        expect(the_result.has('file:///later.do')).toBe(true);
+    });
+
     test('keeps local macros include-only across backward and forward edges', () => {
         const parent_visible_local = make_local_macro('shared', 'file:///parent-include.do');
-        const parent_hidden_local = make_local_macro('shared', 'file:///parent-do.do');
         const visible_include_site: ForwardCallSite = {
             callee_uri: 'file:///visible-include.do',
             call_line: 1,
@@ -253,10 +368,7 @@ describe('collect_visible_reference_uris', () => {
         const visible_do_site: ForwardCallSite = {
             callee_uri: 'file:///visible-do.do',
             call_line: 1,
-            symbols: {
-                ...create_empty_symbol_table(),
-                localMacros: new Map([['shared', parent_hidden_local]]),
-            },
+            symbols: create_empty_symbol_table(),
             effective_type: 'do',
         };
         const my_scope: ResolvedScope = {
@@ -299,6 +411,7 @@ describe('collect_visible_reference_uris', () => {
             5,
             'file:///current.do',
             'local_macro',
+            'shared',
         );
         expect(the_result.has('file:///current.do')).toBe(true);
         expect(the_result.has('file:///done-parent.do')).toBe(false);
@@ -306,5 +419,48 @@ describe('collect_visible_reference_uris', () => {
         expect(the_result.has('file:///visible-include.do')).toBe(true);
         expect(the_result.has('file:///visible-do.do')).toBe(false);
         expect(the_result.has('file:///same-line.do')).toBe(false);
+    });
+
+    test('excludes a stripped included ancestor local after a downstream done-by boundary', () => {
+        const included_local = make_local_macro('shared', 'file:///grand.do');
+        const my_scope: ResolvedScope = {
+            ...empty_scope,
+            chain: [
+                {
+                    uri: 'file:///parent.do',
+                    directive_type: 'done-by',
+                    call_site_line: 0,
+                    symbols: create_empty_symbol_table(),
+                    forward_call_sites: [],
+                    depth: 1,
+                    directive_order: 1,
+                    sort_key: 'a',
+                },
+                {
+                    uri: 'file:///grand.do',
+                    directive_type: 'included-by',
+                    call_site_line: 0,
+                    symbols: {
+                        ...create_empty_symbol_table(),
+                        localMacros: new Map([['shared', included_local]]),
+                    },
+                    forward_call_sites: [],
+                    depth: 2,
+                    directive_order: 0,
+                    sort_key: 'b',
+                },
+            ],
+        };
+        const the_result = collect_visible_reference_uris(
+            my_scope,
+            5,
+            'file:///child.do',
+            'local_macro',
+            'shared',
+        );
+        expect(the_result.size).toBe(1);
+        expect(the_result.has('file:///child.do')).toBe(true);
+        expect(the_result.has('file:///grand.do')).toBe(false);
+        expect(the_result.has('file:///parent.do')).toBe(false);
     });
 });

--- a/tests/unit/scope-resolver/visible-symbols.test.ts
+++ b/tests/unit/scope-resolver/visible-symbols.test.ts
@@ -173,7 +173,7 @@ describe('collect_visible_reference_uris', () => {
         expect(the_result.has('file:///current.do')).toBe(true);
     });
 
-    test('includes only URIs contributing the active visible symbol instance', () => {
+    test('includes every URI that could reference the active symbol instance, regardless of call-site order', () => {
         const parent1_prog = make_program('shared_prog', 'file:///parent1.do');
         const parent2_prog = make_program('shared_prog', 'file:///parent2.do');
         const parent1_callee_prog = make_program(
@@ -263,7 +263,11 @@ describe('collect_visible_reference_uris', () => {
         expect(the_result.has('file:///parent1-callee.do')).toBe(false);
         expect(the_result.has('file:///parent2-callee.do')).toBe(false);
         expect(the_result.has('file:///current-visible.do')).toBe(true);
-        expect(the_result.has('file:///current-hidden.do')).toBe(false);
+        // `current-hidden.do` is called after the cursor line, but the active
+        // instance (contributed by `current-visible.do` at line 1) is still
+        // defined when it runs — so references there are references to the
+        // same definition and must participate in find-references.
+        expect(the_result.has('file:///current-hidden.do')).toBe(true);
     });
 
     test('excludes an earlier same-depth backward parent when a later winner masks it', () => {
@@ -418,7 +422,11 @@ describe('collect_visible_reference_uris', () => {
         expect(the_result.has('file:///included-parent.do')).toBe(true);
         expect(the_result.has('file:///visible-include.do')).toBe(true);
         expect(the_result.has('file:///visible-do.do')).toBe(false);
-        expect(the_result.has('file:///same-line.do')).toBe(false);
+        // `same-line.do` is an `include` call at the cursor line itself; its
+        // inlined body still references the same active local, so it must
+        // participate. Call-site order relative to the cursor is irrelevant
+        // for find-references once the active instance is selected.
+        expect(the_result.has('file:///same-line.do')).toBe(true);
     });
 
     test('excludes a stripped included ancestor local after a downstream done-by boundary', () => {

--- a/tests/unit/unify-forward-call-feeds.test.ts
+++ b/tests/unit/unify-forward-call-feeds.test.ts
@@ -15,7 +15,7 @@ import { StataLexer } from '../../src/lexer';
 import { StataParser } from '../../src/parser';
 import { SemanticAnalyzer, create_empty_symbol_table } from '../../src/analyzer';
 import { ContextTracker } from '../../src/context-tracker';
-import { DocumentState, StataDiagnosticCode, ForwardCallSite, StataLSPConfig, ForwardResolvedScope } from '../../src/types';
+import { DocumentState, StataDiagnosticCode, StataLSPConfig, ResolvedScope } from '../../src/types';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -39,6 +39,17 @@ const DEFAULT_CONFIG: StataLSPConfig = {
 
 function create_mock_connection() {
     return { sendDiagnostics: () => {} };
+}
+
+/**
+ * Wire a stub ScopeResolver whose .resolve() returns the provided
+ * ResolvedScope. Used to feed canned forward_call_symbols to
+ * DiagnosticsProvider without standing up a full resolver.
+ */
+function make_stub_scope_resolver(resolved_scope: ResolvedScope): ScopeResolver {
+    const the_stub = new ScopeResolver();
+    (the_stub as any).resolve = async () => resolved_scope;
+    return the_stub;
 }
 
 function create_document_state(content: string, uri: string): DocumentState {
@@ -106,8 +117,8 @@ describe('unify-forward-call-feeds refactoring', () => {
         fs.rmSync(temp_dir, { recursive: true, force: true });
     });
 
-    describe('scope_resolver null (fallback path)', () => {
-        test('forward_scope is used when scope_resolver is null', async () => {
+    describe('scope_resolver carries forward_call_symbols', () => {
+        test('stub resolver providing forward_call_symbols suppresses undefined warnings', async () => {
             const callee_path = path.join(temp_dir, 'callee.do');
             fs.writeFileSync(callee_path, 'global child_var = "test"\n');
 
@@ -118,10 +129,15 @@ describe('unify-forward-call-feeds refactoring', () => {
             const caller_uri = URI.file(caller_path).toString();
             const doc_state = create_document_state(caller_content, caller_uri);
 
-            // Create forward_scope with the symbol
-            const forward_scope: ForwardResolvedScope = {
+            // Build a ResolvedScope carrying forward_call_symbols.
+            const resolved_scope: ResolvedScope = {
+                chain: [],
                 symbols: create_empty_symbol_table(),
-                call_sites: [{
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: false,
+                forward_call_symbols: [{
                     callee_uri: URI.file(callee_path).toString(),
                     call_line: 0,
                     symbols: {
@@ -134,21 +150,20 @@ describe('unify-forward-call-feeds refactoring', () => {
                     },
                     effective_type: 'do',
                 }],
-                diagnostics: [],
             };
 
-            // Get diagnostics with forward_scope but NO scope_resolver
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
+
             const diagnostics = await provider.get_diagnostics(
                 doc_state,
                 DEFAULT_CONFIG,
                 undefined, // workspace_symbols
-                undefined, // scope_resolver is null
-                undefined, // cancellation_token
-                forward_scope
+                stub_resolver
             );
 
-            // Should NOT have undefined macro warning since forward_scope provides the symbol
-            const undefined_warnings = diagnostics.filter(d => 
+            // Should NOT have undefined macro warning since the stub resolver
+            // provides the symbol via resolved_scope.forward_call_symbols.
+            const undefined_warnings = diagnostics.filter(d =>
                 d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
                 d.message.includes('child_var')
             );
@@ -173,14 +188,13 @@ describe('unify-forward-call-feeds refactoring', () => {
             const forward_scope_resolver = new ForwardScopeResolver(scope_resolver);
             scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
 
-            // Get diagnostics with scope_resolver (no forward_scope parameter)
+            // Get diagnostics with scope_resolver — the scope resolver provides
+            // forward_call_symbols on the ResolvedScope it returns.
             const diagnostics = await provider.get_diagnostics(
                 doc_state,
                 DEFAULT_CONFIG,
                 undefined, // workspace_symbols
-                scope_resolver,
-                undefined, // cancellation_token
-                undefined  // forward_scope is undefined - should use resolved_scope.forward_call_symbols
+                scope_resolver
             );
 
             // The scope_resolver will resolve forward calls and provide symbols
@@ -206,10 +220,15 @@ describe('unify-forward-call-feeds refactoring', () => {
             const caller_uri = URI.file(caller_path).toString();
             const doc_state = create_document_state(caller_content, caller_uri);
 
-            // Create forward_scope with duplicate entries (simulating both directive and command)
-            const forward_scope: ForwardResolvedScope = {
+            // ResolvedScope with duplicate entries (simulating both directive and command).
+            const resolved_scope: ResolvedScope = {
+                chain: [],
                 symbols: create_empty_symbol_table(),
-                call_sites: [
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: false,
+                forward_call_symbols: [
                     // From @lsp-do directive
                     {
                         callee_uri: URI.file(callee_path).toString(),
@@ -239,20 +258,19 @@ describe('unify-forward-call-feeds refactoring', () => {
                         effective_type: 'do',
                     },
                 ],
-                diagnostics: [],
             };
+
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
 
             const diagnostics = await provider.get_diagnostics(
                 doc_state,
                 DEFAULT_CONFIG,
                 undefined,
-                undefined,
-                undefined,
-                forward_scope
+                stub_resolver
             );
 
             // Should handle duplicates gracefully - no undefined macro warning
-            const undefined_warnings = diagnostics.filter(d => 
+            const undefined_warnings = diagnostics.filter(d =>
                 d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
                 d.message.includes('child_var')
             );
@@ -271,10 +289,15 @@ describe('unify-forward-call-feeds refactoring', () => {
             const caller_uri = URI.file(caller_path).toString();
             const doc_state = create_document_state(caller_content, caller_uri);
 
-            // Create forward_scope simulating do then include
-            const forward_scope: ForwardResolvedScope = {
+            // ResolvedScope simulating do then include.
+            const resolved_scope: ResolvedScope = {
+                chain: [],
                 symbols: create_empty_symbol_table(),
-                call_sites: [
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: false,
+                forward_call_symbols: [
                     // From do command (excludes locals)
                     {
                         callee_uri: URI.file(callee_path).toString(),
@@ -309,20 +332,19 @@ describe('unify-forward-call-feeds refactoring', () => {
                         effective_type: 'include',
                     },
                 ],
-                diagnostics: [],
             };
+
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
 
             const diagnostics = await provider.get_diagnostics(
                 doc_state,
                 DEFAULT_CONFIG,
                 undefined,
-                undefined,
-                undefined,
-                forward_scope
+                stub_resolver
             );
 
             // Both local_var and global_var should be found (no undefined warnings)
-            const undefined_warnings = diagnostics.filter(d => 
+            const undefined_warnings = diagnostics.filter(d =>
                 d.code === StataDiagnosticCode.UNDEFINED_MACRO
             );
             expect(undefined_warnings).toHaveLength(0);


### PR DESCRIPTION
- **Add design spec for issue #129 unify visible-at-cursor**
- **Add visible-symbols helpers for issue #129**
- **Fix type errors in visible-symbols tests (issue #129)**
- **Strengthen visible-symbols property test (issue #129)**
- **Use shared get_visible_forward_call_sites in hover (issue #129)**
- **Retire forward_scope legacy path in completion (issue #129)**
- **Remove unused ForwardCallSite import in completion (issue #129)**
- **Retire forward_scope legacy path in diagnostics (issue #129)**
- **Fix go-to-def for forward-called symbols (issue #129)**
- **Apply call-site filter to find_definitions (issue #129)**
- **Align find_definitions fallback with scan path (issue #129)**
- **Use shared get_visible_forward_call_sites in classify_word_symbol (issue #129)**
- **Remove dead forward_scope plumbing from server handlers (issue #129)**
- **Document narrower tier-2 scoping in find-references (issue #129)**
- **Document narrower tier-2 scoping in AGENTS.md too (issue #129)**
- **Fix find-references visible file scoping**
- **Fix visible-symbol precedence across references hover and completion**
- **Tighten variable in-scope test to exercise cross-file path (issue #129)**
- **Resolve forward-included local macros in go-to-definition**
- **Respect later current-file defs over earlier forward calls**
- **Find references to locals across include boundaries**

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Definition, hover, completion, and reference results now respect cursor-visible precedence and same-name conflict resolution, preferring the active visible symbol and limiting non-variable declaration pooling to visible/precedent files.
  * Diagnostics no longer emit certain forward-scope duplicate/obsolete diagnostics.

* **Documentation**
  * Updated Find References scoping docs to explain visibility filtering, effective-scope precedence, and workspace-wide variable pooling.

* **Tests**
  * Added extensive unit, property, and integration tests covering visibility, forward-call precedence, and reference/definition behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->