### PR TITLE
Address open CodeQL security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Restrict the default GITHUB_TOKEN to the minimum scopes every job needs:
+#   - contents: read -> actions/checkout + build/test steps
+#   - pull-requests: read -> dorny/paths-filter in the `changes` job
+# No job in this workflow pushes commits, uploads artifacts, comments on PRs,
+# or publishes packages; those responsibilities live in the release/update
+# workflows, which declare their own permissions.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   changes:
     name: Detect changed paths

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -23,6 +23,7 @@ import {
     compute_line_offsets,
     DocumentLike,
 } from '../utils/line-utils';
+import { build_do_include_pattern } from '../utils/stata-call-patterns';
 
 // Accept both spec form with colon (@lsp-done-by:) and legacy form without colon.
 // Accept both quoted and unquoted paths.
@@ -43,9 +44,9 @@ const PARAM_MATCH = /match="([^"]+)"/;
 const DECLARATION_DIRECTIVE_PATTERN = /@lsp-(local|global|scalar|matrix|program)(?:\s+(.*))?$/;
 
 // Shared pattern to match do/include/run statements with optional prefix commands.
-// Keywords must be lowercase (Stata is case-sensitive).
-// Common prefixes: quietly/qui, capture/cap, noisily/noi, version.
-const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?)\s+)*\s*(do|include|run)\s+(?:"([^"]+)"|([^\s,]+))/;
+// Prefix alternatives live in utils/stata-call-patterns so this pattern and the
+// prefix-only variant in scope-resolver stay in lockstep.
+const DO_INCLUDE_PATTERN = build_do_include_pattern('(?:"([^"]+)"|([^\\s,]+))');
 
 // Shared pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments.
 const CALL_DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+(?:"([^"]+)"|([^\s]+))/;

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -44,12 +44,8 @@ const DECLARATION_DIRECTIVE_PATTERN = /@lsp-(local|global|scalar|matrix|program)
 
 // Shared pattern to match do/include/run statements with optional prefix commands.
 // Keywords must be lowercase (Stata is case-sensitive).
-// Common prefixes: quietly/qui, capture/cap, noisily/noi, version, timer.
-//
-// The `timer` branch is written so each whitespace run is consumed by a single
-// `\s+`; the outer `\s+` that follows this group always supplies the separator
-// before the next token. This avoids nested-quantifier ReDoS (CodeQL js/redos).
-const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer\s+(?:(?:on|off|clear|list)(?:\s+\d+)?|\d+))\s+)*\s*(do|include|run)\s+(?:"([^"]+)"|([^\s,]+))/;
+// Common prefixes: quietly/qui, capture/cap, noisily/noi, version.
+const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?)\s+)*\s*(do|include|run)\s+(?:"([^"]+)"|([^\s,]+))/;
 
 // Shared pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments.
 const CALL_DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+(?:"([^"]+)"|([^\s]+))/;

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -42,6 +42,18 @@ const PARAM_MATCH = /match="([^"]+)"/;
 // Captures: [1] = directive type, [2] = rest of line after directive keyword
 const DECLARATION_DIRECTIVE_PATTERN = /@lsp-(local|global|scalar|matrix|program)(?:\s+(.*))?$/;
 
+// Shared pattern to match do/include/run statements with optional prefix commands.
+// Keywords must be lowercase (Stata is case-sensitive).
+// Common prefixes: quietly/qui, capture/cap, noisily/noi, version, timer.
+//
+// The `timer` branch is written so each whitespace run is consumed by a single
+// `\s+`; the outer `\s+` that follows this group always supplies the separator
+// before the next token. This avoids nested-quantifier ReDoS (CodeQL js/redos).
+const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer(?:\s+(?:on|off|clear|list))?(?:\s+\d+)?)\s+)*\s*(do|include|run)\s+(?:"([^"]+)"|([^\s,]+))/;
+
+// Shared pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments.
+const CALL_DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+(?:"([^"]+)"|([^\s]+))/;
+
 function looks_like_unquoted_path_token(token: string): boolean {
     // Heuristic for valid unquoted paths:
     // - Reject things that look like parameters (line=..., match="...")
@@ -553,14 +565,6 @@ export class DirectiveParser {
         const doc: DocumentLike = { content: parent_content, line_offsets: compute_line_offsets(parent_content) };
         const line_count = get_line_count(doc);
 
-        // Pattern to match do/include/run statements with optional prefix commands
-        // Keywords must be lowercase (Stata is case-sensitive)
-        // Common prefixes: quietly/qui, capture/cap, noisily/noi, version, timer
-        const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer\s+(?:on|off|clear|list)?\s*\d*)\s+)*\s*(do|include|run)\s+(?:"([^"]+)"|([^\s,]+))/;
-
-        // Pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments
-        const DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+(?:"([^"]+)"|([^\s]+))/;
-
         // Normalize child filename for comparison (remove .do suffix if present)
         // File extension check is case-insensitive
         const child_basename = path.basename(child_filename);
@@ -598,7 +602,7 @@ export class DirectiveParser {
 
             // Also check for @lsp-do, @lsp-run, @lsp-include directives in comment lines
             if (my_trimmed.startsWith('*') || my_trimmed.startsWith('//')) {
-                const directive_match = my_trimmed.match(DIRECTIVE_PATTERN);
+                const directive_match = my_trimmed.match(CALL_DIRECTIVE_PATTERN);
                 if (directive_match) {
                     const my_quoted_path = directive_match[2];
                     const my_unquoted_path = directive_match[3];
@@ -635,14 +639,6 @@ export class DirectiveParser {
     ): { line: number; call_type: 'do' | 'run' | 'include' } | undefined {
         const doc: DocumentLike = { content: parent_content, line_offsets: compute_line_offsets(parent_content) };
         const line_count = get_line_count(doc);
-
-        // Pattern to match do/include/run statements with optional prefix commands
-        // Keywords must be lowercase (Stata is case-sensitive)
-        // Common prefixes: quietly/qui, capture/cap, noisily/noi, version, timer
-        const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer\s+(?:on|off|clear|list)?\s*\d*)\s+)*\s*(do|include|run)\s+(?:"([^"]+)"|([^\s,]+))/;
-
-        // Pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments
-        const DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+(?:"([^"]+)"|([^\s]+))/;
 
         // Normalize child filename for comparison (remove .do suffix if present)
         // File extension check is case-insensitive
@@ -682,7 +678,7 @@ export class DirectiveParser {
 
             // Also check for @lsp-do, @lsp-run, @lsp-include directives in comment lines
             if (my_trimmed.startsWith('*') || my_trimmed.startsWith('//')) {
-                const directive_match = my_trimmed.match(DIRECTIVE_PATTERN);
+                const directive_match = my_trimmed.match(CALL_DIRECTIVE_PATTERN);
                 if (directive_match) {
                     const my_call_type = directive_match[1] as 'do' | 'run' | 'include';
                     const my_quoted_path = directive_match[2];
@@ -736,14 +732,6 @@ export class DirectiveParser {
         const line_count = get_line_count(doc);
         const the_call_sites: Array<{ line: number; call_type: 'do' | 'run' | 'include' }> = [];
 
-        // Pattern to match do/include/run statements with optional prefix commands
-        // Keywords must be lowercase (Stata is case-sensitive)
-        // Common prefixes: quietly/qui, capture/cap, noisily/noi, version, timer
-        const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer\s+(?:on|off|clear|list)?\s*\d*)\s+)*\s*(do|include|run)\s+(?:"([^"]+)"|([^\s,]+))/;
-
-        // Pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments
-        const DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+(?:"([^"]+)"|([^\s]+))/;
-
         // Normalize child filename for comparison (remove .do suffix if present)
         // File extension check is case-insensitive
         const child_basename = path.basename(child_filename);
@@ -782,7 +770,7 @@ export class DirectiveParser {
 
             // Also check for @lsp-do, @lsp-run, @lsp-include directives in comment lines
             if (my_trimmed.startsWith('*') || my_trimmed.startsWith('//')) {
-                const directive_match = my_trimmed.match(DIRECTIVE_PATTERN);
+                const directive_match = my_trimmed.match(CALL_DIRECTIVE_PATTERN);
                 if (directive_match) {
                     const my_call_type = directive_match[1] as 'do' | 'run' | 'include';
                     const my_quoted_path = directive_match[2];

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -49,7 +49,7 @@ const DECLARATION_DIRECTIVE_PATTERN = /@lsp-(local|global|scalar|matrix|program)
 // The `timer` branch is written so each whitespace run is consumed by a single
 // `\s+`; the outer `\s+` that follows this group always supplies the separator
 // before the next token. This avoids nested-quantifier ReDoS (CodeQL js/redos).
-const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer(?:\s+(?:on|off|clear|list))?(?:\s+\d+)?)\s+)*\s*(do|include|run)\s+(?:"([^"]+)"|([^\s,]+))/;
+const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer\s+(?:(?:on|off|clear|list)(?:\s+\d+)?|\d+))\s+)*\s*(do|include|run)\s+(?:"([^"]+)"|([^\s,]+))/;
 
 // Shared pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments.
 const CALL_DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+(?:"([^"]+)"|([^\s]+))/;

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -61,7 +61,7 @@ const DEFAULT_CONFIG: ScopeResolverConfig = {
 // the next token. This avoids nested-quantifier ReDoS (CodeQL js/redos).
 // Hoisted to module scope so the RegExp is compiled once; neither pattern uses
 // the `g` flag, so there is no `lastIndex` state to reset between calls.
-const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer(?:\s+(?:on|off|clear|list))?(?:\s+\d+)?)\s+)*\s*(do|include|run)\s+/;
+const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer\s+(?:(?:on|off|clear|list)(?:\s+\d+)?|\d+))\s+)*\s*(do|include|run)\s+/;
 
 // Pattern to match @lsp-do, @lsp-run, @lsp-include directives in comment lines.
 const DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+/;

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -54,6 +54,18 @@ const DEFAULT_CONFIG: ScopeResolverConfig = {
     max_chain_depth: 20,
 };
 
+// Pattern to match do/include/run commands with optional prefix commands.
+// Keywords must be lowercase (Stata is case-sensitive).
+// The `timer` branch is written so each whitespace run is consumed by a single
+// `\s+`; the outer `\s+` that follows this group supplies the separator before
+// the next token. This avoids nested-quantifier ReDoS (CodeQL js/redos).
+// Hoisted to module scope so the RegExp is compiled once; neither pattern uses
+// the `g` flag, so there is no `lastIndex` state to reset between calls.
+const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer(?:\s+(?:on|off|clear|list))?(?:\s+\d+)?)\s+)*\s*(do|include|run)\s+/;
+
+// Pattern to match @lsp-do, @lsp-run, @lsp-include directives in comment lines.
+const DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+/;
+
 /**
  * Build a Partial<ScopeResolverConfig> with undefined values filtered out.
  * This prevents undefined values from overriding defaults when spread-merged
@@ -404,17 +416,7 @@ export class ScopeResolver {
     private validate_call_statement(line_content: string): 'do' | 'run' | 'include' | undefined {
         const my_trimmed = line_content.trim();
 
-        // Pattern to match do/include/run commands with optional prefix commands.
-        // Keywords must be lowercase (Stata is case-sensitive).
-        // The `timer` branch is written so each whitespace run is consumed by a single
-        // `\s+`; the outer `\s+` that follows this group supplies the separator before
-        // the next token. This avoids nested-quantifier ReDoS (CodeQL js/redos).
-        const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer(?:\s+(?:on|off|clear|list))?(?:\s+\d+)?)\s+)*\s*(do|include|run)\s+/;
-
-        // Pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments
-        const DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+/;
-
-        // Check for command pattern
+        // Check for command pattern (uses module-level DO_INCLUDE_PATTERN)
         const command_match = my_trimmed.match(DO_INCLUDE_PATTERN);
         if (command_match) {
             return command_match[1] as 'do' | 'run' | 'include';

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -56,12 +56,9 @@ const DEFAULT_CONFIG: ScopeResolverConfig = {
 
 // Pattern to match do/include/run commands with optional prefix commands.
 // Keywords must be lowercase (Stata is case-sensitive).
-// The `timer` branch is written so each whitespace run is consumed by a single
-// `\s+`; the outer `\s+` that follows this group supplies the separator before
-// the next token. This avoids nested-quantifier ReDoS (CodeQL js/redos).
 // Hoisted to module scope so the RegExp is compiled once; neither pattern uses
 // the `g` flag, so there is no `lastIndex` state to reset between calls.
-const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer\s+(?:(?:on|off|clear|list)(?:\s+\d+)?|\d+))\s+)*\s*(do|include|run)\s+/;
+const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?)\s+)*\s*(do|include|run)\s+/;
 
 // Pattern to match @lsp-do, @lsp-run, @lsp-include directives in comment lines.
 const DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+/;

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -404,9 +404,12 @@ export class ScopeResolver {
     private validate_call_statement(line_content: string): 'do' | 'run' | 'include' | undefined {
         const my_trimmed = line_content.trim();
 
-        // Pattern to match do/include/run commands with optional prefix commands
-        // Keywords must be lowercase (Stata is case-sensitive)
-        const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer\s+(?:on|off|clear|list)?\s*\d*)\s+)*\s*(do|include|run)\s+/;
+        // Pattern to match do/include/run commands with optional prefix commands.
+        // Keywords must be lowercase (Stata is case-sensitive).
+        // The `timer` branch is written so each whitespace run is consumed by a single
+        // `\s+`; the outer `\s+` that follows this group supplies the separator before
+        // the next token. This avoids nested-quantifier ReDoS (CodeQL js/redos).
+        const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?|timer(?:\s+(?:on|off|clear|list))?(?:\s+\d+)?)\s+)*\s*(do|include|run)\s+/;
 
         // Pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments
         const DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+/;

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -38,6 +38,7 @@ import { SemanticAnalyzer, create_empty_symbol_table, merge_symbol_tables } from
 import { logger } from '../utils/logger';
 import { get_line_text, get_line_count, compute_line_offsets } from '../utils/line-utils';
 import { get_workspace_root_for_uri } from '../utils/workspace-roots';
+import { build_do_include_pattern } from '../utils/stata-call-patterns';
 
 export {
     get_visible_symbols_at,
@@ -55,10 +56,11 @@ const DEFAULT_CONFIG: ScopeResolverConfig = {
 };
 
 // Pattern to match do/include/run commands with optional prefix commands.
-// Keywords must be lowercase (Stata is case-sensitive).
-// Hoisted to module scope so the RegExp is compiled once; neither pattern uses
-// the `g` flag, so there is no `lastIndex` state to reset between calls.
-const DO_INCLUDE_PATTERN = /^\s*(?:(?:qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?)\s+)*\s*(do|include|run)\s+/;
+// Prefix alternatives live in utils/stata-call-patterns so this pattern and the
+// path-capturing variant in directive-parser stay in lockstep. Built once at
+// module load; neither pattern uses the `g` flag, so there is no `lastIndex`
+// state to reset between calls.
+const DO_INCLUDE_PATTERN = build_do_include_pattern('');
 
 // Pattern to match @lsp-do, @lsp-run, @lsp-include directives in comment lines.
 const DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+/;

--- a/src/utils/stata-call-patterns.ts
+++ b/src/utils/stata-call-patterns.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared regex fragments for matching Stata `do`/`run`/`include` call sites.
+ *
+ * Used by both `directive-parser` (which captures the called path) and
+ * `scope-resolver` (which only checks the prefix). Keeping the prefix
+ * alternatives in one place prevents the two patterns from silently drifting
+ * when Stata prefix commands are added or removed.
+ */
+
+// Stata prefix commands that can legally precede `do`, `run`, or `include`.
+// Keywords must be lowercase (Stata is case-sensitive). Written so that every
+// whitespace run is consumed by exactly one `\s+` when this fragment is wrapped
+// in `(?:(?:<prefix>)\s+)*`, avoiding nested-quantifier ReDoS (CodeQL js/redos).
+//
+// Intentionally excluded: `timer` is a standalone command in Stata
+// (`timer on 1`, `timer off 1`, `timer clear`, `timer list`), not a prefix
+// command — `timer do "x.do"` is not legal syntax.
+export const CALL_PREFIX_ALTERNATIVES =
+    /qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?/.source;
+
+/**
+ * Build a regex that matches a `do`/`run`/`include` call line with optional
+ * prefix commands. The returned regex captures the call keyword as group 1;
+ * additional capture groups in `path_suffix` are appended as groups 2+.
+ *
+ * Pass `path_suffix = ''` for a prefix-only check; pass a suffix like
+ * `(?:"([^"]+)"|([^\\s,]+))` to also capture the called path.
+ */
+export function build_do_include_pattern(path_suffix: string): RegExp {
+    return new RegExp(
+        `^\\s*(?:(?:${CALL_PREFIX_ALTERNATIVES})\\s+)*\\s*(do|include|run)\\s+${path_suffix}`,
+    );
+}

--- a/tests/property/lsp-working-directory-option-content-transform.prop.test.ts
+++ b/tests/property/lsp-working-directory-option-content-transform.prop.test.ts
@@ -37,7 +37,12 @@ function transform_content_with_cd(
         directory = workspace_directory ?? file_directory;
     }
     
-    const escaped_dir = directory.replace(/"/g, '\\"');
+    // Escape backslashes first, then quotes, so paths with literal `\` or `"`
+    // are not mis-parsed (and to satisfy CodeQL's incomplete-sanitization check
+    // on this test-local reimplementation of the content transform).
+    const escaped_dir = directory
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"');
     return `cd "${escaped_dir}"\n${content}`;
 }
 

--- a/tests/property/macro-completion-context.prop.test.ts
+++ b/tests/property/macro-completion-context.prop.test.ts
@@ -15,7 +15,13 @@ function make_document_and_position(content_with_cursor_marker: string): { docum
     const marker_index = content_with_cursor_marker.indexOf('|');
     expect(marker_index).toBeGreaterThanOrEqual(0);
 
-    const content = content_with_cursor_marker.replace('|', '');
+    // Remove only the marker at the found index (any later '|' characters are
+    // real content and must be preserved). Using slice avoids the ambiguity of
+    // String.prototype.replace with a string argument and silences CodeQL's
+    // js/incomplete-sanitization check.
+    const content =
+        content_with_cursor_marker.slice(0, marker_index) +
+        content_with_cursor_marker.slice(marker_index + 1);
 
     const before_marker = content_with_cursor_marker.substring(0, marker_index);
     const line = before_marker.split('\n').length - 1;

--- a/tests/property/send-to-stata-statement-detection.prop.test.ts
+++ b/tests/property/send-to-stata-statement-detection.prop.test.ts
@@ -443,8 +443,12 @@ describe('Feature: send-to-stata - Working Directory Handling', () => {
             directory = workspace_root ?? path.dirname(file_path);
         }
         
-        // Escape quotes in path for Stata
-        const escaped_dir = directory.replace(/"/g, '\\"');
+        // Escape backslashes first, then quotes, so paths with literal `\` or `"`
+        // are not mis-parsed by Stata (and to keep CodeQL's incomplete-sanitization
+        // check happy for this test-local reimplementation).
+        const escaped_dir = directory
+            .replace(/\\/g, '\\\\')
+            .replace(/"/g, '\\"');
         return `cd "${escaped_dir}"\n${content}`;
     }
 

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -293,6 +293,15 @@ global after 2
         expect(result).toBe(1);
     });
 
+    test('infer_call_site_for_file should NOT treat bare timer as a prefix', () => {
+        const parent_content = `global setup 1
+timer do "child.do"
+global after 2
+`;
+        const result = parser.infer_call_site_for_file(parent_content, 'child.do');
+        expect(result).toBeUndefined();
+    });
+
     test('infer_call_site_for_file should still compare filenames case-insensitively', () => {
         // File extension comparison is allowed to be case-insensitive
         const parent_content = `global setup 1


### PR DESCRIPTION
Close all 17 open [code-scanning alerts](https://github.com/jbearak/sight/security/code-scanning) in three buckets:

## 1. `js/redos` — 8 high-severity alerts
The call-site inference regex was duplicated in four locations and included a `timer\s+(?:on|off|clear|list)?\s*\d*` branch inside a `(?:…\s+)*` group. The inner `\s+` plus trailing `\s*` overlap with the outer `\s+`, so long runs like `timer   timer   timer …` could be split exponentially many ways during backtracking.

- **Removed the `timer` branch outright.** In Stata, `timer` is a standalone command (`timer on 1`, `timer off 1`, `timer clear`, `timer list`), not a prefix command — `timer do "x.do"` is not legal Stata. The branch was therefore never semantically useful, and removing it is the simplest way to eliminate the ReDoS. A new unit test (`infer_call_site_for_file should NOT treat bare timer as a prefix`) pins this behavior.
- Hoisted the three duplicated `directive-parser` regexes into module-level `DO_INCLUDE_PATTERN` / `CALL_DIRECTIVE_PATTERN` constants (also matches the repo's "hoist regex out of hot loops" guideline).
- `scope-resolver` keeps its own (prefix-only, no path capture) variant, now hoisted to module scope as well.
- Remaining prefix branches (`qui(?:etly)?`, `cap(?:ture)?`, `noi(?:sily)?`, `version\s+\d+(?:\.\d+)?`) are ReDoS-safe: none of their internal whitespace/digit structure overlaps ambiguously with the outer `\s+` separator.

Locations fixed: `src/scope-resolver/index.ts:409`, `src/directive-parser/index.ts:559`, `:642`, `:742`.

## 2. `js/incomplete-sanitization` — 3 high-severity alerts
Two `send-to-stata` test helpers reimplemented an older path escape as `directory.replace(/"/g, '\\"')`, which silently drops literal backslashes. Changed both helpers to escape backslashes first, then quotes. The existing hard-coded assertions (and the property-test path generators) never introduce `\` so they continue to pass.

`tests/property/macro-completion-context.prop.test.ts` used `content_with_cursor_marker.replace('|', '')` to strip a cursor marker whose index was already computed by `indexOf('|')`. Switched to an explicit `slice(0, i) + slice(i + 1)` so intent is obvious and CodeQL no longer flags it.

## 3. `actions/missing-workflow-permissions` — 6 medium-severity alerts
`.github/workflows/ci.yml` had no `permissions:` block, so every job inherited the default (writable) `GITHUB_TOKEN` scope. Added a top-level block:

```yaml
permissions:
  contents: read
  pull-requests: read
```

- `contents: read` covers `actions/checkout` and the build/test steps.
- `pull-requests: read` is required by `dorny/paths-filter@v3` in the `changes` job (its API call to `GET /repos/{owner}/{repo}/pulls/{number}/files` needs that scope under the fine-grained token model).

No job in this workflow pushes, uploads artifacts, comments on PRs, or publishes packages — those live in the release/update workflows, which already declare their own permissions. `actions/cache` uses a separate `ACTIONS_RUNTIME_TOKEN` and is unaffected.

## Verification
- `bun run typecheck` — clean.
- `bun test` — 5185 pass, 2 pre-existing skips, 0 fail.

## Artifacts
- [Warp conversation](https://app.warp.dev/conversation/63ffd0a3-c559-4982-a18a-302a4a6d97c9)
- [Implementation plan](https://app.warp.dev/drive/notebook/YkH2C7aI7a28j0tocmzCHc)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of directory paths containing special characters (backslashes and quotes) in Stata working directory operations.

* **Tests**
  * Enhanced test coverage for statement detection and path transformation with complex directory paths.

* **Chores**
  * Strengthened GitHub Actions workflow security by restricting token permissions to the minimum required scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->