### PR TITLE
Clarify local macro inheritance diagnostics

### DIFF
--- a/src/utils/out-of-scope-message.ts
+++ b/src/utils/out-of-scope-message.ts
@@ -48,8 +48,8 @@ export function format_out_of_scope_message(
         case 'inheritance_excludes_locals':
             return (
                 `${display_name} is defined in ${reason.source_file} but ` +
-                'local macros are not inherited via do/run ' +
-                '(use include or @lsp-included-by)'
+                'local macros are not inherited via `do` or `run` ' +
+                '(write `include` instead)'
             );
         case 'same_file_forward':
             return (

--- a/src/utils/out-of-scope-message.ts
+++ b/src/utils/out-of-scope-message.ts
@@ -48,8 +48,8 @@ export function format_out_of_scope_message(
         case 'inheritance_excludes_locals':
             return (
                 `${display_name} is defined in ${reason.source_file} but ` +
-                'local macros are not inherited via `do` or `run` ' +
-                '(write `include` instead)'
+                'local macros are not inherited via do or run ' +
+                '(use include instead)'
             );
         case 'same_file_forward':
             return (

--- a/tests/integration/current-file-forward-call-diagnostics.test.ts
+++ b/tests/integration/current-file-forward-call-diagnostics.test.ts
@@ -161,7 +161,7 @@ display \`do_local'`;
             expect(informative!.message).toContain('do_local');
             expect(informative!.message).toContain('helper_do_local.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via do/run'
+                'local macros are not inherited via `do` or `run`'
             );
 
             const plain_undefined = line1_diags.filter(
@@ -205,7 +205,7 @@ di \`veggie'`;
             expect(informative!.message).toContain('veggie');
             expect(informative!.message).toContain('demo_child.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via do/run'
+                'local macros are not inherited via `do` or `run`'
             );
 
             // The plain "Undefined local macro" diagnostic should be replaced,
@@ -289,7 +289,7 @@ di \`veggie'`;
             expect(informative!.message).toContain('defs.do');
             expect(informative!.message).not.toContain('child.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via do/run'
+                'local macros are not inherited via `do` or `run`'
             );
         });
 
@@ -331,7 +331,7 @@ di \`veggie'`;
             expect(informative!.message).toContain('child_after.do');
             expect(informative!.message).not.toContain('defs_after.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via do/run'
+                'local macros are not inherited via `do` or `run`'
             );
         });
 
@@ -371,7 +371,7 @@ di \`veggie'`;
             expect(informative!.message).toContain('sibling_b.do');
             expect(informative!.message).not.toContain('sibling_a.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via do/run'
+                'local macros are not inherited via `do` or `run`'
             );
         });
 
@@ -416,7 +416,7 @@ di \`veggie'`;
             expect(informative!.message).toContain('bug_a_child.do');
             expect(informative!.message).not.toContain('bug_a_defs.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via do/run'
+                'local macros are not inherited via `do` or `run`'
             );
         });
 

--- a/tests/integration/current-file-forward-call-diagnostics.test.ts
+++ b/tests/integration/current-file-forward-call-diagnostics.test.ts
@@ -161,7 +161,7 @@ display \`do_local'`;
             expect(informative!.message).toContain('do_local');
             expect(informative!.message).toContain('helper_do_local.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via `do` or `run`'
+                'local macros are not inherited via do or run'
             );
 
             const plain_undefined = line1_diags.filter(
@@ -205,7 +205,7 @@ di \`veggie'`;
             expect(informative!.message).toContain('veggie');
             expect(informative!.message).toContain('demo_child.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via `do` or `run`'
+                'local macros are not inherited via do or run'
             );
 
             // The plain "Undefined local macro" diagnostic should be replaced,
@@ -289,7 +289,7 @@ di \`veggie'`;
             expect(informative!.message).toContain('defs.do');
             expect(informative!.message).not.toContain('child.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via `do` or `run`'
+                'local macros are not inherited via do or run'
             );
         });
 
@@ -331,7 +331,7 @@ di \`veggie'`;
             expect(informative!.message).toContain('child_after.do');
             expect(informative!.message).not.toContain('defs_after.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via `do` or `run`'
+                'local macros are not inherited via do or run'
             );
         });
 
@@ -371,7 +371,7 @@ di \`veggie'`;
             expect(informative!.message).toContain('sibling_b.do');
             expect(informative!.message).not.toContain('sibling_a.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via `do` or `run`'
+                'local macros are not inherited via do or run'
             );
         });
 
@@ -416,7 +416,7 @@ di \`veggie'`;
             expect(informative!.message).toContain('bug_a_child.do');
             expect(informative!.message).not.toContain('bug_a_defs.do');
             expect(informative!.message).toContain(
-                'local macros are not inherited via `do` or `run`'
+                'local macros are not inherited via do or run'
             );
         });
 

--- a/tests/integration/local-macro-inheritance-bug.test.ts
+++ b/tests/integration/local-macro-inheritance-bug.test.ts
@@ -85,7 +85,7 @@ describe('Local Macro Inheritance Bug', () => {
         );
         expect(macro_diagnostics.length).toBe(1);
         expect(macro_diagnostics[0].message).toContain(
-            'local macros are not inherited via `do` or `run`'
+            'local macros are not inherited via do or run'
         );
         expect(macro_diagnostics[0].message).not.toContain('after the call site');
     });

--- a/tests/integration/local-macro-inheritance-bug.test.ts
+++ b/tests/integration/local-macro-inheritance-bug.test.ts
@@ -84,7 +84,9 @@ describe('Local Macro Inheritance Bug', () => {
             d.message.includes('local macros') && !d.message.includes('Could not identify call site')
         );
         expect(macro_diagnostics.length).toBe(1);
-        expect(macro_diagnostics[0].message).toContain('local macros are not inherited via do/run');
+        expect(macro_diagnostics[0].message).toContain(
+            'local macros are not inherited via `do` or `run`'
+        );
         expect(macro_diagnostics[0].message).not.toContain('after the call site');
     });
 });

--- a/tests/integration/out-of-scope-diagnostic-message-bug.test.ts
+++ b/tests/integration/out-of-scope-diagnostic-message-bug.test.ts
@@ -113,7 +113,7 @@ describe('Out-of-Scope Diagnostic Message Bug - Exact Scenario', () => {
         
         expect(country_name_diagnostic).toBeDefined();
         expect(country_name_diagnostic!.message).toContain(
-            'local macros are not inherited via `do` or `run`'
+            'local macros are not inherited via do or run'
         );
         expect(country_name_diagnostic!.message).not.toContain('after the call site');
     });
@@ -188,7 +188,7 @@ describe('Out-of-Scope Diagnostic Message Bug - Exact Scenario', () => {
         
         for (const diagnostic of survey_local_diagnostics) {
             expect(diagnostic.message).toContain(
-                'local macros are not inherited via `do` or `run`'
+                'local macros are not inherited via do or run'
             );
             expect(diagnostic.message).not.toContain('after the call site');
         }

--- a/tests/integration/out-of-scope-diagnostic-message-bug.test.ts
+++ b/tests/integration/out-of-scope-diagnostic-message-bug.test.ts
@@ -112,7 +112,9 @@ describe('Out-of-Scope Diagnostic Message Bug - Exact Scenario', () => {
         );
         
         expect(country_name_diagnostic).toBeDefined();
-        expect(country_name_diagnostic!.message).toContain('local macros are not inherited via do/run');
+        expect(country_name_diagnostic!.message).toContain(
+            'local macros are not inherited via `do` or `run`'
+        );
         expect(country_name_diagnostic!.message).not.toContain('after the call site');
     });
 
@@ -185,7 +187,9 @@ describe('Out-of-Scope Diagnostic Message Bug - Exact Scenario', () => {
         expect(survey_local_diagnostics.length).toBe(3);
         
         for (const diagnostic of survey_local_diagnostics) {
-            expect(diagnostic.message).toContain('local macros are not inherited via do/run');
+            expect(diagnostic.message).toContain(
+                'local macros are not inherited via `do` or `run`'
+            );
             expect(diagnostic.message).not.toContain('after the call site');
         }
 

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -1507,7 +1507,9 @@ display \`result'
                 d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
             );
             expect(out_of_scope_diag).toBeDefined();
-            expect(out_of_scope_diag?.message).toContain('local macros are not inherited via do/run');
+            expect(out_of_scope_diag?.message).toContain(
+                'local macros are not inherited via `do` or `run`'
+            );
             expect(out_of_scope_diag?.message).toContain('country_name');
             expect(out_of_scope_diag?.message).not.toContain('after the call site');
         });

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -1508,7 +1508,7 @@ display \`result'
             );
             expect(out_of_scope_diag).toBeDefined();
             expect(out_of_scope_diag?.message).toContain(
-                'local macros are not inherited via `do` or `run`'
+                'local macros are not inherited via do or run'
             );
             expect(out_of_scope_diag?.message).toContain('country_name');
             expect(out_of_scope_diag?.message).not.toContain('after the call site');

--- a/tests/unit/out-of-scope-message.test.ts
+++ b/tests/unit/out-of-scope-message.test.ts
@@ -19,7 +19,7 @@ describe('format_out_of_scope_message', () => {
                 source_file: 'parent.do',
             })
         ).toBe(
-            "`foo' is defined in parent.do but local macros are not inherited via do/run (use include or @lsp-included-by)"
+            "`foo' is defined in parent.do but local macros are not inherited via `do` or `run` (write `include` instead)"
         );
     });
 

--- a/tests/unit/out-of-scope-message.test.ts
+++ b/tests/unit/out-of-scope-message.test.ts
@@ -19,7 +19,7 @@ describe('format_out_of_scope_message', () => {
                 source_file: 'parent.do',
             })
         ).toBe(
-            "`foo' is defined in parent.do but local macros are not inherited via `do` or `run` (write `include` instead)"
+            "`foo' is defined in parent.do but local macros are not inherited via do or run (use include instead)"
         );
     });
 

--- a/tests/unit/scope-resolver-backward-locals.test.ts
+++ b/tests/unit/scope-resolver-backward-locals.test.ts
@@ -85,7 +85,7 @@ describe('Backward directive locals inheritance', () => {
         const out_of_scope = gp_local_diag.find(d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL);
         if (out_of_scope) {
             expect(out_of_scope.message).toContain(
-                'local macros are not inherited via `do` or `run`'
+                'local macros are not inherited via do or run'
             );
         }
     });

--- a/tests/unit/scope-resolver-backward-locals.test.ts
+++ b/tests/unit/scope-resolver-backward-locals.test.ts
@@ -84,7 +84,9 @@ describe('Backward directive locals inheritance', () => {
         // If it's OUT_OF_SCOPE_SYMBOL, verify the message explains inheritance
         const out_of_scope = gp_local_diag.find(d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL);
         if (out_of_scope) {
-            expect(out_of_scope.message).toContain('local macros are not inherited via do/run');
+            expect(out_of_scope.message).toContain(
+                'local macros are not inherited via `do` or `run`'
+            );
         }
     });
 


### PR DESCRIPTION
## Summary
- simplify the local-macro inheritance diagnostic wording
- remove markdown-style backticks so the message renders cleanly in VS Code hovers
- update focused unit and integration tests for the new text

## Testing
- bun test /Users/jmb/repos/sight/tests/unit/out-of-scope-message.test.ts /Users/jmb/repos/sight/tests/unit/scope-resolver-backward-locals.test.ts /Users/jmb/repos/sight/tests/integration/out-of-scope-diagnostic-message-bug.test.ts /Users/jmb/repos/sight/tests/integration/current-file-forward-call-diagnostics.test.ts /Users/jmb/repos/sight/tests/integration/local-macro-inheritance-bug.test.ts /Users/jmb/repos/sight/tests/unit/diagnostics-provider.test.ts

## Artifacts
- Conversation: https://app.warp.dev/conversation/ddeab827-457d-46d1-a909-f7a3cbc89485

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
