### PR TITLE
perf(hover): use binary search to locate tokens at cursor

### DIFF
--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -46,6 +46,10 @@ import type { WorkspaceIndexer } from '../indexer';
 import { build_scope_resolver_config } from '../scope-resolver';
 import { get_visible_symbols_at } from '../scope-resolver';
 import { get_line_text } from '../utils/line-utils';
+import {
+    find_last_token_starting_before,
+    find_token_index_at_position,
+} from '../utils/token-utils';
 import { is_cursor_in_comment } from '../utils/comment-utils';
 import { is_cursor_in_string_literal } from '../utils/string-literal-utils';
 
@@ -310,6 +314,11 @@ export class HoverProvider {
      * True when the cursor is past a top-level comma in the current statement,
      * i.e. in option-argument position. Uses the token stream so commas inside
      * strings, macro references, and nested parentheses are ignored correctly.
+     *
+     * Complexity: O(log N + K) where N is the token count and K is the
+     * number of tokens in the current statement. Binary-searches the cursor
+     * location, scans backwards to the statement start, then forward-scans
+     * that window to preserve the original depth-tracking semantics.
      */
     private is_after_top_level_comma(
         document: DocumentState,
@@ -320,25 +329,33 @@ export class HoverProvider {
             return false;
         }
 
-        let paren_depth = 0;
-        let bracket_depth = 0;
-        let saw_top_level_comma = false;
+        // Locate the last token that starts strictly before the cursor.
+        // Tokens starting at the cursor itself don't contribute, matching
+        // the pre-optimization behavior.
+        const end_index = find_last_token_starting_before(tokens, position);
+        if (end_index < 0) {
+            return false;
+        }
 
-        for (const token of tokens) {
-            const at_or_past_cursor =
-                token.range.start.line > position.line ||
-                (token.range.start.line === position.line &&
-                 token.range.start.character >= position.character);
-            if (at_or_past_cursor) {
+        // Walk backwards to find the start of the current statement. If
+        // no STATEMENT_TERMINATOR is found, the statement starts at the
+        // beginning of the file.
+        let statement_start_index = 0;
+        for (let i = end_index; i >= 0; i--) {
+            if (tokens[i].type === 'STATEMENT_TERMINATOR') {
+                statement_start_index = i + 1;
                 break;
             }
+        }
 
-            if (token.type === 'STATEMENT_TERMINATOR') {
-                paren_depth = 0;
-                bracket_depth = 0;
-                saw_top_level_comma = false;
-                continue;
-            }
+        // Forward scan the statement window, matching the original
+        // depth-tracking semantics. A comma counts as top-level whenever
+        // the forward-scan paren/bracket depths are both zero when it is
+        // encountered, regardless of the cursor's depth.
+        let paren_depth = 0;
+        let bracket_depth = 0;
+        for (let i = statement_start_index; i <= end_index; i++) {
+            const token = tokens[i];
             if (token.type === 'LPAREN') {
                 paren_depth++;
             } else if (token.type === 'RPAREN') {
@@ -352,11 +369,11 @@ export class HoverProvider {
                 && paren_depth === 0
                 && bracket_depth === 0
             ) {
-                saw_top_level_comma = true;
+                return true;
             }
         }
 
-        return saw_top_level_comma;
+        return false;
     }
 
     /**
@@ -1179,6 +1196,11 @@ export class HoverProvider {
     /**
      * Token-based subcommand context detection.
      * Finds the hovered token and checks if the previous non-trivia token is a prefix command.
+     *
+     * Complexity: O(log N + S) where N is the token count and S is the
+     * number of tokens in the current statement. Binary-searches the
+     * hovered token and scans backwards only as far as the most recent
+     * STATEMENT_TERMINATOR.
      */
     private get_subcommand_context_from_tokens(
         document: DocumentState,
@@ -1189,26 +1211,23 @@ export class HoverProvider {
         is_subcommand: boolean;
         prefix_command: string | null;
     } {
+        if (cancellation_token?.isCancellationRequested) {
+            return { is_subcommand: false, prefix_command: null };
+        }
         const tokens = document.tokens!;
         const STANDARD_PREFIXES = ['by', 'bysort', 'quietly', 'capture', 'noisily', 'qui', 'cap', 'noi'];
         const TRIVIA_TYPES = ['WHITESPACE', 'COMMENT_LINE', 'COMMENT_BLOCK', 'CONTINUATION'];
 
-        // Find the token at the hovered position
-        let hovered_token_index = -1;
-        for (let i = 0; i < tokens.length; i++) {
-            if (i % 500 === 0 && cancellation_token?.isCancellationRequested) {
-                return { is_subcommand: false, prefix_command: null };
-            }
-            const token = tokens[i];
-            if (token.range.start.line === position.line &&
-                token.range.start.character <= position.character &&
-                token.range.end.character >= position.character &&
-                token.type === 'WORD' &&
-                token.value === hovered_word) {
-                hovered_token_index = i;
-                break;
-            }
-        }
+        // Find the WORD token whose value matches `hovered_word` at the
+        // cursor position via binary search. The usual candidate is the
+        // token whose range contains the cursor; at a trailing boundary
+        // (cursor immediately after the word), the matching token is the
+        // preceding one, so we fall back to check it.
+        const hovered_token_index = this.find_hovered_word_token_index(
+            tokens,
+            position,
+            hovered_word
+        );
 
         if (hovered_token_index === -1) {
             return { is_subcommand: false, prefix_command: null };
@@ -1307,6 +1326,46 @@ export class HoverProvider {
         }
 
         return { is_subcommand: true, prefix_command: potential_prefix };
+    }
+
+    /**
+     * Locate the WORD token at the cursor that matches `hovered_word`.
+     *
+     * Uses `find_token_index_at_position` (LSP [start, end) semantics) and
+     * falls back to the preceding token when the cursor sits exactly at
+     * the end boundary of a word (e.g. just after the final character).
+     * This mirrors the inclusive-end check the linear scan performed.
+     */
+    private find_hovered_word_token_index(
+        tokens: Token[],
+        position: Position,
+        hovered_word: string
+    ): number {
+        const is_match = (token: Token): boolean =>
+            token.type === 'WORD'
+            && token.value === hovered_word
+            && token.range.start.line === position.line;
+
+        const covering = find_token_index_at_position(tokens, position);
+        if (covering !== -1 && is_match(tokens[covering])) {
+            return covering;
+        }
+
+        // Cursor may be at the trailing boundary of the word, where the
+        // covering token under LSP [start, end) semantics is the next
+        // token (e.g. whitespace). Check the immediately preceding token
+        // with inclusive-end semantics.
+        const prev_index = find_last_token_starting_before(tokens, position);
+        if (
+            prev_index !== -1
+            && prev_index !== covering
+            && is_match(tokens[prev_index])
+            && tokens[prev_index].range.end.character >= position.character
+        ) {
+            return prev_index;
+        }
+
+        return -1;
     }
 
     /**

--- a/src/utils/token-utils.ts
+++ b/src/utils/token-utils.ts
@@ -1,0 +1,112 @@
+import { Position } from 'vscode-languageserver';
+import { Token } from '../types';
+
+/**
+ * Binary-search utilities for the `document.tokens` array.
+ *
+ * The lexer emits tokens in document order, so `tokens[i].range.start`
+ * is monotonically non-decreasing. That lets us locate a token for a
+ * given cursor position in O(log N) instead of scanning the whole
+ * array. Hover, completion, and related providers fire per keystroke
+ * on large files, so these helpers keep the hot path insulated from
+ * file size.
+ */
+
+/**
+ * Return true iff `a` is strictly before `b` in document order.
+ */
+function position_before(a: Position, b: Position): boolean {
+    return (
+        a.line < b.line ||
+        (a.line === b.line && a.character < b.character)
+    );
+}
+
+/**
+ * Return true iff `a` is at-or-before `b` in document order.
+ */
+function position_at_or_before(a: Position, b: Position): boolean {
+    return (
+        a.line < b.line ||
+        (a.line === b.line && a.character <= b.character)
+    );
+}
+
+/**
+ * Binary search for the last token whose start position is at or before the
+ * given position. Returns -1 when no token starts at or before the position
+ * (i.e. the array is empty or the first token starts strictly after it).
+ *
+ * Tokens are assumed to be sorted by start position in document order.
+ */
+export function find_last_token_starting_at_or_before(
+    tokens: Token[],
+    position: Position
+): number {
+    let low = 0;
+    let high = tokens.length - 1;
+    let best = -1;
+    while (low <= high) {
+        const mid = (low + high) >>> 1;
+        const start = tokens[mid].range.start;
+        if (position_at_or_before(start, position)) {
+            best = mid;
+            low = mid + 1;
+        } else {
+            high = mid - 1;
+        }
+    }
+    return best;
+}
+
+/**
+ * Binary search for the last token whose start position is strictly before
+ * the given position. Returns -1 when no such token exists.
+ *
+ * This matches the "tokens preceding the cursor" semantics used by the
+ * hover provider's top-level-comma detection, where a token starting
+ * exactly at the cursor is considered "at the cursor", not "before".
+ */
+export function find_last_token_starting_before(
+    tokens: Token[],
+    position: Position
+): number {
+    let low = 0;
+    let high = tokens.length - 1;
+    let best = -1;
+    while (low <= high) {
+        const mid = (low + high) >>> 1;
+        const start = tokens[mid].range.start;
+        if (position_before(start, position)) {
+            best = mid;
+            low = mid + 1;
+        } else {
+            high = mid - 1;
+        }
+    }
+    return best;
+}
+
+/**
+ * Binary search for the token whose range contains the given position.
+ * Uses LSP `[start, end)` semantics: the start position is inclusive and
+ * the end position is exclusive. Returns -1 when no token covers the
+ * position (e.g. the cursor is in trailing whitespace).
+ *
+ * Tokens are assumed to be sorted by start position in document order
+ * and non-overlapping.
+ */
+export function find_token_index_at_position(
+    tokens: Token[],
+    position: Position
+): number {
+    const candidate = find_last_token_starting_at_or_before(tokens, position);
+    if (candidate === -1) {
+        return -1;
+    }
+    const end = tokens[candidate].range.end;
+    if (position_before(position, end)) {
+        return candidate;
+    }
+    return -1;
+}

--- a/tests/unit/utils/token-utils.test.ts
+++ b/tests/unit/utils/token-utils.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for token-utils binary search helpers.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { Token } from '../../../src/types';
+import {
+    find_last_token_starting_at_or_before,
+    find_last_token_starting_before,
+    find_token_index_at_position,
+} from '../../../src/utils/token-utils';
+
+/**
+ * Helper to build a simple single-line token list from (value, type) pairs,
+ * laying tokens out consecutively with no gaps.
+ */
+function build_tokens(
+    the_parts: Array<{ value: string; type: Token['type'] }>,
+    line: number = 0
+): Token[] {
+    const the_tokens: Token[] = [];
+    let char = 0;
+    for (const my_part of the_parts) {
+        the_tokens.push({
+            type: my_part.type,
+            value: my_part.value,
+            range: {
+                start: { line, character: char },
+                end: { line, character: char + my_part.value.length },
+            },
+        });
+        char += my_part.value.length;
+    }
+    return the_tokens;
+}
+
+describe('token-utils', () => {
+    describe('find_last_token_starting_at_or_before', () => {
+        it('returns -1 for empty token arrays', () => {
+            const index = find_last_token_starting_at_or_before(
+                [],
+                { line: 0, character: 0 }
+            );
+            expect(index).toBe(-1);
+        });
+
+        it('returns -1 when all tokens start after the position', () => {
+            // tokens start at column 5
+            const the_tokens = build_tokens(
+                [{ value: 'hello', type: 'WORD' }]
+            );
+            the_tokens[0].range.start.character = 5;
+            the_tokens[0].range.end.character = 10;
+            const index = find_last_token_starting_at_or_before(
+                the_tokens,
+                { line: 0, character: 0 }
+            );
+            expect(index).toBe(-1);
+        });
+
+        it('returns the last token starting at or before the cursor', () => {
+            // `ab cd` → tokens: WORD 'ab' [0,2), WS ' ' [2,3), WORD 'cd' [3,5)
+            const the_tokens = build_tokens([
+                { value: 'ab', type: 'WORD' },
+                { value: ' ', type: 'WHITESPACE' },
+                { value: 'cd', type: 'WORD' },
+            ]);
+
+            // Cursor inside 'ab' → returns index 0
+            expect(
+                find_last_token_starting_at_or_before(
+                    the_tokens,
+                    { line: 0, character: 1 }
+                )
+            ).toBe(0);
+            // Cursor at boundary between 'ab' and ' ' → returns WS
+            expect(
+                find_last_token_starting_at_or_before(
+                    the_tokens,
+                    { line: 0, character: 2 }
+                )
+            ).toBe(1);
+            // Cursor inside 'cd' → returns index 2
+            expect(
+                find_last_token_starting_at_or_before(
+                    the_tokens,
+                    { line: 0, character: 4 }
+                )
+            ).toBe(2);
+        });
+    });
+
+    describe('find_last_token_starting_before', () => {
+        it('returns -1 for empty token arrays', () => {
+            const index = find_last_token_starting_before(
+                [],
+                { line: 0, character: 5 }
+            );
+            expect(index).toBe(-1);
+        });
+
+        it('returns -1 when the cursor is before the first token', () => {
+            const the_tokens = build_tokens([
+                { value: 'hello', type: 'WORD' },
+            ]);
+            const index = find_last_token_starting_before(
+                the_tokens,
+                { line: 0, character: 0 }
+            );
+            expect(index).toBe(-1);
+        });
+
+        it('excludes tokens starting exactly at the cursor', () => {
+            // `ab cd` - cursor at column 3 (start of 'cd')
+            const the_tokens = build_tokens([
+                { value: 'ab', type: 'WORD' },
+                { value: ' ', type: 'WHITESPACE' },
+                { value: 'cd', type: 'WORD' },
+            ]);
+            // Position 3 is the start of 'cd'; tokens starting at the
+            // cursor do not count, so the last token strictly before is WS.
+            expect(
+                find_last_token_starting_before(
+                    the_tokens,
+                    { line: 0, character: 3 }
+                )
+            ).toBe(1);
+        });
+
+        it('handles multi-line token layouts', () => {
+            const the_tokens: Token[] = [
+                {
+                    type: 'WORD',
+                    value: 'foo',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 3 },
+                    },
+                },
+                {
+                    type: 'STATEMENT_TERMINATOR',
+                    value: '\n',
+                    range: {
+                        start: { line: 0, character: 3 },
+                        end: { line: 1, character: 0 },
+                    },
+                },
+                {
+                    type: 'WORD',
+                    value: 'bar',
+                    range: {
+                        start: { line: 1, character: 0 },
+                        end: { line: 1, character: 3 },
+                    },
+                },
+            ];
+            // Cursor at line 1, char 2 (inside 'bar')
+            const index = find_last_token_starting_before(
+                the_tokens,
+                { line: 1, character: 2 }
+            );
+            expect(index).toBe(2);
+            // Cursor at line 1, char 0 (start of 'bar') — 'bar' starts at
+            // cursor so it is excluded; the terminator also starts at line
+            // 0 char 3 which is before line 1 char 0, so it wins.
+            expect(
+                find_last_token_starting_before(
+                    the_tokens,
+                    { line: 1, character: 0 }
+                )
+            ).toBe(1);
+        });
+    });
+
+    describe('find_token_index_at_position', () => {
+        it('returns -1 for empty token arrays', () => {
+            const index = find_token_index_at_position(
+                [],
+                { line: 0, character: 0 }
+            );
+            expect(index).toBe(-1);
+        });
+
+        it('returns the token whose range contains the cursor', () => {
+            const the_tokens = build_tokens([
+                { value: 'ab', type: 'WORD' },
+                { value: ' ', type: 'WHITESPACE' },
+                { value: 'cd', type: 'WORD' },
+            ]);
+            // Inside 'ab'
+            expect(
+                find_token_index_at_position(
+                    the_tokens,
+                    { line: 0, character: 0 }
+                )
+            ).toBe(0);
+            expect(
+                find_token_index_at_position(
+                    the_tokens,
+                    { line: 0, character: 1 }
+                )
+            ).toBe(0);
+            // At column 2 (start of whitespace, end of 'ab')
+            // LSP [start, end) — whitespace covers this
+            expect(
+                find_token_index_at_position(
+                    the_tokens,
+                    { line: 0, character: 2 }
+                )
+            ).toBe(1);
+            // Inside 'cd'
+            expect(
+                find_token_index_at_position(
+                    the_tokens,
+                    { line: 0, character: 3 }
+                )
+            ).toBe(2);
+            expect(
+                find_token_index_at_position(
+                    the_tokens,
+                    { line: 0, character: 4 }
+                )
+            ).toBe(2);
+        });
+
+        it('returns -1 when the cursor is past the last token', () => {
+            const the_tokens = build_tokens([
+                { value: 'ab', type: 'WORD' },
+            ]);
+            // Column 2 is the end of 'ab' (exclusive in LSP semantics)
+            expect(
+                find_token_index_at_position(
+                    the_tokens,
+                    { line: 0, character: 2 }
+                )
+            ).toBe(-1);
+            expect(
+                find_token_index_at_position(
+                    the_tokens,
+                    { line: 0, character: 10 }
+                )
+            ).toBe(-1);
+        });
+
+        it('scales to large token arrays via binary search', () => {
+            // Build a sparse token array with 10k entries; every
+            // token is one character wide with a one-character gap.
+            const the_tokens: Token[] = [];
+            const TOKEN_COUNT = 10_000;
+            for (let i = 0; i < TOKEN_COUNT; i++) {
+                the_tokens.push({
+                    type: 'WORD',
+                    value: 'x',
+                    range: {
+                        start: { line: 0, character: i * 2 },
+                        end: { line: 0, character: i * 2 + 1 },
+                    },
+                });
+            }
+
+            // Cursor in the middle of the last token
+            const last_index = find_token_index_at_position(
+                the_tokens,
+                { line: 0, character: (TOKEN_COUNT - 1) * 2 }
+            );
+            expect(last_index).toBe(TOKEN_COUNT - 1);
+
+            // Cursor in a gap between tokens — not covered by any token
+            const gap_index = find_token_index_at_position(
+                the_tokens,
+                { line: 0, character: 5 }
+            );
+            expect(gap_index).toBe(-1);
+
+            // Cursor before any token
+            const before_index = find_token_index_at_position(
+                the_tokens,
+                { line: 0, character: -1 }
+            );
+            expect(before_index).toBe(-1);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

`HoverProvider.is_after_top_level_comma` and `get_subcommand_context_from_tokens` previously scanned `document.tokens` from index 0 on every hover request, making latency linear in file size. On very large Stata scripts this added measurable per-hover overhead.

## Changes

**New: `src/utils/token-utils.ts`**
- `find_last_token_starting_at_or_before(tokens, position)` — last token with `start <= position`.
- `find_last_token_starting_before(tokens, position)` — strict-less-than variant used when tokens starting exactly at the cursor should be excluded.
- `find_token_index_at_position(tokens, position)` — token covering `position` under LSP `[start, end)` semantics.

**`src/providers/hover.ts`**
- `is_after_top_level_comma` now binary-searches the cursor, walks backwards to the nearest `STATEMENT_TERMINATOR`, then forward-scans only the current statement. The original depth-tracking semantics are preserved (e.g. a top-level comma is still detected when the cursor sits inside a nested paren group such as `vce(...)`), so no hover test semantics change.
- `get_subcommand_context_from_tokens` now binary-searches the hovered token and falls back to the immediately-preceding token at a trailing word boundary to keep the inclusive-end matching the old linear scan had. The obsolete `i % 500 === 0` periodic cancellation check is removed since the helper is O(log N).

**`tests/unit/utils/token-utils.test.ts`**
- Covers empty arrays, cursor before/inside/at-boundary/past tokens, multi-line layouts, and a 10k-token scaling smoke test.

## Complexity

Both hot paths drop from **O(N)** to **O(log N + K)** where K is the number of tokens in the current statement (typically < 50 for Stata), insulating hover latency from overall file size.

## Verification

- `bun run typecheck` passes.
- Full test suite (`bun run test`): **5299 pass, 2 skipped (pre-existing), 0 fail** across 492 files.

## Conversation

https://app.warp.dev/conversation/86f448f3-2607-41e3-a8a1-6d5f82eae042

Co-Authored-By: Oz <oz-agent@warp.dev>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved editor responsiveness and performance when hovering over code elements and using code completion features through optimization of token lookup algorithms, resulting in faster tooltip display and more fluid interactions.

* **Tests**
  * Added comprehensive test coverage for token lookup functionality, including edge cases, multi-line layouts, and large-scale scenarios, to ensure reliability and stability of hover tooltips and code completion features across various code structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->