### PR TITLE
Clean up out-of-scope diagnostic rewrites

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,10 +30,13 @@ Control how the LSP reports errors, warnings, and other diagnostics.
 | `sight.diagnostics.severity.cStyleLogicalInControlFlow` | enum | `"information"` | Severity for C-style logical operators (`&&`, `\|\|`) in if/else if control flow statements. These work but are stylistically discouraged. Options: `"error"`, `"warning"`, `"information"`, `"hint"`, `"off"` |
 | `sight.diagnostics.indentation`                | boolean | `false`         | Enable indentation diagnostics (missing indentation in blocks, unnecessary indentation after comments)                |
 
-Cross-file "out of scope" diagnostics are not emitted independently. They are
-more specific rewrites of undefined macro/variable diagnostics after cross-file
-scope resolution. If the underlying undefined diagnostic is disabled, the
-corresponding out-of-scope diagnostic is also suppressed.
+When the scope resolver can prove a referenced macro or variable exists but is
+unreachable, Sight replaces the generic undefined-symbol diagnostic with a more
+specific `OUT_OF_SCOPE_SYMBOL` message at the same severity. This applies when
+the symbol is defined later in the same file, defined after the relevant call
+site in another file, or excluded because local macros do not inherit through
+`do`/`run`. If the underlying undefined diagnostic is disabled, the rewrite is
+also suppressed.
 
 <a name="why-indentation-diagnostics-disabled"></a>
 > **Why Indentation Diagnostics Are Disabled by Default**
@@ -185,7 +188,6 @@ You can also configure the LSP using a `.sight.json` file in your workspace root
     "maxChainDepth": 20,
     "assumeCallSite": "end",
     "diagnostics": {
-      "outOfScope": "information",
       "missingFile": "warning",
       "callSiteIdentification": "information"
     }
@@ -204,7 +206,6 @@ You can also configure the LSP using a `.sight.json` file in your workspace root
 | `crossFile.maxChainDepth`               | number               | `20`            | Maximum combined depth for forward + backward resolution                |
 | `crossFile.maxCalleeRevalidations`      | number               | `10`            | Maximum number of open callee documents to revalidate per caller change |
 | `crossFile.assumeCallSite`              | `"end"` \| `"start"` | `"end"`         | Where to assume call site when not specified and inference fails        |
-| `crossFile.diagnostics.outOfScope`      | severity             | `"information"` | Severity used when rewriting undefined-symbol diagnostics as out-of-scope cross-file diagnostics; if the base undefined-macro/variable diagnostic is off, nothing is emitted |
 | `crossFile.diagnostics.missingFile`     | severity             | `"warning"`     | Severity for missing directive file diagnostics                         |
 | `crossFile.diagnostics.callSiteIdentification` | severity      | `"information"` | Severity for call site identification diagnostics                       |
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -424,12 +424,17 @@ order, accounting for cross-file relationships and call sites.
    file
 2. **Cross-file call sites**: Only symbols defined on or before the call site
    in the parent file are considered available
-3. **Out-of-scope warnings**: References to symbols defined after the call site
-   generate warnings
+3. **Out-of-scope rewrites**: When a referenced symbol exists but is
+   unreachable, the generic undefined-symbol diagnostic is replaced with a
+   more specific `OUT_OF_SCOPE_SYMBOL` message
 
 **Out-of-scope symbol handling:**
-- Symbols defined after the call site are flagged as "out-of-scope"
-- These symbols appear in completions but generate warnings when used
+- Symbols defined after the call site remain available for completions and
+  hover, but diagnostics rewrite the base undefined-symbol warning into a more
+  specific out-of-scope message
+- Same-file later definitions use `used before it is defined (line N)`
+- `do`/`run` chains that would only expose a local under `include` report that
+  locals are not inherited via `do`/`run`
 - Use `line=` or `match=` parameters to specify exact call sites when
   automatic detection is incorrect
 
@@ -592,7 +597,6 @@ Cross-file resolution is configured via `.sight.json` in your workspace root.
 | `crossFile.maxChainDepth`                     | number   | `20`            | Maximum combined depth for forward + backward resolution |
 | `crossFile.maxCalleeRevalidations`            | number   | `10`            | Maximum open callee documents to revalidate per change |
 | `crossFile.assumeCallSite`                    | string   | `"end"`         | Where to assume call site when inference fails (`"end"` or `"start"`) |
-| `crossFile.diagnostics.outOfScope`            | severity | `"information"` | Severity used when rewriting undefined-symbol diagnostics as out-of-scope cross-file diagnostics; if the base undefined-macro/variable diagnostic is off, nothing is emitted |
 | `crossFile.diagnostics.missingFile`           | severity | `"warning"`     | Severity for missing directive file diagnostics        |
 | `crossFile.diagnostics.callSiteIdentification`| severity | `"information"` | Severity for call site identification diagnostics      |
 

--- a/docs/superpowers/specs/2026-04-22-out-of-scope-diagnostic-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-22-out-of-scope-diagnostic-cleanup-design.md
@@ -27,7 +27,7 @@ A separate issue (#148) tracks the larger question of unifying same-file and cro
 - Do all rewrites in the provider. The analyzer continues to emit `UNDEFINED_MACRO` / `UNDEFINED_VARIABLE` unchanged. Any current or future analyzer emission site for undefined symbols picks up the rewrite for free.
 - Add same-file forward-reference rewriting to the provider: when an undefined-macro / undefined-global reference has a matching later definition in the current document, emit `OUT_OF_SCOPE_SYMBOL` with `used before it is defined (line N)`.
 - Teach `extract_symbol_name_from_diagnostic` to parse `Potentially undefined variable: <name>` so the variable-diagnostic path can feed the rewrite.
-- Add proper reference-kind classification (`local | global | variable | null`) and tighten `out_of_scope_type_matches_reference` so a variable reference only matches a variable out-of-scope entry (and similarly for macros).
+- Add proper reference-kind classification (`local | global | variable | null`) and tighten `out_of_scope_type_matches_reference` so a variable reference only matches a variable out-of-scope entry (and similarly for macros). Scalars, matrices, and programs are deliberately excluded from variable-kind matching — see "Bare-identifier scoping" below.
 - Introduce a shared message helper in a neutral module (`src/utils/out-of-scope-message.ts`) that formats the message for any supported symbol kind and reason.
 - Ensure every rewrite goes through the existing `should_suppress_undefined_symbol` check so `@lsp-ignore` / `@lsp-ignore-next` are honored uniformly.
 
@@ -35,6 +35,7 @@ A separate issue (#148) tracks the larger question of unifying same-file and cro
 
 - Position-aware same-file forward-reference analysis for variables (see #147). The variable path only gains out-of-scope rewriting for diagnostics the analyzer already emits; it does not gain new forward-reference detection inside a single file.
 - Unifying same-file and cross-file enrichment into a general provider-side pipeline (see #148).
+- Scalar-aware analysis. Bare identifiers in expression contexts that act as scalars (e.g., `display x + 1` where `x` is a `scalar`) are not diagnosed today and remain un-diagnosed by this spec. A separate, opt-in strictness mode for scalar-like references is tracked in #149 and is explicitly non-blocking for this work.
 - Changing defaults for `sight.diagnostics.severity.undefinedMacro` or `undefinedVariable`. Both stay where they are. Stata is dynamic; the Pylance/Ruff model (warning by default, opt-in strict) fits better than the TypeScript model.
 - Any change to hover or completion out-of-scope behavior.
 - Migration support for the removed setting — see the next section.
@@ -146,6 +147,18 @@ Behavior:
 - `diagnostics.severity.undefinedVariable = 'off'` does the same for the variable-form rewrite.
 - The removed `crossFile.diagnostics.outOfScope` no longer participates; its absence does not introduce any new suppression case.
 
+### Bare-identifier scoping
+
+The scope resolver's `OutOfScopeSymbol.type` is a broad union: `'local' | 'global' | 'program' | 'variable' | 'scalar' | 'matrix'`. It is tempting to let an undefined-variable reference rewrite against any of these, since a bare identifier in Stata source code could, in principle, be any of them. This spec intentionally does not do that. The scope of the variable-diagnostic rewrite is narrow: **a variable-kind reference matches only a variable out-of-scope entry.**
+
+Justification:
+
+- **Matrices.** Matrix references in Stata are almost always mediated by matrix syntax (`matrix rowname`, `matrix list`, `mat x = ...`) or the `matrix()` function, not by bare identifiers in varlist positions. Matching `Potentially undefined variable: foo` against an out-of-scope matrix named `foo` would produce a misleading diagnostic telling the user a matrix is "out of scope" when their code actually meant a dataset variable.
+- **Programs.** Program references appear in command position, not varlist position. The analyzer emits `UNDEFINED_VARIABLE` only from varlist-position checks (`src/analyzer/index.ts:2356-2371`); a program of the same name is never the intended target.
+- **Scalars.** Scalar references in Stata are typically written as `scalar x` or `scalar(x)` in expression contexts, not as bare varlist identifiers. Matching `variable → scalar` could be useful in expression-position ambiguities, but the analyzer does not currently distinguish expression-position from varlist-position identifiers — the `UNDEFINED_VARIABLE` diagnostic is only emitted from varlist positions, so broadening the matcher without a classifier improvement would produce false positives in varlist contexts. The right path is to add an opt-in strictness mode (tracked in #149) that first teaches the analyzer to detect scalar-like positions, then widens the matcher in concert.
+
+In short: this spec keeps matching symmetric and conservative — `local ↔ local`, `global ↔ global`, `variable ↔ variable`. Anything broader is #149.
+
 ### Reference-kind classification
 
 Replace the narrow `extract_macro_scope_from_diagnostic` with a broader classifier that returns `'local' | 'global' | 'variable' | null`:
@@ -180,7 +193,7 @@ private out_of_scope_type_matches_reference(
 Consequences:
 - A local-macro reference only matches an out-of-scope `local`.
 - A global-macro reference only matches an out-of-scope `global`.
-- A variable-diagnostic reference only matches an out-of-scope `variable` (not `scalar`, not `matrix`, not `program`). Those other categories remain reachable via hover / completion out-of-scope display, which is unchanged.
+- A variable-diagnostic reference only matches an out-of-scope `variable`. Out-of-scope `scalar`, `matrix`, and `program` entries are never matched by the variable-diagnostic path and remain reachable via hover / completion out-of-scope display (unchanged). See "Bare-identifier scoping" above for the rationale and #149 for the future scalar-aware mode.
 - Unknown reference kinds do not match anything. This is stricter than today's fallback; during implementation, add a focused regression test if any existing fixture exercises the `null` branch (none is expected).
 
 ### Variable name extraction
@@ -204,8 +217,7 @@ The function can early-return on code to avoid accidentally matching macro-forma
 New module: `src/utils/out-of-scope-message.ts`. Placed under `src/utils/` rather than `src/providers/` so the analyzer, any future diagnostic emitter, or tests can import it without coupling to provider internals.
 
 ```ts
-export type OutOfScopeSymbolKind =
-    | 'local' | 'global' | 'variable' | 'scalar' | 'matrix' | 'program';
+export type OutOfScopeSymbolKind = 'local' | 'global' | 'variable';
 
 export type OutOfScopeReason =
     | { kind: 'after_call_site'; call_site_line_0: number; source_file: string }
@@ -219,11 +231,13 @@ export function format_out_of_scope_message(
 ): string;
 ```
 
+The helper's `OutOfScopeSymbolKind` union is deliberately narrower than `OutOfScopeSymbol.type`. Because the strict kind matcher rejects every match except `local ↔ local`, `global ↔ global`, and `variable ↔ variable`, the helper is never invoked with `scalar`, `matrix`, or `program` — keeping those out of the union prevents dead formatting code. When #149 adds scalar-aware matching, the helper's union (and matcher) widens in the same change.
+
 **Display-name formatting** (from `symbol_name` + `symbol_kind`):
 
 - `local` → `` `foo' ``
 - `global` → `$foo`
-- `variable` / `scalar` / `matrix` / `program` → `foo` (bare; no decoration)
+- `variable` → `foo` (bare; no decoration)
 
 **Line-number contract.** The helper accepts **0-indexed** line numbers in `call_site_line_0` and `defined_line_0` and converts them to 1-indexed for display. This matches the internal representation used throughout the codebase (`OutOfScopeSymbol.call_site_line` is 0-indexed per scope-resolver comment at line 2027; AST ranges are 0-indexed). Field names carry the `_0` suffix so the contract is visible at call sites. The `+ 1` conversion lives in the helper and nowhere else.
 
@@ -233,7 +247,12 @@ export function format_out_of_scope_message(
 - `inheritance_excludes_locals` → `DN is defined in <source_file> but local macros are not inherited via do/run (use include or @lsp-included-by)`
 - `same_file_forward` → `DN is used before it is defined (line <defined_line_0 + 1>)`
 
-Unit tests cover every `(kind, reason)` combination that actually occurs (`local × {after_call_site, inheritance_excludes_locals, same_file_forward}`, `global × {after_call_site, same_file_forward}`, `variable × {after_call_site}`). Impossible combinations (e.g., `variable × inheritance_excludes_locals`, which only applies to locals by definition) are simply never constructed; the helper does not need to reject them.
+Unit tests cover every `(kind, reason)` combination that actually occurs:
+- `local × {after_call_site, inheritance_excludes_locals, same_file_forward}`
+- `global × {after_call_site, same_file_forward}`
+- `variable × {after_call_site}`
+
+Impossible combinations (e.g., `variable × inheritance_excludes_locals`, which only applies to locals by definition; `variable × same_file_forward`, which depends on analyzer work deferred to #147) are simply never constructed; the helper does not need to reject them. Kinds outside the narrowed union (`scalar`, `matrix`, `program`) are enforced by TypeScript rather than by tests.
 
 ### Code deletions
 
@@ -248,7 +267,7 @@ Unit tests cover every `(kind, reason)` combination that actually occurs (`local
 - **Message helper** (`tests/unit/out-of-scope-message.test.ts`, new) — cover every `(kind, reason)` combination listed above; assert exact strings, including 1-indexed line numbers derived from 0-indexed inputs.
 - **Symbol extractor** (`tests/unit/diagnostics-provider.test.ts`, existing) — add variable-format cases (`Potentially undefined variable: foo` → `foo`) and a case where a macro-format message is not accidentally parsed as a variable. Retain regression coverage for local and global macro formats.
 - **Reference-kind classifier** (`tests/unit/diagnostics-provider.test.ts`) — one case per `(code, message shape) → kind` expectation, plus a `null` fallback case for unrecognized shapes.
-- **Kind matcher** (`tests/unit/diagnostics-provider.test.ts`) — variable-kind reference only matches variable out-of-scope entries; does not match scalar / matrix / program / local / global.
+- **Kind matcher** (`tests/unit/diagnostics-provider.test.ts`) — variable-kind reference only matches variable out-of-scope entries; explicit negative cases for scalar, matrix, program, local, and global. Macro-kind references correspondingly do not match variable entries.
 - **Rewrite severity** (`tests/unit/diagnostics-provider.test.ts`) — base `undefinedMacro` at each of `error | warning | information | hint` propagates to the `OUT_OF_SCOPE_SYMBOL` severity; `off` yields `null` (no diagnostic emitted). Same matrix for the variable branch keyed to `undefinedVariable`.
 - **`@lsp-ignore` coverage** (`tests/unit/diagnostics-provider.test.ts`) — `@lsp-ignore` and `@lsp-ignore-next` at the reference line both suppress `OUT_OF_SCOPE_SYMBOL` rewrites, for all three rewrite forms (same-file, cross-file backward, cross-file forward).
 - **Same-file forward-ref rewrite** (`tests/unit/diagnostics-provider.test.ts`) — macro referenced before it is defined ⇒ `OUT_OF_SCOPE_SYMBOL` with `used before it is defined (line N)` at the correct 1-indexed line; truly undefined macro ⇒ unchanged `UNDEFINED_MACRO` generic message.

--- a/docs/superpowers/specs/2026-04-22-out-of-scope-diagnostic-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-22-out-of-scope-diagnostic-cleanup-design.md
@@ -1,0 +1,191 @@
+# Out-of-scope diagnostic cleanup
+
+**Status:** design
+**Date:** 2026-04-22
+**Scope:** Delete the misnamed `crossFile.diagnostics.outOfScope` severity setting, fix the `off`-branch divergence between the backward and forward rewrite paths, make the rewrite fire for variables, and give same-file forward references the same specific message that cross-file forward references already get.
+
+## Problem
+
+`OUT_OF_SCOPE_SYMBOL` is not an independent diagnostic source. It is a rewrite of an existing `UNDEFINED_MACRO` / `UNDEFINED_VARIABLE` diagnostic into a more informative message, emitted when the scope resolver can prove the symbol exists but is unreachable at the reference site. The current shape of this feature has four problems:
+
+1. **The setting is shaped wrong.** `sight.crossFile.diagnostics.outOfScope: error | warning | information | off` is modeled as a severity, but the rewrite is not a source — turning it `off` should not silence a diagnostic the user otherwise wants, and setting it independently of the base undefined-symbol severity invites incoherent combinations (e.g., base `off` + out-of-scope `error`).
+
+2. **The backward and forward paths diverge on `off`.** In `src/providers/diagnostics.ts:281-286`, `outOfScope = off` suppresses the rewrite entirely on the backward/directive path, losing any diagnostic. In the forward-call path (`tests/property/forward-call-out-of-scope-oracle.prop.test.ts:495`), the same value falls back to plain `UNDEFINED_MACRO`. Same setting, different behavior.
+
+3. **The rewrite is dead code for variables.** `OutOfScopeSymbol` and `filter_by_call_site` carry variables through (`src/scope-resolver/index.ts:2029-2058`), but `extract_symbol_name_from_diagnostic` (`src/providers/diagnostics.ts:880-894`) only parses macro formats. When the base diagnostic message is `Potentially undefined variable: foo`, no name is extracted and the rewrite never triggers.
+
+4. **Same-file forward references get a generic message.** The analyzer knows, via the preorder-traversal index and `is_macro_defined(..., token_line)`, that `` `foo' `` on line 5 refers to a macro defined on line 10. It still emits the generic `` Undefined local macro: `foo' ``. Cross-file forward references get a specific "defined in X but after the call site" message. The UX is asymmetric for no reason.
+
+A separate issue (#148) tracks the larger question of unifying same-file and cross-file enrichment into a single provider-side pipeline. A separate issue (#147) tracks true position-aware forward-reference analysis for variables. This spec addresses only the cleanup and correctness work.
+
+## Goals
+
+- Delete `sight.crossFile.diagnostics.outOfScope`. Severity of the `OUT_OF_SCOPE_SYMBOL` rewrite is inherited from the base `undefinedMacro` / `undefinedVariable` severity.
+- Collapse the backward and forward rewrite branches in `src/providers/diagnostics.ts` to the same shape: when an out-of-scope match is found and the base severity is not `off`, emit the specific message at the base severity. Delete the last reads of `config.cross_file?.diagnostics?.out_of_scope`.
+- Teach `extract_symbol_name_from_diagnostic` to parse `Potentially undefined variable: <name>` so the rewrite fires for variables whenever `undefinedVariable` is enabled.
+- When the analyzer detects a same-file forward reference to a macro or global, emit `OUT_OF_SCOPE_SYMBOL` with a specific `used before it is defined (line N)` message instead of the generic undefined wording.
+- Introduce a shared message helper (`src/providers/out-of-scope-message.ts`) so the analyzer and the provider produce identical wording for the cases they share.
+
+## Non-goals
+
+- Position-aware forward-reference analysis for variables inside a single file (see #147).
+- Moving all same-file and cross-file enrichment into a unified provider-side pipeline (see #148).
+- Changing the default for `sight.diagnostics.severity.undefinedMacro`. It stays `'warning'`. Stata is a dynamic language and the Pylance/Ruff default (warning, opt-in strict → error) fits better than the TypeScript default (error).
+- Changing the default for `sight.diagnostics.severity.undefinedVariable`. It stays `'off'`. Once #147 lands and improves signal quality, revisit.
+- Any change to hover or completion out-of-scope behavior. They are independent of this rewrite.
+
+## Design
+
+### Configuration
+
+Delete `sight.crossFile.diagnostics.outOfScope` and the corresponding `CrossFileConfig.diagnostics.out_of_scope` field in `src/types/index.ts:710`. Remove it from the default settings in `src/server-handlers.ts:134` and from the workspace-config mapper (`src/utils/workspace-config.ts`). The sibling keys `missing_file` and `max_depth` stay — those really are independent diagnostic sources.
+
+The config validator (`src/utils/config-validator.ts`) accepts the old `crossFile.diagnostics.outOfScope` key as a deprecated alias for one release. When present, it logs a warning ("`crossFile.diagnostics.outOfScope` is no longer used; severity is now inherited from `diagnostics.severity.undefinedMacro`/`undefinedVariable`") and discards the value.
+
+### Runtime flow
+
+The two rewrite branches in `src/providers/diagnostics.ts` (backward/directive at ~260-306, forward-call at ~310-389) collapse to the same control flow:
+
+```
+for each diagnostic with code UNDEFINED_MACRO or UNDEFINED_VARIABLE:
+  symbol_name = extract_symbol_name_from_diagnostic(diag)
+  if not symbol_name: keep base diagnostic
+
+  match = find_out_of_scope_match(resolved_scope, forward_call_sites, symbol_name, reference_scope)
+  if not match: keep base diagnostic
+
+  base_severity = config.diagnostics.severity[diag.code === UNDEFINED_MACRO ? 'undefinedMacro' : 'undefinedVariable']
+  if base_severity === 'off': suppress entirely (no base, no rewrite)
+
+  emit OUT_OF_SCOPE_SYMBOL:
+    range    = diag.range
+    severity = severity_to_lsp(base_severity)
+    message  = format_out_of_scope_message(symbol_name, match.reason)
+    code     = OUT_OF_SCOPE_SYMBOL
+    source   = 'sight'
+```
+
+Concretely:
+
+- Every read of `config.cross_file?.diagnostics?.out_of_scope` in `src/providers/diagnostics.ts` (four sites: ~284, ~301, ~356, ~385) deletes.
+- `cross_file_severity_to_lsp` at ~858-871 becomes `severity_to_lsp` with input union `'error' | 'warning' | 'information'` (no `'off'` since suppression is handled upstream). If the existing `convert_semantic_diagnostic` path already maps base severities to LSP severities correctly, reuse it instead of keeping two helpers.
+- The `is_symbol_defined_in_current_document` short-circuit at ~358-380 stays. Its semantics change slightly: with the analyzer now emitting `OUT_OF_SCOPE_SYMBOL` for same-file forward references (see below), "preserve the analyzer's diagnostic" means preserving a specific same-file forward-ref diagnostic instead of a generic undefined one. That is exactly what we want.
+- Match-finding on the backward path continues to use `resolved_scope.out_of_scope_symbols.find(...)`. On the forward path it continues to walk `get_visible_forward_call_sites(...)`. The two remain separate data sources; only the emit stage converges.
+
+### Shared message helper
+
+New module `src/providers/out-of-scope-message.ts`:
+
+```ts
+export type OutOfScopeReason =
+  | { kind: 'after_call_site'; call_site_line: number; source_file: string }
+  | { kind: 'inheritance_excludes_locals'; source_file: string }
+  | { kind: 'same_file_forward'; defined_line: number };
+
+export function format_out_of_scope_message(
+    symbol_name: string,
+    reason: OutOfScopeReason
+): string;
+```
+
+Wording (all line numbers 1-indexed in the output):
+
+- `after_call_site` → `` `foo' is defined in parent.do but after the call site (line 42) `` (unchanged from today)
+- `inheritance_excludes_locals` → `` `foo' is defined in parent.do but local macros are not inherited via do/run (use include or @lsp-included-by) `` (unchanged from today)
+- `same_file_forward` → `` `foo' is used before it is defined (line 42) `` (new)
+
+The helper is the single place these strings live. Both `src/providers/diagnostics.ts` (for cross-file cases) and `src/analyzer/index.ts` (for same-file cases) call it. A unit test covers each variant.
+
+### Variable extraction
+
+Add one match to `extract_symbol_name_from_diagnostic` in `src/providers/diagnostics.ts:880-894`:
+
+```ts
+const variable_match = diagnostic.message.match(
+    /^Potentially undefined variable: ([a-zA-Z_][a-zA-Z0-9_]*)$/
+);
+if (variable_match) return variable_match[1];
+```
+
+Order is irrelevant; the patterns are mutually exclusive. This single change makes the cross-file out-of-scope rewrite fire for variables whenever `undefinedVariable` is enabled. Same-file forward-reference analysis for variables is out of scope (#147).
+
+### Same-file forward references in the analyzer
+
+In `src/analyzer/index.ts:2631-2674`, the undefined-macro and undefined-global branches already call `is_macro_defined(name, scope, symbols, undefined, token_line)`. Today, when that returns `false` at the reference line but the symbol exists in `symbols.localMacros` or `symbols.globalMacros` (defined later in the file), both cases emit the generic undefined diagnostic.
+
+After this change, the branches check for a later same-file definition and emit `OUT_OF_SCOPE_SYMBOL` with the `same_file_forward` message when one exists:
+
+```ts
+const token_line = token.range.start.line;
+if (macro_name && !this.is_macro_defined(macro_name, 'local', symbols, undefined, token_line)) {
+    const same_file_def = symbols.localMacros.get(macro_name);
+    if (same_file_def) {
+        diagnostics.push({
+            message: format_out_of_scope_message(macro_name, {
+                kind: 'same_file_forward',
+                defined_line: same_file_def.location.range.start.line + 1,
+            }),
+            range: token.range,
+            code: StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
+            severity: 'warning',
+        });
+    } else {
+        diagnostics.push({
+            message: `Undefined local macro: \`${macro_name}'`,
+            range: token.range,
+            code: StataDiagnosticCode.UNDEFINED_MACRO,
+            severity: 'warning',
+        });
+    }
+}
+```
+
+Same structure for the global branch at ~2640-2674, using `symbols.globalMacros` and `$name` wording when no same-file definition exists.
+
+The analyzer continues to emit an internal severity of `'warning'`. The provider's `convert_semantic_diagnostic` path already translates that through `config.diagnostics.severity.undefinedMacro`, so the final LSP severity tracks user configuration. The diagnostic code on the wire is `OUT_OF_SCOPE_SYMBOL` (not `UNDEFINED_MACRO`), which lets the provider's rewrite logic short-circuit when it encounters a same-file forward-ref diagnostic that is already fully formed.
+
+### Provider short-circuit for analyzer-formed OUT_OF_SCOPE_SYMBOL
+
+When the provider iterates over semantic diagnostics and sees an already-formed `OUT_OF_SCOPE_SYMBOL` (i.e., one produced by the analyzer for a same-file forward reference), it passes it through unchanged. The cross-file match-finding only runs for diagnostics with code `UNDEFINED_MACRO` / `UNDEFINED_VARIABLE`. This keeps the two sources from fighting over the same range.
+
+## Testing
+
+### Unit tests
+
+- **Message helper** (`tests/unit/out-of-scope-message.test.ts`, new) — cover all three `OutOfScopeReason` variants; assert exact strings.
+- **Symbol extractor** (`tests/unit/diagnostics-provider.test.ts`, existing) — add cases for `Potentially undefined variable: foo`; regression coverage for the macro/global formats.
+- **Provider rewrite severity** (`tests/unit/diagnostics-provider.test.ts`, existing) — replace assertions that `OUT_OF_SCOPE_SYMBOL` severity comes from `crossFile.diagnostics.outOfScope` with assertions that it matches the mapped base severity. Add a case: base `off` ⇒ no `OUT_OF_SCOPE_SYMBOL` emitted (and no base diagnostic either).
+- **Analyzer same-file forward-ref** (`tests/unit/analyzer/forward-ref.test.ts` or similar, new) — macro defined on line 10 and referenced on line 5 ⇒ `OUT_OF_SCOPE_SYMBOL` with `used before it is defined (line 10)`; macro truly undefined ⇒ unchanged `UNDEFINED_MACRO` generic message; same coverage for globals.
+- **Validator deprecation** (`tests/unit/config-validator.test.ts`, existing) — old `crossFile.diagnostics.outOfScope` key logs a warning and is ignored; no crash if it is the only crossFile-diagnostics key present.
+
+### Property tests
+
+- `tests/property/forward-call-out-of-scope-oracle.prop.test.ts` — update the oracle to predict `OUT_OF_SCOPE_SYMBOL` whenever the base would fire and an out-of-scope match exists. The existing assertion at ~line 495 that the forward path falls back to plain `UNDEFINED_MACRO` when `outOfScope = off` deletes; that branch no longer exists.
+- `tests/property/out-of-scope-diagnostic-correctness.prop.test.ts` and `tests/property/out-of-scope-diagnostic-message-fix.prop.test.ts` — drop references to the old setting; add a parity property: for equivalent backward and forward out-of-scope scenarios, the emitted `OUT_OF_SCOPE_SYMBOL` has the same severity and code.
+- `tests/property/severity-settings.prop.test.ts` — drop `outOfScope` from the severity matrix. Add properties: (a) `undefinedMacro = off` ⇒ no `OUT_OF_SCOPE_SYMBOL` emitted for macros; (b) emitted `OUT_OF_SCOPE_SYMBOL` severity equals mapped `undefinedMacro` / `undefinedVariable` severity.
+
+### Integration tests
+
+- `tests/integration/out-of-scope-diagnostic-message-bug.test.ts`, `local-macro-inheritance-bug.test.ts`, `cross-file-awareness.test.ts`, `callee-revalidation.test.ts` — adjust config fixtures that set `crossFile.diagnostics.outOfScope`; adjust expected severities to track the base.
+- **New**: same-file forward-ref macro (no cross-file setup) ⇒ asserts `OUT_OF_SCOPE_SYMBOL` with `used before it is defined` message and correct line number.
+- **New**: cross-file out-of-scope variable (with `undefinedVariable='warning'` in test config) ⇒ asserts the rewrite now fires. Regression gate for the variable-extractor change.
+
+### Documentation
+
+- `docs/configuration.md` — remove the `crossFile.diagnostics.outOfScope` entry. Under the `diagnostics.severity.undefinedMacro` / `undefinedVariable` entries, add a short note: "When the scope resolver can prove a referenced symbol exists but is unreachable (defined later in the same file, defined after the call site in a parent file, or excluded by `do`/`run` inheritance), the diagnostic is replaced with a specific `OUT_OF_SCOPE_SYMBOL` message at the same severity."
+- `docs/cross-file.md` — remove the `outOfScope` severity column from any configuration tables; reframe out-of-scope as "a specific form of the undefined-symbol diagnostic, not a separate source."
+- `CLAUDE.md` — no changes required. The architecture description at the top of the file already describes `OUT_OF_SCOPE_SYMBOL` correctly as a rewrite.
+
+## Migration & release notes
+
+- **BREAKING (config).** `sight.crossFile.diagnostics.outOfScope` is removed. The validator accepts it as a deprecated alias for one release (logs a warning, ignored). After that, it will be rejected as an unknown key.
+- **BEHAVIOR CHANGE.** Users who had `outOfScope = off` will start seeing the out-of-scope rewrite. The severity now matches their `undefinedMacro` / `undefinedVariable` setting (default `'warning'` for macros, default `'off'` for variables). To silence the rewrite, set the corresponding base setting to `'off'`.
+- **BEHAVIOR CHANGE.** Users who had `outOfScope = error` and rely on escalation above the base will lose that capability. To keep escalation, raise the base `undefinedMacro` to `'error'`.
+- **NEW.** The cross-file out-of-scope rewrite now applies to variables when `undefinedVariable` is enabled (previously dead code).
+- **NEW.** Same-file forward references to macros and globals get a specific `used before it is defined (line N)` message with diagnostic code `OUT_OF_SCOPE_SYMBOL`.
+
+## Risks
+
+- **Variable rewrite side effects.** The variable rewrite path was previously dead. Wiring it up may expose scope-resolver edge cases for variables not previously stressed (e.g., inheritance rules for variables through `do` chains). Property and integration tests exercise the common paths, but watch for reports after release.
+- **Same-file forward-ref false positives.** The analyzer's same-file position tracking is already used for the generic undefined diagnostic, so this change reuses proven logic. The new risk is the diagnostic code change (`UNDEFINED_MACRO` → `OUT_OF_SCOPE_SYMBOL`) — any downstream consumer that filters by code needs to include both.
+- **Deprecation-alias window.** If the ignored-alias warning is noisy, users on older configs will see validator spam until they migrate. Acceptable; that is the point.

--- a/docs/superpowers/specs/2026-04-22-out-of-scope-diagnostic-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-22-out-of-scope-diagnostic-cleanup-design.md
@@ -2,190 +2,289 @@
 
 **Status:** design
 **Date:** 2026-04-22
-**Scope:** Delete the misnamed `crossFile.diagnostics.outOfScope` severity setting, fix the `off`-branch divergence between the backward and forward rewrite paths, make the rewrite fire for variables, and give same-file forward references the same specific message that cross-file forward references already get.
+**Scope:** Remove the misnamed `crossFile.diagnostics.outOfScope` severity setting, fix the `off`-branch divergence between the backward and forward rewrite paths, make the rewrite fire for the variable-diagnostic path, give same-file forward references the same specific message that cross-file forward references already get, and ensure `@lsp-ignore` suppression covers out-of-scope rewrites.
 
 ## Problem
 
-`OUT_OF_SCOPE_SYMBOL` is not an independent diagnostic source. It is a rewrite of an existing `UNDEFINED_MACRO` / `UNDEFINED_VARIABLE` diagnostic into a more informative message, emitted when the scope resolver can prove the symbol exists but is unreachable at the reference site. The current shape of this feature has four problems:
+`OUT_OF_SCOPE_SYMBOL` is not an independent diagnostic source. It is a rewrite of an existing `UNDEFINED_MACRO` / `UNDEFINED_VARIABLE` diagnostic into a more informative message, emitted when the scope resolver can prove the symbol exists but is unreachable at the reference site. The current shape of this feature has five problems:
 
 1. **The setting is shaped wrong.** `sight.crossFile.diagnostics.outOfScope: error | warning | information | off` is modeled as a severity, but the rewrite is not a source — turning it `off` should not silence a diagnostic the user otherwise wants, and setting it independently of the base undefined-symbol severity invites incoherent combinations (e.g., base `off` + out-of-scope `error`).
 
 2. **The backward and forward paths diverge on `off`.** In `src/providers/diagnostics.ts:281-286`, `outOfScope = off` suppresses the rewrite entirely on the backward/directive path, losing any diagnostic. In the forward-call path (`tests/property/forward-call-out-of-scope-oracle.prop.test.ts:495`), the same value falls back to plain `UNDEFINED_MACRO`. Same setting, different behavior.
 
-3. **The rewrite is dead code for variables.** `OutOfScopeSymbol` and `filter_by_call_site` carry variables through (`src/scope-resolver/index.ts:2029-2058`), but `extract_symbol_name_from_diagnostic` (`src/providers/diagnostics.ts:880-894`) only parses macro formats. When the base diagnostic message is `Potentially undefined variable: foo`, no name is extracted and the rewrite never triggers.
+3. **The rewrite is dead code for variables.** `OutOfScopeSymbol` and `filter_by_call_site` carry variables through (`src/scope-resolver/index.ts:2029-2058`), but `extract_symbol_name_from_diagnostic` (`src/providers/diagnostics.ts:880-894`) only parses macro formats. When the base diagnostic message is `Potentially undefined variable: foo`, no name is extracted and the rewrite never triggers. In addition, `extract_macro_scope_from_diagnostic` (`src/providers/diagnostics.ts:1196-1216`) only returns `'local'` or `'global'`, and `out_of_scope_type_matches_reference` falls back to `true` when the reference kind is `null` — so even if extraction succeeded for a variable, kind matching would be lossy.
 
 4. **Same-file forward references get a generic message.** The analyzer knows, via the preorder-traversal index and `is_macro_defined(..., token_line)`, that `` `foo' `` on line 5 refers to a macro defined on line 10. It still emits the generic `` Undefined local macro: `foo' ``. Cross-file forward references get a specific "defined in X but after the call site" message. The UX is asymmetric for no reason.
 
-A separate issue (#148) tracks the larger question of unifying same-file and cross-file enrichment into a single provider-side pipeline. A separate issue (#147) tracks true position-aware forward-reference analysis for variables. This spec addresses only the cleanup and correctness work.
+5. **`@lsp-ignore` does not suppress out-of-scope rewrites.** The suppression helper (`src/providers/diagnostics.ts:642-665`) runs inside `convert_semantic_diagnostic` and is only invoked for diagnostics with code `UNDEFINED_MACRO` / `UNDEFINED_VARIABLE`. The current rewrite emit sites (lines ~298-305 and ~381-388) push fully-formed LSP diagnostics directly, bypassing the suppression check. This is a latent bug.
+
+A separate issue (#148) tracks the larger question of unifying same-file and cross-file enrichment into a single provider-side pipeline. A separate issue (#147) tracks true position-aware forward-reference analysis for variables. This spec handles only the cleanup, parity, and correctness work.
 
 ## Goals
 
-- Delete `sight.crossFile.diagnostics.outOfScope`. Severity of the `OUT_OF_SCOPE_SYMBOL` rewrite is inherited from the base `undefinedMacro` / `undefinedVariable` severity.
-- Collapse the backward and forward rewrite branches in `src/providers/diagnostics.ts` to the same shape: when an out-of-scope match is found and the base severity is not `off`, emit the specific message at the base severity. Delete the last reads of `config.cross_file?.diagnostics?.out_of_scope`.
-- Teach `extract_symbol_name_from_diagnostic` to parse `Potentially undefined variable: <name>` so the rewrite fires for variables whenever `undefinedVariable` is enabled.
-- When the analyzer detects a same-file forward reference to a macro or global, emit `OUT_OF_SCOPE_SYMBOL` with a specific `used before it is defined (line N)` message instead of the generic undefined wording.
-- Introduce a shared message helper (`src/providers/out-of-scope-message.ts`) so the analyzer and the provider produce identical wording for the cases they share.
+- Delete `sight.crossFile.diagnostics.outOfScope` outright. Severity of every `OUT_OF_SCOPE_SYMBOL` rewrite is derived from the base `undefinedMacro` / `undefinedVariable` severity setting.
+- Collapse the backward and forward rewrite branches in `src/providers/diagnostics.ts` to the same shape.
+- Do all rewrites in the provider. The analyzer continues to emit `UNDEFINED_MACRO` / `UNDEFINED_VARIABLE` unchanged. Any current or future analyzer emission site for undefined symbols picks up the rewrite for free.
+- Add same-file forward-reference rewriting to the provider: when an undefined-macro / undefined-global reference has a matching later definition in the current document, emit `OUT_OF_SCOPE_SYMBOL` with `used before it is defined (line N)`.
+- Teach `extract_symbol_name_from_diagnostic` to parse `Potentially undefined variable: <name>` so the variable-diagnostic path can feed the rewrite.
+- Add proper reference-kind classification (`local | global | variable | null`) and tighten `out_of_scope_type_matches_reference` so a variable reference only matches a variable out-of-scope entry (and similarly for macros).
+- Introduce a shared message helper in a neutral module (`src/utils/out-of-scope-message.ts`) that formats the message for any supported symbol kind and reason.
+- Ensure every rewrite goes through the existing `should_suppress_undefined_symbol` check so `@lsp-ignore` / `@lsp-ignore-next` are honored uniformly.
 
 ## Non-goals
 
-- Position-aware forward-reference analysis for variables inside a single file (see #147).
-- Moving all same-file and cross-file enrichment into a unified provider-side pipeline (see #148).
-- Changing the default for `sight.diagnostics.severity.undefinedMacro`. It stays `'warning'`. Stata is a dynamic language and the Pylance/Ruff default (warning, opt-in strict → error) fits better than the TypeScript default (error).
-- Changing the default for `sight.diagnostics.severity.undefinedVariable`. It stays `'off'`. Once #147 lands and improves signal quality, revisit.
-- Any change to hover or completion out-of-scope behavior. They are independent of this rewrite.
+- Position-aware same-file forward-reference analysis for variables (see #147). The variable path only gains out-of-scope rewriting for diagnostics the analyzer already emits; it does not gain new forward-reference detection inside a single file.
+- Unifying same-file and cross-file enrichment into a general provider-side pipeline (see #148).
+- Changing defaults for `sight.diagnostics.severity.undefinedMacro` or `undefinedVariable`. Both stay where they are. Stata is dynamic; the Pylance/Ruff model (warning by default, opt-in strict) fits better than the TypeScript model.
+- Any change to hover or completion out-of-scope behavior.
+- Migration support for the removed setting — see the next section.
 
 ## Design
 
 ### Configuration
 
-Delete `sight.crossFile.diagnostics.outOfScope` and the corresponding `CrossFileConfig.diagnostics.out_of_scope` field in `src/types/index.ts:710`. Remove it from the default settings in `src/server-handlers.ts:134` and from the workspace-config mapper (`src/utils/workspace-config.ts`). The sibling keys `missing_file` and `max_depth` stay — those really are independent diagnostic sources.
+- Delete `sight.crossFile.diagnostics.outOfScope` from the user-facing schema.
+- Delete `CrossFileConfig.diagnostics.out_of_scope` from `src/types/index.ts:710`.
+- Remove the default from `src/server-handlers.ts:134`.
+- Remove any mapping of the key from `src/utils/workspace-config.ts`.
+- Remove any validation branch for the key from `src/utils/config-validator.ts`.
+- Remove references from `docs/configuration.md` and `docs/cross-file.md`.
 
-The config validator (`src/utils/config-validator.ts`) accepts the old `crossFile.diagnostics.outOfScope` key as a deprecated alias for one release. When present, it logs a warning ("`crossFile.diagnostics.outOfScope` is no longer used; severity is now inherited from `diagnostics.severity.undefinedMacro`/`undefinedVariable`") and discards the value.
+**No deprecation support.** The key is removed; there is no alias, no warning, no logging. If a user config still contains the old key, the validator's existing handling of unrecognized keys applies (typically a silent no-op; confirm during implementation). This is a deliberate simplification: the setting is narrow, the project is early, and migration machinery is not worth the code.
 
-### Runtime flow
+The sibling keys `crossFile.diagnostics.missing_file` and `crossFile.diagnostics.max_depth` stay — those really are independent diagnostic sources.
 
-The two rewrite branches in `src/providers/diagnostics.ts` (backward/directive at ~260-306, forward-call at ~310-389) collapse to the same control flow:
+### Rewrite belongs entirely to the provider
+
+The analyzer is not changed by this spec. It continues to emit `UNDEFINED_MACRO` and `UNDEFINED_VARIABLE` with the same wording and severity it does today (`src/analyzer/index.ts:2634`, `2669`, `2364`). All three rewrite forms live in `src/providers/diagnostics.ts`:
+
+1. **Cross-file backward / directive** — matched against `resolved_scope.out_of_scope_symbols` (existing path at ~260-306).
+2. **Cross-file forward-call** — matched against the forward-call walk (existing path at ~310-389).
+3. **Same-file forward reference** — matched against `document.symbols.localMacros` / `document.symbols.globalMacros` with a later `location.range.start.line` than the reference line (new branch, integrated into the same diagnostic iteration).
+
+Putting the rewrite in the provider guarantees that any undefined-symbol diagnostic — regardless of which analyzer path (token-based today, AST-based in the future) produced it — can be rewritten consistently. It also avoids introducing a third emitter of `OUT_OF_SCOPE_SYMBOL` and keeps the diagnostic-code discipline clean (the analyzer emits source codes only; rewrites belong downstream).
+
+### Unified control flow
+
+For each semantic diagnostic with code `UNDEFINED_MACRO` or `UNDEFINED_VARIABLE`:
 
 ```
-for each diagnostic with code UNDEFINED_MACRO or UNDEFINED_VARIABLE:
-  symbol_name = extract_symbol_name_from_diagnostic(diag)
-  if not symbol_name: keep base diagnostic
+1. ref_kind = classify_reference_kind(diag)          // 'local' | 'global' | 'variable' | null
+2. name     = extract_symbol_name_from_diagnostic(diag)
+   if !name: convert and emit the base diagnostic unchanged; continue.
 
-  match = find_out_of_scope_match(resolved_scope, forward_call_sites, symbol_name, reference_scope)
-  if not match: keep base diagnostic
+3. match = find_out_of_scope_match(
+       diag, name, ref_kind,
+       resolved_scope,          // for cross-file backward matches
+       forward_call_sites,      // for cross-file forward matches
+       document.symbols         // for same-file forward matches
+   )
+   if !match: convert and emit the base diagnostic unchanged; continue.
 
-  base_severity = config.diagnostics.severity[diag.code === UNDEFINED_MACRO ? 'undefinedMacro' : 'undefinedVariable']
-  if base_severity === 'off': suppress entirely (no base, no rewrite)
-
-  emit OUT_OF_SCOPE_SYMBOL:
-    range    = diag.range
-    severity = severity_to_lsp(base_severity)
-    message  = format_out_of_scope_message(symbol_name, match.reason)
-    code     = OUT_OF_SCOPE_SYMBOL
-    source   = 'sight'
+4. Build a synthetic SemanticDiagnostic for the rewrite:
+       message  = format_out_of_scope_message(name, match.kind, match.reason)
+       range    = diag.range
+       code     = OUT_OF_SCOPE_SYMBOL
+       severity = diag.severity                      // analyzer-produced, e.g. 'warning'
+   Feed it through convert_semantic_diagnostic, which:
+       - runs should_suppress_undefined_symbol (extended to cover OUT_OF_SCOPE_SYMBOL)
+       - maps severity using the *base* code (see below)
+   If the converter returns null (suppressed or disabled), drop the diagnostic
+   entirely — do not fall back to the base diagnostic.
 ```
 
-Concretely:
+`find_out_of_scope_match` prefers matches in this order, with the first winning:
 
-- Every read of `config.cross_file?.diagnostics?.out_of_scope` in `src/providers/diagnostics.ts` (four sites: ~284, ~301, ~356, ~385) deletes.
-- `cross_file_severity_to_lsp` at ~858-871 becomes `severity_to_lsp` with input union `'error' | 'warning' | 'information'` (no `'off'` since suppression is handled upstream). If the existing `convert_semantic_diagnostic` path already maps base severities to LSP severities correctly, reuse it instead of keeping two helpers.
-- The `is_symbol_defined_in_current_document` short-circuit at ~358-380 stays. Its semantics change slightly: with the analyzer now emitting `OUT_OF_SCOPE_SYMBOL` for same-file forward references (see below), "preserve the analyzer's diagnostic" means preserving a specific same-file forward-ref diagnostic instead of a generic undefined one. That is exactly what we want.
-- Match-finding on the backward path continues to use `resolved_scope.out_of_scope_symbols.find(...)`. On the forward path it continues to walk `get_visible_forward_call_sites(...)`. The two remain separate data sources; only the emit stage converges.
+1. Same-file later definition (kind must match `ref_kind`).
+2. Cross-file backward (call-site-filtered `out_of_scope_symbols`, kind must match).
+3. Cross-file forward-call excluded-by-later-redef (kind must match).
 
-### Shared message helper
+Same-file preference preserves the existing short-circuit intent at diagnostics.ts:358-380 (prefer the more local explanation).
 
-New module `src/providers/out-of-scope-message.ts`:
+### Severity inheritance (including `hint`)
+
+`convert_semantic_diagnostic` currently maps `UNDEFINED_MACRO` / `UNDEFINED_VARIABLE` severity by reading `config.diagnostics.severity.undefinedMacro` / `undefinedVariable`. It supports all four values: `'error' | 'warning' | 'information' | 'hint'` (plus `'off'`, which returns `null` to suppress).
+
+For `OUT_OF_SCOPE_SYMBOL`, the converter must look up the severity of the **base code the rewrite stands in for**:
+
+- `ref_kind === 'local' | 'global'` → use `undefinedMacro`.
+- `ref_kind === 'variable'` → use `undefinedVariable`.
+
+Because this code path needs to know the base code, the simplest wiring is to plumb a `base_code` field on the synthetic semantic diagnostic (optional, used only for rewrites) and have `convert_semantic_diagnostic` treat `code === OUT_OF_SCOPE_SYMBOL` as "read severity from `base_code`". All four values — including `'hint'` — flow through unchanged. `'off'` suppresses the rewrite completely.
 
 ```ts
-export type OutOfScopeReason =
-  | { kind: 'after_call_site'; call_site_line: number; source_file: string }
-  | { kind: 'inheritance_excludes_locals'; source_file: string }
-  | { kind: 'same_file_forward'; defined_line: number };
-
-export function format_out_of_scope_message(
-    symbol_name: string,
-    reason: OutOfScopeReason
-): string;
+type SemanticDiagnostic = {
+    message: string;
+    range: Range;
+    code: StataDiagnosticCode;
+    severity: 'error' | 'warning' | 'information' | 'hint';
+    base_code?: StataDiagnosticCode; // set iff code === OUT_OF_SCOPE_SYMBOL
+};
 ```
 
-Wording (all line numbers 1-indexed in the output):
+The `base_code` field stays internal (not part of the LSP Diagnostic shape). Every rewrite site sets it.
 
-- `after_call_site` → `` `foo' is defined in parent.do but after the call site (line 42) `` (unchanged from today)
-- `inheritance_excludes_locals` → `` `foo' is defined in parent.do but local macros are not inherited via do/run (use include or @lsp-included-by) `` (unchanged from today)
-- `same_file_forward` → `` `foo' is used before it is defined (line 42) `` (new)
+### `@lsp-ignore` suppression
 
-The helper is the single place these strings live. Both `src/providers/diagnostics.ts` (for cross-file cases) and `src/analyzer/index.ts` (for same-file cases) call it. A unit test covers each variant.
-
-### Variable extraction
-
-Add one match to `extract_symbol_name_from_diagnostic` in `src/providers/diagnostics.ts:880-894`:
+`should_suppress_undefined_symbol` already inspects the range, not the code. Extend the gating check in `convert_semantic_diagnostic` at line 683-684 so it also applies when `diagnostic.code === OUT_OF_SCOPE_SYMBOL`:
 
 ```ts
-const variable_match = diagnostic.message.match(
-    /^Potentially undefined variable: ([a-zA-Z_][a-zA-Z0-9_]*)$/
-);
-if (variable_match) return variable_match[1];
-```
-
-Order is irrelevant; the patterns are mutually exclusive. This single change makes the cross-file out-of-scope rewrite fire for variables whenever `undefinedVariable` is enabled. Same-file forward-reference analysis for variables is out of scope (#147).
-
-### Same-file forward references in the analyzer
-
-In `src/analyzer/index.ts:2631-2674`, the undefined-macro and undefined-global branches already call `is_macro_defined(name, scope, symbols, undefined, token_line)`. Today, when that returns `false` at the reference line but the symbol exists in `symbols.localMacros` or `symbols.globalMacros` (defined later in the file), both cases emit the generic undefined diagnostic.
-
-After this change, the branches check for a later same-file definition and emit `OUT_OF_SCOPE_SYMBOL` with the `same_file_forward` message when one exists:
-
-```ts
-const token_line = token.range.start.line;
-if (macro_name && !this.is_macro_defined(macro_name, 'local', symbols, undefined, token_line)) {
-    const same_file_def = symbols.localMacros.get(macro_name);
-    if (same_file_def) {
-        diagnostics.push({
-            message: format_out_of_scope_message(macro_name, {
-                kind: 'same_file_forward',
-                defined_line: same_file_def.location.range.start.line + 1,
-            }),
-            range: token.range,
-            code: StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
-            severity: 'warning',
-        });
-    } else {
-        diagnostics.push({
-            message: `Undefined local macro: \`${macro_name}'`,
-            range: token.range,
-            code: StataDiagnosticCode.UNDEFINED_MACRO,
-            severity: 'warning',
-        });
+if (document &&
+    (diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO ||
+     diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE ||
+     diagnostic.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL)) {
+    if (this.should_suppress_undefined_symbol(document, diagnostic.range)) {
+        return null;
     }
 }
 ```
 
-Same structure for the global branch at ~2640-2674, using `symbols.globalMacros` and `$name` wording when no same-file definition exists.
+Behavior:
+- `@lsp-ignore` on the reference line suppresses the rewrite (just like it suppresses the base diagnostic).
+- `@lsp-ignore-next` on the previous line does the same.
+- `diagnostics.severity.undefinedMacro = 'off'` suppresses both the base diagnostic and the macro-form rewrite (because the converter returns `null` for `'off'`).
+- `diagnostics.severity.undefinedVariable = 'off'` does the same for the variable-form rewrite.
+- The removed `crossFile.diagnostics.outOfScope` no longer participates; its absence does not introduce any new suppression case.
 
-The analyzer continues to emit an internal severity of `'warning'`. The provider's `convert_semantic_diagnostic` path already translates that through `config.diagnostics.severity.undefinedMacro`, so the final LSP severity tracks user configuration. The diagnostic code on the wire is `OUT_OF_SCOPE_SYMBOL` (not `UNDEFINED_MACRO`), which lets the provider's rewrite logic short-circuit when it encounters a same-file forward-ref diagnostic that is already fully formed.
+### Reference-kind classification
 
-### Provider short-circuit for analyzer-formed OUT_OF_SCOPE_SYMBOL
+Replace the narrow `extract_macro_scope_from_diagnostic` with a broader classifier that returns `'local' | 'global' | 'variable' | null`:
 
-When the provider iterates over semantic diagnostics and sees an already-formed `OUT_OF_SCOPE_SYMBOL` (i.e., one produced by the analyzer for a same-file forward reference), it passes it through unchanged. The cross-file match-finding only runs for diagnostics with code `UNDEFINED_MACRO` / `UNDEFINED_VARIABLE`. This keeps the two sources from fighting over the same range.
+```ts
+private classify_reference_kind(
+    diagnostic: { message: string; code: number }
+): 'local' | 'global' | 'variable' | null {
+    if (diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
+        return 'variable';
+    }
+    if (diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO) {
+        if (/`[^']+'/.test(diagnostic.message)) return 'local';
+        if (/\$\{?[a-zA-Z_][a-zA-Z0-9_]*\}?/.test(diagnostic.message)) return 'global';
+    }
+    return null;
+}
+```
+
+`out_of_scope_type_matches_reference` (diagnostics.ts:1230-1250) is tightened to require exact equality between reference kind and the out-of-scope symbol type — no lossy fallback:
+
+```ts
+private out_of_scope_type_matches_reference(
+    out_of_scope_type: 'local' | 'global' | 'program' | 'variable' | 'scalar' | 'matrix',
+    reference_kind: 'local' | 'global' | 'variable' | null
+): boolean {
+    if (reference_kind === null) return false;
+    return reference_kind === out_of_scope_type;
+}
+```
+
+Consequences:
+- A local-macro reference only matches an out-of-scope `local`.
+- A global-macro reference only matches an out-of-scope `global`.
+- A variable-diagnostic reference only matches an out-of-scope `variable` (not `scalar`, not `matrix`, not `program`). Those other categories remain reachable via hover / completion out-of-scope display, which is unchanged.
+- Unknown reference kinds do not match anything. This is stricter than today's fallback; during implementation, add a focused regression test if any existing fixture exercises the `null` branch (none is expected).
+
+### Variable name extraction
+
+Add one match to `extract_symbol_name_from_diagnostic` (diagnostics.ts:880-894):
+
+```ts
+if (diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
+    const variable_match = diagnostic.message.match(
+        /^Potentially undefined variable: ([a-zA-Z_][a-zA-Z0-9_]*)$/
+    );
+    if (variable_match) return variable_match[1];
+    return null;
+}
+```
+
+The function can early-return on code to avoid accidentally matching macro-format patterns against variable messages.
+
+### Shared message helper
+
+New module: `src/utils/out-of-scope-message.ts`. Placed under `src/utils/` rather than `src/providers/` so the analyzer, any future diagnostic emitter, or tests can import it without coupling to provider internals.
+
+```ts
+export type OutOfScopeSymbolKind =
+    | 'local' | 'global' | 'variable' | 'scalar' | 'matrix' | 'program';
+
+export type OutOfScopeReason =
+    | { kind: 'after_call_site'; call_site_line_0: number; source_file: string }
+    | { kind: 'inheritance_excludes_locals'; source_file: string }
+    | { kind: 'same_file_forward'; defined_line_0: number };
+
+export function format_out_of_scope_message(
+    symbol_name: string,
+    symbol_kind: OutOfScopeSymbolKind,
+    reason: OutOfScopeReason
+): string;
+```
+
+**Display-name formatting** (from `symbol_name` + `symbol_kind`):
+
+- `local` → `` `foo' ``
+- `global` → `$foo`
+- `variable` / `scalar` / `matrix` / `program` → `foo` (bare; no decoration)
+
+**Line-number contract.** The helper accepts **0-indexed** line numbers in `call_site_line_0` and `defined_line_0` and converts them to 1-indexed for display. This matches the internal representation used throughout the codebase (`OutOfScopeSymbol.call_site_line` is 0-indexed per scope-resolver comment at line 2027; AST ranges are 0-indexed). Field names carry the `_0` suffix so the contract is visible at call sites. The `+ 1` conversion lives in the helper and nowhere else.
+
+**Message wording** (display name = DN):
+
+- `after_call_site` → `DN is defined in <source_file> but after the call site (line <call_site_line_0 + 1>)`
+- `inheritance_excludes_locals` → `DN is defined in <source_file> but local macros are not inherited via do/run (use include or @lsp-included-by)`
+- `same_file_forward` → `DN is used before it is defined (line <defined_line_0 + 1>)`
+
+Unit tests cover every `(kind, reason)` combination that actually occurs (`local × {after_call_site, inheritance_excludes_locals, same_file_forward}`, `global × {after_call_site, same_file_forward}`, `variable × {after_call_site}`). Impossible combinations (e.g., `variable × inheritance_excludes_locals`, which only applies to locals by definition) are simply never constructed; the helper does not need to reject them.
+
+### Code deletions
+
+- The four reads of `config.cross_file?.diagnostics?.out_of_scope` in `src/providers/diagnostics.ts`.
+- `cross_file_severity_to_lsp` (diagnostics.ts:858-871) — no remaining callers once the reads above are gone.
+- Any symbol exports and doc references to the removed config key.
 
 ## Testing
 
 ### Unit tests
 
-- **Message helper** (`tests/unit/out-of-scope-message.test.ts`, new) — cover all three `OutOfScopeReason` variants; assert exact strings.
-- **Symbol extractor** (`tests/unit/diagnostics-provider.test.ts`, existing) — add cases for `Potentially undefined variable: foo`; regression coverage for the macro/global formats.
-- **Provider rewrite severity** (`tests/unit/diagnostics-provider.test.ts`, existing) — replace assertions that `OUT_OF_SCOPE_SYMBOL` severity comes from `crossFile.diagnostics.outOfScope` with assertions that it matches the mapped base severity. Add a case: base `off` ⇒ no `OUT_OF_SCOPE_SYMBOL` emitted (and no base diagnostic either).
-- **Analyzer same-file forward-ref** (`tests/unit/analyzer/forward-ref.test.ts` or similar, new) — macro defined on line 10 and referenced on line 5 ⇒ `OUT_OF_SCOPE_SYMBOL` with `used before it is defined (line 10)`; macro truly undefined ⇒ unchanged `UNDEFINED_MACRO` generic message; same coverage for globals.
-- **Validator deprecation** (`tests/unit/config-validator.test.ts`, existing) — old `crossFile.diagnostics.outOfScope` key logs a warning and is ignored; no crash if it is the only crossFile-diagnostics key present.
+- **Message helper** (`tests/unit/out-of-scope-message.test.ts`, new) — cover every `(kind, reason)` combination listed above; assert exact strings, including 1-indexed line numbers derived from 0-indexed inputs.
+- **Symbol extractor** (`tests/unit/diagnostics-provider.test.ts`, existing) — add variable-format cases (`Potentially undefined variable: foo` → `foo`) and a case where a macro-format message is not accidentally parsed as a variable. Retain regression coverage for local and global macro formats.
+- **Reference-kind classifier** (`tests/unit/diagnostics-provider.test.ts`) — one case per `(code, message shape) → kind` expectation, plus a `null` fallback case for unrecognized shapes.
+- **Kind matcher** (`tests/unit/diagnostics-provider.test.ts`) — variable-kind reference only matches variable out-of-scope entries; does not match scalar / matrix / program / local / global.
+- **Rewrite severity** (`tests/unit/diagnostics-provider.test.ts`) — base `undefinedMacro` at each of `error | warning | information | hint` propagates to the `OUT_OF_SCOPE_SYMBOL` severity; `off` yields `null` (no diagnostic emitted). Same matrix for the variable branch keyed to `undefinedVariable`.
+- **`@lsp-ignore` coverage** (`tests/unit/diagnostics-provider.test.ts`) — `@lsp-ignore` and `@lsp-ignore-next` at the reference line both suppress `OUT_OF_SCOPE_SYMBOL` rewrites, for all three rewrite forms (same-file, cross-file backward, cross-file forward).
+- **Same-file forward-ref rewrite** (`tests/unit/diagnostics-provider.test.ts`) — macro referenced before it is defined ⇒ `OUT_OF_SCOPE_SYMBOL` with `used before it is defined (line N)` at the correct 1-indexed line; truly undefined macro ⇒ unchanged `UNDEFINED_MACRO` generic message.
 
 ### Property tests
 
-- `tests/property/forward-call-out-of-scope-oracle.prop.test.ts` — update the oracle to predict `OUT_OF_SCOPE_SYMBOL` whenever the base would fire and an out-of-scope match exists. The existing assertion at ~line 495 that the forward path falls back to plain `UNDEFINED_MACRO` when `outOfScope = off` deletes; that branch no longer exists.
-- `tests/property/out-of-scope-diagnostic-correctness.prop.test.ts` and `tests/property/out-of-scope-diagnostic-message-fix.prop.test.ts` — drop references to the old setting; add a parity property: for equivalent backward and forward out-of-scope scenarios, the emitted `OUT_OF_SCOPE_SYMBOL` has the same severity and code.
-- `tests/property/severity-settings.prop.test.ts` — drop `outOfScope` from the severity matrix. Add properties: (a) `undefinedMacro = off` ⇒ no `OUT_OF_SCOPE_SYMBOL` emitted for macros; (b) emitted `OUT_OF_SCOPE_SYMBOL` severity equals mapped `undefinedMacro` / `undefinedVariable` severity.
+- `tests/property/forward-call-out-of-scope-oracle.prop.test.ts` — update the oracle to predict `OUT_OF_SCOPE_SYMBOL` whenever an out-of-scope match exists and the base severity is not `off`. The existing assertion (~line 495) that the forward path falls back to plain `UNDEFINED_MACRO` when `outOfScope = off` deletes; that setting is gone.
+- `tests/property/out-of-scope-diagnostic-correctness.prop.test.ts`, `tests/property/out-of-scope-diagnostic-message-fix.prop.test.ts` — drop references to the old setting. Add a parity property: for equivalent same-file, backward, and forward scenarios, the emitted `OUT_OF_SCOPE_SYMBOL` has identical severity (controlled by base) and identical code.
+- `tests/property/severity-settings.prop.test.ts` — drop `outOfScope` from the severity matrix. Add properties: (a) `undefinedMacro = off` ⇒ no macro-kind `OUT_OF_SCOPE_SYMBOL`; (b) `undefinedVariable = off` ⇒ no variable-kind `OUT_OF_SCOPE_SYMBOL`; (c) for any non-`off` base severity, the rewrite is emitted at exactly that severity.
+- `tests/property/diagnostic-suppression.test.ts` — extend to cover `@lsp-ignore` / `@lsp-ignore-next` suppressing `OUT_OF_SCOPE_SYMBOL` rewrites.
 
 ### Integration tests
 
-- `tests/integration/out-of-scope-diagnostic-message-bug.test.ts`, `local-macro-inheritance-bug.test.ts`, `cross-file-awareness.test.ts`, `callee-revalidation.test.ts` — adjust config fixtures that set `crossFile.diagnostics.outOfScope`; adjust expected severities to track the base.
-- **New**: same-file forward-ref macro (no cross-file setup) ⇒ asserts `OUT_OF_SCOPE_SYMBOL` with `used before it is defined` message and correct line number.
-- **New**: cross-file out-of-scope variable (with `undefinedVariable='warning'` in test config) ⇒ asserts the rewrite now fires. Regression gate for the variable-extractor change.
+- `tests/integration/out-of-scope-diagnostic-message-bug.test.ts`, `local-macro-inheritance-bug.test.ts`, `cross-file-awareness.test.ts`, `callee-revalidation.test.ts` — strip any config fixtures setting the removed `crossFile.diagnostics.outOfScope`; adjust expected severities to match the base.
+- **New**: same-file forward-reference macro (no cross-file setup) ⇒ asserts `OUT_OF_SCOPE_SYMBOL` with the `used before it is defined` message at the correct line.
+- **New**: cross-file out-of-scope variable with `undefinedVariable = 'warning'` ⇒ asserts the variable-form rewrite fires (regression gate for the extractor + classifier changes).
+- **New**: `@lsp-ignore` at the reference line suppresses the rewrite for each of the three rewrite forms.
 
 ### Documentation
 
-- `docs/configuration.md` — remove the `crossFile.diagnostics.outOfScope` entry. Under the `diagnostics.severity.undefinedMacro` / `undefinedVariable` entries, add a short note: "When the scope resolver can prove a referenced symbol exists but is unreachable (defined later in the same file, defined after the call site in a parent file, or excluded by `do`/`run` inheritance), the diagnostic is replaced with a specific `OUT_OF_SCOPE_SYMBOL` message at the same severity."
-- `docs/cross-file.md` — remove the `outOfScope` severity column from any configuration tables; reframe out-of-scope as "a specific form of the undefined-symbol diagnostic, not a separate source."
-- `CLAUDE.md` — no changes required. The architecture description at the top of the file already describes `OUT_OF_SCOPE_SYMBOL` correctly as a rewrite.
+- `docs/configuration.md` — remove the `crossFile.diagnostics.outOfScope` entry entirely. Under `diagnostics.severity.undefinedMacro` / `undefinedVariable`, add a short note: "When the scope resolver can prove a referenced symbol exists but is unreachable (defined later in the same file, defined after the call site in a parent file, or excluded by `do`/`run` inheritance), the diagnostic is replaced with a specific `OUT_OF_SCOPE_SYMBOL` message at the same severity."
+- `docs/cross-file.md` — remove the `outOfScope` severity entry. Reframe out-of-scope as "a specific form of the undefined-symbol diagnostic, not a separate source."
+- `CLAUDE.md` — no changes required.
 
 ## Migration & release notes
 
-- **BREAKING (config).** `sight.crossFile.diagnostics.outOfScope` is removed. The validator accepts it as a deprecated alias for one release (logs a warning, ignored). After that, it will be rejected as an unknown key.
-- **BEHAVIOR CHANGE.** Users who had `outOfScope = off` will start seeing the out-of-scope rewrite. The severity now matches their `undefinedMacro` / `undefinedVariable` setting (default `'warning'` for macros, default `'off'` for variables). To silence the rewrite, set the corresponding base setting to `'off'`.
-- **BEHAVIOR CHANGE.** Users who had `outOfScope = error` and rely on escalation above the base will lose that capability. To keep escalation, raise the base `undefinedMacro` to `'error'`.
-- **NEW.** The cross-file out-of-scope rewrite now applies to variables when `undefinedVariable` is enabled (previously dead code).
-- **NEW.** Same-file forward references to macros and globals get a specific `used before it is defined (line N)` message with diagnostic code `OUT_OF_SCOPE_SYMBOL`.
+- **BREAKING (config).** `sight.crossFile.diagnostics.outOfScope` is removed. No alias, no warning. Users who still have the key in their `.sight.json` will simply find it ignored (the validator's generic unrecognized-key handling applies).
+- **BEHAVIOR CHANGE.** Users who had `outOfScope = off` will start seeing the out-of-scope rewrite. Severity now matches their `undefinedMacro` / `undefinedVariable` setting (default `'warning'` for macros, default `'off'` for variables). To silence the rewrite, set the corresponding base setting to `'off'`.
+- **BEHAVIOR CHANGE.** Users who had `outOfScope = error` and relied on out-of-scope being more severe than the base will lose that escalation. To keep escalation, raise the base `undefinedMacro` to `'error'`.
+- **NEW.** The cross-file out-of-scope rewrite now applies to the undefined-variable diagnostic when `undefinedVariable` is enabled. This does not extend variable analysis itself; it only routes existing undefined-variable diagnostics through the rewrite path when the scope resolver has a matching entry.
+- **NEW.** Same-file forward references to macros and globals get a specific `used before it is defined (line N)` diagnostic with code `OUT_OF_SCOPE_SYMBOL`.
+- **BUG FIX.** `@lsp-ignore` and `@lsp-ignore-next` now suppress `OUT_OF_SCOPE_SYMBOL` rewrites, matching their existing behavior for `UNDEFINED_MACRO` / `UNDEFINED_VARIABLE`.
 
 ## Risks
 
-- **Variable rewrite side effects.** The variable rewrite path was previously dead. Wiring it up may expose scope-resolver edge cases for variables not previously stressed (e.g., inheritance rules for variables through `do` chains). Property and integration tests exercise the common paths, but watch for reports after release.
-- **Same-file forward-ref false positives.** The analyzer's same-file position tracking is already used for the generic undefined diagnostic, so this change reuses proven logic. The new risk is the diagnostic code change (`UNDEFINED_MACRO` → `OUT_OF_SCOPE_SYMBOL`) — any downstream consumer that filters by code needs to include both.
-- **Deprecation-alias window.** If the ignored-alias warning is noisy, users on older configs will see validator spam until they migrate. Acceptable; that is the point.
+- **Tightened kind matching.** Changing `out_of_scope_type_matches_reference` from `null → true` to `null → false` could, in theory, stop matching cases where extraction fails. The classifier covers the cases the current analyzer actually produces, so this should be a net improvement; focused tests guard the expected shapes.
+- **Variable rewrite blast radius.** The variable rewrite path was previously dead. Wiring it up may expose edge cases in scope-resolver variable handling that were never exercised. Property and integration tests cover the common shapes; watch for reports after release.
+- **Diagnostic code drift for consumers.** Same-file forward references previously surfaced as `UNDEFINED_MACRO`; they will now surface as `OUT_OF_SCOPE_SYMBOL` whenever a later definition exists in the same file. Any downstream tool that filters by code must include both codes to see "undefined macro-like" diagnostics.
+- **Removed setting with no warning.** Users on older configs who used the setting will see behavior change without any tooling signal beyond release notes. This is accepted explicitly in the migration plan.

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -16,9 +16,25 @@ import { ScopeResolver, build_scope_resolver_config, get_visible_forward_call_si
 import { createHash } from 'crypto';
 import { DocumentDebounceManager } from '../utils/debounce-manager';
 import { get_line_text, get_line_count } from '../utils/line-utils';
+import {
+    format_out_of_scope_message,
+    OutOfScopeReason as OutOfScopeMessageReason,
+    OutOfScopeSymbolKind,
+} from '../utils/out-of-scope-message';
 import { IndentationDiagnosticAnalyzer } from './indentation-diagnostics';
 import { OperatorSequenceAnalyzer } from './operator-sequence-diagnostics';
 import { MixedLogicalOperatorAnalyzer } from './mixed-logical-diagnostics';
+type SemanticDiagnostic = {
+    message: string;
+    range: any;
+    code: number;
+    severity: 'error' | 'warning' | 'information' | 'hint';
+    base_code?: number;
+};
+type OutOfScopeRewriteMatch = {
+    symbol_kind: OutOfScopeSymbolKind;
+    reason: OutOfScopeMessageReason;
+};
 
 /**
  * DiagnosticsProvider aggregates diagnostics from cached parse results.
@@ -239,156 +255,174 @@ export class DiagnosticsProvider {
                 continue;
             }
 
-            // Check if this is an undefined symbol that's actually defined in cross-file scope
-            if (resolved_scope &&
-                (my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO ||
-                 my_diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE)) {
-                const symbol_name = this.extract_symbol_name_from_diagnostic(my_diagnostic);
-                if (symbol_name) {
-                    // Check if defined in cross-file scope (different sourceUri)
-                    if (this.is_symbol_defined_in_scope(symbol_name, resolved_scope.symbols, my_diagnostic.code, document.uri)) {
-                        continue; // Skip - symbol is defined in parent file
-                    }
-                    
-                    // Check if this macro is a c_local from a program in the resolved scope
-                    // This handles the case where the analyzer didn't have workspace symbols
-                    // but the scope resolver found the program via @lsp-done-by chain
-                    if (my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO) {
-                        if (this.is_c_local_from_resolved_program(symbol_name, resolved_scope.symbols, document, my_diagnostic.range.start.line)) {
-                            continue; // Skip - macro is a c_local from a program in resolved scope
-                        }
-                    }
-                    
-                    // Check if symbol is out-of-scope (defined after call site or
-                    // excluded by inheritance). This path rewrites an existing
-                    // undefined-symbol diagnostic; it is not an independent
-                    // diagnostic source.
-                    // Only match out-of-scope symbols of the same type as the
-                    // reference.
-                    const reference_scope = this.extract_macro_scope_from_diagnostic(my_diagnostic);
-                    const out_of_scope = resolved_scope.out_of_scope_symbols.find(
-                        s => s.name === symbol_name && this.out_of_scope_type_matches_reference(s.type, reference_scope)
-                    );
-                    if (out_of_scope) {
-                        // Suppress the rewrite when the base undefined-symbol
-                        // diagnostic is disabled. OUT_OF_SCOPE_SYMBOL is a
-                        // rewrite, not an independent source, so turning off
-                        // the base should also silence the rewrite.
-                        const base_severity = my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO
-                            ? config.diagnostics.severity.undefinedMacro
-                            : config.diagnostics.severity.undefinedVariable;
-                        if (base_severity === 'off') {
-                            continue;
-                        }
-                        // Check config severity for out-of-scope
-                        const out_of_scope_severity = config.cross_file?.diagnostics?.out_of_scope;
-                        if (out_of_scope_severity === 'off') {
-                            continue;
-                        }
-                        // Emit more informative out-of-scope diagnostic based on reason
-                        const source_file = out_of_scope.source_uri.split('/').pop() || out_of_scope.source_uri;
-                        let message: string;
-                        if (out_of_scope.reason === 'inheritance_excludes_locals') {
-                            message = `'${symbol_name}' is defined in ${source_file} but local macros are not inherited via do/run (use include or @lsp-included-by)`;
-                        } else {
-                            // Convert 0-indexed call_site_line to 1-indexed for display
-                            const display_line = out_of_scope.call_site_line + 1;
-                            message = `'${symbol_name}' is defined in ${source_file} but after the call site (line ${display_line})`;
-                        }
-                        the_diagnostics.push({
-                            range: my_diagnostic.range,
-                            message,
-                            severity: this.cross_file_severity_to_lsp(out_of_scope_severity),
-                            source: 'sight',
-                            code: StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
-                        });
-                        continue;
-                    }
+            const is_undefined_symbol =
+                my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO
+                || my_diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE;
+            const symbol_name = is_undefined_symbol
+                ? this.extract_symbol_name_from_diagnostic(my_diagnostic)
+                : null;
+            const reference_kind = is_undefined_symbol
+                ? this.classify_reference_kind(my_diagnostic)
+                : null;
+
+            // Skip diagnostics when the symbol is truly available from
+            // cross-file scope before attempting any out-of-scope rewrites.
+            if (resolved_scope && symbol_name) {
+                if (this.is_symbol_defined_in_scope(
+                        symbol_name,
+                        resolved_scope.symbols,
+                        my_diagnostic.code,
+                        document.uri
+                    )) {
+                    continue;
+                }
+
+                if (my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    && this.is_c_local_from_resolved_program(
+                        symbol_name,
+                        resolved_scope.symbols,
+                        document,
+                        my_diagnostic.range.start.line
+                    )) {
+                    continue;
                 }
             }
-            
-            // Check if this is an undefined symbol that's defined in a forward-called
-            // file visible at this diagnostic's line. Uses the shared helper.
-            if (resolved_scope &&
-                (my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO ||
-                 my_diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE)) {
-                const symbol_name = this.extract_symbol_name_from_diagnostic(my_diagnostic);
-                if (symbol_name) {
-                    const diag_line = my_diagnostic.range.start.line;
-                    let found_in_forward_call = false;
-                    let excluded_callee_uri: string | undefined;
-                    const reference_scope = this.extract_macro_scope_from_diagnostic(my_diagnostic);
-                    for (const call_site of get_visible_forward_call_sites(resolved_scope, diag_line)) {
-                        if (this.is_symbol_in_forward_call(
-                                symbol_name, call_site.symbols, my_diagnostic.code, call_site.effective_type)) {
-                            found_in_forward_call = true;
-                            break;
-                        }
-                        if (this.is_symbol_excluded_by_forward_call(
-                                symbol_name,
-                                call_site,
-                                my_diagnostic.code,
-                                reference_scope
-                            )) {
-                            // Forward-call symbol precedence is last visible site wins.
-                            // Blame the callee whose local is the effective
-                            // end-of-execution winner for this site's chain
-                            // (see ForwardScopeResolver.compute_effective_end_state_locals).
-                            // Fall back to the direct-child's URI if the
-                            // symbol's sourceUri is missing.
-                            const effective = call_site.excluded_locals?.get(symbol_name);
-                            excluded_callee_uri = effective?.sourceUri ?? call_site.callee_uri;
-                        }
+
+            if (resolved_scope && symbol_name) {
+                const diag_line = my_diagnostic.range.start.line;
+                let found_in_forward_call = false;
+                for (const call_site of get_visible_forward_call_sites(
+                    resolved_scope,
+                    diag_line
+                )) {
+                    if (this.is_symbol_in_forward_call(
+                            symbol_name,
+                            call_site.symbols,
+                            my_diagnostic.code,
+                            call_site.effective_type
+                        )) {
+                        found_in_forward_call = true;
+                        break;
                     }
-                    if (found_in_forward_call) {
+                }
+                if (found_in_forward_call) {
+                    continue;
+                }
+            }
+            if (symbol_name) {
+                const same_file_match = this.find_same_file_out_of_scope_match(
+                    symbol_name,
+                    reference_kind,
+                    document.symbols,
+                    document.uri,
+                    my_diagnostic.range.start.line
+                );
+                if (same_file_match) {
+                    const converted = this.create_out_of_scope_rewrite(
+                        my_diagnostic,
+                        symbol_name,
+                        same_file_match,
+                        config,
+                        document
+                    );
+                    if (converted) {
+                        the_diagnostics.push(converted);
+                    }
+                    continue;
+                }
+            }
+
+            if (resolved_scope && symbol_name) {
+                const backward_match = this.find_backward_out_of_scope_match(
+                    symbol_name,
+                    reference_kind,
+                    resolved_scope
+                );
+                if (backward_match) {
+                    const converted = this.create_out_of_scope_rewrite(
+                        my_diagnostic,
+                        symbol_name,
+                        backward_match,
+                        config,
+                        document
+                    );
+                    if (converted) {
+                        the_diagnostics.push(converted);
+                    }
+                    continue;
+                }
+
+                const diag_line = my_diagnostic.range.start.line;
+                let found_in_forward_call = false;
+                let forward_match: OutOfScopeRewriteMatch | null = null;
+                for (const call_site of get_visible_forward_call_sites(
+                    resolved_scope,
+                    diag_line
+                )) {
+                    if (this.is_symbol_in_forward_call(
+                            symbol_name,
+                            call_site.symbols,
+                            my_diagnostic.code,
+                            call_site.effective_type
+                        )) {
+                        found_in_forward_call = true;
+                        break;
+                    }
+                    if (this.is_symbol_excluded_by_forward_call(
+                            symbol_name,
+                            call_site,
+                            my_diagnostic.code,
+                            reference_kind
+                        )) {
+                        const effective = call_site.excluded_locals?.get(
+                            symbol_name
+                        );
+                        const excluded_callee_uri = effective?.sourceUri
+                            ?? call_site.callee_uri;
+                        const source_file = excluded_callee_uri.split('/').pop()
+                            || excluded_callee_uri;
+                        forward_match = {
+                            symbol_kind: 'local',
+                            reason: {
+                                kind: 'inheritance_excludes_locals',
+                                source_file,
+                            },
+                        };
+                    }
+                }
+                if (found_in_forward_call) {
+                    continue;
+                }
+                if (forward_match) {
+                    if (this.is_symbol_defined_in_current_document(
+                            symbol_name,
+                            document.symbols,
+                            my_diagnostic.code,
+                            document.uri,
+                            reference_kind
+                        )) {
+                        const converted = this.convert_semantic_diagnostic(
+                            my_diagnostic,
+                            config,
+                            document
+                        );
+                        if (converted) {
+                            the_diagnostics.push(converted);
+                        }
                         continue;
                     }
-                    if (excluded_callee_uri) {
-                        // Suppress the rewrite when the base undefined-symbol
-                        // diagnostic is disabled. See comment in the backward
-                        // path above.
-                        const base_severity = my_diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO
-                            ? config.diagnostics.severity.undefinedMacro
-                            : config.diagnostics.severity.undefinedVariable;
-                        if (base_severity === 'off') {
-                            continue;
-                        }
-                        const out_of_scope_severity = config.cross_file?.diagnostics?.out_of_scope;
-                        if (out_of_scope_severity !== 'off') {
-                            if (this.is_symbol_defined_in_current_document(
-                                    symbol_name,
-                                    document.symbols,
-                                    my_diagnostic.code,
-                                    document.uri,
-                                    reference_scope
-                                )) {
-                                // Preserve the analyzer's same-file
-                                // forward-reference diagnostic instead of
-                                // replacing it with cross-file advice. This
-                                // intentionally keeps same-file forward
-                                // references gated by the base undefined-symbol
-                                // severity settings.
-                                const converted = this.convert_semantic_diagnostic(
-                                    my_diagnostic,
-                                    config,
-                                    document
-                                );
-                                if (converted) {
-                                    the_diagnostics.push(converted);
-                                }
-                                continue;
-                            }
-                            const source_file = excluded_callee_uri.split('/').pop() || excluded_callee_uri;
-                            the_diagnostics.push({
-                                range: my_diagnostic.range,
-                                message: `'${symbol_name}' is defined in ${source_file} but local macros are not inherited via do/run (use include or @lsp-include)`,
-                                severity: this.cross_file_severity_to_lsp(out_of_scope_severity),
-                                source: 'sight',
-                                code: StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
-                            });
-                            continue;
-                        }
+
+                    const converted = this.create_out_of_scope_rewrite(
+                        my_diagnostic,
+                        symbol_name,
+                        forward_match,
+                        config,
+                        document
+                    );
+                    if (converted) {
+                        the_diagnostics.push(converted);
                     }
+                    continue;
                 }
             }
             
@@ -508,18 +542,8 @@ export class DiagnosticsProvider {
     /**
      * Extract semantic diagnostics from document diagnostics.
      */
-    private extract_semantic_diagnostics(document: DocumentState): Array<{
-        message: string;
-        range: any;
-        code: number;
-        severity: 'error' | 'warning' | 'information' | 'hint';
-    }> {
-        const semantic_diags: Array<{
-            message: string;
-            range: any;
-            code: number;
-            severity: 'error' | 'warning' | 'information' | 'hint';
-        }> = [];
+    private extract_semantic_diagnostics(document: DocumentState): SemanticDiagnostic[] {
+        const semantic_diags: SemanticDiagnostic[] = [];
         for (const diag of document.diagnostics) {
             if (diag.code && typeof diag.code === 'number') {
                 const code = diag.code as number;
@@ -611,6 +635,19 @@ export class DiagnosticsProvider {
         };
     }
 
+    private get_undefined_symbol_severity_setting(
+        diagnostic_code: number | undefined,
+        config: StataLSPConfig
+    ): 'error' | 'warning' | 'information' | 'hint' | 'off' | null {
+        if (diagnostic_code === StataDiagnosticCode.UNDEFINED_MACRO) {
+            return config.diagnostics.severity.undefinedMacro;
+        }
+        if (diagnostic_code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
+            return config.diagnostics.severity.undefinedVariable;
+        }
+        return null;
+    }
+
     /**
      * Convert a parser error to an LSP Diagnostic.
      */
@@ -669,19 +706,15 @@ export class DiagnosticsProvider {
      * Convert a semantic diagnostic to an LSP Diagnostic.
      */
     private convert_semantic_diagnostic(
-        diagnostic: {
-            message: string;
-            range: any;
-            code: number;
-            severity: 'error' | 'warning' | 'information' | 'hint';
-        },
+        diagnostic: SemanticDiagnostic,
         config: StataLSPConfig,
         document?: DocumentState
     ): Diagnostic | null {
         // Check suppression first for undefined symbol diagnostics
         if (document && 
             (diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO ||
-             diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE)) {
+             diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE ||
+             diagnostic.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL)) {
             if (this.should_suppress_undefined_symbol(document, diagnostic.range)) {
                 return null; // Suppressed
             }
@@ -693,10 +726,18 @@ export class DiagnosticsProvider {
 
         switch (diagnostic.code) {
             case StataDiagnosticCode.UNDEFINED_MACRO:
-            case StataDiagnosticCode.UNDEFINED_VARIABLE: {
-                const severity_setting = diagnostic.code === StataDiagnosticCode.UNDEFINED_MACRO
-                    ? config.diagnostics.severity.undefinedMacro
-                    : config.diagnostics.severity.undefinedVariable;
+            case StataDiagnosticCode.UNDEFINED_VARIABLE:
+            case StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL: {
+                const severity_setting = this.get_undefined_symbol_severity_setting(
+                    diagnostic.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                        ? diagnostic.base_code
+                        : diagnostic.code,
+                    config
+                );
+                if (!severity_setting) {
+                    severity = this.semantic_severity_to_lsp(diagnostic.severity);
+                    break;
+                }
                 severity = this.get_severity_from_config(severity_setting);
                 break;
             }
@@ -714,6 +755,120 @@ export class DiagnosticsProvider {
             severity,
             code: diagnostic.code,
             source: 'sight',
+        };
+    }
+
+    private create_out_of_scope_rewrite(
+        base_diagnostic: SemanticDiagnostic,
+        symbol_name: string,
+        match: OutOfScopeRewriteMatch,
+        config: StataLSPConfig,
+        document: DocumentState
+    ): Diagnostic | null {
+        return this.convert_semantic_diagnostic(
+            {
+                message: format_out_of_scope_message(
+                    symbol_name,
+                    match.symbol_kind,
+                    match.reason
+                ),
+                range: base_diagnostic.range,
+                code: StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
+                severity: base_diagnostic.severity,
+                base_code: base_diagnostic.code,
+            },
+            config,
+            document
+        );
+    }
+
+    private find_same_file_out_of_scope_match(
+        symbol_name: string,
+        reference_kind: 'local' | 'global' | 'variable' | null,
+        symbols: SymbolTable,
+        current_document_uri: string,
+        reference_line: number
+    ): OutOfScopeRewriteMatch | null {
+        if (reference_kind !== 'local' && reference_kind !== 'global') {
+            return null;
+        }
+
+        const get_definition_line = (
+            symbol:
+                | {
+                    sourceUri?: string;
+                    location?: { uri?: string; range?: { start?: { line?: number } } };
+                }
+                | undefined
+        ): number | null => {
+            if (!symbol) {
+                return null;
+            }
+            const symbol_uri = symbol.sourceUri ?? symbol.location?.uri;
+            if (symbol_uri !== current_document_uri) {
+                return null;
+            }
+            const definition_line = symbol.location?.range?.start?.line;
+            return typeof definition_line === 'number' ? definition_line : null;
+        };
+
+        const matching_symbol = reference_kind === 'local'
+            ? symbols.localMacros.get(symbol_name)
+            : symbols.globalMacros.get(symbol_name);
+        const definition_line = get_definition_line(matching_symbol);
+
+        if (definition_line === null || definition_line <= reference_line) {
+            return null;
+        }
+
+        return {
+            symbol_kind: reference_kind,
+            reason: {
+                kind: 'same_file_forward',
+                defined_line_0: definition_line,
+            },
+        };
+    }
+
+    private find_backward_out_of_scope_match(
+        symbol_name: string,
+        reference_kind: 'local' | 'global' | 'variable' | null,
+        resolved_scope: ResolvedScope
+    ): OutOfScopeRewriteMatch | null {
+        if (reference_kind === null) {
+            return null;
+        }
+
+        const out_of_scope = resolved_scope.out_of_scope_symbols.find(my_symbol =>
+            my_symbol.name === symbol_name
+            && this.out_of_scope_type_matches_reference(
+                my_symbol.type,
+                reference_kind
+            )
+        );
+        if (!out_of_scope) {
+            return null;
+        }
+
+        const source_file = out_of_scope.source_uri.split('/').pop()
+            || out_of_scope.source_uri;
+        if (out_of_scope.reason === 'inheritance_excludes_locals') {
+            return {
+                symbol_kind: 'local',
+                reason: {
+                    kind: 'inheritance_excludes_locals',
+                    source_file,
+                },
+            };
+        }
+
+        return {
+            symbol_kind: reference_kind,
+            reason: {
+                kind: 'after_call_site',
+                call_site_line_0: out_of_scope.call_site_line,
+                source_file,
+            },
         };
     }
 
@@ -841,7 +996,12 @@ export class DiagnosticsProvider {
         }
 
         const severity = diagnostic.message.includes('Cannot read file')
-            ? this.cross_file_severity_to_lsp(missing_file_severity)
+            ? (
+                missing_file_severity
+                    ? this.get_severity_from_config(missing_file_severity)
+                        ?? DiagnosticSeverity.Information
+                    : DiagnosticSeverity.Information
+            )
             : this.semantic_severity_to_lsp(diagnostic.severity);
 
         return {
@@ -850,24 +1010,6 @@ export class DiagnosticsProvider {
             severity,
             source: 'sight',
         };
-    }
-
-    /**
-     * Convert cross-file config severity to LSP DiagnosticSeverity.
-     */
-    private cross_file_severity_to_lsp(
-        severity?: 'error' | 'warning' | 'information' | 'off'
-    ): DiagnosticSeverity {
-        switch (severity) {
-            case 'error':
-                return DiagnosticSeverity.Error;
-            case 'warning':
-                return DiagnosticSeverity.Warning;
-            case 'information':
-                return DiagnosticSeverity.Information;
-            default:
-                return DiagnosticSeverity.Information;
-        }
     }
 
     /**
@@ -880,6 +1022,19 @@ export class DiagnosticsProvider {
     private extract_symbol_name_from_diagnostic(
         diagnostic: { message: string; code: number }
     ): string | null {
+        if (diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
+            const variable_match = diagnostic.message.match(
+                /^Potentially undefined variable: ([a-zA-Z_][a-zA-Z0-9_]*)$/
+            );
+            if (variable_match) {
+                return variable_match[1];
+            }
+            return null;
+        }
+
+        if (diagnostic.code !== StataDiagnosticCode.UNDEFINED_MACRO) {
+            return null;
+        }
         // Try local macro format first: `name'
         const local_macro_match = diagnostic.message.match(/`([^']+)'/);
         if (local_macro_match) {
@@ -965,7 +1120,7 @@ export class DiagnosticsProvider {
         symbols: SymbolTable,
         diagnostic_code: number,
         current_document_uri: string,
-        reference_scope?: 'local' | 'global' | null
+        reference_kind?: 'local' | 'global' | 'variable' | null
     ): boolean {
         const is_from_current_document = (
             symbol: { sourceUri?: string; location?: { uri: string } } | undefined
@@ -978,10 +1133,10 @@ export class DiagnosticsProvider {
         };
 
         if (diagnostic_code === StataDiagnosticCode.UNDEFINED_MACRO) {
-            if (reference_scope === 'local') {
+            if (reference_kind === 'local') {
                 return is_from_current_document(symbols.localMacros.get(symbol_name));
             }
-            if (reference_scope === 'global') {
+            if (reference_kind === 'global') {
                 return is_from_current_document(symbols.globalMacros.get(symbol_name));
             }
             return is_from_current_document(symbols.localMacros.get(symbol_name))
@@ -1013,12 +1168,12 @@ export class DiagnosticsProvider {
         symbol_name: string,
         call_site: import('../types').ForwardCallSite,
         diagnostic_code: number,
-        reference_scope: 'local' | 'global' | null | undefined,
+        reference_kind: 'local' | 'global' | 'variable' | null | undefined,
     ): boolean {
         if (diagnostic_code !== StataDiagnosticCode.UNDEFINED_MACRO) {
             return false;
         }
-        if (reference_scope === 'global') {
+        if (reference_kind === 'global') {
             return false;
         }
         if (call_site.effective_type !== 'do') {
@@ -1183,19 +1338,26 @@ export class DiagnosticsProvider {
     }
 
     /**
-     * Extract the macro scope (local or global) from a diagnostic message.
+     * Classify the referenced symbol kind from a diagnostic.
      * 
      * Local macro references use backtick-apostrophe syntax: `name'
      * Global macro references use dollar sign syntax: $name or ${name}
      * 
      * @param diagnostic - The diagnostic containing the message to parse
-     * @returns 'local' if the message contains local macro syntax,
-     *          'global' if it contains global macro syntax,
+     * @returns 'local', 'global', or 'variable' when the reference kind
+     *          can be determined,
      *          null if neither can be determined
      */
-    private extract_macro_scope_from_diagnostic(
+    private classify_reference_kind(
         diagnostic: { message: string; code: number }
-    ): 'local' | 'global' | null {
+    ): 'local' | 'global' | 'variable' | null {
+        if (diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
+            return 'variable';
+        }
+
+        if (diagnostic.code !== StataDiagnosticCode.UNDEFINED_MACRO) {
+            return null;
+        }
         // Check for local macro syntax: `name'
         if (diagnostic.message.includes('`') && diagnostic.message.includes("'")) {
             const local_match = diagnostic.message.match(/`[^']+'/);
@@ -1224,30 +1386,18 @@ export class DiagnosticsProvider {
      * only match out-of-scope global macros, not local macros.
      * 
      * @param out_of_scope_type - The type of the out-of-scope symbol
-     * @param reference_scope - The scope of the reference ('local', 'global', or null)
+     * @param reference_kind - The kind of the reference
      * @returns true if the types match, false otherwise
      */
     private out_of_scope_type_matches_reference(
         out_of_scope_type: 'local' | 'global' | 'program' | 'variable' | 'scalar' | 'matrix',
-        reference_scope: 'local' | 'global' | null
+        reference_kind: 'local' | 'global' | 'variable' | null
     ): boolean {
-        // If we couldn't determine the reference scope, fall back to matching
-        // This preserves backward compatibility for edge cases
-        if (reference_scope === null) {
-            return true;
+        if (reference_kind === null) {
+            return false;
         }
-        
-        // Match local references to local out-of-scope symbols
-        if (reference_scope === 'local' && out_of_scope_type === 'local') {
-            return true;
-        }
-        
-        // Match global references to global out-of-scope symbols
-        if (reference_scope === 'global' && out_of_scope_type === 'global') {
-            return true;
-        }
-        
-        return false;
+
+        return reference_kind === out_of_scope_type;
     }
 
 }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -357,23 +357,11 @@ export class DiagnosticsProvider {
                 }
 
                 const diag_line = my_diagnostic.range.start.line;
-                let found_in_forward_call = false;
                 let forward_match: OutOfScopeRewriteMatch | null = null;
                 for (const call_site of get_visible_forward_call_sites(
                     resolved_scope,
                     diag_line
                 )) {
-                    if (this.is_symbol_in_forward_call(
-                            symbol_name,
-                            call_site.symbols,
-                            my_diagnostic.code,
-                            call_site.effective_type,
-                            document.uri,
-                            reference_kind
-                        )) {
-                        found_in_forward_call = true;
-                        break;
-                    }
                     if (this.is_symbol_excluded_by_forward_call(
                             symbol_name,
                             call_site,
@@ -396,9 +384,6 @@ export class DiagnosticsProvider {
                             },
                         };
                     }
-                }
-                if (found_in_forward_call) {
-                    continue;
                 }
                 if (forward_match) {
                     if (this.is_symbol_defined_in_current_document(

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -1,4 +1,4 @@
-import { Diagnostic, DiagnosticSeverity, Connection, Position, CancellationToken } from 'vscode-languageserver';
+import { Diagnostic, DiagnosticSeverity, Connection, Position, CancellationToken, Range } from 'vscode-languageserver';
 import { DocumentState } from '../document-store';
 import { LanguageContext, ContextDiagnostic, ContextErrorCode } from '../context-tracker/types';
 import {
@@ -26,11 +26,12 @@ import { OperatorSequenceAnalyzer } from './operator-sequence-diagnostics';
 import { MixedLogicalOperatorAnalyzer } from './mixed-logical-diagnostics';
 type SemanticDiagnostic = {
     message: string;
-    range: any;
-    code: number;
+    range: Range;
+    code: StataDiagnosticCode;
     severity: 'error' | 'warning' | 'information' | 'hint';
-    base_code?: number;
+    base_code?: StataDiagnosticCode;
 };
+type ReferenceKind = 'local' | 'global' | 'variable' | null;
 type OutOfScopeRewriteMatch = {
     symbol_kind: OutOfScopeSymbolKind;
     reason: OutOfScopeMessageReason;
@@ -272,7 +273,8 @@ export class DiagnosticsProvider {
                         symbol_name,
                         resolved_scope.symbols,
                         my_diagnostic.code,
-                        document.uri
+                        document.uri,
+                        reference_kind
                     )) {
                     continue;
                 }
@@ -299,7 +301,9 @@ export class DiagnosticsProvider {
                             symbol_name,
                             call_site.symbols,
                             my_diagnostic.code,
-                            call_site.effective_type
+                            call_site.effective_type,
+                            document.uri,
+                            reference_kind
                         )) {
                         found_in_forward_call = true;
                         break;
@@ -363,7 +367,9 @@ export class DiagnosticsProvider {
                             symbol_name,
                             call_site.symbols,
                             my_diagnostic.code,
-                            call_site.effective_type
+                            call_site.effective_type,
+                            document.uri,
+                            reference_kind
                         )) {
                         found_in_forward_call = true;
                         break;
@@ -372,7 +378,8 @@ export class DiagnosticsProvider {
                             symbol_name,
                             call_site,
                             my_diagnostic.code,
-                            reference_kind
+                            reference_kind,
+                            document.uri
                         )) {
                         const effective = call_site.excluded_locals?.get(
                             symbol_name
@@ -425,7 +432,6 @@ export class DiagnosticsProvider {
                     continue;
                 }
             }
-            
             const converted = this.convert_semantic_diagnostic(my_diagnostic, config, document);
             if (converted) {
                 the_diagnostics.push(converted);
@@ -546,8 +552,9 @@ export class DiagnosticsProvider {
         const semantic_diags: SemanticDiagnostic[] = [];
         for (const diag of document.diagnostics) {
             if (diag.code && typeof diag.code === 'number') {
-                const code = diag.code as number;
-                if (code >= 2001 && code <= 2002) {
+                const code = diag.code as StataDiagnosticCode;
+                if (code === StataDiagnosticCode.UNDEFINED_MACRO
+                    || code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
                     // This is a semantic error code
                     const severity_map: Record<DiagnosticSeverity, 'error' | 'warning' | 'information' | 'hint'> = {
                         [DiagnosticSeverity.Error]: 'error',
@@ -636,7 +643,7 @@ export class DiagnosticsProvider {
     }
 
     private get_undefined_symbol_severity_setting(
-        diagnostic_code: number | undefined,
+        diagnostic_code: StataDiagnosticCode | undefined,
         config: StataLSPConfig
     ): 'error' | 'warning' | 'information' | 'hint' | 'off' | null {
         if (diagnostic_code === StataDiagnosticCode.UNDEFINED_MACRO) {
@@ -678,7 +685,7 @@ export class DiagnosticsProvider {
      */
     private should_suppress_undefined_symbol(
         document: DocumentState,
-        diagnostic_range: any
+        diagnostic_range: Range
     ): boolean {
         const diagnostic_line = diagnostic_range.start.line;
         const line_count = get_line_count(document);
@@ -1020,7 +1027,7 @@ export class DiagnosticsProvider {
      * - Quoted format: 'name' (single quotes)
      */
     private extract_symbol_name_from_diagnostic(
-        diagnostic: { message: string; code: number }
+        diagnostic: { message: string; code: StataDiagnosticCode }
     ): string | null {
         if (diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
             const variable_match = diagnostic.message.match(
@@ -1041,10 +1048,12 @@ export class DiagnosticsProvider {
             return local_macro_match[1];
         }
 
-        // Try global macro format: $name
-        const global_macro_match = diagnostic.message.match(/\$([a-zA-Z_][a-zA-Z0-9_]*)/);
+        // Try global macro format: $name or ${name}
+        const global_macro_match = diagnostic.message.match(
+            /\$(?:\{([a-zA-Z_][a-zA-Z0-9_]*)\}|([a-zA-Z_][a-zA-Z0-9_]*))/
+        );
         if (global_macro_match) {
-            return global_macro_match[1];
+            return global_macro_match[1] ?? global_macro_match[2];
         }
 
         // Fall back to quoted format: 'name'
@@ -1060,41 +1069,31 @@ export class DiagnosticsProvider {
     private is_symbol_defined_in_scope(
         symbol_name: string,
         symbols: SymbolTable,
-        diagnostic_code: number,
-        current_document_uri: string
+        diagnostic_code: StataDiagnosticCode,
+        current_document_uri: string,
+        reference_kind: ReferenceKind
     ): boolean {
+        const is_external_symbol = (
+            symbol: { sourceUri?: string } | undefined
+        ): boolean => {
+            return !!symbol?.sourceUri && symbol.sourceUri !== current_document_uri;
+        };
         if (diagnostic_code === StataDiagnosticCode.UNDEFINED_MACRO) {
-            // Check local macros
-            const local_macro = symbols.localMacros.get(symbol_name);
-            if (local_macro && local_macro.sourceUri && local_macro.sourceUri !== current_document_uri) {
-                return true;
+            if (reference_kind === 'local') {
+                return is_external_symbol(symbols.localMacros.get(symbol_name));
             }
-            
-            // Check global macros
-            const global_macro = symbols.globalMacros.get(symbol_name);
-            if (global_macro && global_macro.sourceUri && global_macro.sourceUri !== current_document_uri) {
-                return true;
+            if (reference_kind === 'global') {
+                return is_external_symbol(symbols.globalMacros.get(symbol_name));
             }
             
             return false;
-        } else if (diagnostic_code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
-            // Check variables, scalars, and matrices (all can be referenced as variables)
-            const variable = symbols.variables.get(symbol_name);
-            if (variable && variable.sourceUri && variable.sourceUri !== current_document_uri) {
-                return true;
+        }
+
+        if (diagnostic_code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
+            if (reference_kind !== 'variable') {
+                return false;
             }
-            
-            const scalar = symbols.scalars?.get(symbol_name);
-            if (scalar && scalar.sourceUri && scalar.sourceUri !== current_document_uri) {
-                return true;
-            }
-            
-            const matrix = symbols.matrices?.get(symbol_name);
-            if (matrix && matrix.sourceUri && matrix.sourceUri !== current_document_uri) {
-                return true;
-            }
-            
-            return false;
+            return is_external_symbol(symbols.variables.get(symbol_name));
         }
         return false;
     }
@@ -1118,9 +1117,9 @@ export class DiagnosticsProvider {
     private is_symbol_defined_in_current_document(
         symbol_name: string,
         symbols: SymbolTable,
-        diagnostic_code: number,
+        diagnostic_code: StataDiagnosticCode,
         current_document_uri: string,
-        reference_kind?: 'local' | 'global' | 'variable' | null
+        reference_kind?: ReferenceKind
     ): boolean {
         const is_from_current_document = (
             symbol: { sourceUri?: string; location?: { uri: string } } | undefined
@@ -1167,19 +1166,22 @@ export class DiagnosticsProvider {
     private is_symbol_excluded_by_forward_call(
         symbol_name: string,
         call_site: import('../types').ForwardCallSite,
-        diagnostic_code: number,
-        reference_kind: 'local' | 'global' | 'variable' | null | undefined,
+        diagnostic_code: StataDiagnosticCode,
+        reference_kind: ReferenceKind | undefined,
+        current_document_uri: string,
     ): boolean {
         if (diagnostic_code !== StataDiagnosticCode.UNDEFINED_MACRO) {
             return false;
         }
-        if (reference_kind === 'global') {
+        if (reference_kind !== 'local') {
             return false;
         }
         if (call_site.effective_type !== 'do') {
             return false;
         }
-        return call_site.excluded_locals?.has(symbol_name) ?? false;
+        const excluded_local = call_site.excluded_locals?.get(symbol_name);
+        return !!excluded_local?.sourceUri
+            && excluded_local.sourceUri !== current_document_uri;
     }
 
     /**
@@ -1192,36 +1194,33 @@ export class DiagnosticsProvider {
     private is_symbol_in_forward_call(
         symbol_name: string,
         symbols: SymbolTable,
-        diagnostic_code: number,
-        effective_type: 'do' | 'include'
+        diagnostic_code: StataDiagnosticCode,
+        effective_type: 'do' | 'include',
+        current_document_uri: string,
+        reference_kind: ReferenceKind
     ): boolean {
+        const is_external_symbol = (
+            symbol: { sourceUri?: string } | undefined
+        ): boolean => {
+            return !!symbol?.sourceUri && symbol.sourceUri !== current_document_uri;
+        };
         if (diagnostic_code === StataDiagnosticCode.UNDEFINED_MACRO) {
-            // Local macros only visible from 'include' calls
-            if (effective_type === 'include' && symbols.localMacros.has(symbol_name)) {
-                return true;
+            if (reference_kind === 'local') {
+                return effective_type === 'include'
+                    && is_external_symbol(symbols.localMacros.get(symbol_name));
             }
-            
-            // Check global macros (visible from both do and include)
-            if (symbols.globalMacros.has(symbol_name)) {
-                return true;
-            }
-            
-            return false;
-        } else if (diagnostic_code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
-            // Check variables, scalars, and matrices (all can be referenced as variables)
-            if (symbols.variables.has(symbol_name)) {
-                return true;
-            }
-            
-            if (symbols.scalars?.has(symbol_name)) {
-                return true;
-            }
-            
-            if (symbols.matrices?.has(symbol_name)) {
-                return true;
+            if (reference_kind === 'global') {
+                return is_external_symbol(symbols.globalMacros.get(symbol_name));
             }
             
             return false;
+        }
+
+        if (diagnostic_code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
+            if (reference_kind !== 'variable') {
+                return false;
+            }
+            return is_external_symbol(symbols.variables.get(symbol_name));
         }
         return false;
     }
@@ -1349,8 +1348,8 @@ export class DiagnosticsProvider {
      *          null if neither can be determined
      */
     private classify_reference_kind(
-        diagnostic: { message: string; code: number }
-    ): 'local' | 'global' | 'variable' | null {
+        diagnostic: { message: string; code: StataDiagnosticCode }
+    ): ReferenceKind {
         if (diagnostic.code === StataDiagnosticCode.UNDEFINED_VARIABLE) {
             return 'variable';
         }

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -131,7 +131,6 @@ export const DEFAULT_SETTINGS: StataLSPConfig = {
         max_chain_depth: 20,
         max_callee_revalidations: 10,
         diagnostics: {
-            out_of_scope: 'information',
             missing_file: 'warning',
             max_depth: 'information',
         },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -707,7 +707,6 @@ export interface CrossFileConfig {
   max_chain_depth: number;         // Overall limit for combined resolution
   max_callee_revalidations?: number;  // Maximum callees to revalidate per caller change (default: 10)
   diagnostics: {
-    out_of_scope: 'error' | 'warning' | 'information' | 'off';
     missing_file: 'error' | 'warning' | 'information' | 'off';
     max_depth: 'error' | 'warning' | 'information' | 'off';
     // Severity for call site identification diagnostics

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -272,13 +272,6 @@ export function validate_comment_formatting_config(
         if (cross_file.diagnostics) {
             const valid_severities = ['error', 'warning', 'information', 'info', 'off'];
             const normalize_sev = (s: string) => s === 'info' ? 'information' : s;
-
-            if (
-                cross_file.diagnostics.out_of_scope &&
-                valid_severities.includes(cross_file.diagnostics.out_of_scope)
-            ) {
-                validated_config.cross_file.diagnostics.out_of_scope = normalize_sev(cross_file.diagnostics.out_of_scope) as any;
-            }
             if (
                 cross_file.diagnostics.missing_file &&
                 valid_severities.includes(cross_file.diagnostics.missing_file)

--- a/src/utils/out-of-scope-message.ts
+++ b/src/utils/out-of-scope-message.ts
@@ -1,0 +1,60 @@
+export type OutOfScopeSymbolKind = 'local' | 'global' | 'variable';
+
+export type OutOfScopeReason =
+    | {
+        kind: 'after_call_site';
+        call_site_line_0: number;
+        source_file: string;
+    }
+    | {
+        kind: 'inheritance_excludes_locals';
+        source_file: string;
+    }
+    | {
+        kind: 'same_file_forward';
+        defined_line_0: number;
+    };
+
+function format_symbol_display_name(
+    symbol_name: string,
+    symbol_kind: OutOfScopeSymbolKind
+): string {
+    switch (symbol_kind) {
+        case 'local':
+            return `\`${symbol_name}'`;
+        case 'global':
+            return `$${symbol_name}`;
+        case 'variable':
+            return symbol_name;
+    }
+}
+
+export function format_out_of_scope_message(
+    symbol_name: string,
+    symbol_kind: OutOfScopeSymbolKind,
+    reason: OutOfScopeReason
+): string {
+    const display_name = format_symbol_display_name(
+        symbol_name,
+        symbol_kind
+    );
+
+    switch (reason.kind) {
+        case 'after_call_site':
+            return (
+                `${display_name} is defined in ${reason.source_file} ` +
+                `but after the call site (line ${reason.call_site_line_0 + 1})`
+            );
+        case 'inheritance_excludes_locals':
+            return (
+                `${display_name} is defined in ${reason.source_file} but ` +
+                'local macros are not inherited via do/run ' +
+                '(use include or @lsp-included-by)'
+            );
+        case 'same_file_forward':
+            return (
+                `${display_name} is used before it is defined ` +
+                `(line ${reason.defined_line_0 + 1})`
+            );
+    }
+}

--- a/src/utils/workspace-config.ts
+++ b/src/utils/workspace-config.ts
@@ -101,10 +101,6 @@ export function map_stata_lsp_json_to_partial_config(raw: unknown): DeepPartial<
         const diags = cross_file_obj.diagnostics;
         if (diags && typeof diags === 'object') {
             const diags_obj = diags as Record<string, unknown>;
-
-            if (typeof diags_obj.outOfScope === 'string') {
-                mapped.cross_file!.diagnostics!.out_of_scope = normalize_severity(diags_obj.outOfScope);
-            }
             if (typeof diags_obj.missingFile === 'string') {
                 mapped.cross_file!.diagnostics!.missing_file = normalize_severity(diags_obj.missingFile);
             }

--- a/tests/integration/comprehensive-fixes.test.ts
+++ b/tests/integration/comprehensive-fixes.test.ts
@@ -62,7 +62,6 @@ describe('Comprehensive Integration Tests', () => {
                 max_indexed_files: 1000,
                 assume_call_site: 'end',
                 diagnostics: {
-                    out_of_scope: 'info',
                     missing_file: 'warning',
                 },
             },
@@ -108,7 +107,6 @@ gen new_var = undefined_var`;
                 cross_file: {
                     ...config.cross_file,
                     diagnostics: {
-                        out_of_scope: 'off' as const,
                         missing_file: 'off' as const,
                     },
                 },
@@ -120,7 +118,7 @@ gen new_var = undefined_var`;
             const cross_file_diags = diagnostics.filter(
                 d => d.code === StataDiagnosticCode.UNDEFINED_MACRO ||
                      d.code === StataDiagnosticCode.UNDEFINED_VARIABLE ||
-                     d.code === StataDiagnosticCode.OUT_OF_SCOPE ||
+                     d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL ||
                      d.code === StataDiagnosticCode.MISSING_FILE
             );
             
@@ -146,7 +144,6 @@ local result \`undefined_macro'`;
                 cross_file: {
                     ...config.cross_file,
                     diagnostics: {
-                        out_of_scope: 'info' as const,
                         missing_file: 'off' as const,
                     },
                 },

--- a/tests/integration/current-file-forward-call-diagnostics.test.ts
+++ b/tests/integration/current-file-forward-call-diagnostics.test.ts
@@ -216,7 +216,7 @@ di \`veggie'`;
             expect(plain_undefined.length).toBe(0);
         });
 
-        it('should preserve undefined macro warning when out-of-scope rewrite is disabled', async () => {
+        it('should suppress both the rewrite and base warning when undefinedMacro is off', async () => {
             const child_path = join(test_temp_dir, 'rewrite_off_child.do');
             const child_content = 'local veggie potato';
             writeFileSync(child_path, child_content);
@@ -234,10 +234,11 @@ di \`veggie'`;
                 document_state,
                 {
                     ...config,
-                    cross_file: {
-                        ...config.cross_file,
-                        diagnostics: {
-                            out_of_scope: 'off',
+                    diagnostics: {
+                        ...config.diagnostics,
+                        severity: {
+                            ...config.diagnostics.severity,
+                            undefinedMacro: 'off',
                         },
                     },
                 },
@@ -248,7 +249,7 @@ di \`veggie'`;
             const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
             expect(line1_diags.some(
                 d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
-            )).toBe(true);
+            )).toBe(false);
             expect(line1_diags.some(
                 d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
             )).toBe(false);

--- a/tests/integration/local-macro-inheritance-bug.test.ts
+++ b/tests/integration/local-macro-inheritance-bug.test.ts
@@ -66,8 +66,7 @@ describe('Local Macro Inheritance Bug', () => {
             cross_file: {
                 diagnostics: {
                     undefined_symbol: 'warning',
-                    missing_file: 'warning',
-                    out_of_scope: 'warning'
+                    missing_file: 'warning'
                 }
             }
         };

--- a/tests/integration/loop-do-false-positives.test.ts
+++ b/tests/integration/loop-do-false-positives.test.ts
@@ -36,7 +36,6 @@ const DEFAULT_CONFIG = {
         max_forward_depth: 10,
         diagnostics: {
             undefined_symbol: 'warning' as const,
-            out_of_scope: 'info' as const,
             missing_file: 'warning' as const,
         },
     },

--- a/tests/integration/out-of-scope-diagnostic-cleanup.test.ts
+++ b/tests/integration/out-of-scope-diagnostic-cleanup.test.ts
@@ -1,0 +1,287 @@
+import { afterAll, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { Connection } from 'vscode-languageserver';
+import { URI } from 'vscode-uri';
+import { ContextTracker } from '../../src/context-tracker';
+import { SemanticAnalyzer } from '../../src/analyzer';
+import { DocumentState, DocumentStore } from '../../src/document-store';
+import { StataLexer } from '../../src/lexer';
+import { StataParser } from '../../src/parser';
+import { DiagnosticsProvider } from '../../src/providers/diagnostics';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { Token } from '../../src/types';
+import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
+
+describe('Out-of-scope diagnostic cleanup integration', () => {
+    const test_temp_dir = join(
+        process.cwd(),
+        'temp_out_of_scope_cleanup_test',
+    );
+    let diagnostics_provider: DiagnosticsProvider;
+    let document_store: DocumentStore;
+    let scope_resolver: ScopeResolver;
+
+    const base_config: StataLSPConfig = {
+        diagnostics: {
+            enabled: true,
+            severity: {
+                undefinedMacro: 'warning',
+                undefinedVariable: 'warning',
+                styleWarnings: 'warning',
+            },
+        },
+        cross_file: {
+            assume_call_site: 'end',
+            diagnostics: {
+                missing_file: 'warning',
+                max_depth: 'warning',
+                call_site_identification: 'warning',
+            },
+        },
+    } as unknown as StataLSPConfig;
+
+    beforeEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+        mkdirSync(test_temp_dir);
+
+        const mock_connection = {
+            sendDiagnostics: () => {},
+        } as Connection;
+
+        diagnostics_provider = new DiagnosticsProvider(mock_connection);
+        document_store = new DocumentStore();
+        scope_resolver = new ScopeResolver();
+    });
+
+    afterAll(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function diagnose_target(
+        target_filename: string,
+        target_content: string,
+        extra_files: Array<{ filename: string; content: string }> = [],
+        config: StataLSPConfig = base_config,
+        options?: { enable_undefined_variables?: boolean },
+    ) {
+        for (const my_file of extra_files) {
+            writeFileSync(
+                join(test_temp_dir, my_file.filename),
+                my_file.content,
+            );
+        }
+
+        const target_path = join(test_temp_dir, target_filename);
+        writeFileSync(target_path, target_content);
+        const target_uri = URI.file(target_path).toString();
+        let document: DocumentState;
+
+        if (options?.enable_undefined_variables) {
+            document = create_document_state(
+                target_uri,
+                target_content,
+                true,
+            );
+        } else {
+            await document_store.open(target_uri, target_content, 1);
+            document = document_store.get(target_uri)!;
+        }
+
+        return diagnostics_provider.get_diagnostics(
+            document,
+            config,
+            undefined,
+            scope_resolver,
+        );
+    }
+
+    function create_document_state(
+        uri: string,
+        content: string,
+        enable_undefined_variables = false,
+    ): DocumentState {
+        const lexer = new StataLexer();
+        const parser = new StataParser();
+        const analyzer = new SemanticAnalyzer();
+        const context_tracker = new ContextTracker();
+
+        const lex_result = lexer.tokenize(content);
+        const parse_result = parser.parse(lex_result.tokens);
+        const analysis_result = analyzer.analyze(
+            parse_result.ast,
+            uri,
+            undefined,
+            enable_undefined_variables
+                ? { undefined_variable_enabled: true }
+                : undefined,
+            lex_result.tokens,
+        );
+
+        context_tracker.initialize_from_tokens(lex_result.tokens, content);
+
+        return {
+            uri,
+            version: 1,
+            content,
+            tokens: lex_result.tokens,
+            ast: parse_result.ast,
+            symbols: analysis_result.symbols,
+            diagnostics: analysis_result.diagnostics.map(my_diag => ({
+                range: my_diag.range,
+                message: my_diag.message,
+                severity: 1,
+                code: my_diag.code,
+                source: 'sight',
+            })),
+            context_ranges: context_tracker.get_all_context_ranges(),
+            context_tracker,
+            line_offsets: build_line_offsets(content),
+            forward_calls: analysis_result.forward_calls,
+            token_line_index: build_token_line_index(lex_result.tokens),
+            ignored_lines: analysis_result.ignored_lines,
+        };
+    }
+
+    function build_line_offsets(content: string): number[] {
+        const line_offsets = [0];
+        for (let i = 0; i < content.length; i++) {
+            if (content[i] === '\n') {
+                line_offsets.push(i + 1);
+            }
+        }
+        return line_offsets;
+    }
+
+    function build_token_line_index(tokens: Token[]): Map<number, Token[]> {
+        const token_line_index = new Map<number, Token[]>();
+        for (const my_token of tokens) {
+            const my_line = my_token.range.start.line;
+            const the_line_tokens = token_line_index.get(my_line) ?? [];
+            the_line_tokens.push(my_token);
+            token_line_index.set(my_line, the_line_tokens);
+        }
+        return token_line_index;
+    }
+
+    it('rewrites same-file macro forward references to OUT_OF_SCOPE_SYMBOL', async () => {
+        const diagnostics = await diagnose_target(
+            'same_file_forward.do',
+            ['display `later_macro\'', 'local later_macro "value"'].join('\n'),
+        );
+
+        const line0_diags = diagnostics.filter(d => d.range.start.line === 0);
+        const rewrite = line0_diags.find(
+            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
+        );
+
+        expect(rewrite).toBeDefined();
+        expect(rewrite!.message).toBe(
+            "`later_macro' is used before it is defined (line 2)",
+        );
+        expect(
+            line0_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO,
+            ),
+        ).toBe(false);
+    });
+
+    it('rewrites out-of-scope variables using the variable-specific path', async () => {
+        const diagnostics = await diagnose_target(
+            'child.do',
+            [
+                '// @lsp-done-by "parent.do" line=1',
+                'summarize after_var',
+            ].join('\n'),
+            [
+                {
+                    filename: 'parent.do',
+                    content: ['do "child.do"', 'gen after_var = 1'].join('\n'),
+                },
+            ],
+            base_config,
+            { enable_undefined_variables: true },
+        );
+
+        const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+        const rewrite = line1_diags.find(
+            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
+        );
+
+        expect(rewrite).toBeDefined();
+        expect(rewrite!.message).toBe(
+            'after_var is defined in parent.do but after the call site (line 1)',
+        );
+        expect(
+            line1_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_VARIABLE,
+            ),
+        ).toBe(false);
+    });
+
+    it('suppresses same-line ignore rewrites for same-file, backward, and forward cases', async () => {
+        const same_file_diags = await diagnose_target(
+            'same_file_ignore.do',
+            [
+                'display `same_file_macro\' // @lsp-ignore',
+                'local same_file_macro "value"',
+            ].join('\n'),
+        );
+        expect(
+            same_file_diags.some(
+                d =>
+                    d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('same_file_macro'),
+            ),
+        ).toBe(false);
+
+        const backward_diags = await diagnose_target(
+            'backward_ignore_child.do',
+            [
+                '// @lsp-done-by "backward_ignore_parent.do"',
+                'display $after_global // @lsp-ignore',
+            ].join('\n'),
+            [
+                {
+                    filename: 'backward_ignore_parent.do',
+                    content: [
+                        'do "backward_ignore_child.do"',
+                        'global after_global "value"',
+                    ].join('\n'),
+                },
+            ],
+        );
+        expect(
+            backward_diags.some(
+                d =>
+                    d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('after_global'),
+            ),
+        ).toBe(false);
+
+        const forward_diags = await diagnose_target(
+            'forward_ignore_main.do',
+            [
+                'do "forward_ignore_child.do"',
+                'display `forward_macro\' // @lsp-ignore',
+            ].join('\n'),
+            [
+                {
+                    filename: 'forward_ignore_child.do',
+                    content: 'local forward_macro "value"',
+                },
+            ],
+        );
+        expect(
+            forward_diags.some(
+                d =>
+                    d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('forward_macro'),
+            ),
+        ).toBe(false);
+    });
+});

--- a/tests/integration/out-of-scope-diagnostic-message-bug.test.ts
+++ b/tests/integration/out-of-scope-diagnostic-message-bug.test.ts
@@ -92,8 +92,7 @@ describe('Out-of-Scope Diagnostic Message Bug - Exact Scenario', () => {
             cross_file: {
                 diagnostics: {
                     undefined_symbol: 'warning',
-                    missing_file: 'warning',
-                    out_of_scope: 'warning'
+                    missing_file: 'warning'
                 }
             }
         };
@@ -165,8 +164,7 @@ describe('Out-of-Scope Diagnostic Message Bug - Exact Scenario', () => {
             cross_file: {
                 diagnostics: {
                     undefined_symbol: 'warning',
-                    missing_file: 'warning',
-                    out_of_scope: 'warning'
+                    missing_file: 'warning'
                 }
             }
         };

--- a/tests/property/config-mapping-type-safety.prop.test.ts
+++ b/tests/property/config-mapping-type-safety.prop.test.ts
@@ -64,13 +64,13 @@ describe('Config Mapping Type Safety Property Tests', () => {
         fc.assert(
             fc.property(
                 fc.record({
-                    outOfScope: fc.oneof(
+                    missingFile: fc.oneof(
                         fc.constant('error' as const),
                         fc.constant('warning' as const),
                         fc.constant('information' as const),
                         fc.constant('off' as const)
                     ),
-                    missingFile: fc.oneof(
+                    callSiteIdentification: fc.oneof(
                         fc.constant('error' as const),
                         fc.constant('warning' as const),
                         fc.constant('information' as const),
@@ -89,12 +89,12 @@ describe('Config Mapping Type Safety Property Tests', () => {
                     // Verify nested snake_case mapping
                     expect(my_result.cross_file).toBeDefined();
                     expect(my_result.cross_file!.diagnostics).toBeDefined();
-                    expect(my_result.cross_file!.diagnostics!.out_of_scope).toBe(
-                        my_diagnostics_config.outOfScope
-                    );
                     expect(my_result.cross_file!.diagnostics!.missing_file).toBe(
                         my_diagnostics_config.missingFile
                     );
+                    expect(
+                        my_result.cross_file!.diagnostics!.call_site_identification
+                    ).toBe(my_diagnostics_config.callSiteIdentification);
                 }
             ),
             { numRuns: 100 }
@@ -113,7 +113,6 @@ describe('Config Mapping Type Safety Property Tests', () => {
         const my_raw = {
             crossFile: {
                 diagnostics: {
-                    outOfScope: 'info',
                     missingFile: 'info',
                     callSiteIdentification: 'info',
                 },
@@ -122,9 +121,29 @@ describe('Config Mapping Type Safety Property Tests', () => {
 
         const my_result = map_stata_lsp_json_to_partial_config(my_raw);
 
-        expect(my_result.cross_file!.diagnostics!.out_of_scope).toBe('information');
         expect(my_result.cross_file!.diagnostics!.missing_file).toBe('information');
         expect(my_result.cross_file!.diagnostics!.call_site_identification).toBe('information');
+    });
+
+    /**
+     * Property: legacy outOfScope key should be ignored
+     */
+    it('should ignore legacy outOfScope diagnostics key', () => {
+        const my_raw = {
+            crossFile: {
+                diagnostics: {
+                    outOfScope: 'warning',
+                    missingFile: 'error',
+                },
+            },
+        };
+
+        const my_result = map_stata_lsp_json_to_partial_config(my_raw);
+
+        expect(my_result.cross_file).toBeDefined();
+        expect(my_result.cross_file!.diagnostics).toBeDefined();
+        expect(my_result.cross_file!.diagnostics!.out_of_scope).toBeUndefined();
+        expect(my_result.cross_file!.diagnostics!.missing_file).toBe('error');
     });
 
     /**

--- a/tests/property/config-mapping-type-safety.prop.test.ts
+++ b/tests/property/config-mapping-type-safety.prop.test.ts
@@ -142,7 +142,9 @@ describe('Config Mapping Type Safety Property Tests', () => {
 
         expect(my_result.cross_file).toBeDefined();
         expect(my_result.cross_file!.diagnostics).toBeDefined();
-        expect(my_result.cross_file!.diagnostics!.out_of_scope).toBeUndefined();
+        const my_diagnostics = my_result.cross_file!.diagnostics as
+            Record<string, unknown>;
+        expect(my_diagnostics.out_of_scope).toBeUndefined();
         expect(my_result.cross_file!.diagnostics!.missing_file).toBe('error');
     });
 

--- a/tests/property/cstyle-logical-context-bugfix.prop.test.ts
+++ b/tests/property/cstyle-logical-context-bugfix.prop.test.ts
@@ -64,7 +64,6 @@ describe('C-Style Logical Context Detection Bugfix Property Tests', () => {
             max_forward_depth: 10,
             max_chain_depth: 20,
             diagnostics: {
-                out_of_scope: 'warning',
                 missing_file: 'warning',
                 max_depth: 'warning',
             },

--- a/tests/property/diagnostic-suppression.test.ts
+++ b/tests/property/diagnostic-suppression.test.ts
@@ -51,7 +51,6 @@ describe('Diagnostic Suppression Property Tests', () => {
                 max_indexed_files: 1000,
                 assume_call_site: 'end',
                 diagnostics: {
-                    out_of_scope: 'information',
                     missing_file: 'warning',
                 },
             },
@@ -336,38 +335,27 @@ describe('Diagnostic Suppression Property Tests', () => {
     });
 
     /**
-     * Property: crossFile.diagnostics.outOfScope = 'off' suppresses out-of-scope diagnostics
+     * Property: suppression comments also suppress OUT_OF_SCOPE_SYMBOL rewrites
      */
-    it('should suppress out-of-scope diagnostics when crossFile.diagnostics.outOfScope is off', async () => {
+    it('should suppress OUT_OF_SCOPE_SYMBOL rewrites with suppression comments', async () => {
         await fc.assert(
             fc.asyncProperty(
                 arbitrary_non_reserved_identifier(),
-                async (macro_name: string) => {
-                    const content = `// @lsp-done-by "parent.do" line=5\nlocal result \`${macro_name}'`;
+                fc.constantFrom('@lsp-ignore', '@lsp-ignore-next'),
+                async (macro_name: string, suppress_type: string) => {
+                    const content = suppress_type === '@lsp-ignore'
+                        ? `display \`${macro_name}' // @lsp-ignore\nlocal ${macro_name} value`
+                        : `// @lsp-ignore-next\ndisplay \`${macro_name}'\nlocal ${macro_name} value`;
                     const my_document = create_document_state(content);
-                    
-                    // Set outOfScope to 'off'
-                    const my_suppress_config = {
-                        ...my_config,
-                        cross_file: {
-                            ...my_config.cross_file,
-                            diagnostics: {
-                                ...my_config.cross_file.diagnostics,
-                                out_of_scope: 'off' as const,
-                            },
-                        },
-                    };
-                    
                     const the_diagnostics = await my_diagnostics_provider.get_diagnostics(
                         my_document,
-                        my_suppress_config
+                        my_config
                     );
-                    
-                    // Should not have any out-of-scope diagnostics
+
+                    // Should not have any out-of-scope rewrites
                     const out_of_scope_diags = the_diagnostics.filter(
-                        d => d.code === StataDiagnosticCode.OUT_OF_SCOPE
+                        d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
                     );
-                    
                     return out_of_scope_diags.length === 0;
                 }
             ),
@@ -383,7 +371,7 @@ describe('Diagnostic Suppression Property Tests', () => {
             fc.asyncProperty(
                 fc.string({ minLength: 1, maxLength: 20 }).filter(s => /^[a-zA-Z0-9_-]+$/.test(s)),
                 async (filename: string) => {
-                    const content = `// @lsp-done-by "${filename}.do"`;
+                    const content = `// @lsp-done-by "${filename}.do"\nlocal result \`missing_macro'`;
                     const my_document = create_document_state(content);
                     
                     // Set missingFile to 'off'
@@ -416,23 +404,30 @@ describe('Diagnostic Suppression Property Tests', () => {
     });
 
     /**
-     * Property: Multiple 'off' settings work together for cross-file diagnostics
+     * Property: Multiple 'off' settings work together
      */
-    it('should suppress relevant cross-file diagnostics when multiple crossFile settings are off', async () => {
+    it('should suppress missing-file diagnostics alongside disabled undefined macros', async () => {
         await fc.assert(
             fc.asyncProperty(
                 fc.string({ minLength: 1, maxLength: 20 }).filter(s => /^[a-zA-Z0-9_-]+$/.test(s)),
                 async (filename: string) => {
-                    const content = `// @lsp-done-by "${filename}.do"`;
+                    const content = `// @lsp-done-by "${filename}.do"\nlocal result \`missing_macro'`;
                     const my_document = create_document_state(content);
-                    
-                    // Set crossFile diagnostics to 'off'
+
+                    // Disable both the base undefined-macro diagnostic and
+                    // the missing-file cross-file diagnostic.
                     const my_suppress_all_config = {
                         ...my_config,
+                        diagnostics: {
+                            ...my_config.diagnostics,
+                            severity: {
+                                ...my_config.diagnostics.severity,
+                                undefinedMacro: 'off' as const,
+                            },
+                        },
                         cross_file: {
                             ...my_config.cross_file,
                             diagnostics: {
-                                out_of_scope: 'off' as const,
                                 missing_file: 'off' as const,
                             },
                         },
@@ -443,12 +438,12 @@ describe('Diagnostic Suppression Property Tests', () => {
                         my_suppress_all_config
                     );
                     
-                    // Should not have cross-file related diagnostics
+                    // Should not have either undefined-macro or missing-file diagnostics
                     const cross_file_diags = the_diagnostics.filter(
-                        d => d.code === StataDiagnosticCode.OUT_OF_SCOPE ||
+                        d => d.code === StataDiagnosticCode.UNDEFINED_MACRO ||
+                             d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL ||
                              d.code === StataDiagnosticCode.MISSING_FILE
                     );
-                    
                     return cross_file_diags.length === 0;
                 }
             ),

--- a/tests/property/diagnostic-suppression.test.ts
+++ b/tests/property/diagnostic-suppression.test.ts
@@ -5,7 +5,7 @@
  * for undefined symbol diagnostics.
  */
 
-import { describe, it, beforeEach } from 'bun:test';
+import { describe, it, expect, beforeEach } from 'bun:test';
 import * as fc from 'fast-check';
 import { DiagnosticsProvider } from '../../src/providers/diagnostics';
 import { StataLSPConfig, StataDiagnosticCode } from '../../src/types';
@@ -343,20 +343,52 @@ describe('Diagnostic Suppression Property Tests', () => {
                 arbitrary_non_reserved_identifier(),
                 fc.constantFrom('@lsp-ignore', '@lsp-ignore-next'),
                 async (macro_name: string, suppress_type: string) => {
-                    const content = suppress_type === '@lsp-ignore'
+                    const suppressed_content = suppress_type === '@lsp-ignore'
                         ? `display \`${macro_name}' // @lsp-ignore\nlocal ${macro_name} value`
                         : `// @lsp-ignore-next\ndisplay \`${macro_name}'\nlocal ${macro_name} value`;
-                    const my_document = create_document_state(content);
-                    const the_diagnostics = await my_diagnostics_provider.get_diagnostics(
-                        my_document,
-                        my_config
+                    const control_content = `display \`${macro_name}'\nlocal ${macro_name} value`;
+
+                    const my_suppressed_document = create_document_state(
+                        suppressed_content
+                    );
+                    const my_control_document = create_document_state(
+                        control_content
                     );
 
-                    // Should not have any out-of-scope rewrites
-                    const out_of_scope_diags = the_diagnostics.filter(
-                        d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
-                    );
-                    return out_of_scope_diags.length === 0;
+                    const the_suppressed_diagnostics = await my_diagnostics_provider
+                        .get_diagnostics(
+                            my_suppressed_document,
+                            my_config
+                        );
+                    const the_control_diagnostics = await my_diagnostics_provider
+                        .get_diagnostics(
+                            my_control_document,
+                            my_config
+                        );
+
+                    const control_out_of_scope_diags =
+                        the_control_diagnostics.filter(
+                            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                        );
+                    expect(control_out_of_scope_diags.length).toBeGreaterThan(0);
+
+                    const suppressed_out_of_scope_diags =
+                        the_suppressed_diagnostics.filter(
+                            d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                        );
+                    expect(suppressed_out_of_scope_diags.length).toBe(0);
+
+                    const suppressed_undefined_macro_diags =
+                        the_suppressed_diagnostics.filter(
+                            d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                        );
+                    expect(suppressed_undefined_macro_diags.length).toBe(0);
+
+                    const control_undefined_macro_diags =
+                        the_control_diagnostics.filter(
+                            d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                        );
+                    expect(control_undefined_macro_diags.length).toBe(0);
                 }
             ),
             { numRuns: 50 }
@@ -428,6 +460,7 @@ describe('Diagnostic Suppression Property Tests', () => {
                         cross_file: {
                             ...my_config.cross_file,
                             diagnostics: {
+                                ...my_config.cross_file.diagnostics,
                                 missing_file: 'off' as const,
                             },
                         },

--- a/tests/property/display-line-conversion.prop.test.ts
+++ b/tests/property/display-line-conversion.prop.test.ts
@@ -54,7 +54,6 @@ describe('Display Line Conversion Property Tests', () => {
                 assume_call_site: 'end',
                 diagnostics: {
                     undefined_symbol: 'warning',
-                    out_of_scope: 'info',
                     missing_file: 'warning',
                 },
             },

--- a/tests/property/expression-macro-false-positive.prop.test.ts
+++ b/tests/property/expression-macro-false-positive.prop.test.ts
@@ -63,7 +63,6 @@ describe('Expression Macro False Positive Property Tests', () => {
         max_chain_depth: 20,
         diagnostics: {
           undefined_symbol: 'warning',
-          out_of_scope: 'warning',
           missing_file: 'warning',
           max_depth: 'warning',
         },

--- a/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
+++ b/tests/property/forward-call-out-of-scope-oracle.prop.test.ts
@@ -13,9 +13,11 @@
  *   2. Rewrite attribution — if the reference is blocked by some
  *      do/run boundary but would have been bound under include, the LSP
  *      must emit exactly one OUT_OF_SCOPE_SYMBOL naming the file whose
- *      local is the effective (last-def-wins) definition.
+ *      local is the effective (last-def-wins) definition, unless a
+ *      same-file later definition wins with the same-file rewrite.
  *   3. Generic-warning completeness — if no ancestor defines the name at
- *      all, fall back to UNDEFINED_MACRO (no rewrite).
+ *      all and the root file does not define it later either, fall back
+ *      to UNDEFINED_MACRO (no rewrite).
  *
  * A `regression: pinned scenarios from code review` block below locks
  * the specific bugs this feature's history has hit, so the next Codex
@@ -166,11 +168,10 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties', () => {
                 const blame = oracle.blame_target_for();
                 fc.pre(blame !== null);
                 // When the name is also defined somewhere in root — even
-                // *after* the reference — the LSP intentionally preserves
-                // the analyzer's UNDEFINED_MACRO (same-file forward
-                // reference) rather than rewriting. The rewrite-attribution
-                // property doesn't apply in that case; see issue #145 and
-                // the in-root-forward-reference regression fixture below.
+                // *after* the reference — the same-file OUT_OF_SCOPE_SYMBOL
+                // rewrite wins over forward-call blame. This property is
+                // only about forward-call attribution, so filter those
+                // cases out.
                 fc.pre(!oracle.is_defined_in_root());
                 const h = create_harness();
                 try {
@@ -195,6 +196,7 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties', () => {
                 const oracle = new StataExecutionOracle(graph);
                 fc.pre(!oracle.is_visible_at());
                 fc.pre(oracle.blame_target_for() === null);
+                fc.pre(!oracle.is_defined_in_root());
                 const h = create_harness();
                 try {
                     const outcome = await diagnose_reference(h, graph);
@@ -268,6 +270,7 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — oracle properties (deep graphs, d
                 const oracle = new StataExecutionOracle(graph);
                 fc.pre(!oracle.is_visible_at());
                 fc.pre(oracle.blame_target_for() === null);
+                fc.pre(!oracle.is_defined_in_root());
                 const h = create_harness();
                 try {
                     const outcome = await diagnose_reference(h, graph);
@@ -484,45 +487,11 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         const informative = diags.find(
             d =>
                 d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL &&
-                d.message.includes("'x'"),
+                d.message.includes("`x'"),
         );
         expect(informative).toBeDefined();
         expect(informative!.message).toContain('defs1.do');
         expect(informative!.message).not.toContain('grandchild.do');
-    });
-
-    // Commit 62c5703: preserve undefined macro fallback when
-    // cross_file.diagnostics.out_of_scope = off.
-    test('62c5703: out_of_scope=off keeps plain UNDEFINED_MACRO', async () => {
-        fs.writeFileSync(path.join(h.temp_dir, 'child.do'), 'local veggie beet');
-        const root_content = ['do "child.do"', 'di `veggie\''].join('\n');
-        const root_path = path.join(h.temp_dir, 'main.do');
-        fs.writeFileSync(root_path, root_content);
-        const root_uri = URI.file(root_path).toString();
-        await h.document_store.open(root_uri, root_content, 1);
-        const doc = h.document_store.get(root_uri)!;
-        const rewrite_off: StataLSPConfig = {
-            ...MIN_CONFIG,
-            cross_file: {
-                ...MIN_CONFIG.cross_file,
-                diagnostics: {
-                    out_of_scope: 'off',
-                },
-            },
-        } as unknown as StataLSPConfig;
-        const diags = await h.diagnostics_provider.get_diagnostics(
-            doc,
-            rewrite_off,
-            undefined,
-            h.scope_resolver,
-        );
-        const ref_line = diags.filter(d => d.range.start.line === 1);
-        expect(
-            ref_line.some(d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL),
-        ).toBe(false);
-        expect(
-            ref_line.some(d => d.code === StataDiagnosticCode.UNDEFINED_MACRO),
-        ).toBe(true);
     });
 
     // Codex Gap 5 (run-vs-do asymmetry): `run` should behave like `do` for
@@ -599,11 +568,10 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         expect(informative!.message).toContain('cycle_a.do');
     });
 
-    // Codex Gap 5 (out_of_scope severity passthrough): lowering
-    // cross_file.diagnostics.out_of_scope from warning to information
-    // must preserve the rewrite presence and message; only severity
-    // changes.
-    test('codex gap 5 (severity): out_of_scope severity change preserves presence and text', async () => {
+    // Codex Gap 5 (base severity passthrough): lowering undefinedMacro
+    // from warning to information must preserve the rewrite presence and
+    // message; only severity changes.
+    test('codex gap 5 (severity): base severity change preserves presence and text', async () => {
         fs.writeFileSync(path.join(h.temp_dir, 'severity_child.do'), 'local veggie beet');
         const root_content = ['do "severity_child.do"', 'di `veggie\''].join('\n');
         const root_path = path.join(h.temp_dir, 'main.do');
@@ -613,16 +581,22 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         const doc = h.document_store.get(root_uri)!;
         const warning_config: StataLSPConfig = {
             ...MIN_CONFIG,
-            cross_file: {
-                ...MIN_CONFIG.cross_file,
-                diagnostics: { out_of_scope: 'warning' },
+            diagnostics: {
+                ...MIN_CONFIG.diagnostics,
+                severity: {
+                    ...MIN_CONFIG.diagnostics.severity,
+                    undefinedMacro: 'warning',
+                },
             },
         } as unknown as StataLSPConfig;
         const info_config: StataLSPConfig = {
             ...MIN_CONFIG,
-            cross_file: {
-                ...MIN_CONFIG.cross_file,
-                diagnostics: { out_of_scope: 'information' },
+            diagnostics: {
+                ...MIN_CONFIG.diagnostics,
+                severity: {
+                    ...MIN_CONFIG.diagnostics.severity,
+                    undefinedMacro: 'information',
+                },
             },
         } as unknown as StataLSPConfig;
         const warn_diags = await h.diagnostics_provider.get_diagnostics(
@@ -650,15 +624,10 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
         expect(info_rewrite!.severity).not.toBe(warn_rewrite!.severity);
     });
 
-    // In-root forward reference carve-out (issue #145): when the
-    // referenced local is also defined somewhere in root — even *after*
-    // the reference line — the LSP preserves the analyzer's
-    // UNDEFINED_MACRO (same-file forward reference) and suppresses the
-    // OUT_OF_SCOPE_SYMBOL rewrite, even if a forward-called file also
-    // defines the name. Property 2 filters this case out via
-    // `oracle.is_defined_in_root()`; this fixture pins the rule
-    // explicitly.
-    test('in-root forward reference: UNDEFINED_MACRO preserved, no rewrite', async () => {
+    // When the root file defines the same local later, the same-file
+    // rewrite wins over forward-call blame and uses the shared
+    // `used before it is defined` message.
+    test('in-root forward reference: same-file rewrite wins over forward-call blame', async () => {
         fs.writeFileSync(path.join(h.temp_dir, 'in_root_child.do'), 'local veggie child');
         const root_content = [
             'do "in_root_child.do"',
@@ -687,8 +656,11 @@ describe('Forward-call OUT_OF_SCOPE_SYMBOL — regression: pinned scenarios from
                 d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
                 d.message.includes('veggie'),
         );
-        expect(rewrite).toBeUndefined();
-        expect(generic).toBeDefined();
+        expect(rewrite).toBeDefined();
+        expect(rewrite!.message).toBe(
+            "`veggie' is used before it is defined (line 3)",
+        );
+        expect(generic).toBeUndefined();
     });
 
     // Retained boundary_only contract: when root does A then does B,

--- a/tests/property/helpers/stata-execution-oracle.ts
+++ b/tests/property/helpers/stata-execution-oracle.ts
@@ -63,10 +63,10 @@ export class StataExecutionOracle {
 
     /**
      * True when the referenced name is defined anywhere in the root file
-     * — even after the reference line. The LSP preserves the analyzer's
-     * UNDEFINED_MACRO diagnostic for in-root forward references instead
-     * of rewriting to OUT_OF_SCOPE_SYMBOL; see `src/providers/diagnostics.ts`
-     * around line 358 and issue #145.
+     * — even after the reference line. Those cases now use the same-file
+     * OUT_OF_SCOPE_SYMBOL rewrite (`used before it is defined`) rather than
+     * the forward-call blame rewrite, so oracle properties that are specific
+     * to forward-call attribution filter them out with this helper.
      */
     is_defined_in_root(): boolean {
         const my_root = this.graph.files[0];

--- a/tests/property/inline-expression-evaluation.prop.test.ts
+++ b/tests/property/inline-expression-evaluation.prop.test.ts
@@ -67,7 +67,6 @@ describe('Inline Expression Evaluation Property Tests', () => {
                 max_chain_depth: 20,
                 diagnostics: {
                     undefined_symbol: 'warning',
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },

--- a/tests/property/nested-macro-detection.prop.test.ts
+++ b/tests/property/nested-macro-detection.prop.test.ts
@@ -63,7 +63,6 @@ describe('Nested Macro Detection Property Tests', () => {
         max_chain_depth: 20,
         diagnostics: {
           undefined_symbol: 'warning',
-          out_of_scope: 'warning',
           missing_file: 'warning',
           max_depth: 'warning',
         },

--- a/tests/property/non-nested-invalid-char-detection.prop.test.ts
+++ b/tests/property/non-nested-invalid-char-detection.prop.test.ts
@@ -69,7 +69,6 @@ describe('Non-Nested Invalid Character Detection Property Tests', () => {
         max_chain_depth: 20,
         diagnostics: {
           undefined_symbol: 'warning',
-          out_of_scope: 'warning',
           missing_file: 'warning',
           max_depth: 'warning',
         },

--- a/tests/property/operator-sequence-diagnostics.prop.test.ts
+++ b/tests/property/operator-sequence-diagnostics.prop.test.ts
@@ -203,7 +203,6 @@ describe('Operator Sequence Diagnostics Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -400,7 +399,6 @@ describe('Operator Sequence Diagnostics Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -598,7 +596,6 @@ describe('Operator Sequence Diagnostics Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -728,7 +725,6 @@ describe('Operator Sequence Diagnostics Property Tests', () => {
                             max_forward_depth: 10,
                             max_chain_depth: 20,
                             diagnostics: {
-                                out_of_scope: 'warning',
                                 missing_file: 'warning',
                                 max_depth: 'warning',
                             },
@@ -849,7 +845,6 @@ describe('Operator Sequence Diagnostics Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -1063,7 +1058,6 @@ describe('Operator Sequence Diagnostics Property Tests', () => {
                             max_forward_depth: 10,
                             max_chain_depth: 20,
                             diagnostics: {
-                                out_of_scope: 'warning',
                                 missing_file: 'warning',
                                 max_depth: 'warning',
                             },
@@ -1190,7 +1184,6 @@ describe('Operator Sequence Diagnostics Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -1328,7 +1321,6 @@ describe('Operator Sequence Diagnostics Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -1465,7 +1457,6 @@ describe('Embedded Context Suppression Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -1588,7 +1579,6 @@ describe('Embedded Context Suppression Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -1701,7 +1691,6 @@ describe('Embedded Context Suppression Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -1843,7 +1832,6 @@ describe('Directive Suppression Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -1971,7 +1959,6 @@ describe('Directive Suppression Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -2077,7 +2064,6 @@ describe('Directive Suppression Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -2181,7 +2167,6 @@ describe('Directive Suppression Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -2304,7 +2289,6 @@ describe('C-Style Logical Control Flow Property Tests', () => {
                 max_forward_depth: 10,
                 max_chain_depth: 20,
                 diagnostics: {
-                    out_of_scope: 'warning',
                     missing_file: 'warning',
                     max_depth: 'warning',
                 },
@@ -2510,7 +2494,6 @@ describe('C-Style Logical Control Flow Property Tests', () => {
                             max_forward_depth: 10,
                             max_chain_depth: 20,
                             diagnostics: {
-                                out_of_scope: 'warning',
                                 missing_file: 'warning',
                                 max_depth: 'warning',
                             },

--- a/tests/property/rename-validation-comprehensive.prop.test.ts
+++ b/tests/property/rename-validation-comprehensive.prop.test.ts
@@ -310,7 +310,6 @@ describe('Comprehensive Rename Validation Property Tests', () => {
                             assumeCallSite: fc.constantFrom('start', 'end'),
                             maxForwardDepth: fc.integer({ min: 1, max: 50 }),
                             diagnostics: fc.record({
-                                outOfScope: fc.constantFrom('error', 'warning', 'info', 'off'),
                                 missingFile: fc.constantFrom('error', 'warning', 'info', 'off')
                             })
                         })
@@ -340,12 +339,6 @@ describe('Comprehensive Rename Validation Property Tests', () => {
                             
                             if (sight_config.crossFile.diagnostics) {
                                 expect(mapped.cross_file?.diagnostics).toBeDefined();
-                                
-                                if (sight_config.crossFile.diagnostics.outOfScope) {
-                                    expect(mapped.cross_file?.diagnostics?.out_of_scope)
-                                        .toBe(normalize_severity(sight_config.crossFile.diagnostics.outOfScope));
-                                }
-                                
                                 if (sight_config.crossFile.diagnostics.missingFile) {
                                     expect(mapped.cross_file?.diagnostics?.missing_file)
                                         .toBe(normalize_severity(sight_config.crossFile.diagnostics.missingFile));

--- a/tests/property/severity-settings.prop.test.ts
+++ b/tests/property/severity-settings.prop.test.ts
@@ -51,7 +51,6 @@ describe('Severity Settings Property Tests', () => {
                 max_indexed_files: 1000,
                 assume_call_site: 'end',
                 diagnostics: {
-                    out_of_scope: 'info',
                     missing_file: 'warning',
                     max_depth: 'information',
                 },

--- a/tests/property/stored-result-reference-detection.prop.test.ts
+++ b/tests/property/stored-result-reference-detection.prop.test.ts
@@ -66,7 +66,6 @@ describe('Stored Result Reference Detection Property Tests', () => {
         max_chain_depth: 20,
         diagnostics: {
           undefined_symbol: 'warning',
-          out_of_scope: 'warning',
           missing_file: 'warning',
           max_depth: 'warning',
         },

--- a/tests/property/unbalanced-macro-no-duplicate-diagnostics.prop.test.ts
+++ b/tests/property/unbalanced-macro-no-duplicate-diagnostics.prop.test.ts
@@ -65,7 +65,6 @@ describe('Unbalanced Macro No Duplicate Diagnostics Property Tests', () => {
         max_chain_depth: 20,
         diagnostics: {
           undefined_symbol: 'warning',
-          out_of_scope: 'warning',
           missing_file: 'warning',
           max_depth: 'warning',
         },

--- a/tests/test-config-helper.ts
+++ b/tests/test-config-helper.ts
@@ -19,7 +19,6 @@ export function createTestConfig(overrides: Partial<StataLSPConfig> = {}): Stata
         max_callee_revalidations: 10,
         assume_call_site: 'end',
         diagnostics: {
-            out_of_scope: 'information',
             missing_file: 'warning',
             max_depth: 'warning',
             call_site_identification: 'information'

--- a/tests/unit/default-settings.test.ts
+++ b/tests/unit/default-settings.test.ts
@@ -13,4 +13,12 @@ describe('DEFAULT_SETTINGS', () => {
             expect(DEFAULT_SETTINGS.diagnostics.indentation).toBe(false);
         });
     });
+
+    describe('cross_file.diagnostics', () => {
+        it('should not include removed out_of_scope config', () => {
+            expect('out_of_scope' in DEFAULT_SETTINGS.cross_file.diagnostics).toBe(
+                false
+            );
+        });
+    });
 });

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -922,6 +922,15 @@ display \`result'
             expect(symbol_name).toBeNull();
         });
 
+        it('should extract braced global macro names from undefined macro diagnostics', () => {
+            const symbol_name = (provider as any).extract_symbol_name_from_diagnostic({
+                message: 'Undefined global macro: ${foo}',
+                code: StataDiagnosticCode.UNDEFINED_MACRO,
+            });
+
+            expect(symbol_name).toBe('foo');
+        });
+
         it('should classify reference kinds for local, global, variable, and unknown diagnostics', () => {
             expect((provider as any).classify_reference_kind({
                 message: "Undefined local macro: `foo'",
@@ -930,6 +939,11 @@ display \`result'
 
             expect((provider as any).classify_reference_kind({
                 message: 'Undefined global macro: $foo',
+                code: StataDiagnosticCode.UNDEFINED_MACRO,
+            })).toBe('global');
+
+            expect((provider as any).classify_reference_kind({
+                message: 'Undefined global macro: ${foo}',
                 code: StataDiagnosticCode.UNDEFINED_MACRO,
             })).toBe('global');
 
@@ -983,9 +997,181 @@ display \`result'
                 null
             )).toBe(false);
         });
+
+        it('should not treat null reference kinds as excluded forward-call local matches', () => {
+            const call_site = {
+                callee_uri: 'file:///child.do',
+                call_line: 0,
+                symbols: create_empty_symbol_table(),
+                effective_type: 'do',
+                excluded_locals: new Map([
+                    ['veggie', {
+                        name: 'veggie',
+                        scope: 'local',
+                        location: {
+                            uri: 'file:///child.do',
+                            range: {
+                                start: { line: 0, character: 0 },
+                                end: { line: 0, character: 6 },
+                            },
+                        },
+                        sourceUri: 'file:///child.do',
+                    }],
+                ]),
+            };
+
+            expect((provider as any).is_symbol_excluded_by_forward_call(
+                'veggie',
+                call_site,
+                StataDiagnosticCode.UNDEFINED_MACRO,
+                null,
+                'file:///test.do',
+            )).toBe(false);
+        });
     });
 
     describe('out-of-scope diagnostic messages', () => {
+        it('should not suppress undefined local macros when resolved scope only has a global of the same name', async () => {
+            const content = "display `veggie'";
+            const document = create_real_document_state(content);
+            const resolved_symbols = create_empty_symbol_table();
+            resolved_symbols.globalMacros.set('veggie', {
+                name: 'veggie',
+                scope: 'global',
+                location: {
+                    uri: 'file:///parent.do',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 10 },
+                    },
+                },
+                sourceUri: 'file:///parent.do',
+            });
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: resolved_symbols,
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: false,
+            };
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                stub_resolver
+            );
+
+            const undefined_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    && d.message.includes('veggie')
+            );
+            expect(undefined_diag).toBeDefined();
+        });
+
+        it('should not suppress undefined local macros when a forward include only provides a global of the same name', async () => {
+            const content = [
+                'include "child.do"',
+                "display `veggie'",
+            ].join('\n');
+            const document = create_real_document_state(content);
+            const forward_symbols = create_empty_symbol_table();
+            forward_symbols.globalMacros.set('veggie', {
+                name: 'veggie',
+                scope: 'global',
+                location: {
+                    uri: 'file:///child.do',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 10 },
+                    },
+                },
+                sourceUri: 'file:///child.do',
+            });
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: false,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///child.do',
+                    call_line: 0,
+                    symbols: forward_symbols,
+                    effective_type: 'include',
+                }],
+            };
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                stub_resolver
+            );
+
+            const undefined_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    && d.message.includes('veggie')
+            );
+            expect(undefined_diag).toBeDefined();
+        });
+
+        it('should not suppress undefined variables when resolved scope only has a scalar of the same name', async () => {
+            const document = create_document_state('summarize age');
+            document.diagnostics = [{
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 13 },
+                },
+                message: 'Potentially undefined variable: age',
+                severity: DiagnosticSeverity.Warning,
+                code: StataDiagnosticCode.UNDEFINED_VARIABLE,
+                source: 'sight',
+            }];
+            document.symbols = create_empty_symbol_table();
+
+            const resolved_symbols = create_empty_symbol_table();
+            resolved_symbols.scalars.set('age', {
+                name: 'age',
+                location: {
+                    uri: 'file:///parent.do',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 3 },
+                    },
+                },
+                sourceUri: 'file:///parent.do',
+            });
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: resolved_symbols,
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: false,
+            };
+            const stub_resolver = make_stub_scope_resolver(resolved_scope);
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                stub_resolver
+            );
+
+            const undefined_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_VARIABLE
+                    && d.message.includes('age')
+            );
+            expect(undefined_diag).toBeDefined();
+        });
         it('should inherit macro rewrite severity from undefinedMacro', () => {
             const the_cases = [
                 { severity: 'error' as const, expected: DiagnosticSeverity.Error },
@@ -1619,11 +1805,6 @@ display \`result'
                     severity: {
                         ...DEFAULT_CONFIG.diagnostics.severity,
                         undefinedMacro: 'off' as const,
-                    },
-                },
-                cross_file: {
-                    diagnostics: {
-                        out_of_scope: 'warning' as const,
                     },
                 },
             };

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -903,8 +903,272 @@ display \`result'
         });
     });
 
+    describe('out-of-scope helper methods', () => {
+        it('should extract variable names from undefined variable diagnostics', () => {
+            const symbol_name = (provider as any).extract_symbol_name_from_diagnostic({
+                message: 'Potentially undefined variable: foo',
+                code: StataDiagnosticCode.UNDEFINED_VARIABLE,
+            });
+
+            expect(symbol_name).toBe('foo');
+        });
+
+        it('should not parse macro-form messages as undefined variables', () => {
+            const symbol_name = (provider as any).extract_symbol_name_from_diagnostic({
+                message: "Undefined local macro: `foo'",
+                code: StataDiagnosticCode.UNDEFINED_VARIABLE,
+            });
+
+            expect(symbol_name).toBeNull();
+        });
+
+        it('should classify reference kinds for local, global, variable, and unknown diagnostics', () => {
+            expect((provider as any).classify_reference_kind({
+                message: "Undefined local macro: `foo'",
+                code: StataDiagnosticCode.UNDEFINED_MACRO,
+            })).toBe('local');
+
+            expect((provider as any).classify_reference_kind({
+                message: 'Undefined global macro: $foo',
+                code: StataDiagnosticCode.UNDEFINED_MACRO,
+            })).toBe('global');
+
+            expect((provider as any).classify_reference_kind({
+                message: 'Potentially undefined variable: foo',
+                code: StataDiagnosticCode.UNDEFINED_VARIABLE,
+            })).toBe('variable');
+
+            expect((provider as any).classify_reference_kind({
+                message: 'Undefined macro',
+                code: StataDiagnosticCode.UNDEFINED_MACRO,
+            })).toBeNull();
+        });
+
+        it('should only match out-of-scope symbols when kinds are exactly equal', () => {
+            expect((provider as any).out_of_scope_type_matches_reference(
+                'local',
+                'local'
+            )).toBe(true);
+            expect((provider as any).out_of_scope_type_matches_reference(
+                'global',
+                'global'
+            )).toBe(true);
+            expect((provider as any).out_of_scope_type_matches_reference(
+                'variable',
+                'variable'
+            )).toBe(true);
+
+            expect((provider as any).out_of_scope_type_matches_reference(
+                'scalar',
+                'variable'
+            )).toBe(false);
+            expect((provider as any).out_of_scope_type_matches_reference(
+                'matrix',
+                'variable'
+            )).toBe(false);
+            expect((provider as any).out_of_scope_type_matches_reference(
+                'program',
+                'variable'
+            )).toBe(false);
+            expect((provider as any).out_of_scope_type_matches_reference(
+                'variable',
+                'local'
+            )).toBe(false);
+            expect((provider as any).out_of_scope_type_matches_reference(
+                'variable',
+                'global'
+            )).toBe(false);
+            expect((provider as any).out_of_scope_type_matches_reference(
+                'local',
+                null
+            )).toBe(false);
+        });
+    });
+
     describe('out-of-scope diagnostic messages', () => {
-        it('should preserve same-file forward references when a prior do call excludes matching locals', async () => {
+        it('should inherit macro rewrite severity from undefinedMacro', () => {
+            const the_cases = [
+                { severity: 'error' as const, expected: DiagnosticSeverity.Error },
+                { severity: 'warning' as const, expected: DiagnosticSeverity.Warning },
+                {
+                    severity: 'information' as const,
+                    expected: DiagnosticSeverity.Information
+                },
+                { severity: 'hint' as const, expected: DiagnosticSeverity.Hint },
+                { severity: 'off' as const, expected: null },
+            ];
+
+            for (const my_case of the_cases) {
+                const config = {
+                    ...DEFAULT_CONFIG,
+                    diagnostics: {
+                        ...DEFAULT_CONFIG.diagnostics,
+                        severity: {
+                            ...DEFAULT_CONFIG.diagnostics.severity,
+                            undefinedMacro: my_case.severity,
+                        },
+                    },
+                };
+
+                const converted = (provider as any).convert_semantic_diagnostic(
+                    {
+                        message: "`foo' is defined in parent.do but after the call site (line 1)",
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 5 },
+                        },
+                        code: StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
+                        base_code: StataDiagnosticCode.UNDEFINED_MACRO,
+                        severity: 'warning',
+                    } as any,
+                    config
+                );
+
+                if (my_case.expected === null) {
+                    expect(converted).toBeNull();
+                } else {
+                    expect(converted).toBeDefined();
+                    expect(converted?.severity).toBe(my_case.expected);
+                }
+            }
+        });
+
+        it('should inherit variable rewrite severity from undefinedVariable', () => {
+            const the_cases = [
+                { severity: 'error' as const, expected: DiagnosticSeverity.Error },
+                { severity: 'warning' as const, expected: DiagnosticSeverity.Warning },
+                {
+                    severity: 'information' as const,
+                    expected: DiagnosticSeverity.Information
+                },
+                { severity: 'hint' as const, expected: DiagnosticSeverity.Hint },
+                { severity: 'off' as const, expected: null },
+            ];
+
+            for (const my_case of the_cases) {
+                const config = {
+                    ...DEFAULT_CONFIG,
+                    diagnostics: {
+                        ...DEFAULT_CONFIG.diagnostics,
+                        severity: {
+                            ...DEFAULT_CONFIG.diagnostics.severity,
+                            undefinedVariable: my_case.severity,
+                        },
+                    },
+                };
+
+                const converted = (provider as any).convert_semantic_diagnostic(
+                    {
+                        message: 'foo is defined in parent.do but after the call site (line 1)',
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 3 },
+                        },
+                        code: StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL,
+                        base_code: StataDiagnosticCode.UNDEFINED_VARIABLE,
+                        severity: 'warning',
+                    } as any,
+                    config
+                );
+
+                if (my_case.expected === null) {
+                    expect(converted).toBeNull();
+                } else {
+                    expect(converted).toBeDefined();
+                    expect(converted?.severity).toBe(my_case.expected);
+                }
+            }
+        });
+
+        it('should suppress backward-path rewrites with @lsp-ignore', async () => {
+            const content = "display `country_name' // @lsp-ignore";
+            const document = create_real_document_state(content);
+
+            const resolved_scope = {
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [{
+                    name: 'country_name',
+                    type: 'local' as const,
+                    source_uri: 'file:///parent.do',
+                    defined_line: 10,
+                    call_site_line: -1,
+                    reason: 'inheritance_excludes_locals' as const,
+                }],
+                diagnostics: [],
+                has_directives: true,
+                has_auto_parents: false,
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                make_stub_scope_resolver(resolved_scope as any)
+            );
+
+            expect(the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+            )).toBeUndefined();
+            expect(the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBeUndefined();
+        });
+
+        it('should suppress forward-path rewrites with @lsp-ignore-next', async () => {
+            const content = [
+                'do "child.do"',
+                '// @lsp-ignore-next',
+                "display `veggie'",
+            ].join('\n');
+            const document = create_real_document_state(content);
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: false,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///child.do',
+                    call_line: 0,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'do',
+                    excluded_locals: new Map([
+                        ['veggie', {
+                            name: 'veggie',
+                            scope: 'local',
+                            location: {
+                                uri: 'file:///child.do',
+                                range: {
+                                    start: { line: 0, character: 0 },
+                                    end: { line: 0, character: 12 },
+                                },
+                            },
+                            sourceUri: 'file:///child.do',
+                            definition_line: 0,
+                        }],
+                    ]),
+                }],
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                make_stub_scope_resolver(resolved_scope)
+            );
+
+            expect(the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('veggie')
+            )).toBeUndefined();
+            expect(the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    && d.message.includes('veggie')
+            )).toBeUndefined();
+        });
+        it('should prefer same-file forward-reference rewrites over forward-call blame', async () => {
             const content = [
                 'do "child.do"',
                 "display `veggie'",
@@ -950,17 +1214,69 @@ display \`result'
                 stub_resolver
             );
 
-            const undefined_diag = the_diagnostics.find(
-                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
-                    && d.message.includes('`veggie\'')
-            );
-            expect(undefined_diag).toBeDefined();
 
             const out_of_scope_diag = the_diagnostics.find(
                 d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
                     && d.message.includes('veggie')
             );
+            expect(out_of_scope_diag).toBeDefined();
+            expect(out_of_scope_diag?.message).toBe(
+                "`veggie' is used before it is defined (line 3)"
+            );
+
+            const undefined_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    && d.message.includes("`veggie'")
+            );
+            expect(undefined_diag).toBeUndefined();
+        });
+
+        it('should rewrite same-file global forward references', async () => {
+            const content = [
+                'display $after_global',
+                'global after_global "ready"',
+            ].join('\n');
+            const document = create_real_document_state(content);
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG
+            );
+
+            const out_of_scope_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('$after_global')
+            );
+            expect(out_of_scope_diag).toBeDefined();
+            expect(out_of_scope_diag?.message).toBe(
+                '$after_global is used before it is defined (line 2)'
+            );
+
+            const undefined_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    && d.message.includes('$after_global')
+            );
+            expect(undefined_diag).toBeUndefined();
+        });
+
+        it('should keep truly undefined macros on the generic diagnostic path', async () => {
+            const document = create_real_document_state("display `missing'");
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG
+            );
+
+            const out_of_scope_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+            );
             expect(out_of_scope_diag).toBeUndefined();
+
+            const undefined_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    && d.message.includes('missing')
+            );
+            expect(undefined_diag).toBeDefined();
         });
 
         it('should show inheritance message for locals excluded by done-by', async () => {
@@ -1250,11 +1566,6 @@ display \`result'
                     severity: {
                         ...DEFAULT_CONFIG.diagnostics.severity,
                         undefinedMacro: 'off' as const,
-                    },
-                },
-                cross_file: {
-                    diagnostics: {
-                        out_of_scope: 'warning' as const,
                     },
                 },
             };

--- a/tests/unit/invalid-macro-char-detection.test.ts
+++ b/tests/unit/invalid-macro-char-detection.test.ts
@@ -61,7 +61,6 @@ describe('Invalid Macro Character Detection Unit Tests', () => {
         max_chain_depth: 20,
         diagnostics: {
           undefined_symbol: 'warning',
-          out_of_scope: 'warning',
           missing_file: 'warning',
           max_depth: 'warning',
         },

--- a/tests/unit/out-of-scope-message.test.ts
+++ b/tests/unit/out-of-scope-message.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+import { format_out_of_scope_message } from '../../src/utils/out-of-scope-message';
+
+describe('format_out_of_scope_message', () => {
+    it('formats local after-call-site messages', () => {
+        expect(
+            format_out_of_scope_message('foo', 'local', {
+                kind: 'after_call_site',
+                call_site_line_0: 0,
+                source_file: 'parent.do',
+            })
+        ).toBe("`foo' is defined in parent.do but after the call site (line 1)");
+    });
+
+    it('formats local inheritance-excludes-locals messages', () => {
+        expect(
+            format_out_of_scope_message('foo', 'local', {
+                kind: 'inheritance_excludes_locals',
+                source_file: 'parent.do',
+            })
+        ).toBe(
+            "`foo' is defined in parent.do but local macros are not inherited via do/run (use include or @lsp-included-by)"
+        );
+    });
+
+    it('formats local same-file-forward messages', () => {
+        expect(
+            format_out_of_scope_message('foo', 'local', {
+                kind: 'same_file_forward',
+                defined_line_0: 10,
+            })
+        ).toBe("`foo' is used before it is defined (line 11)");
+    });
+
+    it('formats global after-call-site messages', () => {
+        expect(
+            format_out_of_scope_message('foo', 'global', {
+                kind: 'after_call_site',
+                call_site_line_0: 4,
+                source_file: 'globals.do',
+            })
+        ).toBe('$foo is defined in globals.do but after the call site (line 5)');
+    });
+
+    it('formats global same-file-forward messages', () => {
+        expect(
+            format_out_of_scope_message('foo', 'global', {
+                kind: 'same_file_forward',
+                defined_line_0: 1,
+            })
+        ).toBe('$foo is used before it is defined (line 2)');
+    });
+
+    it('formats variable after-call-site messages', () => {
+        expect(
+            format_out_of_scope_message('foo', 'variable', {
+                kind: 'after_call_site',
+                call_site_line_0: 8,
+                source_file: 'data.do',
+            })
+        ).toBe('foo is defined in data.do but after the call site (line 9)');
+    });
+});


### PR DESCRIPTION
## Summary
- remove the `crossFile.diagnostics.outOfScope` config surface
- add a shared out-of-scope message formatter and unify provider-side rewrite handling
- apply same-file, backward, and forward out-of-scope rewrites with base severity inheritance and ignore-directive suppression
- update diagnostics, property/integration tests, and docs for the new rewrite model

## Validation
- bun run typecheck
- bun test /Users/jmb/repos/sight/tests/unit/out-of-scope-message.test.ts /Users/jmb/repos/sight/tests/unit/diagnostics-provider.test.ts /Users/jmb/repos/sight/tests/property/forward-call-out-of-scope-oracle.prop.test.ts /Users/jmb/repos/sight/tests/property/out-of-scope-diagnostic-correctness.prop.test.ts /Users/jmb/repos/sight/tests/property/out-of-scope-diagnostic-message-fix.prop.test.ts /Users/jmb/repos/sight/tests/property/severity-settings.prop.test.ts /Users/jmb/repos/sight/tests/property/diagnostic-suppression.test.ts /Users/jmb/repos/sight/tests/integration/out-of-scope-diagnostic-message-bug.test.ts /Users/jmb/repos/sight/tests/integration/local-macro-inheritance-bug.test.ts /Users/jmb/repos/sight/tests/integration/cross-file-awareness.test.ts /Users/jmb/repos/sight/tests/integration/callee-revalidation.test.ts /Users/jmb/repos/sight/tests/integration/out-of-scope-diagnostic-cleanup.test.ts
- bun test /Users/jmb/repos/sight/tests/integration/current-file-forward-call-diagnostics.test.ts
- bun run test

## Artifacts
- Conversation: https://app.warp.dev/conversation/9300a171-eeaf-46b8-a534-db94ddaade09

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the legacy cross-file out-of-scope config; rewrite behavior now follows the base undefined-diagnostic severities.

* **New Features**
  * Undefined-symbol diagnostics are rewritten into clearer "out of scope" messages when the symbol exists but is unreachable.
  * Same-file forward-reference messages show "used before it is defined" with corrected line numbers.
  * Out-of-scope handling now recognizes variables; completions and hover remain available.

* **Tests & Docs**
  * Documentation updated and extensive tests added/adjusted to cover new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->