### PR TITLE
include edge case

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,11 @@ Control how the LSP reports errors, warnings, and other diagnostics.
 | `sight.diagnostics.severity.cStyleLogicalInControlFlow` | enum | `"information"` | Severity for C-style logical operators (`&&`, `\|\|`) in if/else if control flow statements. These work but are stylistically discouraged. Options: `"error"`, `"warning"`, `"information"`, `"hint"`, `"off"` |
 | `sight.diagnostics.indentation`                | boolean | `false`         | Enable indentation diagnostics (missing indentation in blocks, unnecessary indentation after comments)                |
 
+Cross-file "out of scope" diagnostics are not emitted independently. They are
+more specific rewrites of undefined macro/variable diagnostics after cross-file
+scope resolution. If the underlying undefined diagnostic is disabled, the
+corresponding out-of-scope diagnostic is also suppressed.
+
 <a name="why-indentation-diagnostics-disabled"></a>
 > **Why Indentation Diagnostics Are Disabled by Default**
 >
@@ -199,7 +204,7 @@ You can also configure the LSP using a `.sight.json` file in your workspace root
 | `crossFile.maxChainDepth`               | number               | `20`            | Maximum combined depth for forward + backward resolution                |
 | `crossFile.maxCalleeRevalidations`      | number               | `10`            | Maximum number of open callee documents to revalidate per caller change |
 | `crossFile.assumeCallSite`              | `"end"` \| `"start"` | `"end"`         | Where to assume call site when not specified and inference fails        |
-| `crossFile.diagnostics.outOfScope`      | severity             | `"information"` | Severity for out-of-scope symbol diagnostics                            |
+| `crossFile.diagnostics.outOfScope`      | severity             | `"information"` | Severity used when rewriting undefined-symbol diagnostics as out-of-scope cross-file diagnostics; if the base undefined-macro/variable diagnostic is off, nothing is emitted |
 | `crossFile.diagnostics.missingFile`     | severity             | `"warning"`     | Severity for missing directive file diagnostics                         |
 | `crossFile.diagnostics.callSiteIdentification` | severity      | `"information"` | Severity for call site identification diagnostics                       |
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -592,7 +592,7 @@ Cross-file resolution is configured via `.sight.json` in your workspace root.
 | `crossFile.maxChainDepth`                     | number   | `20`            | Maximum combined depth for forward + backward resolution |
 | `crossFile.maxCalleeRevalidations`            | number   | `10`            | Maximum open callee documents to revalidate per change |
 | `crossFile.assumeCallSite`                    | string   | `"end"`         | Where to assume call site when inference fails (`"end"` or `"start"`) |
-| `crossFile.diagnostics.outOfScope`            | severity | `"information"` | Severity for out-of-scope symbol diagnostics           |
+| `crossFile.diagnostics.outOfScope`            | severity | `"information"` | Severity used when rewriting undefined-symbol diagnostics as out-of-scope cross-file diagnostics; if the base undefined-macro/variable diagnostic is off, nothing is emitted |
 | `crossFile.diagnostics.missingFile`           | severity | `"warning"`     | Severity for missing directive file diagnostics        |
 | `crossFile.diagnostics.callSiteIdentification`| severity | `"information"` | Severity for call site identification diagnostics      |
 

--- a/docs/superpowers/plans/2026-04-21-simplify-out-of-scope-rewrite.md
+++ b/docs/superpowers/plans/2026-04-21-simplify-out-of-scope-rewrite.md
@@ -1,0 +1,793 @@
+# Simplify OUT_OF_SCOPE_SYMBOL rewrite to single-boundary semantics
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Shrink the OUT_OF_SCOPE_SYMBOL rewrite so it only names a specific file when the suggested one-line fix (promote this `do`/`run` to `include`) actually exposes the referenced local. In every other case, fall back to the plain UNDEFINED_MACRO warning.
+
+**Architecture:** `compute_effective_end_state_locals` becomes an **include-only** walk of a direct callee (no descent through `do`/`run`). Nested call sites bubbled up from inner recursion are always handed out with `excluded_locals: undefined`, because their blame targets don't correspond to a one-line fix at the outer reference. The `boundary_only` `DuplicateCallDecision` variant is deleted — a duplicate `do`-after-`do` goes back to `skip`. The independent oracle (`StataExecutionOracle.blame_target_for`) changes to match: for each root-level `do`/`run` before the reference, walk its callee include-only and take the last binding; return `null` if none matches.
+
+**Tech Stack:** TypeScript, Bun, fast-check.
+
+**Why this shape:**
+- The current all-promotion counterfactual names files that are only reachable if the user promotes *every* downstream `do`/`run`, not just the one the diagnostic text points at (Codex 2026-04 finding).
+- A correct "generic undefined local" warning is already the analyzer's default; handing the user that message in ambiguous chains is acceptable per project owner's call.
+- Shrinking the rewrite deletes the `boundary_only` action, the conditional nested-site strip, and a lot of reasoning about counterfactual descent ordering.
+
+**Non-goals:** We are NOT trying to fix the rewrite for deep chains; we are explicitly choosing generic fallback in those cases. The property test's "deep graphs" variant will still run but will simply validate that most blocked references go to the generic path.
+
+---
+
+## File map
+
+**Production (edit):**
+- `src/forward-scope-resolver/index.ts` — restrict helper to include-only walk; remove `boundary_only` branch; unconditional nested-site strip.
+- `src/types/index.ts` — remove `boundary_only` variant from `DuplicateCallDecision`; refresh `ForwardCallSite.excluded_locals` comment.
+- `src/providers/diagnostics.ts` — no structural changes. (The site-iteration + `excluded_callee_uri` logic still works; it just has less to iterate over.)
+
+**Tests (edit):**
+- `tests/property/helpers/stata-execution-oracle.ts` — rewrite `blame_target_for` (and drop `walk_counterfactual`) for single-boundary semantics.
+- `tests/unit/stata-execution-oracle-counterfactual.test.ts` — flip Bug B and Codex audit expectations.
+- `tests/property/forward-call-out-of-scope-oracle.prop.test.ts` — update Bug B fixture to expect generic UNDEFINED; flip Codex audit fixture to expect `defs1.do`; update codex-gap-5 dedup fixture to `file_2.do` (or delete since its narrative was boundary_only-specific).
+- `tests/unit/forward-scope-resolver-effective-end-state.test.ts` — flip the "nested `do` contributes its locals counterfactually" expectation; update header comment; leave depth/cycle/sort tests alone.
+- `tests/unit/forward-scope-resolver-sort-order.test.ts` — no change needed (sort logic is unchanged).
+
+**Docs (edit):**
+- `CLAUDE.md` — no change (it doesn't describe the counterfactual model at this level of detail).
+- Inline comments in `src/forward-scope-resolver/index.ts` that reference "counterfactual", "all-promotion", "promote every do/run" get rewritten to "include-only walk".
+
+---
+
+### Task 1: Rewrite the oracle to single-boundary semantics
+
+**Files:**
+- Modify: `tests/property/helpers/stata-execution-oracle.ts`
+
+- [ ] **Step 1: Update the oracle implementation**
+
+Replace the existing `blame_target_for` and `walk_counterfactual` with an include-only, per-direct-call walk. Keep `is_visible_at`, `simulate_stack_until_ref`, `get_file_name`, and `is_defined_in_root` as-is (they still model real Stata execution for property 1 and the root-defined carve-out).
+
+```typescript
+// tests/property/helpers/stata-execution-oracle.ts
+/**
+ * Stata execution oracle for forward-call graphs.
+ *
+ * Ground truth for `tests/property/forward-call-out-of-scope-oracle.prop.test.ts`.
+ *
+ * Semantics modelled:
+ *
+ *  - `is_visible_at()` — real Stata: a scope stack pushes a fresh scope on
+ *    `do`/`run` and keeps the caller's scope on `include`. Reports whether
+ *    the referenced name is bound when the reference event fires.
+ *
+ *  - `blame_target_for()` — single-boundary counterfactual: for each
+ *    root-level `do`/`run` call that precedes the reference, promote ONLY
+ *    that one boundary to `include` and ask whether the referenced local
+ *    would then be bound. Internal `do`/`run` boundaries stay opaque —
+ *    `include` is the only edge the walk descends. Returns the file whose
+ *    `local X` is the last (in source order, across visible sites) include-
+ *    reachable binding, or `null` when no single-boundary promotion would
+ *    expose the name.
+ */
+import { ForwardCallGraph } from '../generators/forward-call-graphs';
+
+export class StataExecutionOracle {
+    constructor(private graph: ForwardCallGraph) {}
+
+    is_visible_at(): boolean {
+        const the_scope = this.simulate_stack_until_ref();
+        return the_scope !== null && the_scope.has(this.graph.reference_name);
+    }
+
+    blame_target_for(): number | null {
+        // Iterate root-level events in source order until the reference.
+        // For each do/run call before the reference, compute the include-
+        // only end-state of the callee. The last such call whose end-state
+        // binds `reference_name` wins (matches the diagnostic provider's
+        // last-visible-site precedence).
+        const my_root = this.graph.files[0];
+        let blame: number | null = null;
+        for (let i = 0; i < my_root.events.length; i++) {
+            if (i === this.graph.reference_event_index) break;
+            const my_event = my_root.events[i];
+            if (my_event.kind !== 'do_call' && my_event.kind !== 'run_call') {
+                continue;
+            }
+            const end_state = this.compute_include_only_end_state(
+                my_event.target,
+                new Set<number>(),
+            );
+            const my_winner = end_state.get(this.graph.reference_name);
+            if (my_winner !== undefined) {
+                blame = my_winner;
+            }
+        }
+        return blame;
+    }
+
+    get_file_name(file_index: number): string {
+        return this.graph.files[file_index].filename;
+    }
+
+    /**
+     * True when the referenced name is defined anywhere in the root file
+     * — even after the reference line. The LSP preserves the analyzer's
+     * UNDEFINED_MACRO diagnostic for in-root forward references instead
+     * of rewriting to OUT_OF_SCOPE_SYMBOL; see `src/providers/diagnostics.ts`
+     * around line 358 and issue #145.
+     */
+    is_defined_in_root(): boolean {
+        const my_root = this.graph.files[0];
+        for (const my_event of my_root.events) {
+            if (
+                my_event.kind === 'define_local' &&
+                my_event.name === this.graph.reference_name
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Stack-based real-Stata simulation. Returns the current top-of-stack
+     * scope when the reference event is reached in the root file, or
+     * `null` if the reference is never reached.
+     */
+    private simulate_stack_until_ref(): Map<string, number> | null {
+        const scope_stack: Map<string, number>[] = [new Map()];
+        return this.simulate_file(0, scope_stack, new Set([0]));
+    }
+
+    private simulate_file(
+        file_index: number,
+        scope_stack: Map<string, number>[],
+        visited: Set<number>,
+    ): Map<string, number> | null {
+        const my_file = this.graph.files[file_index];
+        for (let i = 0; i < my_file.events.length; i++) {
+            const my_event = my_file.events[i];
+            if (file_index === 0 && i === this.graph.reference_event_index) {
+                return scope_stack[scope_stack.length - 1];
+            }
+            if (my_event.kind === 'define_local') {
+                scope_stack[scope_stack.length - 1].set(my_event.name, file_index);
+            } else if (my_event.kind === 'include_call') {
+                if (visited.has(my_event.target)) continue;
+                const my_visited = new Set(visited);
+                my_visited.add(my_event.target);
+                const result = this.simulate_file(my_event.target, scope_stack, my_visited);
+                if (result !== null) return result;
+            } else if (
+                my_event.kind === 'do_call' ||
+                my_event.kind === 'run_call'
+            ) {
+                if (visited.has(my_event.target)) continue;
+                const my_visited = new Set(visited);
+                my_visited.add(my_event.target);
+                scope_stack.push(new Map());
+                const result = this.simulate_file(my_event.target, scope_stack, my_visited);
+                scope_stack.pop();
+                if (result !== null) return result;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Include-only end-state: walk the callee in source order, overwriting
+     * bindings as `local X` statements fire, and merging include-reachable
+     * end-states from nested `include` calls. `do`/`run` events are
+     * skipped — they would run in a fresh scope and leave nothing behind.
+     *
+     * Cycle protection is per-path (current_path) so mutual includes
+     * terminate.
+     */
+    private compute_include_only_end_state(
+        file_index: number,
+        current_path: Set<number>,
+    ): Map<string, number> {
+        if (current_path.has(file_index)) return new Map();
+        current_path.add(file_index);
+        try {
+            const the_scope = new Map<string, number>();
+            const my_file = this.graph.files[file_index];
+            for (const my_event of my_file.events) {
+                if (my_event.kind === 'define_local') {
+                    the_scope.set(my_event.name, file_index);
+                } else if (my_event.kind === 'include_call') {
+                    const my_nested = this.compute_include_only_end_state(
+                        my_event.target,
+                        current_path,
+                    );
+                    for (const [my_name, my_owner] of my_nested) {
+                        the_scope.set(my_name, my_owner);
+                    }
+                }
+                // do_call / run_call: skipped.
+            }
+            return the_scope;
+        } finally {
+            current_path.delete(file_index);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update the oracle unit tests to the new semantics**
+
+In `tests/unit/stata-execution-oracle-counterfactual.test.ts`:
+
+Rewrite the describe header comment to mention single-boundary semantics. Change two tests; leave Bug A, a813cca, and the null test unchanged.
+
+`Bug B`: the oracle now returns `null` because there is no root-level `do`/`run` before the reference in the root file (root `include child` + reference).
+
+```typescript
+test('Bug B: root include blocker is not a do/run - returns null', () => {
+    // root: include child; ref macro_a
+    // child: do grandchild
+    // grandchild: local macro_a
+    //
+    // Single-boundary semantics: no root-level do/run precedes the
+    // reference, so no one-line fix on a root `do`/`run` exposes the
+    // binding. The diagnostic falls back to generic UNDEFINED_MACRO and
+    // the oracle must return null.
+    const g = graph([
+        { name: 'main.do', events: [
+            { kind: 'include_call', target: 1 },
+            { kind: 'reference_local', name: 'macro_a' },
+        ]},
+        { name: 'child.do', events: [
+            { kind: 'do_call', target: 2 },
+        ]},
+        { name: 'grandchild.do', events: [
+            { kind: 'define_local', name: 'macro_a' },
+        ]},
+    ], 1, 'macro_a');
+    const oracle = new StataExecutionOracle(g);
+    expect(oracle.blame_target_for()).toBeNull();
+});
+```
+
+`Codex audit`: the oracle now returns `2` (defs1), because root `do child` is the single boundary and child's include-only end-state binds `macro_a` from defs1 (the later `include mid` end-state is empty — mid's only event is a `do`, which the walk skips).
+
+```typescript
+test('Codex audit: nested do under include chain names defs1 (single-boundary)', () => {
+    // root: do child; ref macro_a
+    // child: include defs1; include mid
+    // defs1: local macro_a
+    // mid: do grandchild
+    // grandchild: local macro_a
+    //
+    // Promoting only root's `do child` to `include child` makes child run
+    // in main's scope. child's include-only end-state: include defs1
+    // binds macro_a to defs1; include mid contributes nothing (mid's only
+    // event is a do, which is opaque). grandchild's binding is NOT
+    // exposed by this one-line fix.
+    const g = graph([
+        { name: 'main.do', events: [
+            { kind: 'do_call', target: 1 },
+            { kind: 'reference_local', name: 'macro_a' },
+        ]},
+        { name: 'child.do', events: [
+            { kind: 'include_call', target: 2 },
+            { kind: 'include_call', target: 3 },
+        ]},
+        { name: 'defs1.do', events: [
+            { kind: 'define_local', name: 'macro_a' },
+        ]},
+        { name: 'mid.do', events: [
+            { kind: 'do_call', target: 4 },
+        ]},
+        { name: 'grandchild.do', events: [
+            { kind: 'define_local', name: 'macro_a' },
+        ]},
+    ], 1, 'macro_a');
+    const oracle = new StataExecutionOracle(g);
+    expect(oracle.blame_target_for()).toBe(2); // defs1.do
+});
+```
+
+- [ ] **Step 3: Run the oracle unit tests to verify they pass against the new oracle**
+
+Run: `bun test tests/unit/stata-execution-oracle-counterfactual.test.ts`
+Expected: PASS on all 5 tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/property/helpers/stata-execution-oracle.ts tests/unit/stata-execution-oracle-counterfactual.test.ts
+git commit -m "Simplify oracle to single-boundary include-only walk
+
+The OUT_OF_SCOPE_SYMBOL rewrite is about to emit a specific filename
+only when promoting a single blocking do/run to include would actually
+expose the binding. The oracle mirrors that rule: walk each root-level
+do/run's callee under an include-only event order and take the last
+binding that matches. Internal do/run boundaries stay opaque."
+```
+
+---
+
+### Task 2: Update property-test regression fixtures
+
+**Files:**
+- Modify: `tests/property/forward-call-out-of-scope-oracle.prop.test.ts`
+
+This task updates only the `regression: pinned scenarios from code review` block. The three top-level properties (visibility soundness, rewrite attribution, generic-warning completeness) stay as-written — the oracle change alone is enough to keep them meaningful under the new semantics.
+
+- [ ] **Step 1: Bug B — expect generic UNDEFINED, no rewrite**
+
+Replace the existing `Bug B: do nested under include keeps its boundary blame` test with this one. The narrative flips: under the new rules, there is no root-level do/run preceding the reference, so the rewrite is suppressed and the analyzer's generic warning stands.
+
+```typescript
+// Bug B (this branch): nested do under an include chain used to be
+// forcibly blamed. Under single-boundary semantics the rewrite no longer
+// fires here — there is no root-level `do`/`run` whose promotion would
+// expose the deep binding — so the analyzer's generic UNDEFINED_MACRO
+// stands. Kept as a pin so we don't accidentally regress back to the
+// all-promotion rewrite.
+test('Bug B: nested do under include falls back to generic UNDEFINED_MACRO', async () => {
+    fs.writeFileSync(path.join(h.temp_dir, 'grandchild.do'), 'local veggie beet');
+    fs.writeFileSync(path.join(h.temp_dir, 'child.do'), 'do "grandchild.do"');
+    const root_content = ['include "child.do"', 'di `veggie\''].join('\n');
+    const root_path = path.join(h.temp_dir, 'main.do');
+    fs.writeFileSync(root_path, root_content);
+    const root_uri = URI.file(root_path).toString();
+    await h.document_store.open(root_uri, root_content, 1);
+    const doc = h.document_store.get(root_uri)!;
+    const diags = await h.diagnostics_provider.get_diagnostics(
+        doc,
+        MIN_CONFIG,
+        undefined,
+        h.scope_resolver,
+    );
+    const ref_line_diags = diags.filter(d => d.range.start.line === 1);
+    const rewrite = ref_line_diags.find(
+        d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+             d.message.includes('veggie'),
+    );
+    const generic = ref_line_diags.find(
+        d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+             d.message.includes('veggie'),
+    );
+    expect(rewrite).toBeUndefined();
+    expect(generic).toBeDefined();
+});
+```
+
+- [ ] **Step 2: Codex audit — expect defs1.do, not grandchild.do**
+
+Replace the existing `codex audit` test with this. The include-only walk of child stops at the `do grandchild` inside mid, so the named file is defs1.
+
+```typescript
+// Codex audit (2026-04): under single-boundary semantics, promoting
+// root's `do child` to `include child` makes child run in main's scope.
+// child's include-only end-state binds x from defs1 (reached through
+// include); mid's `do grandchild` is opaque and contributes nothing.
+// The diagnostic must name defs1, not grandchild.
+test('codex audit: single-boundary walk names defs1 (nested do stays opaque)', async () => {
+    fs.writeFileSync(path.join(h.temp_dir, 'defs1.do'), 'local x defs1');
+    fs.writeFileSync(path.join(h.temp_dir, 'grandchild.do'), 'local x grand');
+    fs.writeFileSync(path.join(h.temp_dir, 'mid.do'), 'do "grandchild.do"');
+    fs.writeFileSync(
+        path.join(h.temp_dir, 'child.do'),
+        ['include "defs1.do"', 'include "mid.do"'].join('\n'),
+    );
+    const root_content = ['do "child.do"', 'di `x\''].join('\n');
+    const root_path = path.join(h.temp_dir, 'main.do');
+    fs.writeFileSync(root_path, root_content);
+    const root_uri = URI.file(root_path).toString();
+    await h.document_store.open(root_uri, root_content, 1);
+    const doc = h.document_store.get(root_uri)!;
+    const diags = await h.diagnostics_provider.get_diagnostics(
+        doc,
+        MIN_CONFIG,
+        undefined,
+        h.scope_resolver,
+    );
+    const informative = diags.find(
+        d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+             d.message.includes("'x'"),
+    );
+    expect(informative).toBeDefined();
+    expect(informative!.message).toContain('defs1.do');
+    expect(informative!.message).not.toContain('grandchild.do');
+});
+```
+
+- [ ] **Step 3: Delete the codex-gap-5 dedup-revisit fixture**
+
+The `codex gap 5 (dedup revisit): second direct run emits its own blame` test was specifically about the `boundary_only` dedup action, which is being removed. Under the new rules the second `run file_5` is dedup'd away by the plain `skip` path, and the blame comes from the first `run file_2` — a different (and much less focused) scenario. Delete the test entirely rather than repurpose it; its narrative no longer matches the code it was protecting.
+
+- [ ] **Step 4: Leave run-vs-do, cycle, severity fixtures alone**
+
+These still exercise real behavior under the new semantics:
+- run-vs-do: direct do/run callees emit identical blame (still true — include-only walk is symmetric in call type at the top level).
+- cycle: include-only walk terminates on cycles via `current_path`.
+- severity passthrough: diagnostic message construction unchanged.
+
+No edits.
+
+- [ ] **Step 5: Run the regression block to verify all fixtures pass against the NEW oracle but the CURRENT production (they will fail; that's TDD red)**
+
+Run: `bun test tests/property/forward-call-out-of-scope-oracle.prop.test.ts --test-name-pattern="regression"`
+Expected: FAIL on Bug B (current production emits the specific rewrite) and FAIL on codex audit (current production names grandchild.do). Other regression fixtures pass.
+
+Note the failing tests — they are the contracts we will satisfy in Tasks 4-6.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+git commit -m "Pin regression fixtures to single-boundary rewrite semantics
+
+Bug B now falls back to generic UNDEFINED_MACRO (root's include is not a
+blocking do/run, and nested blame claims no longer bubble out).
+
+Codex audit now names defs1.do — promoting root's do child to include
+exposes defs1's local via child's include chain, but the deeper
+do grandchild remains opaque.
+
+The codex-gap-5 dedup-revisit fixture is removed because its narrative
+was specific to the boundary_only action being deleted in the next
+commits."
+```
+
+---
+
+### Task 3: Update effective-end-state unit tests
+
+**Files:**
+- Modify: `tests/unit/forward-scope-resolver-effective-end-state.test.ts`
+
+Only one test's expectation changes; everything else (empty, last-def, include-then-local, local-then-include, cycle, depth boundary) is unchanged under include-only.
+
+- [ ] **Step 1: Flip the `nested do` test**
+
+Replace the `nested \`do\` contributes its locals counterfactually (promote-all model)` test with an assertion that nested `do` targets are NOT walked. Keep the `fruit` expectation (own local in the callee); drop `veggie` (nested do target's local).
+
+```typescript
+test('nested `do` is opaque: walk does not descend into `do`/`run` callees', async () => {
+    // The helper is the engine behind OUT_OF_SCOPE_SYMBOL rewrites. The
+    // rewrite is a single-boundary counterfactual: "promote THIS one
+    // do/run to include — where would the local now come from?" Deeper
+    // do/run boundaries stay opaque because promoting them would be a
+    // separate fix. So this walk does not descend into `do`/`run`
+    // callees, even when they define the referenced name.
+    const nested_path = path.join(temp_dir, 'nested_do_target.do');
+    fs.writeFileSync(nested_path, 'local veggie beet');
+    const my_path = path.join(temp_dir, 'nested_do.do');
+    fs.writeFileSync(my_path, ['do "nested_do_target.do"', 'local fruit apple'].join('\n'));
+    const result = await walk(my_path);
+    expect(result.has('fruit')).toBe(true);
+    expect(result.has('veggie')).toBe(false);
+    expect(result.get('fruit')!.sourceUri).toContain('nested_do.do');
+});
+```
+
+- [ ] **Step 2: Rewrite the file header docstring**
+
+The top-of-file comment mentions "counterfactual" framing. Update to match the new include-only model:
+
+```typescript
+/**
+ * Unit tests for `ForwardScopeResolver.compute_effective_end_state_locals`.
+ *
+ * The helper computes a callee's include-only end-state: walk its own
+ * `local X` statements in source order, merging the end-states of any
+ * nested `include` callees. `do`/`run` callees are NOT descended — they
+ * would require a separate boundary promotion to expose their bindings.
+ * The helper drives the OUT_OF_SCOPE_SYMBOL rewrite message, so covering
+ * it at unit level catches shadowing/redefinition and cycle-handling
+ * regressions closer to the code under change.
+ */
+```
+
+- [ ] **Step 3: Update the "nested do redef" test narrative**
+
+The test "nested `do` that redefines an earlier include local: include wins when it comes after" still passes algorithmically (the own local comes after the `do`, so it wins either way), but its narrative implies we descend into the `do`. Simplify:
+
+```typescript
+test('own local after opaque `do` wins (nested do target is not walked)', async () => {
+    const nested_path = path.join(temp_dir, 'nested_do_redef.do');
+    fs.writeFileSync(nested_path, 'local shared beet');
+    const my_path = path.join(temp_dir, 'nested_do_overridden.do');
+    fs.writeFileSync(
+        my_path,
+        ['do "nested_do_redef.do"', 'local shared carrot'].join('\n'),
+    );
+    const result = await walk(my_path);
+    expect(result.size).toBe(1);
+    // `do` is opaque, so only the caller's own `local shared carrot`
+    // contributes — no need to reason about which comes first.
+    expect(result.get('shared')!.sourceUri).toContain('nested_do_overridden.do');
+});
+```
+
+- [ ] **Step 4: Run the unit tests (still against CURRENT production — should FAIL on `nested do is opaque`)**
+
+Run: `bun test tests/unit/forward-scope-resolver-effective-end-state.test.ts`
+Expected: FAIL on `nested do is opaque` (current production descends into the nested do and binds `veggie`). Other tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/forward-scope-resolver-effective-end-state.test.ts
+git commit -m "Flip nested-do unit test to opaque-boundary expectation"
+```
+
+---
+
+### Task 4: Production — restrict helper to include-only descent
+
+**Files:**
+- Modify: `src/forward-scope-resolver/index.ts:630-648` (inside `compute_effective_end_state_locals`)
+
+- [ ] **Step 1: Skip `do`/`run` events in the walk**
+
+Find the `for (const my_call of callee_result.forward_calls)` loop inside `compute_effective_end_state_locals`. Add a type filter that keeps only `include`:
+
+```typescript
+for (const my_call of callee_result.forward_calls) {
+    if (!my_call.is_static || !my_call.path) continue;
+    // Include-only descent. `do`/`run` callees run in a fresh scope
+    // and leave no bindings behind for the caller's end-of-execution
+    // state — promoting them to `include` is a separate fix from the
+    // one this helper's blame rewrite suggests.
+    if (my_call.type !== 'include') continue;
+    the_events.push({
+        line: my_call.call_site_line,
+        character: my_call.range.start.character,
+        kind: 'call',
+        call: my_call,
+    });
+}
+```
+
+- [ ] **Step 2: Update the helper's docstring**
+
+Rewrite the docstring above `compute_effective_end_state_locals` to reflect the include-only semantic. Replace the existing multi-paragraph comment with:
+
+```typescript
+/**
+ * Walk a callee's top-level local definitions and nested `include` calls
+ * in source order to compute the effective end-of-file local-macro state
+ * assuming the caller's `do`/`run` of this callee were promoted to
+ * `include`. `do`/`run` calls FROM this callee are NOT descended — they
+ * are still blocking boundaries after the single-boundary promotion, so
+ * their bindings are not exposed by this one-line fix.
+ *
+ * - Own `local X` statements overwrite prior bindings.
+ * - `include` events merge the nested callee's effective end state
+ *   (recursively computed) into the walk.
+ * - `do`/`run` events contribute nothing.
+ *
+ * Used to populate `ForwardCallSite.excluded_locals` for `do`-called
+ * sites so OUT_OF_SCOPE_SYMBOL diagnostics point at the callee whose
+ * local actually wins under a single-boundary promotion.
+ */
+```
+
+- [ ] **Step 3: Run the effective-end-state unit tests — they should now pass**
+
+Run: `bun test tests/unit/forward-scope-resolver-effective-end-state.test.ts`
+Expected: PASS on all tests including `nested do is opaque`.
+
+- [ ] **Step 4: Run the oracle counterfactual unit tests (should also pass — they only depend on the oracle)**
+
+Run: `bun test tests/unit/stata-execution-oracle-counterfactual.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/forward-scope-resolver/index.ts
+git commit -m "Restrict end-state walk to include-only descent
+
+do/run callees were previously walked under a counterfactual-all-
+include model, which produced blame that pointed at files the suggested
+one-line fix (promote the outer do to include) would not actually
+expose. The helper now matches its docstring: promote only this one
+boundary, ask include-only what's bound."
+```
+
+---
+
+### Task 5: Production — unconditional strip of nested excluded_locals
+
+**Files:**
+- Modify: `src/forward-scope-resolver/index.ts:390-409` (nested-site flattening inside `resolve()`)
+
+- [ ] **Step 1: Strip nested excluded_locals unconditionally**
+
+Find the comment block `// Add nested call sites with adjusted call lines...` and the subsequent `for (const nested_site of nested_result.call_sites)` loop. Replace it with:
+
+```typescript
+// Add nested call sites with adjusted call lines. Nested sites inherit
+// the parent call_line for visibility filtering, but their
+// `excluded_locals` are ALWAYS stripped: each nested site's blame
+// target represents a different one-line fix (promoting that deeper
+// do/run to include) than the one the outer reference's diagnostic is
+// about to suggest. Only the direct-child site's excluded_locals claim
+// applies to the user's visible "do X" they could edit.
+for (const nested_site of nested_result.call_sites) {
+    the_call_sites.push({
+        ...nested_site,
+        call_line: my_call.call_site_line,
+        excluded_locals: undefined,
+    });
+}
+```
+
+- [ ] **Step 2: Run the regression fixtures — Bug B and codex audit should now pass**
+
+Run: `bun test tests/property/forward-call-out-of-scope-oracle.prop.test.ts --test-name-pattern="regression"`
+Expected: PASS on Bug B (generic fallback) and codex audit (defs1.do).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/forward-scope-resolver/index.ts
+git commit -m "Strip nested excluded_locals when flattening call sites
+
+Each nested do/run site represents a distinct one-line fix. Bubbling
+its excluded_locals claim up to the outer iteration lets a deeper
+boundary's blame pick a file the outer diagnostic's suggested include
+promotion would not actually expose."
+```
+
+---
+
+### Task 6: Production — remove `boundary_only` variant
+
+**Files:**
+- Modify: `src/types/index.ts:856-866` (`DuplicateCallDecision`)
+- Modify: `src/forward-scope-resolver/index.ts:229-267` (the `boundary_only` branch in `resolve()`) and `src/forward-scope-resolver/index.ts:468-494` (`should_process_call`)
+
+- [ ] **Step 1: Remove the `boundary_only` variant from the type**
+
+Replace the `DuplicateCallDecision` definition with the pre-branch shape:
+
+```typescript
+export type DuplicateCallDecision =
+  | { action: 'skip' }
+  | { action: 'process' }
+  | { action: 'add_locals_only' };
+```
+
+- [ ] **Step 2: Revert `should_process_call` to return `skip` on a duplicate do-after-do**
+
+Replace the trailing comment + `return { action: 'boundary_only' };` in `should_process_call` with the pre-branch skip:
+
+```typescript
+should_process_call(
+    callee_uri: string,
+    call_type: ForwardCallType,
+    visited: Map<string, EffectiveCallType>
+): DuplicateCallDecision {
+    const previous_type = visited.get(callee_uri);
+
+    if (previous_type === undefined) {
+        return { action: 'process' };
+    }
+
+    if (previous_type === 'include') {
+        return { action: 'skip' };
+    }
+
+    // previous_type === 'do': symbol accumulation is unchanged on a
+    // re-visit, and the first direct-child site already carries the
+    // include-only end-state claim for the blame rewrite. A second
+    // do/run re-entry of the same callee produces the same include-only
+    // end-state, so there is nothing new to contribute.
+    if (call_type === 'include') {
+        return { action: 'add_locals_only' };
+    }
+
+    return { action: 'skip' };
+}
+```
+
+- [ ] **Step 3: Remove the `boundary_only` branch from `resolve()`**
+
+Delete the entire block starting with `if (decision.action === 'boundary_only') {` through its matching `continue;`. After `decision.action === 'skip'` handling, the next remaining branch is `const callee_result = await this.get_callee_scope(...)`.
+
+- [ ] **Step 4: Run typecheck and the full test suite**
+
+Run: `bun run typecheck`
+Expected: PASS (no remaining references to `boundary_only`).
+
+Run: `bun test tests/unit/ tests/property/forward-call-out-of-scope-oracle.prop.test.ts tests/property/forward-scope-resolution.prop.test.ts tests/integration/current-file-forward-call-diagnostics.test.ts`
+Expected: PASS across the board.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/index.ts src/forward-scope-resolver/index.ts
+git commit -m "Remove boundary_only DuplicateCallDecision variant
+
+Under single-boundary semantics a do/run re-visit produces the same
+include-only end-state the first visit already claimed, so there is no
+new blame to surface. Returning to 'skip' restores the simpler pre-
+branch dedup contract."
+```
+
+---
+
+### Task 7: Refresh documentation comments
+
+**Files:**
+- Modify: `src/types/index.ts:823-837` (`ForwardCallSite.excluded_locals` docstring)
+
+- [ ] **Step 1: Rewrite the `excluded_locals` docstring**
+
+The current comment mentions "double-claim" filtering between direct-child and nested sites — no longer relevant, because nested sites are unconditionally stripped. Replace with:
+
+```typescript
+// Effective end-of-execution top-level local macros of the callee,
+// computed as the include-only end state of the callee's sub-chain.
+// Populated ONLY on direct-child `do`/`run` sites (calls made from the
+// file being resolved whose original type is `do`/`run`). A blame entry
+// represents "if this one call were promoted to `include`, the
+// referenced local would be bound here" — so the diagnostic can point
+// at the file whose `local` statement actually wins under that one-line
+// fix. Nested sites flattened from a deeper `resolve()` always arrive
+// with `excluded_locals: undefined`; their blame would correspond to a
+// different boundary promotion than the one the outer diagnostic's
+// message suggests.
+excluded_locals?: Map<string, MacroSymbol>;
+```
+
+- [ ] **Step 2: Verify typecheck still passes**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/index.ts
+git commit -m "Refresh ForwardCallSite.excluded_locals docstring"
+```
+
+---
+
+### Task 8: Full test suite + cleanup verification
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run the whole test suite**
+
+Run: `bun run test`
+Expected: PASS — no failures.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Grep for any remaining `boundary_only` or `counterfactual-all` references**
+
+Run: grep across `src/` and `tests/` for `boundary_only` and `counterfactual-all` and `promote every` (multiple matches expected to be zero except in commit-log-style messages or the oracle's new docstrings).
+
+Expected: no production references to `boundary_only`; oracle docstring may still mention "counterfactual" for the `is_visible_at` vs `blame_target_for` contrast.
+
+- [ ] **Step 4: Final review commit (if anything stray was found)**
+
+If the grep uncovered leftover commentary or references, clean them up in a final commit. Otherwise this step is a no-op.
+
+---
+
+## Self-Review checklist
+
+**Spec coverage:**
+- User's stated goal — generic fallback for complex cases, specific rewrite for the one-level-fix case — is Task 4 (include-only descent) + Task 5 (strip nested). ✓
+- Codex audit finding (diagnostic names a file the suggested fix wouldn't expose) — addressed by Task 4 (the walk no longer descends `do`). ✓
+- `boundary_only` + nested-strip conditional no longer needed — Tasks 5 and 6. ✓
+- Oracle independence — new oracle models single-fix semantics without referring to resolver internals (Task 1). ✓
+
+**Placeholder scan:** None detected. Every step includes the actual code or exact command.
+
+**Type consistency:** `DuplicateCallDecision` variants used in `should_process_call` (`skip`/`process`/`add_locals_only`) match the updated type (Task 6). `compute_include_only_end_state` (new oracle method) matches its call sites. `excluded_locals: undefined` assignment matches the optional type.
+
+**Behavior regressions acknowledged:** Bug B no longer emits a specific rewrite (intentional — user accepted generic fallback). The `codex-gap-5 dedup-revisit` fixture is deleted (its narrative was specific to `boundary_only`).

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -388,23 +388,18 @@ export class ForwardScopeResolver {
                     return { symbols: accumulated_symbols, call_sites: the_call_sites, diagnostics: my_context.diagnostics };
                 }
 
-                // Add nested call sites with adjusted call lines. When the
-                // direct-child site already carries `excluded_locals`, its
-                // counterfactual walk descended through every call in the
-                // sub-chain (see compute_effective_end_state_locals) and
-                // its map already holds the last-def-wins answer for every
-                // name defined below it. The deeper nested sites' claims
-                // are strict subsets of that walk and would incorrectly
-                // override it under last-in-iteration-wins, so we strip
-                // them. When the direct-child is `include` (no excluded
-                // locals of its own — the outer call is not a blocking
-                // boundary), deeper nested `do`/`run` sites are the only
-                // carriers of their boundary's blame and must be kept.
+                // Add nested call sites with adjusted call lines. Nested sites inherit
+                // the parent call_line for visibility filtering, but their
+                // `excluded_locals` are ALWAYS stripped: each nested site's blame
+                // target represents a different one-line fix (promoting that deeper
+                // do/run to include) than the one the outer reference's diagnostic is
+                // about to suggest. Only the direct-child site's excluded_locals claim
+                // applies to the user's visible "do X" they could edit.
                 for (const nested_site of nested_result.call_sites) {
                     the_call_sites.push({
                         ...nested_site,
-                        call_line: my_call.call_site_line, // Visibility starts at parent call
-                        excluded_locals: excluded_locals ? undefined : nested_site.excluded_locals,
+                        call_line: my_call.call_site_line,
+                        excluded_locals: undefined,
                     });
                 }
 

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -277,17 +277,29 @@ export class ForwardScopeResolver {
             }
 
             // Record call site. For 'do'/'run' we preserve the callee's
-            // *top-level* local macros separately so diagnostics can explain
-            // why a local that "looks" inherited isn't actually visible.
-            // Program-scoped locals (`containingScope === 'program'`) aren't
-            // caller-visible even under `include`, so including them here
-            // would emit a misleading "use include" suggestion.
+            // *effective* top-level local macros at end-of-execution so
+            // diagnostics can explain why a local that "looks" inherited
+            // isn't actually visible. "Effective end state" means we walk
+            // the callee in execution order, layering in locals from any
+            // nested `include`s the callee makes, so that the callee whose
+            // local would actually shadow earlier ones (last-definition-
+            // wins) is blamed — not whichever happens to come last in the
+            // flattened forward_call_symbols array. Program-scoped locals
+            // (`containingScope === 'program'`) aren't caller-visible even
+            // under `include`, so they're excluded from the walk.
             let excluded_locals: Map<string, MacroSymbol> | undefined;
             if (my_effective_type === 'do') {
-                for (const [my_name, my_symbol] of callee_result.symbols.localMacros) {
-                    if (my_symbol.containingScope !== 'dofile') continue;
-                    if (!excluded_locals) excluded_locals = new Map();
-                    excluded_locals.set(my_name, my_symbol);
+                const effective_end_state = await this.compute_effective_end_state_locals(
+                    callee_uri,
+                    resolved_path,
+                    callee_result.working_directory ?? my_context.working_directory,
+                    new Set(my_stack),
+                    my_context.depth + 1,
+                    resolved_config,
+                    token,
+                );
+                if (effective_end_state.size > 0) {
+                    excluded_locals = effective_end_state;
                 }
             }
             the_call_sites.push({
@@ -326,11 +338,18 @@ export class ForwardScopeResolver {
                     return { symbols: accumulated_symbols, call_sites: the_call_sites, diagnostics: my_context.diagnostics };
                 }
 
-                // Add nested call sites with adjusted call lines
+                // Add nested call sites with adjusted call lines. Clear
+                // `excluded_locals` on nested sites: the direct-child site
+                // above already carries the chain's effective end state,
+                // and leaving per-file excluded_locals here would cause
+                // diagnostics to blame whichever deeper site happens to
+                // come last in array order rather than the callee whose
+                // local actually shadows earlier ones.
                 for (const nested_site of nested_result.call_sites) {
                     the_call_sites.push({
                         ...nested_site,
                         call_line: my_call.call_site_line, // Visibility starts at parent call
+                        excluded_locals: undefined,
                     });
                 }
 
@@ -460,6 +479,96 @@ export class ForwardScopeResolver {
         }
 
         return result;
+    }
+
+    /**
+     * Walk a callee's top-level local definitions and nested `include` calls
+     * in source order to compute the effective end-of-file local-macro state
+     * — i.e., which callee's local would actually shadow the earlier ones.
+     *
+     * - Own `local X` statements overwrite prior bindings.
+     * - An `include` event merges the nested callee's effective end state
+     *   (recursively computed) into the walk.
+     * - `do`/`run` events contribute nothing: those callees run in a fresh
+     *   scope whose locals don't propagate into the caller.
+     *
+     * Used to populate `ForwardCallSite.excluded_locals` for `do`-called
+     * sites so OUT_OF_SCOPE_SYMBOL diagnostics point at the callee whose
+     * local actually wins, not whichever site happens to be last in the
+     * flattened call_sites array.
+     */
+    private async compute_effective_end_state_locals(
+        callee_uri: string,
+        callee_fs_path: string,
+        working_directory: string | undefined,
+        stack: Set<string>,
+        depth: number,
+        resolved_config: ForwardScopeConfig,
+        token?: CancellationToken,
+    ): Promise<Map<string, MacroSymbol>> {
+        if (token?.isCancellationRequested) return new Map();
+        if (stack.has(callee_uri)) return new Map();
+        if (depth >= resolved_config.max_forward_depth) return new Map();
+
+        const callee_result = await this.get_callee_scope(
+            callee_fs_path,
+            callee_uri,
+            working_directory,
+        );
+        if ('error' in callee_result) return new Map();
+
+        stack.add(callee_uri);
+        try {
+            type WalkEvent =
+                | { line: number; kind: 'local'; name: string; symbol: MacroSymbol }
+                | { line: number; kind: 'call'; call: ForwardCall };
+
+            const the_events: WalkEvent[] = [];
+            for (const [my_name, my_symbol] of callee_result.symbols.localMacros) {
+                if (my_symbol.containingScope !== 'dofile') continue;
+                const my_line = my_symbol.definition_line
+                    ?? my_symbol.location.range.start.line;
+                the_events.push({ line: my_line, kind: 'local', name: my_name, symbol: my_symbol });
+            }
+            for (const my_call of callee_result.forward_calls) {
+                if (!my_call.is_static || !my_call.path) continue;
+                if (my_call.type !== 'include') continue;
+                the_events.push({ line: my_call.call_site_line, kind: 'call', call: my_call });
+            }
+            the_events.sort((a, b) => a.line - b.line);
+
+            const the_effective = new Map<string, MacroSymbol>();
+            const nested_working_dir = callee_result.working_directory ?? working_directory;
+            for (const my_event of the_events) {
+                if (token?.isCancellationRequested) break;
+                if (my_event.kind === 'local') {
+                    the_effective.set(my_event.name, my_event.symbol);
+                } else {
+                    const nested_resolved = this.resolve_call_path(
+                        my_event.call.raw_path,
+                        my_event.call.path,
+                        callee_uri,
+                        nested_working_dir,
+                    );
+                    const nested_uri = URI.file(nested_resolved).toString();
+                    const nested_effective = await this.compute_effective_end_state_locals(
+                        nested_uri,
+                        nested_resolved,
+                        nested_working_dir,
+                        stack,
+                        depth + 1,
+                        resolved_config,
+                        token,
+                    );
+                    for (const [my_name, my_symbol] of nested_effective) {
+                        the_effective.set(my_name, my_symbol);
+                    }
+                }
+            }
+            return the_effective;
+        } finally {
+            stack.delete(callee_uri);
+        }
     }
 
     /**

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -275,13 +275,20 @@ export class ForwardScopeResolver {
                 );
             }
 
-            // Record call site. For 'do'/'run' we preserve the callee's local
-            // macros separately so diagnostics can explain why a local that
-            // "looks" inherited isn't actually visible.
-            const excluded_locals = my_effective_type === 'do' &&
-                callee_result.symbols.localMacros.size > 0
-                ? new Map(callee_result.symbols.localMacros)
-                : undefined;
+            // Record call site. For 'do'/'run' we preserve the callee's
+            // *top-level* local macros separately so diagnostics can explain
+            // why a local that "looks" inherited isn't actually visible.
+            // Program-scoped locals (`containingScope === 'program'`) aren't
+            // caller-visible even under `include`, so including them here
+            // would emit a misleading "use include" suggestion.
+            let excluded_locals: Map<string, import('../types').MacroSymbol> | undefined;
+            if (my_effective_type === 'do') {
+                for (const [my_name, my_symbol] of callee_result.symbols.localMacros) {
+                    if (my_symbol.containingScope !== 'dofile') continue;
+                    if (!excluded_locals) excluded_locals = new Map();
+                    excluded_locals.set(my_name, my_symbol);
+                }
+            }
             the_call_sites.push({
                 callee_uri,
                 call_line: my_call.call_site_line,

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -338,18 +338,34 @@ export class ForwardScopeResolver {
                     return { symbols: accumulated_symbols, call_sites: the_call_sites, diagnostics: my_context.diagnostics };
                 }
 
-                // Add nested call sites with adjusted call lines. Clear
-                // `excluded_locals` on nested sites: the direct-child site
-                // above already carries the chain's effective end state,
-                // and leaving per-file excluded_locals here would cause
-                // diagnostics to blame whichever deeper site happens to
-                // come last in array order rather than the callee whose
-                // local actually shadows earlier ones.
+                // Add nested call sites with adjusted call lines. Filter
+                // `excluded_locals` on each nested site rather than stripping
+                // it: if the direct-child site already carries its own
+                // entry for a name (its effective end-state walk claims
+                // it), the nested site must drop that name to avoid
+                // double-blaming. But if the direct-child is `include`
+                // (no excluded_locals) — or simply doesn't claim the
+                // name — the nested site's entry is the only carrier for
+                // the deeper `do` boundary and must be kept.
                 for (const nested_site of nested_result.call_sites) {
+                    let filtered_excluded: Map<string, MacroSymbol> | undefined;
+                    if (nested_site.excluded_locals) {
+                        if (excluded_locals) {
+                            const the_filtered = new Map<string, MacroSymbol>();
+                            for (const [my_name, my_symbol] of nested_site.excluded_locals) {
+                                if (!excluded_locals.has(my_name)) {
+                                    the_filtered.set(my_name, my_symbol);
+                                }
+                            }
+                            filtered_excluded = the_filtered.size > 0 ? the_filtered : undefined;
+                        } else {
+                            filtered_excluded = nested_site.excluded_locals;
+                        }
+                    }
                     the_call_sites.push({
                         ...nested_site,
                         call_line: my_call.call_site_line, // Visibility starts at parent call
-                        excluded_locals: undefined,
+                        excluded_locals: filtered_excluded,
                     });
                 }
 
@@ -526,9 +542,29 @@ export class ForwardScopeResolver {
             const the_events: WalkEvent[] = [];
             for (const [my_name, my_symbol] of callee_result.symbols.localMacros) {
                 if (my_symbol.containingScope !== 'dofile') continue;
-                const my_line = my_symbol.definition_line
+                // Emit one event per definition: the primary plus each entry
+                // in `additional_definitions`. `SemanticAnalyzer` implements
+                // first-def-wins, so every later `local X` in the same file
+                // is stashed under the primary's `additional_definitions`.
+                // Without this, a `local X` that follows an `include` (which
+                // itself bound X to something else) would be invisible to the
+                // effective-end-state walk and the wrong callee would be
+                // blamed. `sourceUri` matches across every definition of the
+                // same local in the same file, so attributing the symbol
+                // payload back to the primary remains correct.
+                const primary_line = my_symbol.definition_line
                     ?? my_symbol.location.range.start.line;
-                the_events.push({ line: my_line, kind: 'local', name: my_name, symbol: my_symbol });
+                the_events.push({ line: primary_line, kind: 'local', name: my_name, symbol: my_symbol });
+                if (my_symbol.additional_definitions) {
+                    for (const my_extra of my_symbol.additional_definitions) {
+                        the_events.push({
+                            line: my_extra.line,
+                            kind: 'local',
+                            name: my_name,
+                            symbol: my_symbol,
+                        });
+                    }
+                }
             }
             for (const my_call of callee_result.forward_calls) {
                 if (!my_call.is_static || !my_call.path) continue;

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -321,32 +321,18 @@ export class ForwardScopeResolver {
                 );
             }
 
-            // Record call site. For 'do'/'run' we preserve the callee's
-            // *effective* top-level local macros at end-of-execution so
-            // diagnostics can explain why a local that "looks" inherited
-            // isn't actually visible. "Effective end state" means we walk
-            // the callee in execution order, layering in locals from any
-            // nested `include`s the callee makes, so that the callee whose
-            // local would actually shadow earlier ones (last-definition-
-            // wins) is blamed — not whichever happens to come last in the
-            // flattened forward_call_symbols array. Program-scoped locals
-            // (`containingScope === 'program'`) aren't caller-visible even
-            // under `include`, so they're excluded from the walk.
+            // Direct-child do/run sites at the outermost resolve() get
+            // their include-only end-state computed so the blame rewrite
+            // can name a file. Nested sites flow through the flattening
+            // loop below, which strips excluded_locals unconditionally —
+            // computing them at nested depths would be dead work.
             //
-            // Gate on `my_call.type` rather than `my_effective_type`: only a
-            // call whose ORIGINAL type is `do`/`run` is a blocking boundary
-            // that could be counterfactually promoted to `include`. A
-            // nested `include` whose effective type was demoted to `do` by
-            // an outer `do` isn't itself blocking — the outer `do` is, and
-            // its end-state walk already captures this included file's
-            // locals. Emitting excluded_locals for the nested include would
-            // double-claim every name and let an inner file's claim
-            // incorrectly overwrite the outer file's execution-order winner.
+            // `my_effective_type === 'do'` is guaranteed when
+            // `my_call.type !== 'include'` at depth 0 (outer
+            // effective_call_type is 'include' and compute_effective_call_type
+            // returns 'do' for non-include calls), so the condition is
+            // redundant but kept for defensive clarity.
             let excluded_locals: Map<string, MacroSymbol> | undefined;
-            // Only compute at the outermost resolve() level. Nested-level
-            // sites flow through the bubbling loop below, which
-            // unconditionally strips excluded_locals — computing them here
-            // would be dead work (T5 rationale).
             if (my_call.type !== 'include' && my_effective_type === 'do' && my_context.depth === 0) {
                 const effective_end_state = await this.compute_effective_end_state_locals(
                     callee_uri,

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -228,12 +228,17 @@ export class ForwardScopeResolver {
 
             if (decision.action === 'boundary_only') {
                 // Dedup'd do/run re-visit: don't re-merge symbols or recurse,
-                // but still push a barrier-only site with excluded_locals.
-                // Without this, a second direct `do`/`run` invocation of a
-                // previously-visited callee would leave no blame carrier at
-                // the outer iteration level, and the rewrite would name the
-                // first visit's sub-chain even when counterfactually
-                // promoting this later boundary would win under last-def.
+                // but still push a barrier-only site with excluded_locals so
+                // the diagnostic rewrite can blame the second boundary's
+                // callee under last-visible-site precedence.
+                //
+                // Only meaningful at the outermost resolve() level — at
+                // depth > 0 this site would be bubbled up and have its
+                // excluded_locals stripped by T5's flattening loop, so the
+                // push is dead work.
+                if (my_context.depth > 0) {
+                    continue;
+                }
                 if (token?.isCancellationRequested) {
                     my_stack.delete(file_uri);
                     return { symbols: accumulated_symbols, call_sites: the_call_sites, diagnostics: my_context.diagnostics };
@@ -241,21 +246,21 @@ export class ForwardScopeResolver {
                 if ('error' in callee_result) {
                     continue;
                 }
-                let boundary_excluded: Map<string, MacroSymbol> | undefined;
-                if (my_effective_type === 'do') {
-                    const effective_end_state = await this.compute_effective_end_state_locals(
-                        callee_uri,
-                        resolved_path,
-                        callee_result.working_directory ?? my_context.working_directory,
-                        new Set(my_stack),
-                        my_context.depth + 1,
-                        resolved_config,
-                        token,
-                    );
-                    if (effective_end_state.size > 0) {
-                        boundary_excluded = effective_end_state;
-                    }
-                }
+                // effective_type === 'do' always holds here (this branch
+                // fires only when the previous visit was 'do' and the
+                // current call is do/run). Compute the include-only
+                // end-state so the rewrite can name the second visit's
+                // blame file.
+                const effective_end_state = await this.compute_effective_end_state_locals(
+                    callee_uri,
+                    resolved_path,
+                    callee_result.working_directory ?? my_context.working_directory,
+                    new Set(my_stack),
+                    my_context.depth + 1,
+                    resolved_config,
+                    token,
+                );
+                const boundary_excluded = effective_end_state.size > 0 ? effective_end_state : undefined;
                 the_call_sites.push({
                     callee_uri,
                     call_line: my_call.call_site_line,
@@ -338,7 +343,11 @@ export class ForwardScopeResolver {
             // double-claim every name and let an inner file's claim
             // incorrectly overwrite the outer file's execution-order winner.
             let excluded_locals: Map<string, MacroSymbol> | undefined;
-            if (my_call.type !== 'include' && my_effective_type === 'do') {
+            // Only compute at the outermost resolve() level. Nested-level
+            // sites flow through the bubbling loop below, which
+            // unconditionally strips excluded_locals — computing them here
+            // would be dead work (T5 rationale).
+            if (my_call.type !== 'include' && my_effective_type === 'do' && my_context.depth === 0) {
                 const effective_end_state = await this.compute_effective_end_state_locals(
                     callee_uri,
                     resolved_path,

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -18,6 +18,7 @@ import {
     ForwardResolvedScope,
     DuplicateCallDecision,
     DirectiveDiagnostic,
+    MacroSymbol,
 } from '../types';
 import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 import { ScopeResolver } from '../scope-resolver';
@@ -281,7 +282,7 @@ export class ForwardScopeResolver {
             // Program-scoped locals (`containingScope === 'program'`) aren't
             // caller-visible even under `include`, so including them here
             // would emit a misleading "use include" suggestion.
-            let excluded_locals: Map<string, import('../types').MacroSymbol> | undefined;
+            let excluded_locals: Map<string, MacroSymbol> | undefined;
             if (my_effective_type === 'do') {
                 for (const [my_name, my_symbol] of callee_result.symbols.localMacros) {
                     if (my_symbol.containingScope !== 'dofile') continue;

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -544,18 +544,19 @@ export class ForwardScopeResolver {
     /**
      * Walk a callee's top-level local definitions and nested `include` calls
      * in source order to compute the effective end-of-file local-macro state
-     * — i.e., which callee's local would actually shadow the earlier ones.
+     * assuming the caller's `do`/`run` of this callee were promoted to
+     * `include`. `do`/`run` calls FROM this callee are NOT descended — they
+     * are still blocking boundaries after the single-boundary promotion, so
+     * their bindings are not exposed by this one-line fix.
      *
      * - Own `local X` statements overwrite prior bindings.
-     * - An `include` event merges the nested callee's effective end state
+     * - `include` events merge the nested callee's effective end state
      *   (recursively computed) into the walk.
-     * - `do`/`run` events contribute nothing: those callees run in a fresh
-     *   scope whose locals don't propagate into the caller.
+     * - `do`/`run` events contribute nothing.
      *
      * Used to populate `ForwardCallSite.excluded_locals` for `do`-called
      * sites so OUT_OF_SCOPE_SYMBOL diagnostics point at the callee whose
-     * local actually wins, not whichever site happens to be last in the
-     * flattened call_sites array.
+     * local actually wins under a single-boundary promotion.
      */
     private async compute_effective_end_state_locals(
         callee_uri: string,
@@ -629,16 +630,11 @@ export class ForwardScopeResolver {
             }
             for (const my_call of callee_result.forward_calls) {
                 if (!my_call.is_static || !my_call.path) continue;
-                // Descend into every call type — `include`, `do`, and `run`.
-                // The diagnostic rewrite is a counterfactual: "if the do/run
-                // that blocks this reference were promoted to include (and
-                // any do/run boundaries further inside along the same
-                // chain were promoted as well), where would the referenced
-                // local last be bound?" Treating do/run as include during
-                // the walk answers exactly that question, and lets the
-                // blame name the inner file that has the last `local X`
-                // in execution order — not whichever file happens to be
-                // at the top of the blocked sub-chain.
+                // Include-only descent. `do`/`run` callees run in a fresh scope
+                // and leave no bindings behind for the caller's end-of-execution
+                // state — promoting them to `include` is a separate fix from the
+                // one this helper's blame rewrite suggests.
+                if (my_call.type !== 'include') continue;
                 the_events.push({
                     line: my_call.call_site_line,
                     character: my_call.range.start.character,

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -223,22 +223,23 @@ export class ForwardScopeResolver {
                 continue;
             }
 
+            // Short-circuit a nested boundary_only re-visit before the
+            // disk-backed callee scope fetch. The site would be bubbled
+            // up and have its excluded_locals stripped by the flattening
+            // loop anyway, so skipping avoids an unnecessary parse.
+            if (decision.action === 'boundary_only' && my_context.depth > 0) {
+                continue;
+            }
+
             // Get callee symbols
             const callee_result = await this.get_callee_scope(resolved_path, callee_uri, my_context.working_directory);
 
             if (decision.action === 'boundary_only') {
-                // Dedup'd do/run re-visit: don't re-merge symbols or recurse,
-                // but still push a barrier-only site with excluded_locals so
-                // the diagnostic rewrite can blame the second boundary's
+                // Dedup'd do/run re-visit at the outermost resolve()
+                // level: don't re-merge symbols or recurse, but push a
+                // barrier-only site with excluded_locals so the
+                // diagnostic rewrite can blame the second boundary's
                 // callee under last-visible-site precedence.
-                //
-                // Only meaningful at the outermost resolve() level — at
-                // depth > 0 this site would be bubbled up and have its
-                // excluded_locals stripped by T5's flattening loop, so the
-                // push is dead work.
-                if (my_context.depth > 0) {
-                    continue;
-                }
                 if (token?.isCancellationRequested) {
                     my_stack.delete(file_uri);
                     return { symbols: accumulated_symbols, call_sites: the_call_sites, diagnostics: my_context.diagnostics };
@@ -596,8 +597,11 @@ export class ForwardScopeResolver {
                 // sorting on line alone would collapse their execution
                 // order. Full (line, character) ordering is robust to
                 // that shape as well as today's `#delimit cr` input.
-                const primary_line = my_symbol.definition_line
-                    ?? my_symbol.location.range.start.line;
+                // Both coordinates come from the same source
+                // (location.range.start) so the sort key is internally
+                // consistent — analyzer emits definition_line equal to
+                // location.range.start.line for primary definitions.
+                const primary_line = my_symbol.location.range.start.line;
                 const primary_char = my_symbol.location.range.start.character;
                 the_events.push({
                     line: primary_line,

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -275,12 +275,19 @@ export class ForwardScopeResolver {
                 );
             }
 
-            // Record call site
+            // Record call site. For 'do'/'run' we preserve the callee's local
+            // macros separately so diagnostics can explain why a local that
+            // "looks" inherited isn't actually visible.
+            const excluded_locals = my_effective_type === 'do' &&
+                callee_result.symbols.localMacros.size > 0
+                ? new Map(callee_result.symbols.localMacros)
+                : undefined;
             the_call_sites.push({
                 callee_uri,
                 call_line: my_call.call_site_line,
                 symbols: inherited_symbols,
                 effective_type: my_effective_type,
+                excluded_locals,
             });
 
             // Accumulate symbols

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -225,6 +225,46 @@ export class ForwardScopeResolver {
 
             // Get callee symbols
             const callee_result = await this.get_callee_scope(resolved_path, callee_uri, my_context.working_directory);
+
+            if (decision.action === 'boundary_only') {
+                // Dedup'd do/run re-visit: don't re-merge symbols or recurse,
+                // but still push a barrier-only site with excluded_locals.
+                // Without this, a second direct `do`/`run` invocation of a
+                // previously-visited callee would leave no blame carrier at
+                // the outer iteration level, and the rewrite would name the
+                // first visit's sub-chain even when counterfactually
+                // promoting this later boundary would win under last-def.
+                if (token?.isCancellationRequested) {
+                    my_stack.delete(file_uri);
+                    return { symbols: accumulated_symbols, call_sites: the_call_sites, diagnostics: my_context.diagnostics };
+                }
+                if ('error' in callee_result) {
+                    continue;
+                }
+                let boundary_excluded: Map<string, MacroSymbol> | undefined;
+                if (my_effective_type === 'do') {
+                    const effective_end_state = await this.compute_effective_end_state_locals(
+                        callee_uri,
+                        resolved_path,
+                        callee_result.working_directory ?? my_context.working_directory,
+                        new Set(my_stack),
+                        my_context.depth + 1,
+                        resolved_config,
+                        token,
+                    );
+                    if (effective_end_state.size > 0) {
+                        boundary_excluded = effective_end_state;
+                    }
+                }
+                the_call_sites.push({
+                    callee_uri,
+                    call_line: my_call.call_site_line,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: my_effective_type,
+                    excluded_locals: boundary_excluded,
+                });
+                continue;
+            }
             
             // Check cancellation after await
             if (token?.isCancellationRequested) {
@@ -287,8 +327,18 @@ export class ForwardScopeResolver {
             // flattened forward_call_symbols array. Program-scoped locals
             // (`containingScope === 'program'`) aren't caller-visible even
             // under `include`, so they're excluded from the walk.
+            //
+            // Gate on `my_call.type` rather than `my_effective_type`: only a
+            // call whose ORIGINAL type is `do`/`run` is a blocking boundary
+            // that could be counterfactually promoted to `include`. A
+            // nested `include` whose effective type was demoted to `do` by
+            // an outer `do` isn't itself blocking — the outer `do` is, and
+            // its end-state walk already captures this included file's
+            // locals. Emitting excluded_locals for the nested include would
+            // double-claim every name and let an inner file's claim
+            // incorrectly overwrite the outer file's execution-order winner.
             let excluded_locals: Map<string, MacroSymbol> | undefined;
-            if (my_effective_type === 'do') {
+            if (my_call.type !== 'include' && my_effective_type === 'do') {
                 const effective_end_state = await this.compute_effective_end_state_locals(
                     callee_uri,
                     resolved_path,
@@ -338,34 +388,23 @@ export class ForwardScopeResolver {
                     return { symbols: accumulated_symbols, call_sites: the_call_sites, diagnostics: my_context.diagnostics };
                 }
 
-                // Add nested call sites with adjusted call lines. Filter
-                // `excluded_locals` on each nested site rather than stripping
-                // it: if the direct-child site already carries its own
-                // entry for a name (its effective end-state walk claims
-                // it), the nested site must drop that name to avoid
-                // double-blaming. But if the direct-child is `include`
-                // (no excluded_locals) — or simply doesn't claim the
-                // name — the nested site's entry is the only carrier for
-                // the deeper `do` boundary and must be kept.
+                // Add nested call sites with adjusted call lines. When the
+                // direct-child site already carries `excluded_locals`, its
+                // counterfactual walk descended through every call in the
+                // sub-chain (see compute_effective_end_state_locals) and
+                // its map already holds the last-def-wins answer for every
+                // name defined below it. The deeper nested sites' claims
+                // are strict subsets of that walk and would incorrectly
+                // override it under last-in-iteration-wins, so we strip
+                // them. When the direct-child is `include` (no excluded
+                // locals of its own — the outer call is not a blocking
+                // boundary), deeper nested `do`/`run` sites are the only
+                // carriers of their boundary's blame and must be kept.
                 for (const nested_site of nested_result.call_sites) {
-                    let filtered_excluded: Map<string, MacroSymbol> | undefined;
-                    if (nested_site.excluded_locals) {
-                        if (excluded_locals) {
-                            const the_filtered = new Map<string, MacroSymbol>();
-                            for (const [my_name, my_symbol] of nested_site.excluded_locals) {
-                                if (!excluded_locals.has(my_name)) {
-                                    the_filtered.set(my_name, my_symbol);
-                                }
-                            }
-                            filtered_excluded = the_filtered.size > 0 ? the_filtered : undefined;
-                        } else {
-                            filtered_excluded = nested_site.excluded_locals;
-                        }
-                    }
                     the_call_sites.push({
                         ...nested_site,
                         call_line: my_call.call_site_line, // Visibility starts at parent call
-                        excluded_locals: filtered_excluded,
+                        excluded_locals: excluded_locals ? undefined : nested_site.excluded_locals,
                     });
                 }
 
@@ -446,7 +485,12 @@ export class ForwardScopeResolver {
             return { action: 'add_locals_only' };
         }
 
-        return { action: 'skip' };
+        // previous_type === 'do' && (call_type === 'do' || 'run').
+        // Symbol accumulation is unchanged (do/run don't add caller locals),
+        // but this is still a distinct blocking boundary whose promotion
+        // would rebind names. Emit a boundary-only site so the diagnostic
+        // rewrite sees its excluded_locals claim.
+        return { action: 'boundary_only' };
     }
 
     /**
@@ -524,7 +568,10 @@ export class ForwardScopeResolver {
     ): Promise<Map<string, MacroSymbol>> {
         if (token?.isCancellationRequested) return new Map();
         if (stack.has(callee_uri)) return new Map();
-        if (depth >= resolved_config.max_forward_depth) return new Map();
+        // Callers invoke with `my_context.depth + 1`, so at `depth == max` we
+        // are still on a file the outer resolver is allowed to process. Only
+        // bail when a further hop would exceed the configured maximum.
+        if (depth > resolved_config.max_forward_depth) return new Map();
 
         const callee_result = await this.get_callee_scope(
             callee_fs_path,
@@ -536,8 +583,8 @@ export class ForwardScopeResolver {
         stack.add(callee_uri);
         try {
             type WalkEvent =
-                | { line: number; kind: 'local'; name: string; symbol: MacroSymbol }
-                | { line: number; kind: 'call'; call: ForwardCall };
+                | { line: number; character: number; kind: 'local'; name: string; symbol: MacroSymbol }
+                | { line: number; character: number; kind: 'call'; call: ForwardCall };
 
             const the_events: WalkEvent[] = [];
             for (const [my_name, my_symbol] of callee_result.symbols.localMacros) {
@@ -552,13 +599,27 @@ export class ForwardScopeResolver {
                 // blamed. `sourceUri` matches across every definition of the
                 // same local in the same file, so attributing the symbol
                 // payload back to the primary remains correct.
+                //
+                // Carry the character position too: under `#delimit ;`, a
+                // local and an include can share a physical line, and
+                // sorting on line alone would collapse their execution
+                // order. Full (line, character) ordering is robust to
+                // that shape as well as today's `#delimit cr` input.
                 const primary_line = my_symbol.definition_line
                     ?? my_symbol.location.range.start.line;
-                the_events.push({ line: primary_line, kind: 'local', name: my_name, symbol: my_symbol });
+                const primary_char = my_symbol.location.range.start.character;
+                the_events.push({
+                    line: primary_line,
+                    character: primary_char,
+                    kind: 'local',
+                    name: my_name,
+                    symbol: my_symbol,
+                });
                 if (my_symbol.additional_definitions) {
                     for (const my_extra of my_symbol.additional_definitions) {
                         the_events.push({
                             line: my_extra.line,
+                            character: my_extra.location.range.start.character,
                             kind: 'local',
                             name: my_name,
                             symbol: my_symbol,
@@ -568,10 +629,24 @@ export class ForwardScopeResolver {
             }
             for (const my_call of callee_result.forward_calls) {
                 if (!my_call.is_static || !my_call.path) continue;
-                if (my_call.type !== 'include') continue;
-                the_events.push({ line: my_call.call_site_line, kind: 'call', call: my_call });
+                // Descend into every call type — `include`, `do`, and `run`.
+                // The diagnostic rewrite is a counterfactual: "if the do/run
+                // that blocks this reference were promoted to include (and
+                // any do/run boundaries further inside along the same
+                // chain were promoted as well), where would the referenced
+                // local last be bound?" Treating do/run as include during
+                // the walk answers exactly that question, and lets the
+                // blame name the inner file that has the last `local X`
+                // in execution order — not whichever file happens to be
+                // at the top of the blocked sub-chain.
+                the_events.push({
+                    line: my_call.call_site_line,
+                    character: my_call.range.start.character,
+                    kind: 'call',
+                    call: my_call,
+                });
             }
-            the_events.sort((a, b) => a.line - b.line);
+            the_events.sort((a, b) => a.line - b.line || a.character - b.character);
 
             const the_effective = new Map<string, MacroSymbol>();
             const nested_working_dir = callee_result.working_directory ?? working_directory;

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -331,9 +331,13 @@ export class DiagnosticsProvider {
                                 reference_scope
                             )) {
                             // Forward-call symbol precedence is last visible site wins.
-                            // Keep the latest excluded boundary so the diagnostic points
-                            // at the callee whose local currently shadows earlier ones.
-                            excluded_callee_uri = call_site.callee_uri;
+                            // Blame the callee whose local is the effective
+                            // end-of-execution winner for this site's chain
+                            // (see ForwardScopeResolver.compute_effective_end_state_locals).
+                            // Fall back to the direct-child's URI if the
+                            // symbol's sourceUri is missing.
+                            const effective = call_site.excluded_locals?.get(symbol_name);
+                            excluded_callee_uri = effective?.sourceUri ?? call_site.callee_uri;
                         }
                     }
                     if (found_in_forward_call) {
@@ -944,6 +948,17 @@ export class DiagnosticsProvider {
      * Check whether the current document defines the referenced symbol itself.
      * Used to preserve same-file forward-reference diagnostics when a matching
      * name also exists in an excluded forward-called file.
+     *
+     * NOTE: program-scoped locals in the current file are intentionally treated
+     * as "same-file" here. A narrower formulation that excluded them was tried
+     * and reverted on 2026-04-21 (commits b852e1c, 3ac1904, 12dc34c, 1e38388)
+     * because the callee-aware "use include" rewrite then fires at top-level
+     * references even when the only local with that name lives inside a
+     * different program body — which is actively misleading. The remaining
+     * design question of emitting a distinct, accurate message for
+     * scope-isolated same-file locals is tracked in
+     * https://github.com/jbearak/sight/issues/145. Do not re-narrow this
+     * guard without resolving that issue.
      */
     private is_symbol_defined_in_current_document(
         symbol_name: string,

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -324,11 +324,27 @@ export class DiagnosticsProvider {
                         continue;
                     }
                     if (excluded_callee_uri) {
-                        if (config.diagnostics.severity.undefinedMacro === 'off') {
-                            continue;
-                        }
                         const out_of_scope_severity = config.cross_file?.diagnostics?.out_of_scope;
                         if (out_of_scope_severity === 'off') {
+                            continue;
+                        }
+                        if (this.is_symbol_defined_in_current_document(
+                                symbol_name,
+                                document.symbols,
+                                my_diagnostic.code,
+                                document.uri,
+                                reference_scope
+                            )) {
+                            // Preserve the analyzer's same-file forward-reference
+                            // diagnostic instead of replacing it with cross-file advice.
+                            const converted = this.convert_semantic_diagnostic(
+                                my_diagnostic,
+                                config,
+                                document
+                            );
+                            if (converted) {
+                                the_diagnostics.push(converted);
+                            }
                             continue;
                         }
                         const source_file = excluded_callee_uri.split('/').pop() || excluded_callee_uri;
@@ -893,6 +909,48 @@ export class DiagnosticsProvider {
             
             return false;
         }
+        return false;
+    }
+
+    /**
+     * Check whether the current document defines the referenced symbol itself.
+     * Used to preserve same-file forward-reference diagnostics when a matching
+     * name also exists in an excluded forward-called file.
+     */
+    private is_symbol_defined_in_current_document(
+        symbol_name: string,
+        symbols: SymbolTable,
+        diagnostic_code: number,
+        current_document_uri: string,
+        reference_scope?: 'local' | 'global' | null
+    ): boolean {
+        const is_from_current_document = (
+            symbol: { sourceUri?: string; location?: { uri: string } } | undefined
+        ): boolean => {
+            if (!symbol) {
+                return false;
+            }
+            return symbol.sourceUri === current_document_uri
+                || symbol.location?.uri === current_document_uri;
+        };
+
+        if (diagnostic_code === StataDiagnosticCode.UNDEFINED_MACRO) {
+            if (reference_scope === 'local') {
+                return is_from_current_document(symbols.localMacros.get(symbol_name));
+            }
+            if (reference_scope === 'global') {
+                return is_from_current_document(symbols.globalMacros.get(symbol_name));
+            }
+            return is_from_current_document(symbols.localMacros.get(symbol_name))
+                || is_from_current_document(symbols.globalMacros.get(symbol_name));
+        }
+
+        if (diagnostic_code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
+            return is_from_current_document(symbols.variables.get(symbol_name))
+                || is_from_current_document(symbols.scalars?.get(symbol_name))
+                || is_from_current_document(symbols.matrices?.get(symbol_name));
+        }
+
         return false;
     }
 

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -324,6 +324,9 @@ export class DiagnosticsProvider {
                         continue;
                     }
                     if (excluded_callee_uri) {
+                        if (config.diagnostics.severity.undefinedMacro === 'off') {
+                            continue;
+                        }
                         const out_of_scope_severity = config.cross_file?.diagnostics?.out_of_scope;
                         if (out_of_scope_severity === 'off') {
                             continue;

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -310,13 +310,15 @@ export class DiagnosticsProvider {
                             found_in_forward_call = true;
                             break;
                         }
-                        if (excluded_callee_uri === undefined &&
-                            this.is_symbol_excluded_by_forward_call(
+                        if (this.is_symbol_excluded_by_forward_call(
                                 symbol_name,
                                 call_site,
                                 my_diagnostic.code,
                                 reference_scope
                             )) {
+                            // Forward-call symbol precedence is last visible site wins.
+                            // Keep the latest excluded boundary so the diagnostic points
+                            // at the callee whose local currently shadows earlier ones.
                             excluded_callee_uri = call_site.callee_uri;
                         }
                     }
@@ -325,37 +327,36 @@ export class DiagnosticsProvider {
                     }
                     if (excluded_callee_uri) {
                         const out_of_scope_severity = config.cross_file?.diagnostics?.out_of_scope;
-                        if (out_of_scope_severity === 'off') {
-                            continue;
-                        }
-                        if (this.is_symbol_defined_in_current_document(
-                                symbol_name,
-                                document.symbols,
-                                my_diagnostic.code,
-                                document.uri,
-                                reference_scope
-                            )) {
-                            // Preserve the analyzer's same-file forward-reference
-                            // diagnostic instead of replacing it with cross-file advice.
-                            const converted = this.convert_semantic_diagnostic(
-                                my_diagnostic,
-                                config,
-                                document
-                            );
-                            if (converted) {
-                                the_diagnostics.push(converted);
+                        if (out_of_scope_severity !== 'off') {
+                            if (this.is_symbol_defined_in_current_document(
+                                    symbol_name,
+                                    document.symbols,
+                                    my_diagnostic.code,
+                                    document.uri,
+                                    reference_scope
+                                )) {
+                                // Preserve the analyzer's same-file forward-reference
+                                // diagnostic instead of replacing it with cross-file advice.
+                                const converted = this.convert_semantic_diagnostic(
+                                    my_diagnostic,
+                                    config,
+                                    document
+                                );
+                                if (converted) {
+                                    the_diagnostics.push(converted);
+                                }
+                                continue;
                             }
+                            const source_file = excluded_callee_uri.split('/').pop() || excluded_callee_uri;
+                            the_diagnostics.push({
+                                range: my_diagnostic.range,
+                                message: `'${symbol_name}' is defined in ${source_file} but local macros are not inherited via do/run (use include or @lsp-include)`,
+                                severity: this.cross_file_severity_to_lsp(out_of_scope_severity),
+                                source: 'sight',
+                                code: StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
+                            });
                             continue;
                         }
-                        const source_file = excluded_callee_uri.split('/').pop() || excluded_callee_uri;
-                        the_diagnostics.push({
-                            range: my_diagnostic.range,
-                            message: `'${symbol_name}' is defined in ${source_file} but local macros are not inherited via do/run (use include or @lsp-include)`,
-                            severity: this.cross_file_severity_to_lsp(out_of_scope_severity),
-                            source: 'sight',
-                            code: StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
-                        });
-                        continue;
                     }
                 }
             }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -259,8 +259,12 @@ export class DiagnosticsProvider {
                         }
                     }
                     
-                    // Check if symbol is out-of-scope (defined after call site or excluded by inheritance)
-                    // Only match out-of-scope symbols of the same type as the reference
+                    // Check if symbol is out-of-scope (defined after call site or
+                    // excluded by inheritance). This path rewrites an existing
+                    // undefined-symbol diagnostic; it is not an independent
+                    // diagnostic source.
+                    // Only match out-of-scope symbols of the same type as the
+                    // reference.
                     const reference_scope = this.extract_macro_scope_from_diagnostic(my_diagnostic);
                     const out_of_scope = resolved_scope.out_of_scope_symbols.find(
                         s => s.name === symbol_name && this.out_of_scope_type_matches_reference(s.type, reference_scope)
@@ -335,8 +339,12 @@ export class DiagnosticsProvider {
                                     document.uri,
                                     reference_scope
                                 )) {
-                                // Preserve the analyzer's same-file forward-reference
-                                // diagnostic instead of replacing it with cross-file advice.
+                                // Preserve the analyzer's same-file
+                                // forward-reference diagnostic instead of
+                                // replacing it with cross-file advice. This
+                                // intentionally keeps same-file forward
+                                // references gated by the base undefined-symbol
+                                // severity settings.
                                 const converted = this.convert_semantic_diagnostic(
                                     my_diagnostic,
                                     config,
@@ -962,9 +970,10 @@ export class DiagnosticsProvider {
      * defined in a file reached via `do`/`run` (locals don't propagate across
      * those boundaries — only `include` inherits locals).
      *
-     * Returning true signals the caller to emit an informative
-     * OUT_OF_SCOPE_SYMBOL diagnostic instead of the generic "Undefined local
-     * macro" message.
+     * Returning true signals the caller to rewrite the existing undefined
+     * local-macro diagnostic into a more informative OUT_OF_SCOPE_SYMBOL
+     * diagnostic. This rewrite still depends on the base undefined-symbol
+     * diagnostic path being enabled.
      */
     private is_symbol_excluded_by_forward_call(
         symbol_name: string,

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -302,14 +302,40 @@ export class DiagnosticsProvider {
                 if (symbol_name) {
                     const diag_line = my_diagnostic.range.start.line;
                     let found_in_forward_call = false;
+                    let excluded_callee_uri: string | undefined;
+                    const reference_scope = this.extract_macro_scope_from_diagnostic(my_diagnostic);
                     for (const call_site of get_visible_forward_call_sites(resolved_scope, diag_line)) {
                         if (this.is_symbol_in_forward_call(
                                 symbol_name, call_site.symbols, my_diagnostic.code, call_site.effective_type)) {
                             found_in_forward_call = true;
                             break;
                         }
+                        if (excluded_callee_uri === undefined &&
+                            this.is_symbol_excluded_by_forward_call(
+                                symbol_name,
+                                call_site,
+                                my_diagnostic.code,
+                                reference_scope
+                            )) {
+                            excluded_callee_uri = call_site.callee_uri;
+                        }
                     }
                     if (found_in_forward_call) {
+                        continue;
+                    }
+                    if (excluded_callee_uri) {
+                        const out_of_scope_severity = config.cross_file?.diagnostics?.out_of_scope;
+                        if (out_of_scope_severity === 'off') {
+                            continue;
+                        }
+                        const source_file = excluded_callee_uri.split('/').pop() || excluded_callee_uri;
+                        the_diagnostics.push({
+                            range: my_diagnostic.range,
+                            message: `'${symbol_name}' is defined in ${source_file} but local macros are not inherited via do/run (use include or @lsp-include)`,
+                            severity: this.cross_file_severity_to_lsp(out_of_scope_severity),
+                            source: 'sight',
+                            code: StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
+                        });
                         continue;
                     }
                 }
@@ -868,10 +894,39 @@ export class DiagnosticsProvider {
     }
 
     /**
+     * Check if an undefined-symbol reference would have been resolved by a
+     * forward-called file, except that the call's effective type excludes this
+     * kind of symbol. Currently only one such case exists: a local macro
+     * defined in a file reached via `do`/`run` (locals don't propagate across
+     * those boundaries — only `include` inherits locals).
+     *
+     * Returning true signals the caller to emit an informative
+     * OUT_OF_SCOPE_SYMBOL diagnostic instead of the generic "Undefined local
+     * macro" message.
+     */
+    private is_symbol_excluded_by_forward_call(
+        symbol_name: string,
+        call_site: import('../types').ForwardCallSite,
+        diagnostic_code: number,
+        reference_scope: 'local' | 'global' | null | undefined,
+    ): boolean {
+        if (diagnostic_code !== StataDiagnosticCode.UNDEFINED_MACRO) {
+            return false;
+        }
+        if (reference_scope === 'global') {
+            return false;
+        }
+        if (call_site.effective_type !== 'do') {
+            return false;
+        }
+        return call_site.excluded_locals?.has(symbol_name) ?? false;
+    }
+
+    /**
      * Check if a symbol is defined in forward call symbols (from current file's forward calls).
      * Unlike is_symbol_defined_in_scope, this does NOT filter by sourceUri because
      * forward calls from the current file should suppress warnings after the call site.
-     * 
+     *
      * For local macros, only 'include' calls contribute locals; 'do'/'run' calls do not.
      */
     private is_symbol_in_forward_call(

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -270,6 +270,16 @@ export class DiagnosticsProvider {
                         s => s.name === symbol_name && this.out_of_scope_type_matches_reference(s.type, reference_scope)
                     );
                     if (out_of_scope) {
+                        // Suppress the rewrite when the base undefined-symbol
+                        // diagnostic is disabled. OUT_OF_SCOPE_SYMBOL is a
+                        // rewrite, not an independent source, so turning off
+                        // the base should also silence the rewrite.
+                        const base_severity = my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO
+                            ? config.diagnostics.severity.undefinedMacro
+                            : config.diagnostics.severity.undefinedVariable;
+                        if (base_severity === 'off') {
+                            continue;
+                        }
                         // Check config severity for out-of-scope
                         const out_of_scope_severity = config.cross_file?.diagnostics?.out_of_scope;
                         if (out_of_scope_severity === 'off') {
@@ -330,6 +340,15 @@ export class DiagnosticsProvider {
                         continue;
                     }
                     if (excluded_callee_uri) {
+                        // Suppress the rewrite when the base undefined-symbol
+                        // diagnostic is disabled. See comment in the backward
+                        // path above.
+                        const base_severity = my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO
+                            ? config.diagnostics.severity.undefinedMacro
+                            : config.diagnostics.severity.undefinedVariable;
+                        if (base_severity === 'off') {
+                            continue;
+                        }
                         const out_of_scope_severity = config.cross_file?.diagnostics?.out_of_scope;
                         if (out_of_scope_severity !== 'off') {
                             if (this.is_symbol_defined_in_current_document(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -856,4 +856,11 @@ export interface ContentProvider {
 export type DuplicateCallDecision =
   | { action: 'skip' }
   | { action: 'process' }
-  | { action: 'add_locals_only' };
+  | { action: 'add_locals_only' }
+  // Previously-visited callee is being invoked again via `do`/`run`.
+  // Its symbols are already accumulated (no new locals for caller,
+  // since locals don't cross do/run), but this is still a distinct
+  // blocking boundary: if promoted counterfactually it would make a
+  // different sub-chain visible at the reference. Emit an
+  // excluded_locals claim without re-merging symbols or recursing.
+  | { action: 'boundary_only' };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -825,10 +825,15 @@ export interface ForwardCallSite {
   // across do/run). Reflects last-definition-wins in execution order:
   // own `local` statements interleaved with any nested `include`s, so
   // diagnostics blame the callee whose local actually shadows earlier
-  // ones. Only populated on direct-child sites (those created for calls
-  // made from the file being resolved). Nested-site entries flattened
-  // from a deeper resolve() strip this field to avoid double-counting.
-  // Absent / empty map when no locals were excluded.
+  // ones. Populated on direct-child sites (those created for calls made
+  // from the file being resolved) whose `effective_type` is 'do'.
+  // Nested-site entries flattened from a deeper resolve() are handed off
+  // with a filtered copy: names already claimed by the enclosing
+  // direct-child site's `excluded_locals` are dropped to avoid
+  // double-counting, but any remaining entries are preserved so that
+  // deeper `do`-boundaries under an `include`-called direct-child still
+  // carry their blame target. Absent / empty map when no locals remain
+  // after filtering.
   excluded_locals?: Map<string, MacroSymbol>;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -861,5 +861,8 @@ export type DuplicateCallDecision =
   // promotion may expose a different file's `local X` than the first
   // visit's callee would. Emit a barrier-only site so the diagnostic
   // rewrite can blame the second boundary under last-visible-site
-  // precedence.
+  // precedence. Note: `resolve()` gates the meaningful handling of this
+  // variant to `depth === 0`; nested-depth occurrences are short-
+  // circuited because the flattening loop strips `excluded_locals` on
+  // bubbled-up nested sites.
   | { action: 'boundary_only' };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -820,20 +820,17 @@ export interface ForwardCallSite {
   call_line: number;        // 0-indexed line in caller
   symbols: SymbolTable;
   effective_type: EffectiveCallType;
-  // Effective end-of-execution top-level local macros of the callee that
-  // were dropped because `effective_type` is 'do' (locals don't propagate
-  // across do/run). Reflects last-definition-wins in execution order:
-  // own `local` statements interleaved with any nested `include`s, so
-  // diagnostics blame the callee whose local actually shadows earlier
-  // ones. Populated on direct-child sites (those created for calls made
-  // from the file being resolved) whose `effective_type` is 'do'.
-  // Nested-site entries flattened from a deeper resolve() are handed off
-  // with a filtered copy: names already claimed by the enclosing
-  // direct-child site's `excluded_locals` are dropped to avoid
-  // double-counting, but any remaining entries are preserved so that
-  // deeper `do`-boundaries under an `include`-called direct-child still
-  // carry their blame target. Absent / empty map when no locals remain
-  // after filtering.
+  // Effective end-of-execution top-level local macros of the callee,
+  // computed as the include-only end state of the callee's sub-chain.
+  // Populated ONLY on direct-child `do`/`run` sites (calls made from the
+  // file being resolved whose original type is `do`/`run`). A blame entry
+  // represents "if this one call were promoted to `include`, the
+  // referenced local would be bound here" — so the diagnostic can point
+  // at the file whose `local` statement actually wins under that one-line
+  // fix. Nested sites flattened from a deeper `resolve()` always arrive
+  // with `excluded_locals: undefined`; their blame would correspond to a
+  // different boundary promotion than the one the outer diagnostic's
+  // message suggests.
   excluded_locals?: Map<string, MacroSymbol>;
 }
 
@@ -858,9 +855,11 @@ export type DuplicateCallDecision =
   | { action: 'process' }
   | { action: 'add_locals_only' }
   // Previously-visited callee is being invoked again via `do`/`run`.
-  // Its symbols are already accumulated (no new locals for caller,
-  // since locals don't cross do/run), but this is still a distinct
-  // blocking boundary: if promoted counterfactually it would make a
-  // different sub-chain visible at the reference. Emit an
-  // excluded_locals claim without re-merging symbols or recursing.
+  // Symbol accumulation is unchanged (do/run don't propagate locals), but
+  // this is still a distinct root-level boundary: the second `do`/`run`
+  // can be promoted to `include` independently of the first, and that
+  // promotion may expose a different file's `local X` than the first
+  // visit's callee would. Emit a barrier-only site so the diagnostic
+  // rewrite can blame the second boundary under last-visible-site
+  // precedence.
   | { action: 'boundary_only' };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -820,6 +820,11 @@ export interface ForwardCallSite {
   call_line: number;        // 0-indexed line in caller
   symbols: SymbolTable;
   effective_type: EffectiveCallType;
+  // Local macros defined in the callee that were dropped because
+  // `effective_type` is 'do' (locals don't propagate across do/run).
+  // Preserved so diagnostics can explain why an inherited-looking macro
+  // isn't visible. Absent / empty map when no locals were excluded.
+  excluded_locals?: Map<string, MacroSymbol>;
 }
 
 export interface ForwardResolvedScope {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -820,10 +820,15 @@ export interface ForwardCallSite {
   call_line: number;        // 0-indexed line in caller
   symbols: SymbolTable;
   effective_type: EffectiveCallType;
-  // Local macros defined in the callee that were dropped because
-  // `effective_type` is 'do' (locals don't propagate across do/run).
-  // Preserved so diagnostics can explain why an inherited-looking macro
-  // isn't visible. Absent / empty map when no locals were excluded.
+  // Effective end-of-execution top-level local macros of the callee that
+  // were dropped because `effective_type` is 'do' (locals don't propagate
+  // across do/run). Reflects last-definition-wins in execution order:
+  // own `local` statements interleaved with any nested `include`s, so
+  // diagnostics blame the callee whose local actually shadows earlier
+  // ones. Only populated on direct-child sites (those created for calls
+  // made from the file being resolved). Nested-site entries flattened
+  // from a deeper resolve() strip this field to avoid double-counting.
+  // Absent / empty map when no locals were excluded.
   excluded_locals?: Map<string, MacroSymbol>;
 }
 

--- a/tests/integration/current-file-forward-call-diagnostics.test.ts
+++ b/tests/integration/current-file-forward-call-diagnostics.test.ts
@@ -207,6 +207,82 @@ di \`veggie'`;
             expect(plain_undefined.length).toBe(0);
         });
 
+        it('should preserve undefined macro warning when out-of-scope rewrite is disabled', async () => {
+            const child_path = join(test_temp_dir, 'rewrite_off_child.do');
+            const child_content = 'local veggie potato';
+            writeFileSync(child_path, child_content);
+
+            const parent_path = join(test_temp_dir, 'rewrite_off_parent.do');
+            const parent_content = `do rewrite_off_child.do
+di \`veggie'`;
+            writeFileSync(parent_path, parent_content);
+
+            const parent_uri = URI.file(parent_path).toString();
+            await document_store.open(parent_uri, parent_content, 1);
+            const document_state = document_store.get(parent_uri)!;
+
+            const diagnostics = await diagnostics_provider.get_diagnostics(
+                document_state,
+                {
+                    ...config,
+                    cross_file: {
+                        ...config.cross_file,
+                        diagnostics: {
+                            out_of_scope: 'off',
+                        },
+                    },
+                },
+                undefined,
+                scope_resolver
+            );
+
+            const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(true);
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+            )).toBe(false);
+        });
+
+        it('should report the highest-precedence excluded forward callee for shadowed locals', async () => {
+            const defs_path = join(test_temp_dir, 'defs.do');
+            const defs_content = 'local veggie beet';
+            writeFileSync(defs_path, defs_content);
+
+            const child_path = join(test_temp_dir, 'child.do');
+            const child_content = `local veggie carrot
+include "defs.do"`;
+            writeFileSync(child_path, child_content);
+
+            const main_path = join(test_temp_dir, 'main_shadowed_local.do');
+            const main_content = `do "child.do"
+di \`veggie'`;
+            writeFileSync(main_path, main_content);
+
+            const main_uri = URI.file(main_path).toString();
+            await document_store.open(main_uri, main_content, 1);
+            const document_state = document_store.get(main_uri)!;
+
+            const diagnostics = await diagnostics_provider.get_diagnostics(
+                document_state,
+                config,
+                undefined,
+                scope_resolver
+            );
+
+            const informative = diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('veggie')
+            );
+            expect(informative).toBeDefined();
+            expect(informative!.message).toContain('defs.do');
+            expect(informative!.message).not.toContain('child.do');
+            expect(informative!.message).toContain(
+                'local macros are not inherited via do/run'
+            );
+        });
+
         it('should NOT suggest switching to include when callee local is program-scoped', async () => {
             // Program-scoped locals in the callee are not visible to the
             // caller even with `include`, so the "use include" message would

--- a/tests/integration/current-file-forward-call-diagnostics.test.ts
+++ b/tests/integration/current-file-forward-call-diagnostics.test.ts
@@ -149,16 +149,25 @@ display \`do_local'`;
                 scope_resolver
             );
 
-            // Should have an undefined-macro-shaped warning on line 1. The
-            // diagnostics provider now upgrades this to the informative
-            // OUT_OF_SCOPE_SYMBOL variant that names the callee, but either
-            // code is a legitimate "not inherited via do" report.
+            // Should have the callee-aware OUT_OF_SCOPE_SYMBOL rewrite on
+            // line 1 — the analyzer's generic "Undefined local macro" should
+            // be replaced with a message that names the callee file and
+            // explains that locals don't cross do/run boundaries.
             const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
-            expect(line1_diags.some(d =>
-                d.code === StataDiagnosticCode.UNDEFINED_MACRO ||
-                (d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
-                    d.message.includes('local macros are not inherited via do/run'))
-            )).toBe(true);
+            const informative = line1_diags.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+            );
+            expect(informative).toBeDefined();
+            expect(informative!.message).toContain('do_local');
+            expect(informative!.message).toContain('helper_do_local.do');
+            expect(informative!.message).toContain(
+                'local macros are not inherited via do/run'
+            );
+
+            const plain_undefined = line1_diags.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(plain_undefined.length).toBe(0);
         });
 
         it('should emit informative diagnostic when local macro is defined in a do-called file', async () => {

--- a/tests/integration/current-file-forward-call-diagnostics.test.ts
+++ b/tests/integration/current-file-forward-call-diagnostics.test.ts
@@ -149,9 +149,62 @@ display \`do_local'`;
                 scope_resolver
             );
 
-            // Should have undefined macro warning on line 1 (do doesn't inherit locals)
+            // Should have an undefined-macro-shaped warning on line 1. The
+            // diagnostics provider now upgrades this to the informative
+            // OUT_OF_SCOPE_SYMBOL variant that names the callee, but either
+            // code is a legitimate "not inherited via do" report.
             const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
-            expect(line1_diags.some(d => d.code === StataDiagnosticCode.UNDEFINED_MACRO)).toBe(true);
+            expect(line1_diags.some(d =>
+                d.code === StataDiagnosticCode.UNDEFINED_MACRO ||
+                (d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                    d.message.includes('local macros are not inherited via do/run'))
+            )).toBe(true);
+        });
+
+        it('should emit informative diagnostic when local macro is defined in a do-called file', async () => {
+            // Mirror of the child.do "local macros are not inherited via do/run" message,
+            // but emitted in the parent file where the forward do call happens.
+            const child_path = join(test_temp_dir, 'demo_child.do');
+            const child_content = `di "hello"
+local veggie potato`;
+            writeFileSync(child_path, child_content);
+
+            const parent_path = join(test_temp_dir, 'demo_parent.do');
+            const parent_content = `local fruit apple
+do demo_child.do
+di \`veggie'`;
+            writeFileSync(parent_path, parent_content);
+
+            const parent_uri = URI.file(parent_path).toString();
+            await document_store.open(parent_uri, parent_content, 1);
+            const document_state = document_store.get(parent_uri)!;
+
+            const diagnostics = await diagnostics_provider.get_diagnostics(
+                document_state,
+                config,
+                undefined,
+                scope_resolver
+            );
+
+            // Line 2: `di \`veggie'` — veggie is defined in demo_child.do but
+            // not inherited via do.
+            const line2_diags = diagnostics.filter(d => d.range.start.line === 2);
+            const informative = line2_diags.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+            );
+            expect(informative).toBeDefined();
+            expect(informative!.message).toContain('veggie');
+            expect(informative!.message).toContain('demo_child.do');
+            expect(informative!.message).toContain(
+                'local macros are not inherited via do/run'
+            );
+
+            // The plain "Undefined local macro" diagnostic should be replaced,
+            // not duplicated alongside the informative one.
+            const plain_undefined = line2_diags.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(plain_undefined.length).toBe(0);
         });
 
         it('should NOT warn about undefined global macro AFTER @lsp-do', async () => {

--- a/tests/integration/current-file-forward-call-diagnostics.test.ts
+++ b/tests/integration/current-file-forward-call-diagnostics.test.ts
@@ -374,6 +374,100 @@ di \`veggie'`;
             );
         });
 
+        it('should blame the callee that redefines the local after an include (Bug A regression)', async () => {
+            // Bug A: in child.do, the sequence is
+            //   local veggie carrot      (primary definition)
+            //   include "defs.do"        (defs sets veggie=beet)
+            //   local veggie spinach     (redefinition — additional_definitions entry)
+            // In execution order, child's line-2 redefinition wins.
+            // Correct attribution for the OUT_OF_SCOPE_SYMBOL rewrite: child.do.
+            const defs_path = join(test_temp_dir, 'bug_a_defs.do');
+            const defs_content = 'local veggie beet';
+            writeFileSync(defs_path, defs_content);
+
+            const child_path = join(test_temp_dir, 'bug_a_child.do');
+            const child_content = `local veggie carrot
+include "bug_a_defs.do"
+local veggie spinach`;
+            writeFileSync(child_path, child_content);
+
+            const main_path = join(test_temp_dir, 'bug_a_main.do');
+            const main_content = `do "bug_a_child.do"
+di \`veggie'`;
+            writeFileSync(main_path, main_content);
+
+            const main_uri = URI.file(main_path).toString();
+            await document_store.open(main_uri, main_content, 1);
+            const document_state = document_store.get(main_uri)!;
+
+            const diagnostics = await diagnostics_provider.get_diagnostics(
+                document_state,
+                config,
+                undefined,
+                scope_resolver
+            );
+
+            const informative = diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('veggie')
+            );
+            expect(informative).toBeDefined();
+            expect(informative!.message).toContain('bug_a_child.do');
+            expect(informative!.message).not.toContain('bug_a_defs.do');
+            expect(informative!.message).toContain(
+                'local macros are not inherited via do/run'
+            );
+        });
+
+        it('should emit OUT_OF_SCOPE_SYMBOL for do nested under include chain (Bug B regression)', async () => {
+            // Bug B: main includes child, which does grandchild. The
+            // direct-child site (include) has no excluded_locals, so the
+            // deeper `do`-boundary beneath it was losing its only carrier.
+            // Expected: OUT_OF_SCOPE_SYMBOL rewrite blaming grandchild.do
+            // ("locals are not inherited via do/run"). Not generic undefined.
+            const grandchild_path = join(test_temp_dir, 'bug_b_grandchild.do');
+            const grandchild_content = 'local veggie beet';
+            writeFileSync(grandchild_path, grandchild_content);
+
+            const child_path = join(test_temp_dir, 'bug_b_child.do');
+            const child_content = 'do "bug_b_grandchild.do"';
+            writeFileSync(child_path, child_content);
+
+            const main_path = join(test_temp_dir, 'bug_b_main.do');
+            const main_content = `include "bug_b_child.do"
+di \`veggie'`;
+            writeFileSync(main_path, main_content);
+
+            const main_uri = URI.file(main_path).toString();
+            await document_store.open(main_uri, main_content, 1);
+            const document_state = document_store.get(main_uri)!;
+
+            const diagnostics = await diagnostics_provider.get_diagnostics(
+                document_state,
+                config,
+                undefined,
+                scope_resolver
+            );
+
+            const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+            const informative = line1_diags.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('veggie')
+            );
+            expect(informative).toBeDefined();
+            expect(informative!.message).toContain('bug_b_grandchild.do');
+            expect(informative!.message).toContain(
+                'local macros are not inherited via do/run'
+            );
+
+            // The generic "Undefined local macro" should be suppressed in favor
+            // of the informative rewrite.
+            const plain_undefined = line1_diags.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(plain_undefined.length).toBe(0);
+        });
+
         it('should NOT suggest switching to include when callee local is program-scoped', async () => {
             // Program-scoped locals in the callee are not visible to the
             // caller even with `include`, so the "use include" message would

--- a/tests/integration/current-file-forward-call-diagnostics.test.ts
+++ b/tests/integration/current-file-forward-call-diagnostics.test.ts
@@ -207,6 +207,46 @@ di \`veggie'`;
             expect(plain_undefined.length).toBe(0);
         });
 
+        it('should NOT suggest switching to include when callee local is program-scoped', async () => {
+            // Program-scoped locals in the callee are not visible to the
+            // caller even with `include`, so the "use include" message would
+            // mislead. The generic "Undefined local macro" is correct here.
+            const child_path = join(test_temp_dir, 'helper_prog_local.do');
+            const child_content = `program define myprog
+    local veggie potato
+    di "\`veggie'"
+end`;
+            writeFileSync(child_path, child_content);
+
+            const parent_path = join(test_temp_dir, 'main_prog_local.do');
+            const parent_content = `do helper_prog_local.do
+di \`veggie'`;
+            writeFileSync(parent_path, parent_content);
+
+            const parent_uri = URI.file(parent_path).toString();
+            await document_store.open(parent_uri, parent_content, 1);
+            const document_state = document_store.get(parent_uri)!;
+
+            const diagnostics = await diagnostics_provider.get_diagnostics(
+                document_state,
+                config,
+                undefined,
+                scope_resolver
+            );
+
+            const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+            const misleading = line1_diags.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+            );
+            expect(misleading).toBeUndefined();
+
+            // The generic undefined-local-macro warning is still the correct
+            // diagnostic and should remain present.
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(true);
+        });
+
         it('should NOT warn about undefined global macro AFTER @lsp-do', async () => {
             const helper_path = join(test_temp_dir, 'helper_do_global.do');
             const helper_content = 'global DO_GLOBAL "value"';

--- a/tests/integration/current-file-forward-call-diagnostics.test.ts
+++ b/tests/integration/current-file-forward-call-diagnostics.test.ts
@@ -292,6 +292,88 @@ di \`veggie'`;
             );
         });
 
+        it('should blame the child when the child defines the local AFTER an include that also defines it', async () => {
+            // Execution-order precedence: in child.do, the `include` runs
+            // first (defs.do sets veggie=beet), then child.do's own
+            // `local veggie` overrides it. The effective local at end of
+            // child.do is child's own, so the message should name child.do.
+            const defs_path = join(test_temp_dir, 'defs_after.do');
+            const defs_content = 'local veggie beet';
+            writeFileSync(defs_path, defs_content);
+
+            const child_path = join(test_temp_dir, 'child_after.do');
+            const child_content = `include "defs_after.do"
+local veggie carrot`;
+            writeFileSync(child_path, child_content);
+
+            const main_path = join(test_temp_dir, 'main_child_wins.do');
+            const main_content = `do "child_after.do"
+di \`veggie'`;
+            writeFileSync(main_path, main_content);
+
+            const main_uri = URI.file(main_path).toString();
+            await document_store.open(main_uri, main_content, 1);
+            const document_state = document_store.get(main_uri)!;
+
+            const diagnostics = await diagnostics_provider.get_diagnostics(
+                document_state,
+                config,
+                undefined,
+                scope_resolver
+            );
+
+            const informative = diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('veggie')
+            );
+            expect(informative).toBeDefined();
+            expect(informative!.message).toContain('child_after.do');
+            expect(informative!.message).not.toContain('defs_after.do');
+            expect(informative!.message).toContain(
+                'local macros are not inherited via do/run'
+            );
+        });
+
+        it('should blame the last sibling do-called child that defines the local', async () => {
+            // Two sibling do-calls each defining the same local. The last
+            // one in execution order should be blamed.
+            const child_a_path = join(test_temp_dir, 'sibling_a.do');
+            const child_a_content = 'local veggie carrot';
+            writeFileSync(child_a_path, child_a_content);
+
+            const child_b_path = join(test_temp_dir, 'sibling_b.do');
+            const child_b_content = 'local veggie beet';
+            writeFileSync(child_b_path, child_b_content);
+
+            const main_path = join(test_temp_dir, 'main_siblings.do');
+            const main_content = `do "sibling_a.do"
+do "sibling_b.do"
+di \`veggie'`;
+            writeFileSync(main_path, main_content);
+
+            const main_uri = URI.file(main_path).toString();
+            await document_store.open(main_uri, main_content, 1);
+            const document_state = document_store.get(main_uri)!;
+
+            const diagnostics = await diagnostics_provider.get_diagnostics(
+                document_state,
+                config,
+                undefined,
+                scope_resolver
+            );
+
+            const informative = diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('veggie')
+            );
+            expect(informative).toBeDefined();
+            expect(informative!.message).toContain('sibling_b.do');
+            expect(informative!.message).not.toContain('sibling_a.do');
+            expect(informative!.message).toContain(
+                'local macros are not inherited via do/run'
+            );
+        });
+
         it('should NOT suggest switching to include when callee local is program-scoped', async () => {
             // Program-scoped locals in the callee are not visible to the
             // caller even with `include`, so the "use include" message would

--- a/tests/integration/current-file-forward-call-diagnostics.test.ts
+++ b/tests/integration/current-file-forward-call-diagnostics.test.ts
@@ -419,12 +419,14 @@ di \`veggie'`;
             );
         });
 
-        it('should emit OUT_OF_SCOPE_SYMBOL for do nested under include chain (Bug B regression)', async () => {
-            // Bug B: main includes child, which does grandchild. The
-            // direct-child site (include) has no excluded_locals, so the
-            // deeper `do`-boundary beneath it was losing its only carrier.
-            // Expected: OUT_OF_SCOPE_SYMBOL rewrite blaming grandchild.do
-            // ("locals are not inherited via do/run"). Not generic undefined.
+        it('falls back to generic UNDEFINED_MACRO for do nested under include chain (Bug B)', async () => {
+            // Bug B used to emit a specific OUT_OF_SCOPE_SYMBOL rewrite under
+            // the all-promotion model. Under single-boundary semantics the
+            // root-level boundary in this scenario is `include` (not `do`), so
+            // no one-line fix on a root `do`/`run` would expose the deep
+            // binding defined in the grandchild. The diagnostic therefore
+            // falls back to generic UNDEFINED_MACRO instead of the specific
+            // "locals are not inherited via do/run" rewrite.
             const grandchild_path = join(test_temp_dir, 'bug_b_grandchild.do');
             const grandchild_content = 'local veggie beet';
             writeFileSync(grandchild_path, grandchild_content);
@@ -454,18 +456,13 @@ di \`veggie'`;
                 d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
                     && d.message.includes('veggie')
             );
-            expect(informative).toBeDefined();
-            expect(informative!.message).toContain('bug_b_grandchild.do');
-            expect(informative!.message).toContain(
-                'local macros are not inherited via do/run'
-            );
+            expect(informative).toBeUndefined();
 
-            // The generic "Undefined local macro" should be suppressed in favor
-            // of the informative rewrite.
-            const plain_undefined = line1_diags.filter(
+            const plain_undefined = line1_diags.find(
                 d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    && d.message.includes('veggie')
             );
-            expect(plain_undefined.length).toBe(0);
+            expect(plain_undefined).toBeDefined();
         });
 
         it('should NOT suggest switching to include when callee local is program-scoped', async () => {

--- a/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+++ b/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
@@ -205,6 +205,79 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties', () => {
     });
 });
 
+// Deeper graphs stress the recursive resolve + dedup + filter paths that
+// the default 1-4-file generator under-exercises. Chain depth scales with
+// the DAG size (file i can only call j > i), so pinning the minimum file
+// count above 3 forces chains of length 3-6.
+describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties (deep graphs, depth 3-6)', () => {
+    const deep_graph = () =>
+        arbitrary_forward_call_graph({
+            min_files: 4,
+            max_files: 7,
+            max_events_per_file: 5,
+        });
+
+    test('1. Visibility soundness (deep): visible locals emit no warning', async () => {
+        await fc.assert(
+            fc.asyncProperty(deep_graph(), async graph => {
+                const oracle = new StataExecutionOracle(graph);
+                if (!oracle.is_visible_at()) return;
+                const h = create_harness();
+                try {
+                    const outcome = await diagnose_reference(h, graph);
+                    expect(outcome.has_undefined_macro).toBe(false);
+                    expect(outcome.out_of_scope_count).toBe(0);
+                } finally {
+                    destroy_harness(h);
+                }
+            }),
+            { numRuns: 200 },
+        );
+    });
+
+    test('2. Rewrite attribution (deep): blocked references name the blame file', async () => {
+        await fc.assert(
+            fc.asyncProperty(deep_graph(), async graph => {
+                const oracle = new StataExecutionOracle(graph);
+                if (oracle.is_visible_at()) return;
+                const blame = oracle.blame_target_for();
+                if (blame === null) return;
+                if (oracle.is_defined_in_root()) return;
+                const h = create_harness();
+                try {
+                    const outcome = await diagnose_reference(h, graph);
+                    expect(outcome.out_of_scope_count).toBe(1);
+                    expect(outcome.has_undefined_macro).toBe(false);
+                    const expected_file = oracle.get_file_name(blame);
+                    expect(outcome.out_of_scope_messages[0]).toContain(expected_file);
+                } finally {
+                    destroy_harness(h);
+                }
+            }),
+            { numRuns: 200 },
+        );
+    });
+
+    test('3. Generic-warning completeness (deep): unreachable names emit UNDEFINED only', async () => {
+        await fc.assert(
+            fc.asyncProperty(deep_graph(), async graph => {
+                const oracle = new StataExecutionOracle(graph);
+                if (oracle.is_visible_at()) return;
+                if (oracle.blame_target_for() !== null) return;
+                const h = create_harness();
+                try {
+                    const outcome = await diagnose_reference(h, graph);
+                    expect(outcome.has_undefined_macro).toBe(true);
+                    expect(outcome.out_of_scope_count).toBe(0);
+                } finally {
+                    destroy_harness(h);
+                }
+            }),
+            { numRuns: 200 },
+        );
+    });
+});
+
 describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from code review', () => {
     let h: Harness;
 

--- a/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+++ b/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
@@ -447,6 +447,44 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         ).toBe(false);
     });
 
+    // Codex audit (2026-04): nested `do` beats earlier include-chain claim.
+    // Under real execution the referenced `x` would leak past the `do`
+    // boundary only if the later `do grandchild.do` (reachable through two
+    // includes) were `include`. In execution order `grandchild.do` binds `x`
+    // after `defs1.do`, so last-def-wins names grandchild as the blame
+    // file. Pre-fix the resolver filtered the nested claim out because the
+    // shallower direct-child already owned `x`, and the diagnostic named
+    // `defs1.do` instead.
+    test('codex audit: nested do claim beats earlier include-chain claim', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'defs1.do'), 'local x defs1');
+        fs.writeFileSync(path.join(h.temp_dir, 'grandchild.do'), 'local x grand');
+        fs.writeFileSync(path.join(h.temp_dir, 'mid.do'), 'do "grandchild.do"');
+        fs.writeFileSync(
+            path.join(h.temp_dir, 'child.do'),
+            ['include "defs1.do"', 'include "mid.do"'].join('\n'),
+        );
+        const root_content = ['do "child.do"', 'di `x\''].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            MIN_CONFIG,
+            undefined,
+            h.scope_resolver,
+        );
+        const informative = diags.find(
+            d =>
+                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                d.message.includes("'x'"),
+        );
+        expect(informative).toBeDefined();
+        expect(informative!.message).toContain('grandchild.do');
+        expect(informative!.message).not.toContain('defs1.do');
+    });
+
     // Commit 62c5703: preserve undefined macro fallback when
     // cross_file.diagnostics.out_of_scope = off.
     test('62c5703: out_of_scope=off keeps plain UNDEFINED_MACRO', async () => {
@@ -479,5 +517,182 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         expect(
             ref_line.some(d => d.code === StataDiagnosticCode.UNDEFINED_MACRO),
         ).toBe(true);
+    });
+
+    // Codex Gap 5 (dedup revisit): the same callee is invoked by a `run`
+    // both transitively (through an earlier parent) and directly by the
+    // root. The second direct call must still produce a blame claim even
+    // though `should_process_call` dedups at the symbol layer; otherwise
+    // the rewrite names a file from the first sub-chain and silently
+    // ignores the second boundary's winner.
+    test('codex gap 5 (dedup revisit): second direct run emits its own blame', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'file_6.do'), [
+            'local macro_c 1',
+            'local macro_a 1',
+            'local macro_b 1',
+            'local macro_a 1',
+        ].join('\n'));
+        fs.writeFileSync(path.join(h.temp_dir, 'file_5.do'), [
+            'local macro_c 1',
+            'include "file_6.do"',
+            'local macro_c 1',
+            'local macro_d 1',
+        ].join('\n'));
+        fs.writeFileSync(path.join(h.temp_dir, 'file_3.do'), 'local macro_d 1');
+        fs.writeFileSync(path.join(h.temp_dir, 'file_2.do'), [
+            'include "file_5.do"',
+            'run "file_3.do"',
+            'local macro_a 1',
+        ].join('\n'));
+        const root_content = [
+            'run "file_2.do"',
+            'run "file_5.do"',
+            'di `macro_a\'',
+        ].join('\n');
+        const root_path = path.join(h.temp_dir, 'file_0.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            MIN_CONFIG,
+            undefined,
+            h.scope_resolver,
+        );
+        const informative = diags.find(
+            d =>
+                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                d.message.includes("'macro_a'"),
+        );
+        expect(informative).toBeDefined();
+        // The counterfactual all-include walk binds macro_a last inside
+        // file_6 (via the second `run file_5` → include file_6 chain).
+        expect(informative!.message).toContain('file_6.do');
+    });
+
+    // Codex Gap 5 (run-vs-do asymmetry): `run` should behave like `do` for
+    // local-macro propagation — neither propagates locals to caller — so
+    // the blame rewrite should fire identically.
+    test('codex gap 5 (run vs do): run and do produce the same blame', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'callee_run.do'), 'local veggie beet');
+        fs.writeFileSync(path.join(h.temp_dir, 'callee_do.do'), 'local veggie beet');
+        const root_content_run = ['run "callee_run.do"', 'di `veggie\''].join('\n');
+        const root_content_do = ['do "callee_do.do"', 'di `veggie\''].join('\n');
+
+        fs.writeFileSync(path.join(h.temp_dir, 'main_run.do'), root_content_run);
+        const run_uri = URI.file(path.join(h.temp_dir, 'main_run.do')).toString();
+        await h.document_store.open(run_uri, root_content_run, 1);
+        const run_diags = await h.diagnostics_provider.get_diagnostics(
+            h.document_store.get(run_uri)!,
+            MIN_CONFIG,
+            undefined,
+            h.scope_resolver,
+        );
+        const run_info = run_diags.find(
+            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL && d.message.includes('veggie'),
+        );
+        expect(run_info).toBeDefined();
+        expect(run_info!.message).toContain('callee_run.do');
+
+        fs.writeFileSync(path.join(h.temp_dir, 'main_do.do'), root_content_do);
+        const do_uri = URI.file(path.join(h.temp_dir, 'main_do.do')).toString();
+        await h.document_store.open(do_uri, root_content_do, 1);
+        const do_diags = await h.diagnostics_provider.get_diagnostics(
+            h.document_store.get(do_uri)!,
+            MIN_CONFIG,
+            undefined,
+            h.scope_resolver,
+        );
+        const do_info = do_diags.find(
+            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL && d.message.includes('veggie'),
+        );
+        expect(do_info).toBeDefined();
+        expect(do_info!.message).toContain('callee_do.do');
+    });
+
+    // Codex Gap 5 (cycle safety): mutual-include cycles must not throw or
+    // hang. When the referenced local is defined somewhere in the cycle
+    // reachable through `include`, the rewrite should still fire; when it
+    // is not defined anywhere, plain UNDEFINED_MACRO is preserved.
+    test('codex gap 5 (cycle): mutual includes terminate safely', async () => {
+        fs.writeFileSync(
+            path.join(h.temp_dir, 'cycle_a.do'),
+            ['include "cycle_b.do"', 'local veggie beet'].join('\n'),
+        );
+        fs.writeFileSync(
+            path.join(h.temp_dir, 'cycle_b.do'),
+            'include "cycle_a.do"',
+        );
+        const root_content = ['do "cycle_a.do"', 'di `veggie\''].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            MIN_CONFIG,
+            undefined,
+            h.scope_resolver,
+        );
+        const informative = diags.find(
+            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL && d.message.includes('veggie'),
+        );
+        // Either the rewrite fires naming the defining file, or no
+        // spurious exception. Must not throw or hang.
+        expect(informative).toBeDefined();
+        expect(informative!.message).toContain('cycle_a.do');
+    });
+
+    // Codex Gap 5 (out_of_scope severity passthrough): lowering
+    // cross_file.diagnostics.out_of_scope from warning to information
+    // must preserve the rewrite presence and message; only severity
+    // changes.
+    test('codex gap 5 (severity): out_of_scope severity change preserves presence and text', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'severity_child.do'), 'local veggie beet');
+        const root_content = ['do "severity_child.do"', 'di `veggie\''].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const warning_config: StataLSPConfig = {
+            ...MIN_CONFIG,
+            cross_file: {
+                ...MIN_CONFIG.cross_file,
+                diagnostics: { out_of_scope: 'warning' },
+            },
+        } as unknown as StataLSPConfig;
+        const info_config: StataLSPConfig = {
+            ...MIN_CONFIG,
+            cross_file: {
+                ...MIN_CONFIG.cross_file,
+                diagnostics: { out_of_scope: 'information' },
+            },
+        } as unknown as StataLSPConfig;
+        const warn_diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            warning_config,
+            undefined,
+            h.scope_resolver,
+        );
+        const info_diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            info_config,
+            undefined,
+            h.scope_resolver,
+        );
+        const warn_rewrite = warn_diags.find(
+            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL && d.message.includes('veggie'),
+        );
+        const info_rewrite = info_diags.find(
+            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL && d.message.includes('veggie'),
+        );
+        expect(warn_rewrite).toBeDefined();
+        expect(info_rewrite).toBeDefined();
+        // Message unchanged; only severity differs.
+        expect(info_rewrite!.message).toBe(warn_rewrite!.message);
+        expect(info_rewrite!.severity).not.toBe(warn_rewrite!.severity);
     });
 });

--- a/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+++ b/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
@@ -343,12 +343,14 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         );
         const ref_line_diags = diags.filter(d => d.range.start.line === 1);
         const rewrite = ref_line_diags.find(
-            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
-                 d.message.includes('veggie'),
+            d =>
+                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                d.message.includes('veggie'),
         );
         const generic = ref_line_diags.find(
-            d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
-                 d.message.includes('veggie'),
+            d =>
+                d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                d.message.includes('veggie'),
         );
         expect(rewrite).toBeUndefined();
         expect(generic).toBeDefined();
@@ -476,8 +478,9 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
             h.scope_resolver,
         );
         const informative = diags.find(
-            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
-                 d.message.includes("'x'"),
+            d =>
+                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                d.message.includes("'x'"),
         );
         expect(informative).toBeDefined();
         expect(informative!.message).toContain('defs1.do');

--- a/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+++ b/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Oracle-backed property tests for the forward-call OUT_OF_SCOPE_SYMBOL
+ * rewrite path.
+ *
+ * The {@link StataExecutionOracle} is the ground truth: it executes a
+ * generated graph under Stata's real do/run semantics (fresh scope) and
+ * its counter-factual "all-include" semantics (locals propagate). Three
+ * properties compare that ground truth against what
+ * `DiagnosticsProvider` emits on the same graph:
+ *
+ *   1. Visibility soundness — if the oracle says the reference is
+ *      actually visible, no warning must fire.
+ *   2. Rewrite attribution — if the reference is blocked by some
+ *      do/run boundary but would have been bound under include, the LSP
+ *      must emit exactly one OUT_OF_SCOPE_SYMBOL naming the file whose
+ *      local is the effective (last-def-wins) definition.
+ *   3. Generic-warning completeness — if no ancestor defines the name at
+ *      all, fall back to UNDEFINED_MACRO (no rewrite).
+ *
+ * A `regression: pinned scenarios from code review` block below locks
+ * the specific bugs this feature's history has hit, so the next Codex
+ * review of a fix sees them still intact.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import * as fc from 'fast-check';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { Connection } from 'vscode-languageserver';
+import { DiagnosticsProvider } from '../../src/providers/diagnostics';
+import { DocumentStore } from '../../src/document-store';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
+import {
+    arbitrary_forward_call_graph,
+    render_file,
+    ForwardCallGraph,
+    FileSpec,
+} from './generators/forward-call-graphs';
+import { StataExecutionOracle } from './helpers/stata-execution-oracle';
+
+const MIN_CONFIG: StataLSPConfig = {
+    diagnostics: {
+        enabled: true,
+        severity: {
+            undefinedMacro: 'warning',
+            undefinedVariable: 'information',
+            styleWarnings: 'hint',
+        },
+    },
+    adoPaths: [],
+    cross_file: {
+        assume_call_site: 'end',
+        max_forward_depth: 10,
+    },
+} as unknown as StataLSPConfig;
+
+interface Harness {
+    document_store: DocumentStore;
+    scope_resolver: ScopeResolver;
+    forward_scope_resolver: ForwardScopeResolver;
+    diagnostics_provider: DiagnosticsProvider;
+    temp_dir: string;
+}
+
+function create_harness(): Harness {
+    const mock_connection: Connection = { sendDiagnostics: () => {} } as unknown as Connection;
+    const document_store = new DocumentStore();
+    const scope_resolver = new ScopeResolver();
+    const forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+        max_forward_depth: 10,
+    });
+    scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+    const diagnostics_provider = new DiagnosticsProvider(mock_connection);
+    const temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forward-call-oracle-'));
+    return { document_store, scope_resolver, forward_scope_resolver, diagnostics_provider, temp_dir };
+}
+
+function destroy_harness(h: Harness): void {
+    if (fs.existsSync(h.temp_dir)) {
+        fs.rmSync(h.temp_dir, { recursive: true, force: true });
+    }
+}
+
+function write_files(h: Harness, files: FileSpec[]): void {
+    for (const my_file of files) {
+        fs.writeFileSync(path.join(h.temp_dir, my_file.filename), render_file(my_file));
+    }
+}
+
+interface DiagnosticOutcome {
+    has_undefined_macro: boolean;
+    out_of_scope_count: number;
+    out_of_scope_messages: string[];
+}
+
+async function diagnose_reference(
+    h: Harness,
+    graph: ForwardCallGraph,
+    config: StataLSPConfig = MIN_CONFIG,
+): Promise<DiagnosticOutcome> {
+    write_files(h, graph.files);
+    const root = graph.files[0];
+    const root_path = path.join(h.temp_dir, root.filename);
+    const root_uri = URI.file(root_path).toString();
+    const content = render_file(root);
+    await h.document_store.open(root_uri, content, 1);
+    const document_state = h.document_store.get(root_uri)!;
+    const diagnostics = await h.diagnostics_provider.get_diagnostics(
+        document_state,
+        config,
+        undefined,
+        h.scope_resolver,
+    );
+    const ref_line = graph.reference_event_index;
+    const ref_line_diags = diagnostics.filter(d => d.range.start.line === ref_line);
+    // Only count diagnostics that concern the referenced name — a shared
+    // line may carry unrelated symbol warnings when the generator places
+    // other expressions nearby.
+    const for_this_name = ref_line_diags.filter(d =>
+        d.message.includes(`\`${graph.reference_name}'`) ||
+        d.message.includes(`'${graph.reference_name}'`),
+    );
+    return {
+        has_undefined_macro: for_this_name.some(
+            d => d.code === StataDiagnosticCode.UNDEFINED_MACRO,
+        ),
+        out_of_scope_count: for_this_name.filter(
+            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
+        ).length,
+        out_of_scope_messages: for_this_name
+            .filter(d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL)
+            .map(d => d.message),
+    };
+}
+
+describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties', () => {
+    test('1. Visibility soundness: visible locals emit no warning', async () => {
+        await fc.assert(
+            fc.asyncProperty(arbitrary_forward_call_graph(), async graph => {
+                const oracle = new StataExecutionOracle(graph);
+                if (!oracle.is_visible_at()) return;
+                const h = create_harness();
+                try {
+                    const outcome = await diagnose_reference(h, graph);
+                    expect(outcome.has_undefined_macro).toBe(false);
+                    expect(outcome.out_of_scope_count).toBe(0);
+                } finally {
+                    destroy_harness(h);
+                }
+            }),
+            { numRuns: 200 },
+        );
+    });
+
+    test('2. Rewrite attribution: blocked references name the blame file', async () => {
+        await fc.assert(
+            fc.asyncProperty(arbitrary_forward_call_graph(), async graph => {
+                const oracle = new StataExecutionOracle(graph);
+                if (oracle.is_visible_at()) return;
+                const blame = oracle.blame_target_for();
+                if (blame === null) return;
+                // When the name is also defined somewhere in root — even
+                // *after* the reference — the LSP intentionally preserves
+                // the analyzer's UNDEFINED_MACRO (same-file forward
+                // reference) rather than rewriting. The rewrite-attribution
+                // property doesn't apply in that case; see issue #145.
+                if (oracle.is_defined_in_root()) return;
+                const h = create_harness();
+                try {
+                    const outcome = await diagnose_reference(h, graph);
+                    // Exactly one OUT_OF_SCOPE rewrite; the plain UNDEFINED is
+                    // suppressed in favor of the informative message.
+                    expect(outcome.out_of_scope_count).toBe(1);
+                    expect(outcome.has_undefined_macro).toBe(false);
+                    const expected_file = oracle.get_file_name(blame);
+                    expect(outcome.out_of_scope_messages[0]).toContain(expected_file);
+                } finally {
+                    destroy_harness(h);
+                }
+            }),
+            { numRuns: 200 },
+        );
+    });
+
+    test('3. Generic-warning completeness: unreachable names emit UNDEFINED only', async () => {
+        await fc.assert(
+            fc.asyncProperty(arbitrary_forward_call_graph(), async graph => {
+                const oracle = new StataExecutionOracle(graph);
+                if (oracle.is_visible_at()) return;
+                if (oracle.blame_target_for() !== null) return;
+                const h = create_harness();
+                try {
+                    const outcome = await diagnose_reference(h, graph);
+                    expect(outcome.has_undefined_macro).toBe(true);
+                    expect(outcome.out_of_scope_count).toBe(0);
+                } finally {
+                    destroy_harness(h);
+                }
+            }),
+            { numRuns: 200 },
+        );
+    });
+});
+
+describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from code review', () => {
+    let h: Harness;
+
+    beforeEach(() => {
+        h = create_harness();
+    });
+
+    afterEach(() => {
+        destroy_harness(h);
+    });
+
+    // Bug A (this branch): redefinitions hidden in `additional_definitions`.
+    // child.do has `local veggie` before an include and then again after it;
+    // the late redefinition must be the blame target.
+    test('Bug A: redefinition after include wins (blames child)', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'defs.do'), 'local veggie beet');
+        fs.writeFileSync(
+            path.join(h.temp_dir, 'child.do'),
+            ['local veggie carrot', 'include "defs.do"', 'local veggie spinach'].join('\n'),
+        );
+        const root_content = ['do "child.do"', 'di `veggie\''].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            MIN_CONFIG,
+            undefined,
+            h.scope_resolver,
+        );
+        const informative = diags.find(
+            d =>
+                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                d.message.includes('veggie'),
+        );
+        expect(informative).toBeDefined();
+        expect(informative!.message).toContain('child.do');
+        expect(informative!.message).not.toContain('defs.do');
+    });
+
+    // Bug B (this branch): nested do under an include chain lost its blame
+    // carrier when the direct-child site's excluded_locals were stripped
+    // unconditionally.
+    test('Bug B: do nested under include keeps its boundary blame', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'grandchild.do'), 'local veggie beet');
+        fs.writeFileSync(path.join(h.temp_dir, 'child.do'), 'do "grandchild.do"');
+        const root_content = ['include "child.do"', 'di `veggie\''].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            MIN_CONFIG,
+            undefined,
+            h.scope_resolver,
+        );
+        const ref_line_diags = diags.filter(d => d.range.start.line === 1);
+        const informative = ref_line_diags.find(
+            d =>
+                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                d.message.includes('veggie'),
+        );
+        expect(informative).toBeDefined();
+        expect(informative!.message).toContain('grandchild.do');
+        expect(
+            ref_line_diags.some(d => d.code === StataDiagnosticCode.UNDEFINED_MACRO),
+        ).toBe(false);
+    });
+
+    // Commit a813cca: highest-precedence callee for shadowed locals.
+    // child has `local veggie` then an include that also binds veggie;
+    // the include's definition is the last one in execution order.
+    test('a813cca: highest-precedence shadow is the include', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'defs.do'), 'local veggie beet');
+        fs.writeFileSync(
+            path.join(h.temp_dir, 'child.do'),
+            ['local veggie carrot', 'include "defs.do"'].join('\n'),
+        );
+        const root_content = ['do "child.do"', 'di `veggie\''].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            MIN_CONFIG,
+            undefined,
+            h.scope_resolver,
+        );
+        const informative = diags.find(
+            d =>
+                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                d.message.includes('veggie'),
+        );
+        expect(informative).toBeDefined();
+        expect(informative!.message).toContain('defs.do');
+        expect(informative!.message).not.toContain('child.do');
+    });
+
+    // Commit e8bebbb: respect undefinedMacro=off when emitting rewrite.
+    test('e8bebbb: undefinedMacro=off suppresses the rewrite too', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'child.do'), 'local veggie beet');
+        const root_content = ['do "child.do"', 'di `veggie\''].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const off_config: StataLSPConfig = {
+            ...MIN_CONFIG,
+            diagnostics: {
+                ...MIN_CONFIG.diagnostics,
+                severity: {
+                    ...MIN_CONFIG.diagnostics.severity,
+                    undefinedMacro: 'off',
+                },
+            },
+        };
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            off_config,
+            undefined,
+            h.scope_resolver,
+        );
+        expect(
+            diags.some(d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL),
+        ).toBe(false);
+        expect(
+            diags.some(d => d.code === StataDiagnosticCode.UNDEFINED_MACRO),
+        ).toBe(false);
+    });
+
+    // Commit 180e56e: suppress OUT_OF_SCOPE_SYMBOL when base diagnostic off.
+    // Same scenario as e8bebbb; covered by the config path — kept separate
+    // as a narrative marker for the commit.
+    test('180e56e: base diagnostic off suppresses rewrite', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'child.do'), 'local veggie beet');
+        const root_content = ['do "child.do"', 'di `veggie\''].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const off_config: StataLSPConfig = {
+            ...MIN_CONFIG,
+            diagnostics: {
+                ...MIN_CONFIG.diagnostics,
+                severity: {
+                    ...MIN_CONFIG.diagnostics.severity,
+                    undefinedMacro: 'off',
+                },
+            },
+        };
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            off_config,
+            undefined,
+            h.scope_resolver,
+        );
+        expect(
+            diags.some(d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL),
+        ).toBe(false);
+    });
+
+    // Commit 62c5703: preserve undefined macro fallback when
+    // cross_file.diagnostics.out_of_scope = off.
+    test('62c5703: out_of_scope=off keeps plain UNDEFINED_MACRO', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'child.do'), 'local veggie beet');
+        const root_content = ['do "child.do"', 'di `veggie\''].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const rewrite_off: StataLSPConfig = {
+            ...MIN_CONFIG,
+            cross_file: {
+                ...MIN_CONFIG.cross_file,
+                diagnostics: {
+                    out_of_scope: 'off',
+                },
+            },
+        } as unknown as StataLSPConfig;
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            rewrite_off,
+            undefined,
+            h.scope_resolver,
+        );
+        const ref_line = diags.filter(d => d.range.start.line === 1);
+        expect(
+            ref_line.some(d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL),
+        ).toBe(false);
+        expect(
+            ref_line.some(d => d.code === StataDiagnosticCode.UNDEFINED_MACRO),
+        ).toBe(true);
+    });
+});

--- a/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+++ b/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
@@ -645,4 +645,51 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         expect(info_rewrite!.message).toBe(warn_rewrite!.message);
         expect(info_rewrite!.severity).not.toBe(warn_rewrite!.severity);
     });
+
+    // Retained boundary_only contract: when root does A then does B,
+    // and A internally does B, and A + B each define the same local
+    // differently, the LSP must emit a rewrite naming B (the second
+    // root-level do's callee) under last-visible-site precedence. An
+    // earlier attempt at the plan proposed removing the boundary_only
+    // DuplicateCallDecision variant entirely. A TDD counterexample on
+    // this scenario showed that removal drops B's blame claim — the
+    // first visit's site carries A's include-only end-state (A
+    // overrides B's binding with its own late `local X`), and the
+    // second root-level `do B` gets skipped by plain dedup. Only the
+    // boundary_only path carries B's distinct blame. This fixture is
+    // the pin.
+    test('boundary_only contract: second root-level do names its own callee', async () => {
+        fs.writeFileSync(
+            path.join(h.temp_dir, 'child_b.do'),
+            'local veggie b_binding',
+        );
+        fs.writeFileSync(
+            path.join(h.temp_dir, 'child_a.do'),
+            ['local veggie a_binding', 'do "child_b.do"'].join('\n'),
+        );
+        const root_content = [
+            'do "child_a.do"',
+            'do "child_b.do"',
+            'di `veggie\'',
+        ].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            MIN_CONFIG,
+            undefined,
+            h.scope_resolver,
+        );
+        const informative = diags.find(
+            d =>
+                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                d.message.includes('veggie'),
+        );
+        expect(informative).toBeDefined();
+        expect(informative!.message).toContain('child_b.do');
+        expect(informative!.message).not.toContain('child_a.do');
+    });
 });

--- a/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+++ b/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
@@ -141,7 +141,7 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties', () => {
         await fc.assert(
             fc.asyncProperty(arbitrary_forward_call_graph(), async graph => {
                 const oracle = new StataExecutionOracle(graph);
-                if (!oracle.is_visible_at()) return;
+                fc.pre(oracle.is_visible_at());
                 const h = create_harness();
                 try {
                     const outcome = await diagnose_reference(h, graph);
@@ -159,15 +159,16 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties', () => {
         await fc.assert(
             fc.asyncProperty(arbitrary_forward_call_graph(), async graph => {
                 const oracle = new StataExecutionOracle(graph);
-                if (oracle.is_visible_at()) return;
+                fc.pre(!oracle.is_visible_at());
                 const blame = oracle.blame_target_for();
-                if (blame === null) return;
+                fc.pre(blame !== null);
                 // When the name is also defined somewhere in root — even
                 // *after* the reference — the LSP intentionally preserves
                 // the analyzer's UNDEFINED_MACRO (same-file forward
                 // reference) rather than rewriting. The rewrite-attribution
-                // property doesn't apply in that case; see issue #145.
-                if (oracle.is_defined_in_root()) return;
+                // property doesn't apply in that case; see issue #145 and
+                // the in-root-forward-reference regression fixture below.
+                fc.pre(!oracle.is_defined_in_root());
                 const h = create_harness();
                 try {
                     const outcome = await diagnose_reference(h, graph);
@@ -175,7 +176,7 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties', () => {
                     // suppressed in favor of the informative message.
                     expect(outcome.out_of_scope_count).toBe(1);
                     expect(outcome.has_undefined_macro).toBe(false);
-                    const expected_file = oracle.get_file_name(blame);
+                    const expected_file = oracle.get_file_name(blame!);
                     expect(outcome.out_of_scope_messages[0]).toContain(expected_file);
                 } finally {
                     destroy_harness(h);
@@ -189,8 +190,8 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties', () => {
         await fc.assert(
             fc.asyncProperty(arbitrary_forward_call_graph(), async graph => {
                 const oracle = new StataExecutionOracle(graph);
-                if (oracle.is_visible_at()) return;
-                if (oracle.blame_target_for() !== null) return;
+                fc.pre(!oracle.is_visible_at());
+                fc.pre(oracle.blame_target_for() === null);
                 const h = create_harness();
                 try {
                     const outcome = await diagnose_reference(h, graph);
@@ -221,7 +222,7 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties (deep graphs, d
         await fc.assert(
             fc.asyncProperty(deep_graph(), async graph => {
                 const oracle = new StataExecutionOracle(graph);
-                if (!oracle.is_visible_at()) return;
+                fc.pre(oracle.is_visible_at());
                 const h = create_harness();
                 try {
                     const outcome = await diagnose_reference(h, graph);
@@ -239,16 +240,16 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties (deep graphs, d
         await fc.assert(
             fc.asyncProperty(deep_graph(), async graph => {
                 const oracle = new StataExecutionOracle(graph);
-                if (oracle.is_visible_at()) return;
+                fc.pre(!oracle.is_visible_at());
                 const blame = oracle.blame_target_for();
-                if (blame === null) return;
-                if (oracle.is_defined_in_root()) return;
+                fc.pre(blame !== null);
+                fc.pre(!oracle.is_defined_in_root());
                 const h = create_harness();
                 try {
                     const outcome = await diagnose_reference(h, graph);
                     expect(outcome.out_of_scope_count).toBe(1);
                     expect(outcome.has_undefined_macro).toBe(false);
-                    const expected_file = oracle.get_file_name(blame);
+                    const expected_file = oracle.get_file_name(blame!);
                     expect(outcome.out_of_scope_messages[0]).toContain(expected_file);
                 } finally {
                     destroy_harness(h);
@@ -262,8 +263,8 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties (deep graphs, d
         await fc.assert(
             fc.asyncProperty(deep_graph(), async graph => {
                 const oracle = new StataExecutionOracle(graph);
-                if (oracle.is_visible_at()) return;
-                if (oracle.blame_target_for() !== null) return;
+                fc.pre(!oracle.is_visible_at());
+                fc.pre(oracle.blame_target_for() === null);
                 const h = create_harness();
                 try {
                     const outcome = await diagnose_reference(h, graph);
@@ -644,6 +645,47 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         // Message unchanged; only severity differs.
         expect(info_rewrite!.message).toBe(warn_rewrite!.message);
         expect(info_rewrite!.severity).not.toBe(warn_rewrite!.severity);
+    });
+
+    // In-root forward reference carve-out (issue #145): when the
+    // referenced local is also defined somewhere in root — even *after*
+    // the reference line — the LSP preserves the analyzer's
+    // UNDEFINED_MACRO (same-file forward reference) and suppresses the
+    // OUT_OF_SCOPE_SYMBOL rewrite, even if a forward-called file also
+    // defines the name. Property 2 filters this case out via
+    // `oracle.is_defined_in_root()`; this fixture pins the rule
+    // explicitly.
+    test('in-root forward reference: UNDEFINED_MACRO preserved, no rewrite', async () => {
+        fs.writeFileSync(path.join(h.temp_dir, 'in_root_child.do'), 'local veggie child');
+        const root_content = [
+            'do "in_root_child.do"',
+            'di `veggie\'',
+            'local veggie root',
+        ].join('\n');
+        const root_path = path.join(h.temp_dir, 'main.do');
+        fs.writeFileSync(root_path, root_content);
+        const root_uri = URI.file(root_path).toString();
+        await h.document_store.open(root_uri, root_content, 1);
+        const doc = h.document_store.get(root_uri)!;
+        const diags = await h.diagnostics_provider.get_diagnostics(
+            doc,
+            MIN_CONFIG,
+            undefined,
+            h.scope_resolver,
+        );
+        const ref_line_diags = diags.filter(d => d.range.start.line === 1);
+        const rewrite = ref_line_diags.find(
+            d =>
+                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                d.message.includes('veggie'),
+        );
+        const generic = ref_line_diags.find(
+            d =>
+                d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                d.message.includes('veggie'),
+        );
+        expect(rewrite).toBeUndefined();
+        expect(generic).toBeDefined();
     });
 
     // Retained boundary_only contract: when root does A then does B,

--- a/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+++ b/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
@@ -320,10 +320,13 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         expect(informative!.message).not.toContain('defs.do');
     });
 
-    // Bug B (this branch): nested do under an include chain lost its blame
-    // carrier when the direct-child site's excluded_locals were stripped
-    // unconditionally.
-    test('Bug B: do nested under include keeps its boundary blame', async () => {
+    // Bug B (this branch): nested do under an include chain used to be
+    // forcibly blamed. Under single-boundary semantics the rewrite no longer
+    // fires here — there is no root-level `do`/`run` whose promotion would
+    // expose the deep binding — so the analyzer's generic UNDEFINED_MACRO
+    // stands. Kept as a pin so we don't accidentally regress back to the
+    // all-promotion rewrite.
+    test('Bug B: nested do under include falls back to generic UNDEFINED_MACRO', async () => {
         fs.writeFileSync(path.join(h.temp_dir, 'grandchild.do'), 'local veggie beet');
         fs.writeFileSync(path.join(h.temp_dir, 'child.do'), 'do "grandchild.do"');
         const root_content = ['include "child.do"', 'di `veggie\''].join('\n');
@@ -339,16 +342,16 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
             h.scope_resolver,
         );
         const ref_line_diags = diags.filter(d => d.range.start.line === 1);
-        const informative = ref_line_diags.find(
-            d =>
-                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
-                d.message.includes('veggie'),
+        const rewrite = ref_line_diags.find(
+            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                 d.message.includes('veggie'),
         );
-        expect(informative).toBeDefined();
-        expect(informative!.message).toContain('grandchild.do');
-        expect(
-            ref_line_diags.some(d => d.code === StataDiagnosticCode.UNDEFINED_MACRO),
-        ).toBe(false);
+        const generic = ref_line_diags.find(
+            d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                 d.message.includes('veggie'),
+        );
+        expect(rewrite).toBeUndefined();
+        expect(generic).toBeDefined();
     });
 
     // Commit a813cca: highest-precedence callee for shadowed locals.
@@ -447,15 +450,12 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         ).toBe(false);
     });
 
-    // Codex audit (2026-04): nested `do` beats earlier include-chain claim.
-    // Under real execution the referenced `x` would leak past the `do`
-    // boundary only if the later `do grandchild.do` (reachable through two
-    // includes) were `include`. In execution order `grandchild.do` binds `x`
-    // after `defs1.do`, so last-def-wins names grandchild as the blame
-    // file. Pre-fix the resolver filtered the nested claim out because the
-    // shallower direct-child already owned `x`, and the diagnostic named
-    // `defs1.do` instead.
-    test('codex audit: nested do claim beats earlier include-chain claim', async () => {
+    // Codex audit (2026-04): under single-boundary semantics, promoting
+    // root's `do child` to `include child` makes child run in main's scope.
+    // child's include-only end-state binds x from defs1 (reached through
+    // include); mid's `do grandchild` is opaque and contributes nothing.
+    // The diagnostic must name defs1, not grandchild.
+    test('codex audit: single-boundary walk names defs1 (nested do stays opaque)', async () => {
         fs.writeFileSync(path.join(h.temp_dir, 'defs1.do'), 'local x defs1');
         fs.writeFileSync(path.join(h.temp_dir, 'grandchild.do'), 'local x grand');
         fs.writeFileSync(path.join(h.temp_dir, 'mid.do'), 'do "grandchild.do"');
@@ -476,13 +476,12 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
             h.scope_resolver,
         );
         const informative = diags.find(
-            d =>
-                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
-                d.message.includes("'x'"),
+            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
+                 d.message.includes("'x'"),
         );
         expect(informative).toBeDefined();
-        expect(informative!.message).toContain('grandchild.do');
-        expect(informative!.message).not.toContain('defs1.do');
+        expect(informative!.message).toContain('defs1.do');
+        expect(informative!.message).not.toContain('grandchild.do');
     });
 
     // Commit 62c5703: preserve undefined macro fallback when
@@ -517,58 +516,6 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         expect(
             ref_line.some(d => d.code === StataDiagnosticCode.UNDEFINED_MACRO),
         ).toBe(true);
-    });
-
-    // Codex Gap 5 (dedup revisit): the same callee is invoked by a `run`
-    // both transitively (through an earlier parent) and directly by the
-    // root. The second direct call must still produce a blame claim even
-    // though `should_process_call` dedups at the symbol layer; otherwise
-    // the rewrite names a file from the first sub-chain and silently
-    // ignores the second boundary's winner.
-    test('codex gap 5 (dedup revisit): second direct run emits its own blame', async () => {
-        fs.writeFileSync(path.join(h.temp_dir, 'file_6.do'), [
-            'local macro_c 1',
-            'local macro_a 1',
-            'local macro_b 1',
-            'local macro_a 1',
-        ].join('\n'));
-        fs.writeFileSync(path.join(h.temp_dir, 'file_5.do'), [
-            'local macro_c 1',
-            'include "file_6.do"',
-            'local macro_c 1',
-            'local macro_d 1',
-        ].join('\n'));
-        fs.writeFileSync(path.join(h.temp_dir, 'file_3.do'), 'local macro_d 1');
-        fs.writeFileSync(path.join(h.temp_dir, 'file_2.do'), [
-            'include "file_5.do"',
-            'run "file_3.do"',
-            'local macro_a 1',
-        ].join('\n'));
-        const root_content = [
-            'run "file_2.do"',
-            'run "file_5.do"',
-            'di `macro_a\'',
-        ].join('\n');
-        const root_path = path.join(h.temp_dir, 'file_0.do');
-        fs.writeFileSync(root_path, root_content);
-        const root_uri = URI.file(root_path).toString();
-        await h.document_store.open(root_uri, root_content, 1);
-        const doc = h.document_store.get(root_uri)!;
-        const diags = await h.diagnostics_provider.get_diagnostics(
-            doc,
-            MIN_CONFIG,
-            undefined,
-            h.scope_resolver,
-        );
-        const informative = diags.find(
-            d =>
-                d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
-                d.message.includes("'macro_a'"),
-        );
-        expect(informative).toBeDefined();
-        // The counterfactual all-include walk binds macro_a last inside
-        // file_6 (via the second `run file_5` → include file_6 chain).
-        expect(informative!.message).toContain('file_6.do');
     });
 
     // Codex Gap 5 (run-vs-do asymmetry): `run` should behave like `do` for

--- a/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+++ b/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
@@ -27,15 +27,18 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { URI } from 'vscode-uri';
-import { Connection } from 'vscode-languageserver';
+import type { Connection } from 'vscode-languageserver';
 import { DiagnosticsProvider } from '../../src/providers/diagnostics';
 import { DocumentStore } from '../../src/document-store';
 import { ScopeResolver } from '../../src/scope-resolver';
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
-import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
+import { StataDiagnosticCode } from '../../src/types';
+import type { StataLSPConfig } from '../../src/types';
 import {
     arbitrary_forward_call_graph,
     render_file,
+} from './generators/forward-call-graphs';
+import type {
     ForwardCallGraph,
     FileSpec,
 } from './generators/forward-call-graphs';

--- a/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+++ b/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
@@ -4,8 +4,8 @@
  *
  * The {@link StataExecutionOracle} is the ground truth: it executes a
  * generated graph under Stata's real do/run semantics (fresh scope) and
- * its counter-factual "all-include" semantics (locals propagate). Three
- * properties compare that ground truth against what
+ * a single-boundary counterfactual ("promote this one do/run to
+ * include"). Three properties compare that ground truth against what
  * `DiagnosticsProvider` emits on the same graph:
  *
  *   1. Visibility soundness — if the oracle says the reference is

--- a/tests/property/forward-scope-resolution.prop.test.ts
+++ b/tests/property/forward-scope-resolution.prop.test.ts
@@ -180,13 +180,48 @@ global callee_global = 2
 
     // Property 30: Duplicate Do/Run Call Optimization
     describe('Property 30: Duplicate Do/Run Call Optimization', () => {
-        test('should_process_call returns skip for duplicate do', () => {
+        test('should_process_call returns boundary_only for duplicate do', () => {
+            // Historical note: the resolver used to return `skip` here as a
+            // pure performance optimization, but that dropped the second
+            // direct do/run call's blame claim — the rewrite at the outer
+            // iteration never saw the later boundary even though
+            // counterfactually promoting it would rebind names. Codex's
+            // audit (2026-04) flagged the resulting disagreement with the
+            // oracle; the current contract is `boundary_only`, which
+            // skips symbol merge and nested recursion but still emits an
+            // excluded_locals claim.
             const visited = new Map<string, 'do' | 'include'>();
             visited.set('file:///callee.do', 'do');
 
             const decision = forward_resolver.should_process_call(
                 'file:///callee.do',
                 'do',
+                visited
+            );
+
+            expect(decision.action).toBe('boundary_only');
+        });
+
+        test('should_process_call returns boundary_only for duplicate run', () => {
+            const visited = new Map<string, 'do' | 'include'>();
+            visited.set('file:///callee.do', 'do');
+
+            const decision = forward_resolver.should_process_call(
+                'file:///callee.do',
+                'run',
+                visited
+            );
+
+            expect(decision.action).toBe('boundary_only');
+        });
+
+        test('should_process_call still returns skip for duplicate include', () => {
+            const visited = new Map<string, 'do' | 'include'>();
+            visited.set('file:///callee.do', 'include');
+
+            const decision = forward_resolver.should_process_call(
+                'file:///callee.do',
+                'include',
                 visited
             );
 

--- a/tests/property/generators/forward-call-graphs.ts
+++ b/tests/property/generators/forward-call-graphs.ts
@@ -38,6 +38,7 @@ export interface ForwardCallGraph {
 }
 
 interface GraphConfig {
+    min_files: number;
     max_files: number;
     max_events_per_file: number;
     define_probability: number;
@@ -47,6 +48,7 @@ interface GraphConfig {
 }
 
 const DEFAULT_CONFIG: GraphConfig = {
+    min_files: 1,
     max_files: 4,
     max_events_per_file: 6,
     define_probability: 0.5,
@@ -65,7 +67,7 @@ export function arbitrary_forward_call_graph(
 ): fc.Arbitrary<ForwardCallGraph> {
     const my_config: GraphConfig = { ...DEFAULT_CONFIG, ...overrides };
 
-    return fc.integer({ min: 1, max: my_config.max_files }).chain(file_count => {
+    return fc.integer({ min: my_config.min_files, max: my_config.max_files }).chain(file_count => {
         const file_arbs: fc.Arbitrary<FileSpec>[] = [];
         for (let i = 0; i < file_count; i++) {
             file_arbs.push(arbitrary_file_spec(i, file_count, my_config));

--- a/tests/property/generators/forward-call-graphs.ts
+++ b/tests/property/generators/forward-call-graphs.ts
@@ -1,0 +1,184 @@
+/**
+ * Generator for forward-call graphs used in oracle-backed property tests
+ * (see `tests/property/forward-call-out-of-scope-oracle.prop.test.ts`).
+ *
+ * A graph is a small collection of `.do` files connected by
+ * `include`/`do`/`run` calls. File 0 is always the root — it contains the
+ * reference event the oracle and property tests reason about. Non-root
+ * callees can only target files with a strictly greater index, giving a
+ * DAG with bounded depth (at most `file_count - 1`). The existing resolver
+ * and the oracle both handle cycles, so the generator leaves that space
+ * to regression fixtures rather than random inputs.
+ */
+import * as fc from 'fast-check';
+
+export const MACRO_NAME_POOL = ['macro_a', 'macro_b', 'macro_c', 'macro_d'] as const;
+
+export type MacroName = typeof MACRO_NAME_POOL[number];
+
+export type FileEvent =
+    | { kind: 'define_local'; name: MacroName }
+    | { kind: 'include_call'; target: number }
+    | { kind: 'do_call'; target: number }
+    | { kind: 'run_call'; target: number }
+    | { kind: 'reference_local'; name: MacroName };
+
+export interface FileSpec {
+    filename: string;
+    events: FileEvent[];
+}
+
+export interface ForwardCallGraph {
+    /** files[0] is the root; all reference_local events live here. */
+    files: FileSpec[];
+    /** Event index (== line index) of the reference event inside the root file. */
+    reference_event_index: number;
+    /** Name the reference event dereferences. */
+    reference_name: MacroName;
+}
+
+interface GraphConfig {
+    max_files: number;
+    max_events_per_file: number;
+    define_probability: number;
+    include_probability: number;
+    do_probability: number;
+    run_probability: number;
+}
+
+const DEFAULT_CONFIG: GraphConfig = {
+    max_files: 4,
+    max_events_per_file: 6,
+    define_probability: 0.5,
+    include_probability: 0.2,
+    do_probability: 0.2,
+    run_probability: 0.1,
+};
+
+/**
+ * Generator entry point. The optional overrides let callers tune the
+ * random distribution (e.g., biasing toward `do`-calls to stress the
+ * OUT_OF_SCOPE_SYMBOL rewrite path).
+ */
+export function arbitrary_forward_call_graph(
+    overrides: Partial<GraphConfig> = {}
+): fc.Arbitrary<ForwardCallGraph> {
+    const my_config: GraphConfig = { ...DEFAULT_CONFIG, ...overrides };
+
+    return fc.integer({ min: 1, max: my_config.max_files }).chain(file_count => {
+        const file_arbs: fc.Arbitrary<FileSpec>[] = [];
+        for (let i = 0; i < file_count; i++) {
+            file_arbs.push(arbitrary_file_spec(i, file_count, my_config));
+        }
+        return fc.tuple(...file_arbs).chain(the_files => {
+            return place_root_reference(the_files as FileSpec[]);
+        });
+    });
+}
+
+function arbitrary_file_spec(
+    file_index: number,
+    file_count: number,
+    config: GraphConfig
+): fc.Arbitrary<FileSpec> {
+    const callable_targets: number[] = [];
+    for (let j = file_index + 1; j < file_count; j++) {
+        callable_targets.push(j);
+    }
+
+    return fc
+        .integer({ min: 1, max: config.max_events_per_file })
+        .chain(event_count => {
+            const the_event_arbs: fc.Arbitrary<FileEvent>[] = [];
+            for (let i = 0; i < event_count; i++) {
+                the_event_arbs.push(arbitrary_non_reference_event(callable_targets, config));
+            }
+            return fc.tuple(...the_event_arbs).map(the_events => ({
+                filename: `file_${file_index}.do`,
+                events: the_events as FileEvent[],
+            }));
+        });
+}
+
+function arbitrary_non_reference_event(
+    callable_targets: number[],
+    config: GraphConfig
+): fc.Arbitrary<FileEvent> {
+    const macro_arb = fc.constantFrom(...MACRO_NAME_POOL);
+    const define_arb = macro_arb.map(name => ({ kind: 'define_local' as const, name }));
+
+    const weighted: { arbitrary: fc.Arbitrary<FileEvent>; weight: number }[] = [
+        { arbitrary: define_arb, weight: Math.round(config.define_probability * 100) },
+    ];
+    if (callable_targets.length > 0) {
+        const target_arb = fc.constantFrom(...callable_targets);
+        weighted.push(
+            {
+                arbitrary: target_arb.map(target => ({ kind: 'include_call' as const, target })),
+                weight: Math.round(config.include_probability * 100),
+            },
+            {
+                arbitrary: target_arb.map(target => ({ kind: 'do_call' as const, target })),
+                weight: Math.round(config.do_probability * 100),
+            },
+            {
+                arbitrary: target_arb.map(target => ({ kind: 'run_call' as const, target })),
+                weight: Math.round(config.run_probability * 100),
+            }
+        );
+    }
+    return fc.oneof(...weighted);
+}
+
+function place_root_reference(files: FileSpec[]): fc.Arbitrary<ForwardCallGraph> {
+    const root = files[0];
+    const reference_name_arb = fc.constantFrom(...MACRO_NAME_POOL);
+    // Position the reference event at a random index; the reference becomes
+    // part of the root's event sequence so later tests can read it by line.
+    return fc
+        .tuple(reference_name_arb, fc.integer({ min: 0, max: root.events.length }))
+        .map(([reference_name, reference_index]) => {
+            const the_events: FileEvent[] = [
+                ...root.events.slice(0, reference_index),
+                { kind: 'reference_local', name: reference_name },
+                ...root.events.slice(reference_index),
+            ];
+            const the_files: FileSpec[] = [
+                { filename: root.filename, events: the_events },
+                ...files.slice(1),
+            ];
+            return {
+                files: the_files,
+                reference_event_index: reference_index,
+                reference_name,
+            };
+        });
+}
+
+/**
+ * Render a file's events into Stata source. Each event takes one line so
+ * that `event_index` matches the 0-indexed line number where the event
+ * appears — this lets the oracle and the LSP agree on line references.
+ */
+export function render_file(file: FileSpec): string {
+    const the_lines: string[] = [];
+    for (const my_event of file.events) {
+        the_lines.push(render_event(my_event));
+    }
+    return the_lines.join('\n');
+}
+
+function render_event(event: FileEvent): string {
+    switch (event.kind) {
+        case 'define_local':
+            return `local ${event.name} 1`;
+        case 'include_call':
+            return `include "file_${event.target}.do"`;
+        case 'do_call':
+            return `do "file_${event.target}.do"`;
+        case 'run_call':
+            return `run "file_${event.target}.do"`;
+        case 'reference_local':
+            return `di \`${event.name}'`;
+    }
+}

--- a/tests/property/generators/forward-call-graphs.ts
+++ b/tests/property/generators/forward-call-graphs.ts
@@ -6,9 +6,23 @@
  * `include`/`do`/`run` calls. File 0 is always the root — it contains the
  * reference event the oracle and property tests reason about. Non-root
  * callees can only target files with a strictly greater index, giving a
- * DAG with bounded depth (at most `file_count - 1`). The existing resolver
- * and the oracle both handle cycles, so the generator leaves that space
- * to regression fixtures rather than random inputs.
+ * DAG with bounded depth (at most `file_count - 1`). Revisits (same file
+ * reached via two DAG paths) DO occur and exercise the resolver's
+ * `should_process_call` / `boundary_only` dedup path.
+ *
+ * Scenarios not randomized here, kept as pinned regressions in the
+ * `regression: pinned scenarios from code review` block:
+ *   - Cycles (mutual include) — cycle-safety is unit-tested in
+ *     `tests/unit/forward-scope-resolver-effective-end-state.test.ts`
+ *     and pinned in the property test file.
+ *   - Same-line multi-statement rendering (`#delimit ;`) — requires
+ *     analyzer support for include-under-semicolon that is not yet in
+ *     place; sort-by-(line, character) is unit-tested in
+ *     `tests/unit/forward-scope-resolver-sort-order.test.ts` with
+ *     stubbed events.
+ *   - `@lsp-do` / `@lsp-run` / `@lsp-include` directive rendering —
+ *     parser treats them the same as the bare commands after parsing;
+ *     covered by directive-specific integration tests.
  */
 import * as fc from 'fast-check';
 

--- a/tests/property/generators/index.ts
+++ b/tests/property/generators/index.ts
@@ -61,6 +61,19 @@ export {
   arbitrary_document_with_mixed_symbols,
 } from './documents';
 
+// Forward-call graph generators (used by oracle-backed property tests)
+export {
+  arbitrary_forward_call_graph,
+  render_file,
+  MACRO_NAME_POOL,
+} from './forward-call-graphs';
+export type {
+  ForwardCallGraph,
+  FileSpec,
+  FileEvent,
+  MacroName,
+} from './forward-call-graphs';
+
 // Section generators
 export {
   arbitrary_section_name,

--- a/tests/property/helpers/stata-execution-oracle.ts
+++ b/tests/property/helpers/stata-execution-oracle.ts
@@ -2,33 +2,26 @@
  * Stata execution oracle for forward-call graphs.
  *
  * Ground truth for `tests/property/forward-call-out-of-scope-oracle.prop.test.ts`.
- * Implemented independently from `ForwardScopeResolver` — it uses simpler,
- * structurally different data flow (a linear flattened list of call sites
- * + last-match-wins resolution) so that regressions in the resolver don't
- * silently reproduce in the oracle.
+ * Derived from Stata runtime semantics, not from `ForwardScopeResolver`'s
+ * algorithm — so a resolver bug cannot silently propagate into the oracle.
  *
  * Semantics modelled:
  *
- *  - `is_visible_at()` — real Stata semantics: a stack-based simulator
- *    pushes a fresh scope on `do`/`run` and keeps the caller's scope on
- *    `include`. Reports whether the referenced name is bound when the
- *    reference event fires.
+ *  - `is_visible_at()` — real Stata: a scope stack pushes a fresh scope on
+ *    `do`/`run` and keeps the caller's scope on `include`. Reports whether
+ *    the referenced name is bound when the reference event fires.
  *
- *  - `blame_target_for()` — last-matching-claim wins. Each `do`/`run`
- *    boundary reachable at-or-before the reference becomes a claim whose
- *    payload is the callee's include-chain end-of-execution locals.
- *    Deeper nested claims are filtered against the shallower direct-child
- *    they bubble through, so a name already claimed by a shallower
- *    sibling doesn't get re-claimed by a deeper one (matching the LSP's
- *    `excluded_locals` filtering). Among claims that survive filtering,
- *    the last one in source order wins.
+ *  - `blame_target_for()` — counterfactual "all-include" Stata: promote
+ *    every `do`/`run` boundary reachable from the root to `include`,
+ *    execute the flattened chain in source order, and return the file
+ *    index whose `local X` most recently bound the referenced name before
+ *    the reference event fires. The resolver's flattening, dedup, and
+ *    excluded-locals filtering are *not* mirrored: the oracle re-runs
+ *    each callee as the simulator encounters it (stopping only on the
+ *    current recursion path to avoid infinite loops), and the final
+ *    binding of the referenced name is the blame file.
  */
 import { ForwardCallGraph } from '../generators/forward-call-graphs';
-
-interface Claim {
-    /** Map from local name → file index that defined it in the include walk. */
-    end_state: Map<string, number>;
-}
 
 export class StataExecutionOracle {
     constructor(private graph: ForwardCallGraph) {}
@@ -39,15 +32,15 @@ export class StataExecutionOracle {
     }
 
     blame_target_for(): number | null {
-        const the_claims = this.collect_claims_at_ref();
-        let my_winner: number | null = null;
-        for (const my_claim of the_claims) {
-            const my_owner = my_claim.end_state.get(this.graph.reference_name);
-            if (my_owner !== undefined) {
-                my_winner = my_owner;
-            }
-        }
-        return my_winner;
+        // Counterfactual: promote every do/run to include and re-execute
+        // the reachable chain from the root. Every `local X` overwrites
+        // prior bindings (last-def-wins). The result is the file that
+        // last bound `reference_name` before the reference event fires.
+        const the_scope = new Map<string, number>();
+        const reached = this.walk_counterfactual(0, the_scope, new Set<number>());
+        if (!reached) return null;
+        const my_winner = the_scope.get(this.graph.reference_name);
+        return my_winner ?? null;
     }
 
     get_file_name(file_index: number): string {
@@ -77,8 +70,7 @@ export class StataExecutionOracle {
     /**
      * Stack-based real-Stata simulation. Returns the current top-of-stack
      * scope when the reference event is reached in the root file, or
-     * `null` if the reference is never reached (unreachable by the
-     * simulation — shouldn't happen with well-formed graphs).
+     * `null` if the reference is never reached.
      */
     private simulate_stack_until_ref(): Map<string, number> | null {
         const scope_stack: Map<string, number>[] = [new Map()];
@@ -121,125 +113,51 @@ export class StataExecutionOracle {
     }
 
     /**
-     * Walks an individual file through `include` events only, following
-     * the last-def-wins rule across its own `local` statements and the
-     * recursively-included files. Used to compute the payload a `do`/`run`
-     * boundary would carry (i.e., what the caller would see if the
-     * boundary were `include`).
+     * Counterfactual walk: every `include`/`do`/`run` expands inline into
+     * a single shared scope. Walks the root forward-order until the
+     * reference event fires. Returns `true` once the reference is
+     * reached; returns `false` if the walk exhausts without finding it.
+     *
+     * Cycle protection is per-call-path (`current_path`) rather than a
+     * global visited set, matching real Stata's re-execution on each
+     * call and preserving the last-def-wins ordering that two separate
+     * visits to the same file can introduce.
      */
-    private include_chain_end_state(
+    private walk_counterfactual(
         file_index: number,
-        visited: Set<number>,
-    ): Map<string, number> {
-        if (visited.has(file_index)) return new Map();
-        const my_visited = new Set(visited);
-        my_visited.add(file_index);
-        const the_end_state = new Map<string, number>();
-        const my_file = this.graph.files[file_index];
-        for (const my_event of my_file.events) {
-            if (my_event.kind === 'define_local') {
-                the_end_state.set(my_event.name, file_index);
-            } else if (my_event.kind === 'include_call') {
-                const nested = this.include_chain_end_state(my_event.target, my_visited);
-                for (const [my_name, my_file_index] of nested) {
-                    the_end_state.set(my_name, my_file_index);
+        scope: Map<string, number>,
+        current_path: Set<number>,
+    ): boolean {
+        if (current_path.has(file_index)) return false;
+        current_path.add(file_index);
+        try {
+            const my_file = this.graph.files[file_index];
+            for (let i = 0; i < my_file.events.length; i++) {
+                const my_event = my_file.events[i];
+                if (
+                    file_index === 0 &&
+                    i === this.graph.reference_event_index
+                ) {
+                    return true;
+                }
+                if (my_event.kind === 'define_local') {
+                    scope.set(my_event.name, file_index);
+                } else if (
+                    my_event.kind === 'include_call' ||
+                    my_event.kind === 'do_call' ||
+                    my_event.kind === 'run_call'
+                ) {
+                    const reached = this.walk_counterfactual(
+                        my_event.target,
+                        scope,
+                        current_path,
+                    );
+                    if (reached) return true;
                 }
             }
-            // do/run contribute nothing to the include-chain walk.
-        }
-        return the_end_state;
-    }
-
-    /**
-     * Produce the flattened list of claims that would survive at root's
-     * reference. Mirrors the LSP's flattening: each `do`/`run` reachable
-     * via any call type creates a claim, and claims that bubble up
-     * through a shallower direct-child have their names filtered against
-     * that direct-child's claim. Also mirrors the resolver's dedup rule:
-     * a file visited once as `do` won't be re-processed for another
-     * `do`/`run`, and a file visited as `include` won't be re-processed
-     * at all.
-     */
-    private collect_claims_at_ref(): Claim[] {
-        const the_claims: Claim[] = [];
-        // Shared across the whole walk so sibling branches see each
-        // other's visits (matches `ForwardResolveContext.visited`).
-        const visited = new Map<number, 'include' | 'do'>();
-        this.resolve_file(0, this.graph.reference_event_index, 'include', visited, the_claims);
-        return the_claims;
-    }
-
-    private resolve_file(
-        file_index: number,
-        stop_event_index: number | null,
-        parent_effective: 'include' | 'do',
-        visited: Map<number, 'include' | 'do'>,
-        out_claims: Claim[],
-    ): void {
-        const my_file = this.graph.files[file_index];
-        const limit = stop_event_index ?? my_file.events.length;
-        for (let i = 0; i < limit; i++) {
-            const my_event = my_file.events[i];
-            if (
-                my_event.kind !== 'include_call' &&
-                my_event.kind !== 'do_call' &&
-                my_event.kind !== 'run_call'
-            ) {
-                continue;
-            }
-            const call_type: 'include' | 'do' =
-                my_event.kind === 'include_call' ? 'include' : 'do';
-            const my_effective: 'include' | 'do' =
-                parent_effective === 'do' || call_type === 'do' ? 'do' : 'include';
-
-            // Dedup: matches `should_process_call` on the resolver side.
-            const my_prev = visited.get(my_event.target);
-            let action: 'process' | 'skip' | 'add_locals_only';
-            if (my_prev === undefined) {
-                action = 'process';
-            } else if (my_prev === 'include') {
-                action = 'skip';
-            } else if (call_type === 'include') {
-                // Previously visited as `do`; an `include` to the same
-                // file only adds its already-known locals. Doesn't create
-                // a new blame claim.
-                action = 'add_locals_only';
-            } else {
-                action = 'skip';
-            }
-            if (action === 'skip') continue;
-            visited.set(my_event.target, my_effective);
-            if (action === 'add_locals_only') continue;
-
-            // Direct-child claim for this call.
-            let direct_claim: Map<string, number> | null = null;
-            if (my_effective === 'do') {
-                const the_end_state = this.include_chain_end_state(my_event.target, new Set());
-                if (the_end_state.size > 0) {
-                    direct_claim = the_end_state;
-                    out_claims.push({ end_state: the_end_state });
-                }
-            }
-            // Recurse into the callee; collect its claims into a scratch
-            // list, filter against `direct_claim`, then append to out_claims.
-            const the_nested: Claim[] = [];
-            this.resolve_file(my_event.target, null, my_effective, visited, the_nested);
-            for (const my_nested of the_nested) {
-                let filtered_end_state: Map<string, number>;
-                if (direct_claim !== null) {
-                    filtered_end_state = new Map();
-                    for (const [my_name, my_file_index] of my_nested.end_state) {
-                        if (!direct_claim.has(my_name)) {
-                            filtered_end_state.set(my_name, my_file_index);
-                        }
-                    }
-                } else {
-                    filtered_end_state = my_nested.end_state;
-                }
-                if (filtered_end_state.size > 0) {
-                    out_claims.push({ end_state: filtered_end_state });
-                }
-            }
+            return false;
+        } finally {
+            current_path.delete(file_index);
         }
     }
 }

--- a/tests/property/helpers/stata-execution-oracle.ts
+++ b/tests/property/helpers/stata-execution-oracle.ts
@@ -2,6 +2,9 @@
  * Stata execution oracle for forward-call graphs.
  *
  * Ground truth for `tests/property/forward-call-out-of-scope-oracle.prop.test.ts`.
+ * Derived from Stata runtime semantics, not from `ForwardScopeResolver`'s
+ * algorithm — so a resolver bug cannot silently propagate into the
+ * oracle.
  *
  * Semantics modelled:
  *
@@ -129,8 +132,11 @@ export class StataExecutionOracle {
      * end-states from nested `include` calls. `do`/`run` events are
      * skipped — they would run in a fresh scope and leave nothing behind.
      *
-     * Cycle protection is per-path (current_path) so mutual includes
-     * terminate.
+     * Cycle protection is per-path (current_path), not a global visited
+     * set, because an include-only walk may legitimately re-enter a file
+     * reached through two distinct include chains and rebind on the
+     * second visit — last-def-wins depends on seeing both. We block only
+     * when recursion would re-enter a file already on the current stack.
      */
     private compute_include_only_end_state(
         file_index: number,

--- a/tests/property/helpers/stata-execution-oracle.ts
+++ b/tests/property/helpers/stata-execution-oracle.ts
@@ -1,0 +1,245 @@
+/**
+ * Stata execution oracle for forward-call graphs.
+ *
+ * Ground truth for `tests/property/forward-call-out-of-scope-oracle.prop.test.ts`.
+ * Implemented independently from `ForwardScopeResolver` — it uses simpler,
+ * structurally different data flow (a linear flattened list of call sites
+ * + last-match-wins resolution) so that regressions in the resolver don't
+ * silently reproduce in the oracle.
+ *
+ * Semantics modelled:
+ *
+ *  - `is_visible_at()` — real Stata semantics: a stack-based simulator
+ *    pushes a fresh scope on `do`/`run` and keeps the caller's scope on
+ *    `include`. Reports whether the referenced name is bound when the
+ *    reference event fires.
+ *
+ *  - `blame_target_for()` — last-matching-claim wins. Each `do`/`run`
+ *    boundary reachable at-or-before the reference becomes a claim whose
+ *    payload is the callee's include-chain end-of-execution locals.
+ *    Deeper nested claims are filtered against the shallower direct-child
+ *    they bubble through, so a name already claimed by a shallower
+ *    sibling doesn't get re-claimed by a deeper one (matching the LSP's
+ *    `excluded_locals` filtering). Among claims that survive filtering,
+ *    the last one in source order wins.
+ */
+import { ForwardCallGraph } from '../generators/forward-call-graphs';
+
+interface Claim {
+    /** Map from local name → file index that defined it in the include walk. */
+    end_state: Map<string, number>;
+}
+
+export class StataExecutionOracle {
+    constructor(private graph: ForwardCallGraph) {}
+
+    is_visible_at(): boolean {
+        const the_scope = this.simulate_stack_until_ref();
+        return the_scope !== null && the_scope.has(this.graph.reference_name);
+    }
+
+    blame_target_for(): number | null {
+        const the_claims = this.collect_claims_at_ref();
+        let my_winner: number | null = null;
+        for (const my_claim of the_claims) {
+            const my_owner = my_claim.end_state.get(this.graph.reference_name);
+            if (my_owner !== undefined) {
+                my_winner = my_owner;
+            }
+        }
+        return my_winner;
+    }
+
+    get_file_name(file_index: number): string {
+        return this.graph.files[file_index].filename;
+    }
+
+    /**
+     * True when the referenced name is defined anywhere in the root file
+     * — even after the reference line. The LSP preserves the analyzer's
+     * UNDEFINED_MACRO diagnostic for in-root forward references instead
+     * of rewriting to OUT_OF_SCOPE_SYMBOL; see `src/providers/diagnostics.ts`
+     * around line 358 and issue #145.
+     */
+    is_defined_in_root(): boolean {
+        const my_root = this.graph.files[0];
+        for (const my_event of my_root.events) {
+            if (
+                my_event.kind === 'define_local' &&
+                my_event.name === this.graph.reference_name
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Stack-based real-Stata simulation. Returns the current top-of-stack
+     * scope when the reference event is reached in the root file, or
+     * `null` if the reference is never reached (unreachable by the
+     * simulation — shouldn't happen with well-formed graphs).
+     */
+    private simulate_stack_until_ref(): Map<string, number> | null {
+        const scope_stack: Map<string, number>[] = [new Map()];
+        return this.simulate_file(0, scope_stack, new Set([0]));
+    }
+
+    private simulate_file(
+        file_index: number,
+        scope_stack: Map<string, number>[],
+        visited: Set<number>,
+    ): Map<string, number> | null {
+        const my_file = this.graph.files[file_index];
+        for (let i = 0; i < my_file.events.length; i++) {
+            const my_event = my_file.events[i];
+            if (file_index === 0 && i === this.graph.reference_event_index) {
+                return scope_stack[scope_stack.length - 1];
+            }
+            if (my_event.kind === 'define_local') {
+                scope_stack[scope_stack.length - 1].set(my_event.name, file_index);
+            } else if (my_event.kind === 'include_call') {
+                if (visited.has(my_event.target)) continue;
+                const my_visited = new Set(visited);
+                my_visited.add(my_event.target);
+                const result = this.simulate_file(my_event.target, scope_stack, my_visited);
+                if (result !== null) return result;
+            } else if (
+                my_event.kind === 'do_call' ||
+                my_event.kind === 'run_call'
+            ) {
+                if (visited.has(my_event.target)) continue;
+                const my_visited = new Set(visited);
+                my_visited.add(my_event.target);
+                scope_stack.push(new Map());
+                const result = this.simulate_file(my_event.target, scope_stack, my_visited);
+                scope_stack.pop();
+                if (result !== null) return result;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Walks an individual file through `include` events only, following
+     * the last-def-wins rule across its own `local` statements and the
+     * recursively-included files. Used to compute the payload a `do`/`run`
+     * boundary would carry (i.e., what the caller would see if the
+     * boundary were `include`).
+     */
+    private include_chain_end_state(
+        file_index: number,
+        visited: Set<number>,
+    ): Map<string, number> {
+        if (visited.has(file_index)) return new Map();
+        const my_visited = new Set(visited);
+        my_visited.add(file_index);
+        const the_end_state = new Map<string, number>();
+        const my_file = this.graph.files[file_index];
+        for (const my_event of my_file.events) {
+            if (my_event.kind === 'define_local') {
+                the_end_state.set(my_event.name, file_index);
+            } else if (my_event.kind === 'include_call') {
+                const nested = this.include_chain_end_state(my_event.target, my_visited);
+                for (const [my_name, my_file_index] of nested) {
+                    the_end_state.set(my_name, my_file_index);
+                }
+            }
+            // do/run contribute nothing to the include-chain walk.
+        }
+        return the_end_state;
+    }
+
+    /**
+     * Produce the flattened list of claims that would survive at root's
+     * reference. Mirrors the LSP's flattening: each `do`/`run` reachable
+     * via any call type creates a claim, and claims that bubble up
+     * through a shallower direct-child have their names filtered against
+     * that direct-child's claim. Also mirrors the resolver's dedup rule:
+     * a file visited once as `do` won't be re-processed for another
+     * `do`/`run`, and a file visited as `include` won't be re-processed
+     * at all.
+     */
+    private collect_claims_at_ref(): Claim[] {
+        const the_claims: Claim[] = [];
+        // Shared across the whole walk so sibling branches see each
+        // other's visits (matches `ForwardResolveContext.visited`).
+        const visited = new Map<number, 'include' | 'do'>();
+        this.resolve_file(0, this.graph.reference_event_index, 'include', visited, the_claims);
+        return the_claims;
+    }
+
+    private resolve_file(
+        file_index: number,
+        stop_event_index: number | null,
+        parent_effective: 'include' | 'do',
+        visited: Map<number, 'include' | 'do'>,
+        out_claims: Claim[],
+    ): void {
+        const my_file = this.graph.files[file_index];
+        const limit = stop_event_index ?? my_file.events.length;
+        for (let i = 0; i < limit; i++) {
+            const my_event = my_file.events[i];
+            if (
+                my_event.kind !== 'include_call' &&
+                my_event.kind !== 'do_call' &&
+                my_event.kind !== 'run_call'
+            ) {
+                continue;
+            }
+            const call_type: 'include' | 'do' =
+                my_event.kind === 'include_call' ? 'include' : 'do';
+            const my_effective: 'include' | 'do' =
+                parent_effective === 'do' || call_type === 'do' ? 'do' : 'include';
+
+            // Dedup: matches `should_process_call` on the resolver side.
+            const my_prev = visited.get(my_event.target);
+            let action: 'process' | 'skip' | 'add_locals_only';
+            if (my_prev === undefined) {
+                action = 'process';
+            } else if (my_prev === 'include') {
+                action = 'skip';
+            } else if (call_type === 'include') {
+                // Previously visited as `do`; an `include` to the same
+                // file only adds its already-known locals. Doesn't create
+                // a new blame claim.
+                action = 'add_locals_only';
+            } else {
+                action = 'skip';
+            }
+            if (action === 'skip') continue;
+            visited.set(my_event.target, my_effective);
+            if (action === 'add_locals_only') continue;
+
+            // Direct-child claim for this call.
+            let direct_claim: Map<string, number> | null = null;
+            if (my_effective === 'do') {
+                const the_end_state = this.include_chain_end_state(my_event.target, new Set());
+                if (the_end_state.size > 0) {
+                    direct_claim = the_end_state;
+                    out_claims.push({ end_state: the_end_state });
+                }
+            }
+            // Recurse into the callee; collect its claims into a scratch
+            // list, filter against `direct_claim`, then append to out_claims.
+            const the_nested: Claim[] = [];
+            this.resolve_file(my_event.target, null, my_effective, visited, the_nested);
+            for (const my_nested of the_nested) {
+                let filtered_end_state: Map<string, number>;
+                if (direct_claim !== null) {
+                    filtered_end_state = new Map();
+                    for (const [my_name, my_file_index] of my_nested.end_state) {
+                        if (!direct_claim.has(my_name)) {
+                            filtered_end_state.set(my_name, my_file_index);
+                        }
+                    }
+                } else {
+                    filtered_end_state = my_nested.end_state;
+                }
+                if (filtered_end_state.size > 0) {
+                    out_claims.push({ end_state: filtered_end_state });
+                }
+            }
+        }
+    }
+}

--- a/tests/property/helpers/stata-execution-oracle.ts
+++ b/tests/property/helpers/stata-execution-oracle.ts
@@ -2,8 +2,6 @@
  * Stata execution oracle for forward-call graphs.
  *
  * Ground truth for `tests/property/forward-call-out-of-scope-oracle.prop.test.ts`.
- * Derived from Stata runtime semantics, not from `ForwardScopeResolver`'s
- * algorithm — so a resolver bug cannot silently propagate into the oracle.
  *
  * Semantics modelled:
  *
@@ -11,15 +9,14 @@
  *    `do`/`run` and keeps the caller's scope on `include`. Reports whether
  *    the referenced name is bound when the reference event fires.
  *
- *  - `blame_target_for()` — counterfactual "all-include" Stata: promote
- *    every `do`/`run` boundary reachable from the root to `include`,
- *    execute the flattened chain in source order, and return the file
- *    index whose `local X` most recently bound the referenced name before
- *    the reference event fires. The resolver's flattening, dedup, and
- *    excluded-locals filtering are *not* mirrored: the oracle re-runs
- *    each callee as the simulator encounters it (stopping only on the
- *    current recursion path to avoid infinite loops), and the final
- *    binding of the referenced name is the blame file.
+ *  - `blame_target_for()` — single-boundary counterfactual: for each
+ *    root-level `do`/`run` call that precedes the reference, promote ONLY
+ *    that one boundary to `include` and ask whether the referenced local
+ *    would then be bound. Internal `do`/`run` boundaries stay opaque —
+ *    `include` is the only edge the walk descends. Returns the file whose
+ *    `local X` is the last (in source order, across visible sites) include-
+ *    reachable binding, or `null` when no single-boundary promotion would
+ *    expose the name.
  */
 import { ForwardCallGraph } from '../generators/forward-call-graphs';
 
@@ -32,15 +29,29 @@ export class StataExecutionOracle {
     }
 
     blame_target_for(): number | null {
-        // Counterfactual: promote every do/run to include and re-execute
-        // the reachable chain from the root. Every `local X` overwrites
-        // prior bindings (last-def-wins). The result is the file that
-        // last bound `reference_name` before the reference event fires.
-        const the_scope = new Map<string, number>();
-        const reached = this.walk_counterfactual(0, the_scope, new Set<number>());
-        if (!reached) return null;
-        const my_winner = the_scope.get(this.graph.reference_name);
-        return my_winner ?? null;
+        // Iterate root-level events in source order until the reference.
+        // For each do/run call before the reference, compute the include-
+        // only end-state of the callee. The last such call whose end-state
+        // binds `reference_name` wins (matches the diagnostic provider's
+        // last-visible-site precedence).
+        const my_root = this.graph.files[0];
+        let blame: number | null = null;
+        for (let i = 0; i < my_root.events.length; i++) {
+            if (i === this.graph.reference_event_index) break;
+            const my_event = my_root.events[i];
+            if (my_event.kind !== 'do_call' && my_event.kind !== 'run_call') {
+                continue;
+            }
+            const end_state = this.compute_include_only_end_state(
+                my_event.target,
+                new Set<number>(),
+            );
+            const my_winner = end_state.get(this.graph.reference_name);
+            if (my_winner !== undefined) {
+                blame = my_winner;
+            }
+        }
+        return blame;
     }
 
     get_file_name(file_index: number): string {
@@ -113,49 +124,38 @@ export class StataExecutionOracle {
     }
 
     /**
-     * Counterfactual walk: every `include`/`do`/`run` expands inline into
-     * a single shared scope. Walks the root forward-order until the
-     * reference event fires. Returns `true` once the reference is
-     * reached; returns `false` if the walk exhausts without finding it.
+     * Include-only end-state: walk the callee in source order, overwriting
+     * bindings as `local X` statements fire, and merging include-reachable
+     * end-states from nested `include` calls. `do`/`run` events are
+     * skipped — they would run in a fresh scope and leave nothing behind.
      *
-     * Cycle protection is per-call-path (`current_path`) rather than a
-     * global visited set, matching real Stata's re-execution on each
-     * call and preserving the last-def-wins ordering that two separate
-     * visits to the same file can introduce.
+     * Cycle protection is per-path (current_path) so mutual includes
+     * terminate.
      */
-    private walk_counterfactual(
+    private compute_include_only_end_state(
         file_index: number,
-        scope: Map<string, number>,
         current_path: Set<number>,
-    ): boolean {
-        if (current_path.has(file_index)) return false;
+    ): Map<string, number> {
+        if (current_path.has(file_index)) return new Map();
         current_path.add(file_index);
         try {
+            const the_scope = new Map<string, number>();
             const my_file = this.graph.files[file_index];
-            for (let i = 0; i < my_file.events.length; i++) {
-                const my_event = my_file.events[i];
-                if (
-                    file_index === 0 &&
-                    i === this.graph.reference_event_index
-                ) {
-                    return true;
-                }
+            for (const my_event of my_file.events) {
                 if (my_event.kind === 'define_local') {
-                    scope.set(my_event.name, file_index);
-                } else if (
-                    my_event.kind === 'include_call' ||
-                    my_event.kind === 'do_call' ||
-                    my_event.kind === 'run_call'
-                ) {
-                    const reached = this.walk_counterfactual(
+                    the_scope.set(my_event.name, file_index);
+                } else if (my_event.kind === 'include_call') {
+                    const my_nested = this.compute_include_only_end_state(
                         my_event.target,
-                        scope,
                         current_path,
                     );
-                    if (reached) return true;
+                    for (const [my_name, my_owner] of my_nested) {
+                        the_scope.set(my_name, my_owner);
+                    }
                 }
+                // do_call / run_call: skipped.
             }
-            return false;
+            return the_scope;
         } finally {
             current_path.delete(file_index);
         }

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -927,7 +927,7 @@ display \`result'
                     excluded_locals: new Map([
                         ['veggie', {
                             name: 'veggie',
-                            type: 'local',
+                            scope: 'local',
                             location: {
                                 uri: 'file:///child.do',
                                 range: {
@@ -1206,7 +1206,7 @@ display \`result'
             expect(out_of_scope_diag?.message).toContain('after the call site');
         });
 
-        it('should emit forward-call out-of-scope diagnostics when undefinedMacro is off', async () => {
+        it('should suppress forward-call out-of-scope diagnostic when undefinedMacro is off', async () => {
             const content = [
                 'do "child.do"',
                 "display `veggie'",
@@ -1228,7 +1228,7 @@ display \`result'
                     excluded_locals: new Map([
                         ['veggie', {
                             name: 'veggie',
-                            type: 'local',
+                            scope: 'local',
                             location: {
                                 uri: 'file:///child.do',
                                 range: {
@@ -1270,12 +1270,67 @@ display \`result'
                 d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
                     && d.message.includes('veggie')
             );
-            expect(out_of_scope_diag).toBeDefined();
-            expect(out_of_scope_diag?.message).toContain('local macros are not inherited via do/run');
+            expect(out_of_scope_diag).toBeUndefined();
 
             const undefined_diag = the_diagnostics.find(
                 d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
                     && d.message.includes('`veggie\'')
+            );
+            expect(undefined_diag).toBeUndefined();
+        });
+
+        it('should suppress backward-path out-of-scope diagnostic when undefinedMacro is off', async () => {
+            const content = `display \`country_name'`;
+            const document = create_real_document_state(content);
+
+            const resolved_scope = {
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [{
+                    name: 'country_name',
+                    type: 'local' as const,
+                    source_uri: 'file:///parent.do',
+                    defined_line: 10,
+                    call_site_line: -1,
+                    reason: 'inheritance_excludes_locals' as const,
+                }],
+                diagnostics: [],
+                has_directives: true,
+                has_auto_parents: false,
+            };
+
+            const mock_scope_resolver = {
+                resolve: async () => resolved_scope,
+            };
+            const config = {
+                ...DEFAULT_CONFIG,
+                diagnostics: {
+                    ...DEFAULT_CONFIG.diagnostics,
+                    severity: {
+                        ...DEFAULT_CONFIG.diagnostics.severity,
+                        undefinedMacro: 'off' as const,
+                    },
+                },
+                cross_file: {
+                    diagnostics: {
+                        out_of_scope: 'warning' as const,
+                    },
+                },
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                config,
+                undefined,
+                mock_scope_resolver as any
+            );
+
+            const out_of_scope_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+            );
+            expect(out_of_scope_diag).toBeUndefined();
+
+            const undefined_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
             );
             expect(undefined_diag).toBeUndefined();
         });

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -904,6 +904,65 @@ display \`result'
     });
 
     describe('out-of-scope diagnostic messages', () => {
+        it('should preserve same-file forward references when a prior do call excludes matching locals', async () => {
+            const content = [
+                'do "child.do"',
+                "display `veggie'",
+                'local veggie carrot',
+            ].join('\n');
+            const document = create_real_document_state(content);
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: false,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///child.do',
+                    call_line: 0,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'do',
+                    excluded_locals: new Map([
+                        ['veggie', {
+                            name: 'veggie',
+                            type: 'local',
+                            location: {
+                                uri: 'file:///child.do',
+                                range: {
+                                    start: { line: 0, character: 0 },
+                                    end: { line: 0, character: 12 },
+                                },
+                            },
+                            sourceUri: 'file:///child.do',
+                            definition_line: 0,
+                        }],
+                    ]),
+                }],
+            };
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                stub_resolver
+            );
+
+            const undefined_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    && d.message.includes('`veggie\'')
+            );
+            expect(undefined_diag).toBeDefined();
+
+            const out_of_scope_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('veggie')
+            );
+            expect(out_of_scope_diag).toBeUndefined();
+        });
+
         it('should show inheritance message for locals excluded by done-by', async () => {
             // When a local macro is defined in parent but excluded due to done-by inheritance,
             // the message should explain that locals aren't inherited via do/run
@@ -1145,6 +1204,80 @@ display \`result'
             );
             expect(out_of_scope_diag).toBeDefined();
             expect(out_of_scope_diag?.message).toContain('after the call site');
+        });
+
+        it('should emit forward-call out-of-scope diagnostics when undefinedMacro is off', async () => {
+            const content = [
+                'do "child.do"',
+                "display `veggie'",
+            ].join('\n');
+            const document = create_real_document_state(content);
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: false,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///child.do',
+                    call_line: 0,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'do',
+                    excluded_locals: new Map([
+                        ['veggie', {
+                            name: 'veggie',
+                            type: 'local',
+                            location: {
+                                uri: 'file:///child.do',
+                                range: {
+                                    start: { line: 0, character: 0 },
+                                    end: { line: 0, character: 12 },
+                                },
+                            },
+                            sourceUri: 'file:///child.do',
+                            definition_line: 0,
+                        }],
+                    ]),
+                }],
+            };
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
+            const config = {
+                ...DEFAULT_CONFIG,
+                diagnostics: {
+                    ...DEFAULT_CONFIG.diagnostics,
+                    severity: {
+                        ...DEFAULT_CONFIG.diagnostics.severity,
+                        undefinedMacro: 'off' as const,
+                    },
+                },
+                cross_file: {
+                    diagnostics: {
+                        out_of_scope: 'warning' as const,
+                    },
+                },
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                config,
+                undefined,
+                stub_resolver
+            );
+
+            const out_of_scope_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('veggie')
+            );
+            expect(out_of_scope_diag).toBeDefined();
+            expect(out_of_scope_diag?.message).toContain('local macros are not inherited via do/run');
+
+            const undefined_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    && d.message.includes('`veggie\'')
+            );
+            expect(undefined_diag).toBeUndefined();
         });
     });
 });

--- a/tests/unit/forward-scope-resolver-effective-end-state.test.ts
+++ b/tests/unit/forward-scope-resolver-effective-end-state.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for `ForwardScopeResolver.compute_effective_end_state_locals`.
+ *
+ * The helper is private; these tests access it via `(fsr as any)` to
+ * exercise the walk directly without standing up a full diagnostics
+ * pipeline. The helper drives the OUT_OF_SCOPE_SYMBOL rewrite message,
+ * so covering it at unit level catches shadowing/redefinition and
+ * cycle-handling regressions closer to the code under change.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { ScopeResolver } from '../../src/scope-resolver';
+
+describe('ForwardScopeResolver.compute_effective_end_state_locals', () => {
+    let temp_dir: string;
+    let scope_resolver: ScopeResolver;
+    let forward_resolver: ForwardScopeResolver;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fsr-effective-'));
+        scope_resolver = new ScopeResolver();
+        forward_resolver = new ForwardScopeResolver(scope_resolver, { max_forward_depth: 10 });
+        scope_resolver.set_forward_scope_resolver(forward_resolver);
+    });
+
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    async function walk(callee_fs_path: string): Promise<Map<string, any>> {
+        const callee_uri = URI.file(callee_fs_path).toString();
+        return (forward_resolver as any).compute_effective_end_state_locals(
+            callee_uri,
+            callee_fs_path,
+            undefined,
+            new Set<string>(),
+            1,
+            { max_forward_depth: 10 },
+            undefined,
+        );
+    }
+
+    test('empty callee returns empty map', async () => {
+        const my_path = path.join(temp_dir, 'empty.do');
+        fs.writeFileSync(my_path, '');
+        const result = await walk(my_path);
+        expect(result.size).toBe(0);
+    });
+
+    test('callee with only own locals: last-def-wins across primary + additional_definitions', async () => {
+        const my_path = path.join(temp_dir, 'own_locals.do');
+        fs.writeFileSync(my_path, ['local veggie carrot', 'local fruit apple', 'local veggie beet'].join('\n'));
+        const result = await walk(my_path);
+        expect(result.size).toBe(2);
+        expect(result.has('veggie')).toBe(true);
+        expect(result.has('fruit')).toBe(true);
+        // The late redefinition (line 2) wins; without the Bug A fix the
+        // walk would only see the primary at line 0.
+        const my_veggie = result.get('veggie');
+        expect(my_veggie.sourceUri).toContain('own_locals.do');
+    });
+
+    test('include-then-local: local wins when it comes after the include', async () => {
+        const defs_path = path.join(temp_dir, 'defs_include_then_local.do');
+        fs.writeFileSync(defs_path, 'local veggie beet');
+        const my_path = path.join(temp_dir, 'include_then_local.do');
+        fs.writeFileSync(my_path, ['include "defs_include_then_local.do"', 'local veggie carrot'].join('\n'));
+        const result = await walk(my_path);
+        expect(result.size).toBe(1);
+        // The caller's own `local` is the last write, so the callee itself
+        // should own the bound symbol (not defs.do).
+        const my_veggie = result.get('veggie');
+        expect(my_veggie.sourceUri).toContain('include_then_local.do');
+    });
+
+    test('local-then-include: include wins when it comes after the local', async () => {
+        const defs_path = path.join(temp_dir, 'defs_local_then_include.do');
+        fs.writeFileSync(defs_path, 'local veggie beet');
+        const my_path = path.join(temp_dir, 'local_then_include.do');
+        fs.writeFileSync(my_path, ['local veggie carrot', 'include "defs_local_then_include.do"'].join('\n'));
+        const result = await walk(my_path);
+        expect(result.size).toBe(1);
+        const my_veggie = result.get('veggie');
+        expect(my_veggie.sourceUri).toContain('defs_local_then_include.do');
+    });
+
+    test('nested `do` contributes nothing to the result (locals do not propagate)', async () => {
+        const nested_path = path.join(temp_dir, 'nested_do_target.do');
+        fs.writeFileSync(nested_path, 'local veggie beet');
+        const my_path = path.join(temp_dir, 'nested_do.do');
+        fs.writeFileSync(my_path, ['do "nested_do_target.do"', 'local fruit apple'].join('\n'));
+        const result = await walk(my_path);
+        // fruit is the callee's own local; veggie is behind a `do` and
+        // must not appear.
+        expect(result.size).toBe(1);
+        expect(result.has('fruit')).toBe(true);
+        expect(result.has('veggie')).toBe(false);
+    });
+
+    test('cycle terminates and returns empty without throwing', async () => {
+        const a_path = path.join(temp_dir, 'cycle_a.do');
+        const b_path = path.join(temp_dir, 'cycle_b.do');
+        fs.writeFileSync(a_path, 'include "cycle_b.do"');
+        fs.writeFileSync(b_path, 'include "cycle_a.do"');
+        const result = await walk(a_path);
+        // Neither file defines a local — cycle is safely broken.
+        expect(result.size).toBe(0);
+    });
+
+    test('depth bound: exceeding max_forward_depth returns empty without throwing', async () => {
+        const my_path = path.join(temp_dir, 'depth_limited.do');
+        fs.writeFileSync(my_path, 'local veggie beet');
+        const callee_uri = URI.file(my_path).toString();
+        const result = await (forward_resolver as any).compute_effective_end_state_locals(
+            callee_uri,
+            my_path,
+            undefined,
+            new Set<string>(),
+            // depth starts at 10 — at-or-above max_forward_depth, should bail.
+            10,
+            { max_forward_depth: 10 },
+            undefined,
+        );
+        expect(result.size).toBe(0);
+    });
+});

--- a/tests/unit/forward-scope-resolver-effective-end-state.test.ts
+++ b/tests/unit/forward-scope-resolver-effective-end-state.test.ts
@@ -1,11 +1,13 @@
 /**
  * Unit tests for `ForwardScopeResolver.compute_effective_end_state_locals`.
  *
- * The helper is private; these tests access it via `(fsr as any)` to
- * exercise the walk directly without standing up a full diagnostics
- * pipeline. The helper drives the OUT_OF_SCOPE_SYMBOL rewrite message,
- * so covering it at unit level catches shadowing/redefinition and
- * cycle-handling regressions closer to the code under change.
+ * The helper computes a callee's include-only end-state: walk its own
+ * `local X` statements in source order, merging the end-states of any
+ * nested `include` callees. `do`/`run` callees are NOT descended — they
+ * would require a separate boundary promotion to expose their bindings.
+ * The helper drives the OUT_OF_SCOPE_SYMBOL rewrite message, so covering
+ * it at unit level catches shadowing/redefinition and cycle-handling
+ * regressions closer to the code under change.
  */
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
@@ -88,29 +90,24 @@ describe('ForwardScopeResolver.compute_effective_end_state_locals', () => {
         expect(my_veggie.sourceUri).toContain('defs_local_then_include.do');
     });
 
-    test('nested `do` contributes its locals counterfactually (promote-all model)', async () => {
-        // The helper computes the counterfactual end-state under "every
-        // do/run along this sub-chain is promoted to include". Real-Stata
-        // execution still blocks `do`, but the blame rewrite is a hint
-        // about what the user would see if the whole sub-chain were
-        // include'd — so nested `do` must contribute its locals here.
+    test('nested `do` is opaque: walk does not descend into `do`/`run` callees', async () => {
+        // The helper is the engine behind OUT_OF_SCOPE_SYMBOL rewrites. The
+        // rewrite is a single-boundary counterfactual: "promote THIS one
+        // do/run to include — where would the local now come from?" Deeper
+        // do/run boundaries stay opaque because promoting them would be a
+        // separate fix. So this walk does not descend into `do`/`run`
+        // callees, even when they define the referenced name.
         const nested_path = path.join(temp_dir, 'nested_do_target.do');
         fs.writeFileSync(nested_path, 'local veggie beet');
         const my_path = path.join(temp_dir, 'nested_do.do');
         fs.writeFileSync(my_path, ['do "nested_do_target.do"', 'local fruit apple'].join('\n'));
         const result = await walk(my_path);
         expect(result.has('fruit')).toBe(true);
-        expect(result.has('veggie')).toBe(true);
-        // Last-def-wins across the chain: fruit from callee, veggie from
-        // the nested do target.
-        expect(result.get('veggie')!.sourceUri).toContain('nested_do_target.do');
+        expect(result.has('veggie')).toBe(false);
         expect(result.get('fruit')!.sourceUri).toContain('nested_do.do');
     });
 
-    test('nested `do` that redefines an earlier include local: include wins when it comes after', async () => {
-        // Under the counterfactual-all-promote model, sub-chain local
-        // definitions overwrite earlier ones in source order. Here the
-        // `do` appears BEFORE the later own-local, so the own-local wins.
+    test('own local after opaque `do` wins (nested do target is not walked)', async () => {
         const nested_path = path.join(temp_dir, 'nested_do_redef.do');
         fs.writeFileSync(nested_path, 'local shared beet');
         const my_path = path.join(temp_dir, 'nested_do_overridden.do');
@@ -120,6 +117,8 @@ describe('ForwardScopeResolver.compute_effective_end_state_locals', () => {
         );
         const result = await walk(my_path);
         expect(result.size).toBe(1);
+        // `do` is opaque, so only the caller's own `local shared carrot`
+        // contributes — no need to reason about which comes first.
         expect(result.get('shared')!.sourceUri).toContain('nested_do_overridden.do');
     });
 

--- a/tests/unit/forward-scope-resolver-effective-end-state.test.ts
+++ b/tests/unit/forward-scope-resolver-effective-end-state.test.ts
@@ -88,17 +88,39 @@ describe('ForwardScopeResolver.compute_effective_end_state_locals', () => {
         expect(my_veggie.sourceUri).toContain('defs_local_then_include.do');
     });
 
-    test('nested `do` contributes nothing to the result (locals do not propagate)', async () => {
+    test('nested `do` contributes its locals counterfactually (promote-all model)', async () => {
+        // The helper computes the counterfactual end-state under "every
+        // do/run along this sub-chain is promoted to include". Real-Stata
+        // execution still blocks `do`, but the blame rewrite is a hint
+        // about what the user would see if the whole sub-chain were
+        // include'd — so nested `do` must contribute its locals here.
         const nested_path = path.join(temp_dir, 'nested_do_target.do');
         fs.writeFileSync(nested_path, 'local veggie beet');
         const my_path = path.join(temp_dir, 'nested_do.do');
         fs.writeFileSync(my_path, ['do "nested_do_target.do"', 'local fruit apple'].join('\n'));
         const result = await walk(my_path);
-        // fruit is the callee's own local; veggie is behind a `do` and
-        // must not appear.
-        expect(result.size).toBe(1);
         expect(result.has('fruit')).toBe(true);
-        expect(result.has('veggie')).toBe(false);
+        expect(result.has('veggie')).toBe(true);
+        // Last-def-wins across the chain: fruit from callee, veggie from
+        // the nested do target.
+        expect(result.get('veggie')!.sourceUri).toContain('nested_do_target.do');
+        expect(result.get('fruit')!.sourceUri).toContain('nested_do.do');
+    });
+
+    test('nested `do` that redefines an earlier include local: include wins when it comes after', async () => {
+        // Under the counterfactual-all-promote model, sub-chain local
+        // definitions overwrite earlier ones in source order. Here the
+        // `do` appears BEFORE the later own-local, so the own-local wins.
+        const nested_path = path.join(temp_dir, 'nested_do_redef.do');
+        fs.writeFileSync(nested_path, 'local shared beet');
+        const my_path = path.join(temp_dir, 'nested_do_overridden.do');
+        fs.writeFileSync(
+            my_path,
+            ['do "nested_do_redef.do"', 'local shared carrot'].join('\n'),
+        );
+        const result = await walk(my_path);
+        expect(result.size).toBe(1);
+        expect(result.get('shared')!.sourceUri).toContain('nested_do_overridden.do');
     });
 
     test('cycle terminates and returns empty without throwing', async () => {
@@ -111,8 +133,13 @@ describe('ForwardScopeResolver.compute_effective_end_state_locals', () => {
         expect(result.size).toBe(0);
     });
 
-    test('depth bound: exceeding max_forward_depth returns empty without throwing', async () => {
-        const my_path = path.join(temp_dir, 'depth_limited.do');
+    test('depth boundary: at max_forward_depth still surfaces own top-level locals', async () => {
+        // Callers invoke this helper with `my_context.depth + 1`, so a direct
+        // `do` child of the file at `depth == max - 1` arrives here at
+        // `depth == max`. It would be processed by the outer resolver, so the
+        // helper must also surface the callee's own locals for the
+        // diagnostic rewrite to name the blame file.
+        const my_path = path.join(temp_dir, 'at_max.do');
         fs.writeFileSync(my_path, 'local veggie beet');
         const callee_uri = URI.file(my_path).toString();
         const result = await (forward_resolver as any).compute_effective_end_state_locals(
@@ -120,8 +147,51 @@ describe('ForwardScopeResolver.compute_effective_end_state_locals', () => {
             my_path,
             undefined,
             new Set<string>(),
-            // depth starts at 10 — at-or-above max_forward_depth, should bail.
             10,
+            { max_forward_depth: 10 },
+            undefined,
+        );
+        expect(result.size).toBe(1);
+        expect(result.has('veggie')).toBe(true);
+    });
+
+    test('depth boundary: at max refuses to descend into own includes', async () => {
+        // The helper stops recursing once the next hop would exceed
+        // `max_forward_depth`, so nested-include locals from beyond the
+        // boundary should be absent even though own locals are present.
+        const nested_path = path.join(temp_dir, 'nested_defs_at_boundary.do');
+        fs.writeFileSync(nested_path, 'local nested_veggie beet');
+        const my_path = path.join(temp_dir, 'at_max_with_nested_include.do');
+        fs.writeFileSync(
+            my_path,
+            ['local own_veggie beet', 'include "nested_defs_at_boundary.do"'].join('\n'),
+        );
+        const callee_uri = URI.file(my_path).toString();
+        const result = await (forward_resolver as any).compute_effective_end_state_locals(
+            callee_uri,
+            my_path,
+            undefined,
+            new Set<string>(),
+            10,
+            { max_forward_depth: 10 },
+            undefined,
+        );
+        expect(result.has('own_veggie')).toBe(true);
+        expect(result.has('nested_veggie')).toBe(false);
+    });
+
+    test('depth beyond max: returns empty without throwing', async () => {
+        // Past the boundary, we don't process the file at all — any symbols
+        // claimed here would misattribute blame past the configured depth.
+        const my_path = path.join(temp_dir, 'past_max.do');
+        fs.writeFileSync(my_path, 'local veggie beet');
+        const callee_uri = URI.file(my_path).toString();
+        const result = await (forward_resolver as any).compute_effective_end_state_locals(
+            callee_uri,
+            my_path,
+            undefined,
+            new Set<string>(),
+            11,
             { max_forward_depth: 10 },
             undefined,
         );

--- a/tests/unit/forward-scope-resolver-sort-order.test.ts
+++ b/tests/unit/forward-scope-resolver-sort-order.test.ts
@@ -109,8 +109,9 @@ describe('compute_effective_end_state_locals sort order', () => {
             undefined,
         );
         expect(result.size).toBe(1);
-        const winner: MacroSymbol = result.get('veggie');
-        expect(winner.sourceUri).toBe(callee_uri);
+        const winner = result.get('veggie');
+        expect(winner).toBeDefined();
+        expect(winner!.sourceUri).toBe(callee_uri);
     });
 
     test('same-line local-then-include: include (later character) wins', async () => {
@@ -151,7 +152,8 @@ describe('compute_effective_end_state_locals sort order', () => {
             undefined,
         );
         expect(result.size).toBe(1);
-        const winner: MacroSymbol = result.get('veggie');
-        expect(winner.sourceUri).toBe(defs_uri);
+        const winner = result.get('veggie');
+        expect(winner).toBeDefined();
+        expect(winner!.sourceUri).toBe(defs_uri);
     });
 });

--- a/tests/unit/forward-scope-resolver-sort-order.test.ts
+++ b/tests/unit/forward-scope-resolver-sort-order.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit test for the sort comparator inside
+ * `ForwardScopeResolver.compute_effective_end_state_locals`.
+ *
+ * The helper orders walk events to produce last-def-wins blame. Codex's
+ * audit flagged that sorting by `line` alone collapses same-line events
+ * — this matters under Stata's `#delimit ;` mode where an include and a
+ * `local` redefinition can share one physical line. The analyzer does
+ * not currently extract forward calls under `#delimit ;`, so a full
+ * end-to-end repro is parser-blocked; this test exercises the sort logic
+ * in isolation by stubbing the resolver's callee-scope fetch to return
+ * events that share a line but differ in character position.
+ */
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { ScopeResolver } from '../../src/scope-resolver';
+import type { ForwardCall, MacroSymbol, SymbolTable } from '../../src/types';
+
+function empty_symbol_table(): SymbolTable {
+    return {
+        programs: new Map(),
+        localMacros: new Map(),
+        globalMacros: new Map(),
+        variables: new Map(),
+        scalars: new Map(),
+        matrices: new Map(),
+    };
+}
+
+function make_local(uri: string, name: string, line: number, character: number): MacroSymbol {
+    return {
+        name,
+        scope: 'local',
+        location: {
+            uri,
+            range: {
+                start: { line, character },
+                end: { line, character: character + 5 + name.length },
+            },
+        },
+        sourceUri: uri,
+        definition_line: line,
+        containingScope: 'dofile',
+    };
+}
+
+function make_include_call(line: number, character: number, target_path: string): ForwardCall {
+    return {
+        type: 'include',
+        path: target_path,
+        raw_path: target_path,
+        call_site_line: line,
+        range: {
+            start: { line, character },
+            end: { line, character: character + 10 },
+        },
+        source: 'command',
+        is_static: true,
+    };
+}
+
+describe('compute_effective_end_state_locals sort order', () => {
+    let scope_resolver: ScopeResolver;
+    let forward_resolver: ForwardScopeResolver;
+
+    beforeEach(() => {
+        scope_resolver = new ScopeResolver();
+        forward_resolver = new ForwardScopeResolver(scope_resolver, { max_forward_depth: 10 });
+        scope_resolver.set_forward_scope_resolver(forward_resolver);
+    });
+
+    test('same-line include-then-local: local (later character) wins', async () => {
+        const callee_uri = 'file:///stub/callee.do';
+        const defs_uri = 'file:///stub/defs.do';
+        // Callee has: `include defs.do` at col 0, then `local veggie carrot`
+        // at col 30 — BOTH on line 5.
+        const callee_local_at_col30 = make_local(callee_uri, 'veggie', 5, 30);
+        const defs_local_at_col0 = make_local(defs_uri, 'veggie', 0, 0);
+        (forward_resolver as any).get_callee_scope = async (_path: string, uri: string) => {
+            if (uri === callee_uri) {
+                return {
+                    symbols: {
+                        ...empty_symbol_table(),
+                        localMacros: new Map([['veggie', callee_local_at_col30]]),
+                    },
+                    forward_calls: [make_include_call(5, 0, '/stub/defs.do')],
+                };
+            }
+            if (uri === defs_uri) {
+                return {
+                    symbols: {
+                        ...empty_symbol_table(),
+                        localMacros: new Map([['veggie', defs_local_at_col0]]),
+                    },
+                    forward_calls: [],
+                };
+            }
+            throw new Error('unexpected uri: ' + uri);
+        };
+        // Also need resolve_call_path to return the defs fs path unchanged.
+        (forward_resolver as any).resolve_call_path = (_raw: string, resolved: string) => resolved;
+        const result = await (forward_resolver as any).compute_effective_end_state_locals(
+            callee_uri,
+            '/stub/callee.do',
+            undefined,
+            new Set<string>(),
+            1,
+            { max_forward_depth: 10 },
+            undefined,
+        );
+        expect(result.size).toBe(1);
+        const winner: MacroSymbol = result.get('veggie');
+        expect(winner.sourceUri).toBe(callee_uri);
+    });
+
+    test('same-line local-then-include: include (later character) wins', async () => {
+        const callee_uri = 'file:///stub/callee2.do';
+        const defs_uri = 'file:///stub/defs2.do';
+        const callee_local_at_col0 = make_local(callee_uri, 'veggie', 5, 0);
+        const defs_local = make_local(defs_uri, 'veggie', 0, 0);
+        (forward_resolver as any).get_callee_scope = async (_path: string, uri: string) => {
+            if (uri === callee_uri) {
+                return {
+                    symbols: {
+                        ...empty_symbol_table(),
+                        localMacros: new Map([['veggie', callee_local_at_col0]]),
+                    },
+                    // Include happens at col 30 — AFTER the local on the same line.
+                    forward_calls: [make_include_call(5, 30, '/stub/defs2.do')],
+                };
+            }
+            if (uri === defs_uri) {
+                return {
+                    symbols: {
+                        ...empty_symbol_table(),
+                        localMacros: new Map([['veggie', defs_local]]),
+                    },
+                    forward_calls: [],
+                };
+            }
+            throw new Error('unexpected uri: ' + uri);
+        };
+        (forward_resolver as any).resolve_call_path = (_raw: string, resolved: string) => resolved;
+        const result = await (forward_resolver as any).compute_effective_end_state_locals(
+            callee_uri,
+            '/stub/callee2.do',
+            undefined,
+            new Set<string>(),
+            1,
+            { max_forward_depth: 10 },
+            undefined,
+        );
+        expect(result.size).toBe(1);
+        const winner: MacroSymbol = result.get('veggie');
+        expect(winner.sourceUri).toBe(defs_uri);
+    });
+});

--- a/tests/unit/stata-execution-oracle-counterfactual.test.ts
+++ b/tests/unit/stata-execution-oracle-counterfactual.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the counterfactual blame model in `StataExecutionOracle`.
+ *
+ * The oracle is the ground truth for the forward-call OUT_OF_SCOPE_SYMBOL
+ * property tests. It must be an *independent* source of truth — derived
+ * from Stata runtime semantics rather than the resolver's algorithm — so
+ * that a regression in `ForwardScopeResolver` does not silently propagate
+ * into the oracle.
+ *
+ * The counterfactual model: promote every `do`/`run` boundary reachable
+ * from the root to `include`, execute the flattened chain in source
+ * order, and ask which file last bound the referenced name before the
+ * reference event. Implemented independently of the LSP — no dedup rules,
+ * no claim-flattening, no excluded-locals filtering.
+ */
+import { describe, test, expect } from 'bun:test';
+import { StataExecutionOracle } from '../property/helpers/stata-execution-oracle';
+import { ForwardCallGraph } from '../property/generators/forward-call-graphs';
+
+function graph(files: { name: string; events: any[] }[], reference_event_index: number, reference_name: string): ForwardCallGraph {
+    return {
+        files: files.map(f => ({ filename: f.name, events: f.events })),
+        reference_event_index,
+        reference_name: reference_name as any,
+    };
+}
+
+describe('StataExecutionOracle.blame_target_for (counterfactual)', () => {
+    test('Bug A: redefinition after include wins (blames child)', () => {
+        // child: local veggie(carrot); include defs; local veggie(spinach)
+        // defs: local veggie(beet)
+        // root: do child; ref veggie
+        const g = graph([
+            { name: 'main.do', events: [
+                { kind: 'do_call', target: 1 },
+                { kind: 'reference_local', name: 'macro_a' },
+            ]},
+            { name: 'child.do', events: [
+                { kind: 'define_local', name: 'macro_a' }, // carrot
+                { kind: 'include_call', target: 2 },
+                { kind: 'define_local', name: 'macro_a' }, // spinach
+            ]},
+            { name: 'defs.do', events: [
+                { kind: 'define_local', name: 'macro_a' }, // beet
+            ]},
+        ], 1, 'macro_a');
+        const oracle = new StataExecutionOracle(g);
+        expect(oracle.blame_target_for()).toBe(1); // child.do
+    });
+
+    test('Bug B: do nested under include names grandchild', () => {
+        // root: include child; ref veggie
+        // child: do grandchild
+        // grandchild: local veggie
+        const g = graph([
+            { name: 'main.do', events: [
+                { kind: 'include_call', target: 1 },
+                { kind: 'reference_local', name: 'macro_a' },
+            ]},
+            { name: 'child.do', events: [
+                { kind: 'do_call', target: 2 },
+            ]},
+            { name: 'grandchild.do', events: [
+                { kind: 'define_local', name: 'macro_a' },
+            ]},
+        ], 1, 'macro_a');
+        const oracle = new StataExecutionOracle(g);
+        expect(oracle.blame_target_for()).toBe(2); // grandchild.do
+    });
+
+    test('a813cca: later include-in-chain wins', () => {
+        // root: do child; ref veggie
+        // child: local veggie(carrot); include defs
+        // defs: local veggie(beet)
+        const g = graph([
+            { name: 'main.do', events: [
+                { kind: 'do_call', target: 1 },
+                { kind: 'reference_local', name: 'macro_a' },
+            ]},
+            { name: 'child.do', events: [
+                { kind: 'define_local', name: 'macro_a' },
+                { kind: 'include_call', target: 2 },
+            ]},
+            { name: 'defs.do', events: [
+                { kind: 'define_local', name: 'macro_a' },
+            ]},
+        ], 1, 'macro_a');
+        const oracle = new StataExecutionOracle(g);
+        expect(oracle.blame_target_for()).toBe(2); // defs.do
+    });
+
+    test('Codex audit: nested do under include chain names grandchild', () => {
+        // root: do child; ref x
+        // child: include defs1; include mid
+        // defs1: local x
+        // mid: do grandchild
+        // grandchild: local x
+        const g = graph([
+            { name: 'main.do', events: [
+                { kind: 'do_call', target: 1 },
+                { kind: 'reference_local', name: 'macro_a' },
+            ]},
+            { name: 'child.do', events: [
+                { kind: 'include_call', target: 2 },
+                { kind: 'include_call', target: 3 },
+            ]},
+            { name: 'defs1.do', events: [
+                { kind: 'define_local', name: 'macro_a' },
+            ]},
+            { name: 'mid.do', events: [
+                { kind: 'do_call', target: 4 },
+            ]},
+            { name: 'grandchild.do', events: [
+                { kind: 'define_local', name: 'macro_a' },
+            ]},
+        ], 1, 'macro_a');
+        const oracle = new StataExecutionOracle(g);
+        expect(oracle.blame_target_for()).toBe(4); // grandchild.do
+    });
+
+    test('name not defined anywhere returns null', () => {
+        const g = graph([
+            { name: 'main.do', events: [
+                { kind: 'do_call', target: 1 },
+                { kind: 'reference_local', name: 'macro_b' },
+            ]},
+            { name: 'child.do', events: [
+                { kind: 'define_local', name: 'macro_a' },
+            ]},
+        ], 1, 'macro_b');
+        const oracle = new StataExecutionOracle(g);
+        expect(oracle.blame_target_for()).toBeNull();
+    });
+});

--- a/tests/unit/stata-execution-oracle-counterfactual.test.ts
+++ b/tests/unit/stata-execution-oracle-counterfactual.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the counterfactual blame model in `StataExecutionOracle`.
+ * Unit tests for the single-boundary blame model in `StataExecutionOracle`.
  *
  * The oracle is the ground truth for the forward-call OUT_OF_SCOPE_SYMBOL
  * property tests. It must be an *independent* source of truth — derived
@@ -7,11 +7,13 @@
  * that a regression in `ForwardScopeResolver` does not silently propagate
  * into the oracle.
  *
- * The counterfactual model: promote every `do`/`run` boundary reachable
- * from the root to `include`, execute the flattened chain in source
- * order, and ask which file last bound the referenced name before the
- * reference event. Implemented independently of the LSP — no dedup rules,
- * no claim-flattening, no excluded-locals filtering.
+ * The single-boundary model: for each root-level `do`/`run` call that
+ * precedes the reference, promote ONLY that one boundary to `include` and
+ * walk the callee under an include-only end-state rule (own `local`
+ * statements + recursion through `include` only). Return the file whose
+ * binding wins under that single-boundary promotion, or null if no such
+ * promotion would expose the name. Nested `do`/`run` stay opaque —
+ * exposing them would require a separate fix.
  */
 import { describe, test, expect } from 'bun:test';
 import { StataExecutionOracle } from '../property/helpers/stata-execution-oracle';
@@ -48,10 +50,15 @@ describe('StataExecutionOracle.blame_target_for (counterfactual)', () => {
         expect(oracle.blame_target_for()).toBe(1); // child.do
     });
 
-    test('Bug B: do nested under include names grandchild', () => {
-        // root: include child; ref veggie
+    test('Bug B: root include blocker is not a do/run - returns null', () => {
+        // root: include child; ref macro_a
         // child: do grandchild
-        // grandchild: local veggie
+        // grandchild: local macro_a
+        //
+        // Single-boundary semantics: no root-level do/run precedes the
+        // reference, so no one-line fix on a root `do`/`run` exposes the
+        // binding. The diagnostic falls back to generic UNDEFINED_MACRO and
+        // the oracle must return null.
         const g = graph([
             { name: 'main.do', events: [
                 { kind: 'include_call', target: 1 },
@@ -65,7 +72,7 @@ describe('StataExecutionOracle.blame_target_for (counterfactual)', () => {
             ]},
         ], 1, 'macro_a');
         const oracle = new StataExecutionOracle(g);
-        expect(oracle.blame_target_for()).toBe(2); // grandchild.do
+        expect(oracle.blame_target_for()).toBeNull();
     });
 
     test('a813cca: later include-in-chain wins', () => {
@@ -89,12 +96,18 @@ describe('StataExecutionOracle.blame_target_for (counterfactual)', () => {
         expect(oracle.blame_target_for()).toBe(2); // defs.do
     });
 
-    test('Codex audit: nested do under include chain names grandchild', () => {
-        // root: do child; ref x
+    test('Codex audit: nested do under include chain names defs1 (single-boundary)', () => {
+        // root: do child; ref macro_a
         // child: include defs1; include mid
-        // defs1: local x
+        // defs1: local macro_a
         // mid: do grandchild
-        // grandchild: local x
+        // grandchild: local macro_a
+        //
+        // Promoting only root's `do child` to `include child` makes child run
+        // in main's scope. child's include-only end-state: include defs1
+        // binds macro_a to defs1; include mid contributes nothing (mid's only
+        // event is a do, which is opaque). grandchild's binding is NOT
+        // exposed by this one-line fix.
         const g = graph([
             { name: 'main.do', events: [
                 { kind: 'do_call', target: 1 },
@@ -115,7 +128,7 @@ describe('StataExecutionOracle.blame_target_for (counterfactual)', () => {
             ]},
         ], 1, 'macro_a');
         const oracle = new StataExecutionOracle(g);
-        expect(oracle.blame_target_for()).toBe(4); // grandchild.do
+        expect(oracle.blame_target_for()).toBe(2); // defs1.do
     });
 
     test('name not defined anywhere returns null', () => {

--- a/tests/unit/stata-execution-oracle-counterfactual.test.ts
+++ b/tests/unit/stata-execution-oracle-counterfactual.test.ts
@@ -17,13 +17,21 @@
  */
 import { describe, test, expect } from 'bun:test';
 import { StataExecutionOracle } from '../property/helpers/stata-execution-oracle';
-import { ForwardCallGraph } from '../property/generators/forward-call-graphs';
+import {
+    ForwardCallGraph,
+    FileEvent,
+    MacroName,
+} from '../property/generators/forward-call-graphs';
 
-function graph(files: { name: string; events: any[] }[], reference_event_index: number, reference_name: string): ForwardCallGraph {
+function graph(
+    files: { name: string; events: FileEvent[] }[],
+    reference_event_index: number,
+    reference_name: MacroName,
+): ForwardCallGraph {
     return {
         files: files.map(f => ({ filename: f.name, events: f.events })),
         reference_event_index,
-        reference_name: reference_name as any,
+        reference_name,
     };
 }
 


### PR DESCRIPTION
- **Emit callee-aware diagnostic for do-called locals**
- **Restrict excluded_locals to top-level callee locals**

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostics now recognize local macros excluded by do/run boundaries and emit callee-aware out-of-scope rewrites with correct blame attribution.

* **Bug Fixes**
  * Suppresses rewritten out-of-scope diagnostics when the underlying undefined diagnostic is disabled; fixes attribution and duplicate-call boundary handling.

* **Documentation**
  * Clarified cross-file out-of-scope rewrite semantics and config dependency; added planning notes for future simplification.

* **Tests**
  * Large expansion of unit, integration, property, and generator tests (oracle, helpers, and fixtures) covering excluded-locals, attribution, and config-driven suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->