### PR TITLE
Fix markdown rendering of Stata backtick syntax in config docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ global file_global value
 
 **First definition wins**: When a macro is defined multiple times, references before the first definition produce warnings, but references after the first definition do not (even if they appear before later redefinitions).
 
-**Macro-creating options**: The analyzer recognizes `local()` and `global()` options on built-in commands (`levelsof`, `glevelsof`) and user-defined programs (via `c_local `option'` and `global `option'` patterns matching syntax declarations).
+**Macro-creating options**: The analyzer recognizes `local()` and `global()` options on built-in commands (`levelsof`, `glevelsof`) and user-defined programs (via `` c_local `option' `` and `` global `option' `` patterns matching syntax declarations).
 
 ## Tuning autocomplete behavior
 


### PR DESCRIPTION
Wrap `c_local `option'` and `global `option'` in double backticks so
the backtick-apostrophe delimiters render as inline code instead of
breaking the markdown.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved inline code formatting in configuration documentation for enhanced readability of syntax declaration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->