### PR TITLE
Fix hover ambiguity between command and expression positions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,22 @@ commands. Do NOT use `toLowerCase()` for keyword/command matching.
 Exceptions where case-insensitivity is acceptable:
 - File extensions (`.do`, `.DO` - filesystem dependent)
 - LSP directives (`@lsp-done-by` - our convention, not Stata syntax)
-- Command database lookups for completion/hover (user convenience)
+- Command database lookups for completion/hover (user convenience): when
+  matching a single piece of user-typed text against the canonical command
+  database (e.g., `command_db.get_command(word)`), lowercasing the user input
+  is fine — the database itself normalizes on entry.
+
+The exception is narrow. The following are NOT covered and must use exact-case
+comparison:
+- Hardcoded lists of canonical command names in provider code (e.g., prefix-
+  command arrays like `['by', 'bysort', 'quietly', ...]`). Stata rejects
+  `BY x: reg ...`, so treating `BY` as a prefix produces misleading hover and
+  completion for code that won't run.
+- Comparisons between two pieces of source text at the same position (e.g.,
+  `token.value.toLowerCase() === hovered_word.toLowerCase()` where both sides
+  came from the same document). Lowercasing both sides is redundant when
+  positional overlap is already checked; it adds noise and can mask bugs if
+  the positional check is later weakened.
 
 ## Architecture Overview
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1162,6 +1162,19 @@ export class HoverProvider {
     }
 
     /**
+     * True when the source-text word is recognized as a prefix command with
+     * subcommands (e.g. `frame`, `mi`). Stata prefix commands are
+     * case-sensitive and canonical-lowercase; `has_subcommands` lowercases
+     * internally, so mis-cased forms like `FRAME` need an explicit guard.
+     */
+    private is_canonical_prefix_with_subcommands(source_word: string): boolean {
+        if (source_word !== source_word.toLowerCase()) {
+            return false;
+        }
+        return this.command_db.has_subcommands(source_word);
+    }
+
+    /**
      * Token-based subcommand context detection.
      * Finds the hovered token and checks if the previous non-trivia token is a prefix command.
      */
@@ -1262,8 +1275,7 @@ export class HoverProvider {
         // The word at command_word_index should be the prefix command
         const potential_prefix = the_statement_words[command_word_index].value;
 
-        // Check if this command has subcommands using the database
-        if (!this.command_db.has_subcommands(potential_prefix)) {
+        if (!this.is_canonical_prefix_with_subcommands(potential_prefix)) {
             return { is_subcommand: false, prefix_command: null };
         }
 
@@ -1348,9 +1360,13 @@ export class HoverProvider {
             const after_colon = text_before_hovered.split(':').pop()?.trim() || '';
             const words_after_colon = after_colon.split(/\s+/).filter(t => t.length > 0);
             if (words_after_colon.length > 0) {
-                // Reset to check words after colon
-                const potential_prefix = words_after_colon[0].toLowerCase();
-                if (this.command_db.has_subcommands(potential_prefix) && words_after_colon.length === 1) {
+                // Reset to check words after colon. Preserve source case so
+                // mis-cased prefix commands are rejected by the case guard.
+                const potential_prefix = words_after_colon[0];
+                if (
+                    this.is_canonical_prefix_with_subcommands(potential_prefix)
+                    && words_after_colon.length === 1
+                ) {
                     const subcommands = this.command_db.get_subcommands(potential_prefix);
                     const is_valid = subcommands?.some(
                         sub => sub.name.toLowerCase() === hovered_word.toLowerCase()
@@ -1367,11 +1383,12 @@ export class HoverProvider {
             return { is_subcommand: false, prefix_command: null };
         }
 
-        // The token at command_index should be the prefix command
-        const potential_prefix = tokens_before[command_index].toLowerCase();
+        // The token at command_index should be the prefix command.
+        // Preserve source case so mis-cased prefixes (e.g. `FRAME`) are
+        // rejected by the case guard.
+        const potential_prefix = tokens_before[command_index];
 
-        // Check if this command has subcommands using the database
-        if (!this.command_db.has_subcommands(potential_prefix)) {
+        if (!this.is_canonical_prefix_with_subcommands(potential_prefix)) {
             return { is_subcommand: false, prefix_command: null };
         }
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -37,6 +37,7 @@ import {
     ArgumentSpec,
     ResolvedScope,
     ScopeResolverConfig,
+    CommandInfo,
 } from '../types';
 import { IContextTracker } from '../context-tracker/types';
 import { LanguageContext } from '../context-tracker/types';
@@ -50,6 +51,37 @@ import { is_cursor_in_string_literal } from '../utils/string-literal-utils';
 
 const MARKDOWN_TEXT_ESCAPE_PATTERN =
     /([\\`*_{}\[\]()#+\-.!|])/g;
+
+const STATA_EXPRESSION_FUNCTION_ALIASES = new Map<string, string>([
+    ['byte', 'byte'],
+    ['date', 'date'],
+    ['daily', 'daily'],
+    ['double', 'double'],
+    ['exp', 'exp'],
+    ['float', 'float'],
+    ['halfyearly', 'halfyearly'],
+    ['int', 'int'],
+    ['log', 'log'],
+    ['long', 'long'],
+    ['lower', 'lower'],
+    ['max', 'max'],
+    ['mi', 'missing'],
+    ['min', 'min'],
+    ['missing', 'missing'],
+    ['mod', 'mod'],
+    ['monthly', 'monthly'],
+    ['normal', 'normal'],
+    ['poisson', 'poisson'],
+    ['proper', 'proper'],
+    ['quarterly', 'quarterly'],
+    ['recode', 'recode'],
+    ['string', 'string'],
+    ['sum', 'sum'],
+    ['trunc', 'trunc'],
+    ['upper', 'upper'],
+    ['weekly', 'weekly'],
+    ['yearly', 'yearly'],
+]);
 
 /**
  * One entry in a symbol's `additional_definitions` array.
@@ -246,6 +278,17 @@ export class HoverProvider {
         if (the_symbol_matches.length > 0) {
             const formatted_content = this.format_multi_symbol_hover(the_symbol_matches);
             return { contents: formatted_content, range };
+        }
+
+        // Function calls can share text with prefix commands. For example,
+        // `mi(bar)` is the `missing()` function, not the `mi` prefix command.
+        const expression_function_hover = this.get_expression_function_hover(
+            document,
+            range,
+            word
+        );
+        if (expression_function_hover) {
+            return { contents: expression_function_hover, range };
         }
 
         // Fallback: Check for subcommand context (not a symbol type)
@@ -1778,42 +1821,97 @@ export class HoverProvider {
     private get_command_hover(word: string): MarkupContent | null {
         const command = this.command_db.lookup(word);
         if (command) {
-            let hover_text = `**${command.name}**`;
-
-            if (command.options && command.options.length > 0) {
-                const option_names = command.options.map(opt => opt.name).join(', ');
-                hover_text += `\n\n**Options:** ${option_names}`;
-            }
-
-            hover_text += `\n\nSee Stata documentation: \`help ${command.name}\``;
-
-            return {
-                kind: MarkupKind.Markdown,
-                value: hover_text,
-            };
+            return this.format_builtin_command_hover(command);
         }
 
         // Try broadening the search to abbreviations
         const matches = this.command_db.expand_abbreviation(word);
         if (matches.length === 1) {
             const cmd = matches[0];
-
-            let hover_text = `**${cmd.name}** (abbreviated as \`${word}\`)`;
-
-            if (cmd.options && cmd.options.length > 0) {
-                const option_names = cmd.options.map(opt => opt.name).join(', ');
-                hover_text += `\n\n**Options:** ${option_names}`;
-            }
-
-            hover_text += `\n\nSee Stata documentation: \`help ${cmd.name}\``;
-
-            return {
-                kind: MarkupKind.Markdown,
-                value: hover_text,
-            };
+            return this.format_builtin_command_hover(cmd, word);
         }
 
         return null;
+    }
+
+    private get_expression_function_hover(
+        document: DocumentState,
+        range: { start: Position; end: Position },
+        word: string
+    ): MarkupContent | null {
+        if (!this.is_followed_by_open_paren(document, range.end)) {
+            return null;
+        }
+
+        const function_name = this.resolve_expression_function_name(word);
+        if (!function_name) {
+            return null;
+        }
+
+        const command = this.command_db.lookup(function_name);
+        if (!command) {
+            return null;
+        }
+
+        return this.format_expression_function_hover(
+            function_name,
+            function_name === word ? undefined : word
+        );
+    }
+
+    private is_followed_by_open_paren(
+        document: DocumentState,
+        position: Position
+    ): boolean {
+        const line = get_line_text(document, position.line);
+        let i = position.character;
+        while (i < line.length && /\s/.test(line[i])) {
+            i++;
+        }
+        return line[i] === '(';
+    }
+
+    private resolve_expression_function_name(word: string): string | null {
+        return STATA_EXPRESSION_FUNCTION_ALIASES.get(word) ?? null;
+    }
+
+    private format_expression_function_hover(
+        function_name: string,
+        abbreviated_as?: string
+    ): MarkupContent {
+        let hover_text = `**Function:** **${function_name}**()`;
+        if (abbreviated_as && abbreviated_as !== function_name) {
+            hover_text += ` (abbreviated as \`${abbreviated_as}\`)`;
+        }
+
+        hover_text += `\n\nSee Stata documentation: \`help ${function_name}()\``;
+
+        return {
+            kind: MarkupKind.Markdown,
+            value: hover_text,
+        };
+    }
+
+    private format_builtin_command_hover(
+        command: CommandInfo,
+        abbreviated_as?: string
+    ): MarkupContent {
+        let hover_text = `**${command.name}**`;
+        if (abbreviated_as && abbreviated_as !== command.name) {
+            hover_text += ` (abbreviated as \`${abbreviated_as}\`)`;
+        }
+
+        if (command.options && command.options.length > 0) {
+            const option_names = command.options.map(opt => opt.name).join(', ');
+            hover_text += `\n\n**Options:** ${option_names}`;
+        }
+
+        hover_text += `\n\nSee Stata documentation: \`help ${command.name}\``;
+
+        return {
+            kind: MarkupKind.Markdown,
+            value: hover_text,
+        };
     }
 
     /**

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1325,8 +1325,13 @@ export class HoverProvider {
             command_index++;
         }
 
-        // Handle "by varlist:" pattern
-        if (text_before_hovered.includes(':')) {
+        // Handle "by varlist:" pattern only when we actually skipped a
+        // lowercase by/bysort prefix. This keeps merge syntax like 1:m, or
+        // mis-cased BY, from being treated as a by-prefix colon form.
+        const skipped_by = tokens_before
+            .slice(0, command_index)
+            .some(t => t === 'by' || t === 'bysort');
+        if (skipped_by && text_before_hovered.includes(':')) {
             const after_colon = text_before_hovered.split(':').pop()?.trim() || '';
             const words_after_colon = after_colon.split(/\s+/).filter(t => t.length > 0);
             if (words_after_colon.length > 0) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -52,35 +52,38 @@ import { is_cursor_in_string_literal } from '../utils/string-literal-utils';
 const MARKDOWN_TEXT_ESCAPE_PATTERN =
     /([\\`*_{}\[\]()#+\-.!|])/g;
 
+const STATA_EXPRESSION_FUNCTIONS = new Set<string>([
+    'byte',
+    'date',
+    'daily',
+    'double',
+    'exp',
+    'float',
+    'halfyearly',
+    'int',
+    'log',
+    'long',
+    'lower',
+    'max',
+    'min',
+    'missing',
+    'mod',
+    'monthly',
+    'normal',
+    'poisson',
+    'proper',
+    'quarterly',
+    'recode',
+    'string',
+    'sum',
+    'trunc',
+    'upper',
+    'weekly',
+    'yearly',
+]);
+
 const STATA_EXPRESSION_FUNCTION_ALIASES = new Map<string, string>([
-    ['byte', 'byte'],
-    ['date', 'date'],
-    ['daily', 'daily'],
-    ['double', 'double'],
-    ['exp', 'exp'],
-    ['float', 'float'],
-    ['halfyearly', 'halfyearly'],
-    ['int', 'int'],
-    ['log', 'log'],
-    ['long', 'long'],
-    ['lower', 'lower'],
-    ['max', 'max'],
     ['mi', 'missing'],
-    ['min', 'min'],
-    ['missing', 'missing'],
-    ['mod', 'mod'],
-    ['monthly', 'monthly'],
-    ['normal', 'normal'],
-    ['poisson', 'poisson'],
-    ['proper', 'proper'],
-    ['quarterly', 'quarterly'],
-    ['recode', 'recode'],
-    ['string', 'string'],
-    ['sum', 'sum'],
-    ['trunc', 'trunc'],
-    ['upper', 'upper'],
-    ['weekly', 'weekly'],
-    ['yearly', 'yearly'],
 ]);
 
 /**
@@ -316,6 +319,7 @@ export class HoverProvider {
         }
 
         let paren_depth = 0;
+        let bracket_depth = 0;
         let saw_top_level_comma = false;
 
         for (const token of tokens) {
@@ -329,6 +333,7 @@ export class HoverProvider {
 
             if (token.type === 'STATEMENT_TERMINATOR') {
                 paren_depth = 0;
+                bracket_depth = 0;
                 saw_top_level_comma = false;
                 continue;
             }
@@ -336,7 +341,15 @@ export class HoverProvider {
                 paren_depth++;
             } else if (token.type === 'RPAREN') {
                 if (paren_depth > 0) paren_depth--;
-            } else if (token.type === 'COMMA' && paren_depth === 0) {
+            } else if (token.type === 'LBRACKET') {
+                bracket_depth++;
+            } else if (token.type === 'RBRACKET') {
+                if (bracket_depth > 0) bracket_depth--;
+            } else if (
+                token.type === 'COMMA'
+                && paren_depth === 0
+                && bracket_depth === 0
+            ) {
                 saw_top_level_comma = true;
             }
         }
@@ -1811,7 +1824,7 @@ export class HoverProvider {
         }
 
         const command = this.command_db.lookup(function_name);
-        if (!command) {
+        if (!command && !STATA_EXPRESSION_FUNCTIONS.has(function_name)) {
             return null;
         }
 
@@ -1834,6 +1847,9 @@ export class HoverProvider {
     }
 
     private resolve_expression_function_name(word: string): string | null {
+        if (STATA_EXPRESSION_FUNCTIONS.has(word)) {
+            return word;
+        }
         return STATA_EXPRESSION_FUNCTION_ALIASES.get(word) ?? null;
     }
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -268,6 +268,13 @@ export class HoverProvider {
             return { contents: formatted_content, range };
         }
 
+        // Past a top-level comma the word is an option name, which shares
+        // spellings with Stata commands (e.g. `replace`) and functions
+        // (e.g. `sum`). Don't fall through to command/function hover there.
+        if (this.is_after_top_level_comma(document, position)) {
+            return null;
+        }
+
         // Function calls can share text with prefix commands. For example,
         // `mi(bar)` is the `missing()` function, not the `mi` prefix command.
         const expression_function_hover = this.get_expression_function_hover(
@@ -292,6 +299,49 @@ export class HoverProvider {
         }
 
         return null;
+    }
+
+    /**
+     * True when the cursor is past a top-level comma in the current statement,
+     * i.e. in option-argument position. Uses the token stream so commas inside
+     * strings, macro references, and nested parentheses are ignored correctly.
+     */
+    private is_after_top_level_comma(
+        document: DocumentState,
+        position: Position
+    ): boolean {
+        const tokens = document.tokens;
+        if (!tokens || tokens.length === 0) {
+            return false;
+        }
+
+        let paren_depth = 0;
+        let saw_top_level_comma = false;
+
+        for (const token of tokens) {
+            const at_or_past_cursor =
+                token.range.start.line > position.line ||
+                (token.range.start.line === position.line &&
+                 token.range.start.character >= position.character);
+            if (at_or_past_cursor) {
+                break;
+            }
+
+            if (token.type === 'STATEMENT_TERMINATOR') {
+                paren_depth = 0;
+                saw_top_level_comma = false;
+                continue;
+            }
+            if (token.type === 'LPAREN') {
+                paren_depth++;
+            } else if (token.type === 'RPAREN') {
+                if (paren_depth > 0) paren_depth--;
+            } else if (token.type === 'COMMA' && paren_depth === 0) {
+                saw_top_level_comma = true;
+            }
+        }
+
+        return saw_top_level_comma;
     }
 
     /**

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -271,15 +271,10 @@ export class HoverProvider {
             return { contents: formatted_content, range };
         }
 
-        // Past a top-level comma the word is an option name, which shares
-        // spellings with Stata commands (e.g. `replace`) and functions
-        // (e.g. `sum`). Don't fall through to command/function hover there.
-        if (this.is_after_top_level_comma(document, position)) {
-            return null;
-        }
-
         // Function calls can share text with prefix commands. For example,
         // `mi(bar)` is the `missing()` function, not the `mi` prefix command.
+        // Checked before the top-level-comma guard so that expression
+        // functions inside option arguments (e.g. `vce(mi(bar))`) resolve.
         const expression_function_hover = this.get_expression_function_hover(
             document,
             range,
@@ -287,6 +282,13 @@ export class HoverProvider {
         );
         if (expression_function_hover) {
             return { contents: expression_function_hover, range };
+        }
+
+        // Past a top-level comma the word is an option name, which shares
+        // spellings with Stata commands (e.g. `replace`) and functions
+        // (e.g. `sum`). Don't fall through to command/function hover there.
+        if (this.is_after_top_level_comma(document, position)) {
+            return null;
         }
 
         // Fallback: Check for subcommand context (not a symbol type)
@@ -1837,11 +1839,6 @@ export class HoverProvider {
 
         const function_name = this.resolve_expression_function_name(word);
         if (!function_name) {
-            return null;
-        }
-
-        const command = this.command_db.lookup(function_name);
-        if (!command && !STATA_EXPRESSION_FUNCTIONS.has(function_name)) {
             return null;
         }
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1126,7 +1126,7 @@ export class HoverProvider {
                 token.range.start.character <= position.character &&
                 token.range.end.character >= position.character &&
                 token.type === 'WORD' &&
-                token.value.toLowerCase() === hovered_word.toLowerCase()) {
+                token.value === hovered_word) {
                 hovered_token_index = i;
                 break;
             }
@@ -1145,12 +1145,13 @@ export class HoverProvider {
             }
         }
 
-        // Collect non-trivia WORD tokens from statement start to hovered token
+        // Collect non-trivia WORD tokens from statement start to hovered token.
+        // Preserve raw source case; Stata commands/prefixes are case-sensitive.
         const the_statement_words: { value: string; index: number }[] = [];
         for (let i = statement_start_index; i <= hovered_token_index; i++) {
             const token = tokens[i];
             if (token.type === 'WORD' && !TRIVIA_TYPES.includes(token.type)) {
-                the_statement_words.push({ value: token.value.toLowerCase(), index: i });
+                the_statement_words.push({ value: token.value, index: i });
             }
         }
 
@@ -1165,26 +1166,33 @@ export class HoverProvider {
             command_word_index++;
         }
 
-        // Handle "by varlist:" pattern - skip to after colon
-        // Check if there's a colon between command_word_index and hovered token
+        // Handle "by varlist:" pattern - skip to after colon.
+        // Only applies when we skipped a by/bysort prefix; otherwise a stray
+        // colon (or mis-cased `BY`) shouldn't bump us past its varlist.
+        const BY_PREFIXES = ['by', 'bysort'];
+        const skipped_by_prefix = the_statement_words
+            .slice(0, command_word_index)
+            .some(w => BY_PREFIXES.includes(w.value));
         let found_colon = false;
-        for (let i = the_statement_words[command_word_index].index; i < hovered_token_index; i++) {
-            if (tokens[i].type === 'COLON') {
-                found_colon = true;
-                // Find next WORD after colon
-                for (let j = i + 1; j <= hovered_token_index; j++) {
-                    if (tokens[j].type === 'WORD') {
-                        // Update command_word_index to point to this word
-                        for (let k = 0; k < the_statement_words.length; k++) {
-                            if (the_statement_words[k].index === j) {
-                                command_word_index = k;
-                                break;
+        if (skipped_by_prefix) {
+            for (let i = the_statement_words[command_word_index].index; i < hovered_token_index; i++) {
+                if (tokens[i].type === 'COLON') {
+                    found_colon = true;
+                    // Find next WORD after colon
+                    for (let j = i + 1; j <= hovered_token_index; j++) {
+                        if (tokens[j].type === 'WORD') {
+                            // Update command_word_index to point to this word
+                            for (let k = 0; k < the_statement_words.length; k++) {
+                                if (the_statement_words[k].index === j) {
+                                    command_word_index = k;
+                                    break;
+                                }
                             }
+                            break;
                         }
-                        break;
                     }
+                    break;
                 }
-                break;
             }
         }
 
@@ -1238,7 +1246,7 @@ export class HoverProvider {
 
         // Find word boundaries for the hovered word
         const word_info = this.get_word_at_position(document, position);
-        if (!word_info || word_info.word.toLowerCase() !== hovered_word.toLowerCase()) {
+        if (!word_info || word_info.word !== hovered_word) {
             return { is_subcommand: false, prefix_command: null };
         }
 
@@ -1258,11 +1266,12 @@ export class HoverProvider {
             return { is_subcommand: false, prefix_command: null };
         }
 
-        // Skip standard prefix commands (by, quietly, capture, etc.)
+        // Skip standard prefix commands (by, quietly, capture, etc.).
+        // Stata prefix commands are case-sensitive and must be lowercase.
         const standard_prefixes = ['by', 'bysort', 'quietly', 'capture', 'noisily', 'qui', 'cap', 'noi'];
         let command_index = 0;
         while (command_index < tokens_before.length &&
-               standard_prefixes.includes(tokens_before[command_index].toLowerCase())) {
+               standard_prefixes.includes(tokens_before[command_index])) {
             command_index++;
         }
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -231,18 +231,6 @@ export class HoverProvider {
             );
         }
 
-        // Check if we're in option context BEFORE checking for commands
-        const option_context = this.is_in_option_context(document, position);
-        if (option_context.in_option_context) {
-            // Try to get option hover
-            const option_hover = this.get_option_hover(option_context.command_name, word);
-            if (option_hover) {
-                return { contents: option_hover, range };
-            }
-            // Don't fall through to command lookup
-            return null;
-        }
-
         // Check for block delimiter hover (works in any context)
         const delimiter_hover = this.get_block_delimiter_hover(word, my_context, document, position);
         if (delimiter_hover) {
@@ -1363,96 +1351,6 @@ export class HoverProvider {
             }
         }
 
-        return null;
-    }
-
-    /**
-     * Check if a position is in option context (after a comma).
-     */
-    private is_in_option_context(
-        document: DocumentState,
-        position: Position
-    ): { in_option_context: boolean; command_name: string | null } {
-        const line = get_line_text(document, position.line);
-        if (line === '') {
-            return { in_option_context: false, command_name: null };
-        }
-        const text_before_cursor = line.substring(0, position.character);
-
-        // Find last comma not inside quotes or parentheses
-        let last_comma_pos = -1;
-        let in_quotes = false;
-        let paren_depth = 0;
-        let quote_char = '';
-
-        for (let i = 0; i < text_before_cursor.length; i++) {
-            const char = text_before_cursor[i];
-
-            if (!in_quotes) {
-                if (char === '"' || char === "'") {
-                    in_quotes = true;
-                    quote_char = char;
-                } else if (char === '(') {
-                    paren_depth++;
-                } else if (char === ')') {
-                    paren_depth--;
-                } else if (char === ',' && paren_depth === 0) {
-                    last_comma_pos = i;
-                }
-            } else {
-                if (char === quote_char) {
-                    in_quotes = false;
-                    quote_char = '';
-                }
-            }
-        }
-
-        if (last_comma_pos >= 0) {
-            const text_before_comma = text_before_cursor.substring(0, last_comma_pos);
-            const command_name = this.extract_command_name(text_before_comma);
-            return { in_option_context: true, command_name };
-        }
-
-        return { in_option_context: false, command_name: null };
-    }
-
-    /**
-     * Extract command name from text, handling prefixes and abbreviations.
-     */
-    private extract_command_name(text: string): string | null {
-        const trimmed = text.trim();
-        if (!trimmed) return null;
-
-        // Split into tokens
-        const tokens = trimmed.split(/\s+/);
-        if (tokens.length === 0) return null;
-
-        // Handle prefix commands
-        const prefixes = ['by', 'bysort', 'quietly', 'capture', 'noisily', 'qui', 'cap', 'noi'];
-        let command_index = 0;
-
-        // Skip prefix commands
-        while (command_index < tokens.length && prefixes.includes(tokens[command_index].toLowerCase())) {
-            command_index++;
-        }
-
-        if (command_index >= tokens.length) return null;
-
-        let command_name = tokens[command_index];
-
-        // Handle colon syntax (e.g., "merge 1:m" -> "merge")
-        if (command_name.includes(':')) {
-            command_name = command_name.split(':')[0];
-        }
-
-        return command_name;
-    }
-
-    /**
-     * Get hover information for an option.
-     */
-    private get_option_hover(command_name: string | null, option_name: string): MarkupContent | null {
-        // Don't show hover for options
         return null;
     }
 

--- a/tests/integration/lsp-lifecycle.test.ts
+++ b/tests/integration/lsp-lifecycle.test.ts
@@ -18,6 +18,8 @@ import {
 } from '../../src/server-handlers';
 import { InitializeParams, TextDocumentSyncKind } from 'vscode-languageserver/node';
 import { DocumentStore } from '../../src/document-store';
+import { HoverProvider } from '../../src/providers/hover';
+import { CommandDatabase } from '../../src/commands';
 
 /**
  * Creates mock dependencies for testing handlers.
@@ -318,6 +320,32 @@ describe('LSP Lifecycle - Handler Factories', () => {
             });
 
             expect(result).toBeNull();
+        });
+
+        it('should resolve expression-function hover after top-level comma', async () => {
+            const deps = create_mock_dependencies();
+            deps.hover_provider = new HoverProvider(new CommandDatabase());
+
+            const uri = 'file:///hover-after-top-level-comma.do';
+            const content = 'regress y x, vce(mi(bar))';
+            await deps.document_store.open(uri, content, 1);
+
+            const handler = create_hover_handler(deps);
+            const result = await handler({
+                textDocument: { uri },
+                position: { line: 0, character: 17 },
+            });
+
+            expect(result).not.toBeNull();
+            expect(result?.contents).toBeDefined();
+            if (
+                result?.contents
+                && typeof result.contents === 'object'
+                && 'value' in result.contents
+            ) {
+                expect(result.contents.value).toContain('**missing**');
+                expect(result.contents.value).toContain('help missing()');
+            }
         });
     });
 

--- a/tests/property/hover-command-expression-position.prop.test.ts
+++ b/tests/property/hover-command-expression-position.prop.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Property tests for hover disambiguation between command and expression
+ * position.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import * as fc from 'fast-check';
+import { HoverProvider } from '../../src/providers/hover';
+import { CommandDatabase } from '../../src/commands';
+import type { CommandCache } from '../../src/command-database/types';
+import { DocumentState } from '../../src/document-store';
+import { StataLexer } from '../../src/lexer';
+import { SymbolTable } from '../../src/types';
+import { compute_line_offsets } from '../../src/utils/line-utils';
+import { arbitrary_non_reserved_identifier } from './generators';
+
+function create_document(content: string): DocumentState {
+    const lexer = new StataLexer();
+    const lex_result = lexer.tokenize(content);
+
+    return {
+        uri: 'file:///hover-position.do',
+        version: 1,
+        content,
+        tokens: lex_result.tokens,
+        ast: null,
+        symbols: {
+            programs: new Map(),
+            localMacros: new Map(),
+            globalMacros: new Map(),
+            variables: new Map(),
+            scalars: new Map(),
+            matrices: new Map(),
+        } as SymbolTable,
+        diagnostics: [],
+        line_offsets: compute_line_offsets(content),
+    } as DocumentState;
+}
+
+const AMBIGUOUS_FUNCTION_CASES = [
+    { alias: 'mi', target: 'missing' },
+    { alias: 'missing', target: 'missing' },
+    { alias: 'sum', target: 'sum' },
+    { alias: 'byte', target: 'byte' },
+    { alias: 'double', target: 'double' },
+    { alias: 'exp', target: 'exp' },
+    { alias: 'float', target: 'float' },
+    { alias: 'int', target: 'int' },
+    { alias: 'long', target: 'long' },
+    { alias: 'log', target: 'log' },
+    { alias: 'max', target: 'max' },
+    { alias: 'min', target: 'min' },
+    { alias: 'mod', target: 'mod' },
+    { alias: 'string', target: 'string' },
+    { alias: 'lower', target: 'lower' },
+    { alias: 'upper', target: 'upper' },
+    { alias: 'proper', target: 'proper' },
+    { alias: 'date', target: 'date' },
+    { alias: 'daily', target: 'daily' },
+    { alias: 'weekly', target: 'weekly' },
+    { alias: 'monthly', target: 'monthly' },
+    { alias: 'quarterly', target: 'quarterly' },
+    { alias: 'halfyearly', target: 'halfyearly' },
+    { alias: 'yearly', target: 'yearly' },
+    { alias: 'normal', target: 'normal' },
+    { alias: 'poisson', target: 'poisson' },
+    { alias: 'recode', target: 'recode' },
+    { alias: 'trunc', target: 'trunc' },
+] as const;
+
+function create_command(name: string, option_name: string) {
+    return {
+        name,
+        min_abbreviation: name.length,
+        options: [
+            {
+                name: option_name,
+                min_abbreviation: Math.min(3, option_name.length),
+                has_argument: false,
+            },
+        ],
+        priority: 3 as const,
+    };
+}
+
+function create_ambiguous_command_db(): CommandDatabase {
+    const db = new CommandDatabase();
+    const cache: CommandCache = {
+        version: 18,
+        commands: {
+            mi: {
+                name: 'mi',
+                min_abbreviation: 2,
+                options: [
+                    {
+                        name: 'offset',
+                        min_abbreviation: 3,
+                        has_argument: true,
+                    },
+                    {
+                        name: 'augment',
+                        min_abbreviation: 3,
+                        has_argument: false,
+                    },
+                    {
+                        name: 'conditional',
+                        min_abbreviation: 4,
+                        has_argument: true,
+                    },
+                    {
+                        name: 'bootstrap',
+                        min_abbreviation: 4,
+                        has_argument: false,
+                    },
+                ],
+                priority: 3,
+            },
+            byte: create_command('byte', 'format'),
+            double: create_command('double', 'precision'),
+            missing: create_command('missing', 'within'),
+            sum: create_command('sum', 'detail'),
+            exp: create_command('exp', 'replace'),
+            float: create_command('float', 'storage'),
+            interval: create_command('interval', 'step'),
+            long: create_command('long', 'display'),
+            log: create_command('log', 'append'),
+            max: create_command('max', 'iterate'),
+            min: create_command('min', 'trace'),
+            models: create_command('models', 'all'),
+            string: create_command('string', 'format'),
+            lower: create_command('lower', 'casewise'),
+            upper: create_command('upper', 'uppercase'),
+            proper: create_command('proper', 'locale'),
+            date: create_command('date', 'mask'),
+            daily: create_command('daily', 'clock'),
+            weekly: create_command('weekly', 'week'),
+            monthly: create_command('monthly', 'month'),
+            quarterly: create_command('quarterly', 'quarter'),
+            halfyearly: create_command('halfyearly', 'half'),
+            yearly: create_command('yearly', 'year'),
+            normal: create_command('normal', 'standard'),
+            poisson: create_command('poisson', 'mean'),
+            recode: create_command('recode', 'generate'),
+            truncate: create_command('truncate', 'limit'),
+        },
+        abbreviations: {
+            int: 'interval',
+            miss: 'missing',
+            missi: 'missing',
+            missin: 'missing',
+            mod: 'models',
+            trunc: 'truncate',
+        },
+    };
+    db.load_cache(cache);
+    return db;
+}
+
+function hover_value(hover: Awaited<ReturnType<HoverProvider['get_hover']>>): string {
+    if (!hover || typeof hover.contents !== 'object' || !('value' in hover.contents)) {
+        throw new Error('Expected markdown hover contents');
+    }
+    return hover.contents.value;
+}
+
+function index_inside_word(content: string, word: string): number {
+    const start = content.indexOf(word);
+    if (start < 0) {
+        throw new Error(`Could not find ${word} in ${content}`);
+    }
+    return start + Math.floor(word.length / 2);
+}
+
+function command_hover_name(command_name: string): string {
+    if (command_name === 'int') {
+        return 'interval';
+    }
+    if (command_name === 'mod') {
+        return 'models';
+    }
+    if (command_name === 'trunc') {
+        return 'truncate';
+    }
+    return command_name;
+}
+
+describe('Hover Command vs Expression Position Property Tests', () => {
+    const command_db = create_ambiguous_command_db();
+    const hover_provider = new HoverProvider(command_db);
+
+    const identifier = arbitrary_non_reserved_identifier();
+    const function_case = fc.constantFrom(...AMBIGUOUS_FUNCTION_CASES);
+    const optional_space = fc.constantFrom('', ' ', '  ');
+
+    it('resolves ambiguous expression function calls to function hover', () => {
+        fc.assert(
+            fc.asyncProperty(
+                function_case,
+                optional_space,
+                identifier,
+                fc.constantFrom(
+                    (fn: string, space: string, arg: string) =>
+                        `replace foo = . if ${fn}${space}(${arg})`,
+                    (fn: string, space: string, arg: string) =>
+                        `generate flag = ${fn}${space}(${arg})`,
+                    (fn: string, space: string, arg: string) =>
+                        `display ${fn}${space}(${arg})`
+                ),
+                async (my_case, space, arg, template) => {
+                    const content = template(my_case.alias, space, arg);
+                    const document = create_document(content);
+                    const hover = await hover_provider.get_hover(
+                        document,
+                        {
+                            line: 0,
+                            character: index_inside_word(
+                                content,
+                                my_case.alias
+                            ),
+                        }
+                    );
+                    const value = hover_value(hover);
+
+                    expect(value).toContain('**Function:**');
+                    expect(value).toContain(`**${my_case.target}**()`);
+                    expect(value).not.toContain('**Options:**');
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    it('keeps ambiguous names in command position on command hover', () => {
+        fc.assert(
+            fc.asyncProperty(
+                fc.constantFrom('', 'quietly ', 'capture ', 'by id: '),
+                fc.constantFrom(
+                    ...AMBIGUOUS_FUNCTION_CASES.map(my_case => my_case.alias)
+                ),
+                identifier,
+                async (prefix, command_name, variable_name) => {
+                    const content = `${prefix}${command_name} ${variable_name}`;
+                    const document = create_document(content);
+                    const hover = await hover_provider.get_hover(
+                        document,
+                        {
+                            line: 0,
+                            character: index_inside_word(content, command_name),
+                        }
+                    );
+                    const value = hover_value(hover);
+
+                    expect(value).toContain(
+                        `**${command_hover_name(command_name)}**`
+                    );
+                    expect(value).toContain('**Options:**');
+                    expect(value).not.toContain('**Function:**');
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+});

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -166,6 +166,30 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             }
         });
 
+        it('should provide macro hover inside an option argument', async () => {
+            const my_content = "regress y x, cluster(`mymacro')";
+            const my_doc = create_test_document(my_content, {
+                localMacros: new Map([
+                    ['mymacro', {
+                        name: 'mymacro',
+                        sourceUri: 'file:///test.do',
+                        value: 'id',
+                        type: 'local',
+                    }],
+                ]),
+            });
+            init_tracker_from_source(context_tracker, my_content);
+
+            // cursor is on "mymacro" at column 23
+            const my_hover = await hover_provider.get_hover(my_doc, { line: 0, character: 23 });
+
+            expect(my_hover).not.toBeNull();
+            expect(my_hover?.contents).toBeDefined();
+            if (typeof my_hover?.contents === 'object' && 'value' in my_hover.contents) {
+                expect(my_hover.contents.value).toContain('Local Macro');
+            }
+        });
+
         it(
             'should resolve mi() expression hover to missing, not the mi prefix command',
             async () => {

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -117,6 +117,28 @@ function create_mi_missing_command_db(): CommandDatabase {
     return db;
 }
 
+function create_frame_command_db(): CommandDatabase {
+    const db = new CommandDatabase();
+    const cache: CommandCache = {
+        version: 18,
+        commands: {
+            frame: {
+                name: 'frame',
+                min_abbreviation: 5,
+                options: [],
+                subcommands: [
+                    { name: 'create', min_abbreviation: 6 },
+                    { name: 'drop', min_abbreviation: 4 },
+                ],
+                priority: 3,
+            },
+        },
+        abbreviations: {},
+    };
+    db.load_cache(cache);
+    return db;
+}
+
 describe('HoverProvider - Context-Aware Behavior', () => {
     let hover_provider: HoverProvider;
     let context_tracker: ContextTracker;
@@ -163,6 +185,39 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             expect(my_hover?.contents).toBeDefined();
             if (typeof my_hover?.contents === 'object' && 'value' in my_hover.contents) {
                 expect(my_hover.contents.value).toContain('Local Macro');
+            }
+        });
+
+        it('should return subcommand hover for valid lowercase `by` prefix', async () => {
+            command_db = create_frame_command_db();
+            hover_provider = new HoverProvider(command_db, context_tracker);
+
+            const my_content = 'by x: frame create mygood';
+            const my_doc = create_test_document(my_content);
+            init_tracker_from_source(context_tracker, my_content);
+
+            // cursor is on "create" at column 15
+            const my_hover = await hover_provider.get_hover(my_doc, { line: 0, character: 15 });
+
+            expect(my_hover).not.toBeNull();
+            if (typeof my_hover?.contents === 'object' && 'value' in my_hover.contents) {
+                expect(my_hover.contents.value).toContain('Frame Subcommand');
+            }
+        });
+
+        it('should not treat uppercase `BY` as a prefix command (Stata is case-sensitive)', async () => {
+            command_db = create_frame_command_db();
+            hover_provider = new HoverProvider(command_db, context_tracker);
+
+            const my_content = 'BY x: frame create mygood';
+            const my_doc = create_test_document(my_content);
+            init_tracker_from_source(context_tracker, my_content);
+
+            // cursor is on "create" at column 15
+            const my_hover = await hover_provider.get_hover(my_doc, { line: 0, character: 15 });
+
+            if (my_hover && typeof my_hover.contents === 'object' && 'value' in my_hover.contents) {
+                expect(my_hover.contents.value).not.toContain('Frame Subcommand');
             }
         });
 

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -219,6 +219,51 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             expect(my_hover).toBeNull();
         });
 
+        it(
+            'should not treat uppercase `FRAME` as a prefix command with subcommands '
+            + '(Stata is case-sensitive)',
+            async () => {
+                command_db = create_frame_command_db();
+                hover_provider = new HoverProvider(command_db, context_tracker);
+
+                const my_content = 'FRAME create mygood';
+                const my_doc = create_test_document(my_content);
+                init_tracker_from_source(context_tracker, my_content);
+
+                // cursor is on "create" at column 8
+                const my_hover = await hover_provider.get_hover(my_doc, { line: 0, character: 8 });
+
+                expect(my_hover).toBeNull();
+            }
+        );
+
+        it(
+            'should not treat mis-cased `FRAME` as a prefix command in the line fallback',
+            () => {
+                command_db = create_frame_command_db();
+                hover_provider = new HoverProvider(command_db, context_tracker);
+
+                const my_content = 'FRAME create mygood';
+                const my_doc = {
+                    uri: 'file:///test.do',
+                    version: 1,
+                    content: my_content,
+                    tokens: [],
+                } as unknown as DocumentState;
+
+                const my_result = (hover_provider as any).get_subcommand_context_from_line(
+                    my_doc,
+                    { line: 0, character: 8 } as Position,
+                    'create'
+                );
+
+                expect(my_result).toEqual({
+                    is_subcommand: false,
+                    prefix_command: null,
+                });
+            }
+        );
+
         it('should not treat non-by colons as by-prefix syntax in line fallback', () => {
             command_db = create_frame_command_db();
             hover_provider = new HoverProvider(command_db, context_tracker);

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -221,6 +221,44 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             }
         });
 
+        it('should not show command hover for an option name after a top-level comma', async () => {
+            // `replace` is a Stata command and also a merge option. In option
+            // position the command hover would mislead the user.
+            const my_db = new CommandDatabase();
+            my_db.load_cache({
+                version: 18,
+                commands: {
+                    merge: {
+                        name: 'merge',
+                        min_abbreviation: 5,
+                        options: [
+                            { name: 'replace', min_abbreviation: 3, has_argument: false },
+                        ],
+                        priority: 3,
+                    },
+                    replace: {
+                        name: 'replace',
+                        min_abbreviation: 3,
+                        options: [],
+                        priority: 3,
+                    },
+                },
+                abbreviations: {},
+            });
+            const my_provider = new HoverProvider(my_db, context_tracker);
+
+            const my_content = 'merge 1:1 id using foo, replace';
+            const my_doc = create_test_document(my_content);
+            init_tracker_from_source(context_tracker, my_content);
+
+            // cursor inside "replace" (starts at column 24)
+            const my_hover = await my_provider.get_hover(my_doc, { line: 0, character: 26 });
+
+            if (my_hover && typeof my_hover.contents === 'object' && 'value' in my_hover.contents) {
+                expect(my_hover.contents.value).not.toContain('help replace');
+            }
+        });
+
         it('should provide macro hover inside an option argument', async () => {
             const my_content = "regress y x, cluster(`mymacro')";
             const my_doc = create_test_document(my_content, {

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -205,7 +205,7 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             }
         });
 
-        it('should not treat uppercase `BY` as a prefix command (Stata is case-sensitive)', async () => {
+        it('should not return subcommand hover for uppercase `BY` prefix (Stata is case-sensitive)', async () => {
             command_db = create_frame_command_db();
             hover_provider = new HoverProvider(command_db, context_tracker);
 
@@ -220,7 +220,7 @@ describe('HoverProvider - Context-Aware Behavior', () => {
         });
 
         it(
-            'should not treat uppercase `FRAME` as a prefix command with subcommands '
+            'should not return subcommand hover for uppercase `FRAME` prefix '
             + '(Stata is case-sensitive)',
             async () => {
                 command_db = create_frame_command_db();
@@ -238,7 +238,25 @@ describe('HoverProvider - Context-Aware Behavior', () => {
         );
 
         it(
-            'should not treat mis-cased `FRAME` as a prefix command in the line fallback',
+            'should not return subcommand hover for mixed-case `Frame` prefix '
+            + '(Stata is case-sensitive)',
+            async () => {
+                command_db = create_frame_command_db();
+                hover_provider = new HoverProvider(command_db, context_tracker);
+
+                const my_content = 'Frame create mygood';
+                const my_doc = create_test_document(my_content);
+                init_tracker_from_source(context_tracker, my_content);
+
+                // cursor is on "create" at column 8
+                const my_hover = await hover_provider.get_hover(my_doc, { line: 0, character: 8 });
+
+                expect(my_hover).toBeNull();
+            }
+        );
+
+        it(
+            'should not detect line-fallback subcommand context for uppercase `FRAME` prefix',
             () => {
                 command_db = create_frame_command_db();
                 hover_provider = new HoverProvider(command_db, context_tracker);

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -7,6 +7,7 @@ import { init_tracker_from_source } from '../test-context-helper';
 import { Position } from 'vscode-languageserver';
 import { HoverProvider } from '../../src/providers/hover';
 import { CommandDatabase } from '../../src/commands';
+import type { CommandCache } from '../../src/command-database/types';
 import { DocumentState } from '../../src/document-store';
 import { SymbolTable, MacroSymbol, ProgramSymbol, VariableSymbol } from '../../src/types';
 import { ContextTracker } from '../../src/context-tracker';
@@ -61,6 +62,61 @@ function create_test_command_db(): CommandDatabase {
     return db;
 }
 
+function create_mi_missing_command_db(): CommandDatabase {
+    const db = new CommandDatabase();
+    const cache: CommandCache = {
+        version: 18,
+        commands: {
+            mi: {
+                name: 'mi',
+                min_abbreviation: 2,
+                options: [
+                    {
+                        name: 'offset',
+                        min_abbreviation: 3,
+                        has_argument: true,
+                    },
+                    {
+                        name: 'augment',
+                        min_abbreviation: 3,
+                        has_argument: false,
+                    },
+                    {
+                        name: 'conditional',
+                        min_abbreviation: 4,
+                        has_argument: true,
+                    },
+                    {
+                        name: 'bootstrap',
+                        min_abbreviation: 4,
+                        has_argument: false,
+                    },
+                ],
+                priority: 3,
+            },
+            missing: {
+                name: 'missing',
+                min_abbreviation: 4,
+                options: [
+                    {
+                        name: 'within',
+                        min_abbreviation: 6,
+                        has_argument: true,
+                    },
+                ],
+                priority: 3,
+            },
+        },
+        abbreviations: {
+            miss: 'missing',
+            missi: 'missing',
+            missin: 'missing',
+        },
+    };
+    db.load_cache(cache);
+    return db;
+}
+
 describe('HoverProvider - Context-Aware Behavior', () => {
     let hover_provider: HoverProvider;
     let context_tracker: ContextTracker;
@@ -109,6 +165,37 @@ describe('HoverProvider - Context-Aware Behavior', () => {
                 expect(my_hover.contents.value).toContain('Local Macro');
             }
         });
+
+        it(
+            'should resolve mi() expression hover to missing, not the mi prefix command',
+            async () => {
+                command_db = create_mi_missing_command_db();
+                hover_provider = new HoverProvider(command_db, context_tracker);
+
+                const my_content = 'replace foo = . if mi(bar)';
+                const my_doc = create_test_document(my_content);
+                init_tracker_from_source(context_tracker, my_content);
+
+                const my_hover = await hover_provider.get_hover(
+                    my_doc,
+                    { line: 0, character: 20 }
+                );
+
+                expect(my_hover).not.toBeNull();
+                expect(my_hover?.contents).toBeDefined();
+                if (
+                    typeof my_hover?.contents === 'object'
+                    && 'value' in my_hover.contents
+                ) {
+                    expect(my_hover.contents.value).toContain('**missing**');
+                    expect(my_hover.contents.value).not.toContain('offset');
+                    expect(my_hover.contents.value).not.toContain('augment');
+                    expect(my_hover.contents.value)
+                        .not.toContain('conditional');
+                    expect(my_hover.contents.value).not.toContain('bootstrap');
+                }
+            }
+        );
     });
 
     describe('Comment Context Hover', () => {

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -216,9 +216,7 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             // cursor is on "create" at column 15
             const my_hover = await hover_provider.get_hover(my_doc, { line: 0, character: 15 });
 
-            if (my_hover && typeof my_hover.contents === 'object' && 'value' in my_hover.contents) {
-                expect(my_hover.contents.value).not.toContain('Frame Subcommand');
-            }
+            expect(my_hover).toBeNull();
         });
 
         it('should not treat non-by colons as by-prefix syntax in line fallback', () => {
@@ -278,8 +276,36 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             // cursor inside "replace" (starts at column 24)
             const my_hover = await my_provider.get_hover(my_doc, { line: 0, character: 26 });
 
-            if (my_hover && typeof my_hover.contents === 'object' && 'value' in my_hover.contents) {
-                expect(my_hover.contents.value).not.toContain('help replace');
+            expect(my_hover).toBeNull();
+        });
+
+        it('should not treat commas inside brackets as top-level commas', () => {
+            const my_doc = create_test_document('matrix x = y[1, 2] replace');
+
+            const my_result = (hover_provider as any).is_after_top_level_comma(
+                my_doc,
+                { line: 0, character: 18 } as Position
+            );
+
+            expect(my_result).toBe(false);
+        });
+
+        it('should provide expression-function hover for mod even without cache metadata', async () => {
+            hover_provider = new HoverProvider(create_test_command_db(), context_tracker);
+
+            const my_content = 'generate x = mod(y, 2)';
+            const my_doc = create_test_document(my_content);
+            init_tracker_from_source(context_tracker, my_content);
+
+            const my_hover = await hover_provider.get_hover(
+                my_doc,
+                { line: 0, character: 13 }
+            );
+
+            expect(my_hover).not.toBeNull();
+            expect(my_hover?.contents).toBeDefined();
+            if (typeof my_hover?.contents === 'object' && 'value' in my_hover.contents) {
+                expect(my_hover.contents.value).toContain('**Function:** **mod**()');
             }
         });
 

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -426,6 +426,32 @@ describe('HoverProvider - Context-Aware Behavior', () => {
                 }
             }
         );
+
+        it(
+            'should resolve mi() to missing even after a top-level comma',
+            async () => {
+                command_db = create_mi_missing_command_db();
+                hover_provider = new HoverProvider(command_db, context_tracker);
+
+                const my_content = 'regress y x, vce(mi(bar))';
+                const my_doc = create_test_document(my_content);
+                init_tracker_from_source(context_tracker, my_content);
+
+                const my_hover = await hover_provider.get_hover(
+                    my_doc,
+                    { line: 0, character: 17 }
+                );
+
+                expect(my_hover).not.toBeNull();
+                expect(my_hover?.contents).toBeDefined();
+                if (
+                    typeof my_hover?.contents === 'object'
+                    && 'value' in my_hover.contents
+                ) {
+                    expect(my_hover.contents.value).toContain('**missing**');
+                }
+            }
+        );
     });
 
     describe('Comment Context Hover', () => {

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -221,6 +221,30 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             }
         });
 
+        it('should not treat non-by colons as by-prefix syntax in line fallback', () => {
+            command_db = create_frame_command_db();
+            hover_provider = new HoverProvider(command_db, context_tracker);
+
+            const my_content = 'merge 1:m frame create mygood';
+            const my_doc = {
+                uri: 'file:///test.do',
+                version: 1,
+                content: my_content,
+                tokens: [],
+            } as unknown as DocumentState;
+
+            const my_result = (hover_provider as any).get_subcommand_context_from_line(
+                my_doc,
+                { line: 0, character: 16 } as Position,
+                'create'
+            );
+
+            expect(my_result).toEqual({
+                is_subcommand: false,
+                prefix_command: null,
+            });
+        });
+
         it('should not show command hover for an option name after a top-level comma', async () => {
             // `replace` is a Stata command and also a merge option. In option
             // position the command hover would mislead the user.


### PR DESCRIPTION
## Summary
- Prefer expression-function hover when a hovered name is followed by `(`, so `mi(bar)` now resolves to `missing` instead of showing `mi` prefix options
- Tighten option-position handling so top-level comma arguments do not fall through to command or function hover
- Add focused unit and property coverage for ambiguous command/function names and option-argument cases

## Testing
- Added regression coverage in unit hover tests for `mi(bar)`
- Added property-based tests for ambiguous names in both expression and command positions
- Typecheck and hover-focused tests passed locally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expression-function hover cards that show function labels and resolved names, including abbreviation info.

* **Bug Fixes**
  * Improved case-sensitive command/prefix matching and tightened subcommand detection.
  * Suppressed command hover in option-argument positions to avoid incorrect hover content.

* **Documentation**
  * Clarified case-handling guidance for matching rules.

* **Tests**
  * Added extensive property and unit tests covering hover disambiguation and context-sensitive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->