### PR TITLE
Follow up abbreviation regressions and test stability

### DIFF
--- a/scripts/generate-cache.ts
+++ b/scripts/generate-cache.ts
@@ -13,6 +13,10 @@ import { get_command_priority } from '../src/command-database/priority-tiers.js'
 
 const BATCH_SIZE = 100;  // Process 100 files concurrently
 
+const COMMAND_ABBREVIATION_OVERRIDES: Record<string, string> = {
+    di: 'display',
+};
+
 /**
  * Fundamental Stata commands that MUST be in the cache.
  * These are hardcoded as a safety net in case help file parsing misses them.
@@ -76,7 +80,9 @@ function find_stata_path(): string {
  * Build abbreviations map from commands.
  * Maps each valid abbreviation to its full command name.
  */
-function build_abbreviations(commands: Record<string, CommandInfo>): Record<string, string> {
+export function build_abbreviations(
+    commands: Record<string, CommandInfo>
+): Record<string, string> {
     const abbreviations: Record<string, string> = {};
     
     for (const [name, info] of Object.entries(commands)) {
@@ -88,7 +94,18 @@ function build_abbreviations(commands: Record<string, CommandInfo>): Record<stri
             }
         }
     }
-    
+    for (const [abbrev, command_name] of Object.entries(
+        COMMAND_ABBREVIATION_OVERRIDES
+    )) {
+        const command_info = commands[command_name];
+        if (
+            command_info
+            && abbrev.length >= command_info.min_abbreviation
+            && command_name.startsWith(abbrev)
+        ) {
+            abbreviations[abbrev] = command_name;
+        }
+    }
     return abbreviations;
 }
 
@@ -168,6 +185,55 @@ export function merge_options(
     }
     
     return [];
+}
+
+function convert_builtin_subcommand_to_cache_format(
+    builtin_subcommand: { name: string; minAbbreviation: string }
+): { name: string; min_abbreviation: number } {
+    return {
+        name: builtin_subcommand.name,
+        min_abbreviation: builtin_subcommand.minAbbreviation.length,
+    };
+}
+
+export function apply_builtin_metadata_fallback(
+    commands: Record<string, CommandInfo>
+): { options_fallback_count: number; subcommands_fallback_count: number } {
+    const builtin_map = new Map<string, typeof BUILTIN_COMMANDS[0]>();
+    for (const my_cmd of BUILTIN_COMMANDS) {
+        builtin_map.set(my_cmd.name.toLowerCase(), my_cmd);
+    }
+
+    let options_fallback_count = 0;
+    let subcommands_fallback_count = 0;
+
+    for (const [cmd_name, cmd_info] of Object.entries(commands)) {
+        const builtin_info = builtin_map.get(cmd_name);
+        if (!builtin_info) {
+            continue;
+        }
+
+        if (builtin_info.options) {
+            const merged = merge_options(cmd_info.options, builtin_info.options);
+            if (merged.length > 0 && cmd_info.options.length === 0) {
+                cmd_info.options = merged;
+                options_fallback_count++;
+            }
+        }
+
+        if (
+            builtin_info.subcommands
+            && builtin_info.subcommands.length > 0
+            && (!cmd_info.subcommands || cmd_info.subcommands.length === 0)
+        ) {
+            cmd_info.subcommands = builtin_info.subcommands.map(
+                convert_builtin_subcommand_to_cache_format
+            );
+            subcommands_fallback_count++;
+        }
+    }
+
+    return { options_fallback_count, subcommands_fallback_count };
 }
 
 /**
@@ -373,27 +439,18 @@ export async function generate_cache(options: GenerateOptions): Promise<{ cache:
         }
     }
     
-    // Apply hardcoded options fallback for commands with no SMCL options
-    const builtin_map = new Map<string, typeof BUILTIN_COMMANDS[0]>();
-    for (const my_cmd of BUILTIN_COMMANDS) {
-        builtin_map.set(my_cmd.name.toLowerCase(), my_cmd);
-    }
-    
-    let options_fallback_count = 0;
-    for (const [cmd_name, cmd_info] of Object.entries(commands)) {
-        const builtin_info = builtin_map.get(cmd_name);
-        if (builtin_info && builtin_info.options) {
-            // Use merge_options to apply fallback
-            const merged = merge_options(cmd_info.options, builtin_info.options);
-            if (merged.length > 0 && cmd_info.options.length === 0) {
-                cmd_info.options = merged;
-                options_fallback_count++;
-            }
-        }
-    }
+    const {
+        options_fallback_count,
+        subcommands_fallback_count,
+    } = apply_builtin_metadata_fallback(commands);
     
     if (options_fallback_count > 0) {
         console.log(`\nApplied hardcoded options fallback to ${options_fallback_count} commands`);
+    }
+    if (subcommands_fallback_count > 0) {
+        console.log(
+            `Applied hardcoded subcommands fallback to ${subcommands_fallback_count} commands`
+        );
     }
     
     // Validate legacy command coverage
@@ -448,7 +505,7 @@ if (import.meta.main) {
     
     try {
         const { cache, result } = await generate_cache({ version, output_path, max_files, force });
-        writeFileSync(output_path, JSON.stringify(cache, null, 2));
+        writeFileSync(output_path, `${JSON.stringify(cache, null, 2)}\n`);
         
         console.log(`\nCache written to: ${output_path}`);
         console.log(`Commands: ${Object.keys(cache.commands).length}`);

--- a/src/command-database/caches/v18.json
+++ b/src/command-database/caches/v18.json
@@ -14515,7 +14515,53 @@
       "name": "frame",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "subcommands": [
+        {
+          "name": "create",
+          "min_abbreviation": 6
+        },
+        {
+          "name": "change",
+          "min_abbreviation": 6
+        },
+        {
+          "name": "copy",
+          "min_abbreviation": 4
+        },
+        {
+          "name": "drop",
+          "min_abbreviation": 4
+        },
+        {
+          "name": "rename",
+          "min_abbreviation": 6
+        },
+        {
+          "name": "put",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "post",
+          "min_abbreviation": 4
+        },
+        {
+          "name": "dir",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "reset",
+          "min_abbreviation": 5
+        },
+        {
+          "name": "list",
+          "min_abbreviation": 4
+        },
+        {
+          "name": "prefix",
+          "min_abbreviation": 6
+        }
+      ]
     },
     "pwf": {
       "name": "pwf",
@@ -21694,7 +21740,77 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "subcommands": [
+        {
+          "name": "set",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "describe",
+          "min_abbreviation": 1
+        },
+        {
+          "name": "estimate",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "impute",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "register",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "unregister",
+          "min_abbreviation": 5
+        },
+        {
+          "name": "passive",
+          "min_abbreviation": 4
+        },
+        {
+          "name": "varying",
+          "min_abbreviation": 4
+        },
+        {
+          "name": "convert",
+          "min_abbreviation": 4
+        },
+        {
+          "name": "export",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "import",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "merge",
+          "min_abbreviation": 5
+        },
+        {
+          "name": "append",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "expand",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "reshape",
+          "min_abbreviation": 4
+        },
+        {
+          "name": "update",
+          "min_abbreviation": 3
+        },
+        {
+          "name": "xeq",
+          "min_abbreviation": 3
+        }
+      ]
     },
     "utility": {
       "name": "utility",
@@ -44802,7 +44918,7 @@
     "constra": "constraint",
     "constrai": "constraint",
     "constrain": "constraint",
-    "di": "dir",
+    "di": "display",
     "cap": "capture",
     "capt": "capture",
     "captu": "capture",

--- a/src/command-database/index.ts
+++ b/src/command-database/index.ts
@@ -249,39 +249,7 @@ class CommandDatabase {
      * Register a command (for compatibility with legacy API).
      */
     register(info: ProviderCommandInfo): void {
-        if (!this.cache) {
-            this.cache = {
-                version: 18,
-                commands: {},
-                abbreviations: {}
-            };
-        }
-        
-        const normalized = info.name.toLowerCase();
-        
-        // Convert provider OptionInfo (minAbbreviation: string) to cache OptionInfo (min_abbreviation: number)
-        const the_cache_options = (info.options || []).map(my_opt => ({
-            name: my_opt.name,
-            min_abbreviation: my_opt.minAbbreviation.length,
-            has_argument: my_opt.hasArgument
-        }));
-
-        // Convert provider SubcommandInfo to cache SubcommandInfo
-        const the_cache_subcommands = info.subcommands?.map(sub => ({
-            name: sub.name,
-            min_abbreviation: sub.minAbbreviation.length
-        }));
-        
-        // Build command info, only including syntax if provided
-        const my_command_info: CommandInfo = {
-            name: info.name,
-            min_abbreviation: info.minAbbreviation.length,
-            options: the_cache_options,
-            subcommands: the_cache_subcommands,
-            priority: info.priority || get_command_priority(info.name)
-        };
-        
-        this.cache.commands[normalized] = my_command_info;
+        this.register_raw(info);
         this.recompute_resolved_abbreviations();
         this.all_commands_cached = null; // Invalidate cached array
         this.cache_version++;
@@ -292,8 +260,44 @@ class CommandDatabase {
      */
     register_all(the_commands: ProviderCommandInfo[]): void {
         for (const my_cmd of the_commands) {
-            this.register(my_cmd);
+            this.register_raw(my_cmd);
         }
+        this.recompute_resolved_abbreviations();
+        this.all_commands_cached = null; // Invalidate cached array
+        this.cache_version++;
+    }
+
+    private register_raw(info: ProviderCommandInfo): void {
+        if (!this.cache) {
+            this.cache = {
+                version: 18,
+                commands: {},
+                abbreviations: {}
+            };
+        }
+
+        const normalized = info.name.toLowerCase();
+
+        const the_cache_options = (info.options || []).map(my_opt => ({
+            name: my_opt.name,
+            min_abbreviation: my_opt.minAbbreviation.length,
+            has_argument: my_opt.hasArgument
+        }));
+
+        const the_cache_subcommands = info.subcommands?.map(sub => ({
+            name: sub.name,
+            min_abbreviation: sub.minAbbreviation.length
+        }));
+
+        const my_command_info: CommandInfo = {
+            name: info.name,
+            min_abbreviation: info.minAbbreviation.length,
+            options: the_cache_options,
+            subcommands: the_cache_subcommands,
+            priority: info.priority || get_command_priority(info.name)
+        };
+
+        this.cache.commands[normalized] = my_command_info;
     }
 
     /**
@@ -321,6 +325,21 @@ class CommandDatabase {
         this.cache_version++;
     }
 
+    /**
+     * Rebuilds the collision-aware abbreviation map.
+     *
+     * Phase 1 seeds from `cache.abbreviations` so hand-curated entries
+     * survive. Phase 2 walks all commands in priority order; a strictly
+     * higher-priority match overrides a seed, so advisory cache mappings
+     * lose to a real stronger candidate but win ties within the same tier.
+     *
+     * Exact command names are never placed in the map because direct
+     * lookup precedence handles those. The sort order
+     *
+     *   priority -> min_abbreviation -> name length -> alphabetical
+     *
+     * keeps same-tier backfill deterministic.
+     */
     private recompute_resolved_abbreviations(): void {
         this.resolved_abbreviations = Object.create(null);
         if (!this.cache) return;

--- a/src/command-database/index.ts
+++ b/src/command-database/index.ts
@@ -271,8 +271,8 @@ class CommandDatabase {
         if (!this.cache) {
             this.cache = {
                 version: 18,
-                commands: {},
-                abbreviations: {}
+                commands: Object.create(null),
+                abbreviations: Object.create(null)
             };
         }
 
@@ -329,9 +329,10 @@ class CommandDatabase {
      * Rebuilds the collision-aware abbreviation map.
      *
      * Phase 1 seeds from `cache.abbreviations` so hand-curated entries
-     * survive. Phase 2 walks all commands in priority order; a strictly
-     * higher-priority match overrides a seed, so advisory cache mappings
-     * lose to a real stronger candidate but win ties within the same tier.
+     * survive. Phase 2 walks all commands in priority order; a stronger
+     * candidate overrides a seed only on a strict priority win, so curated
+     * cache mappings keep same-tier ties while still losing to a real higher
+     * priority command.
      *
      * Exact command names are never placed in the map because direct
      * lookup precedence handles those. The sort order
@@ -393,7 +394,8 @@ class CommandDatabase {
 
                 const existing_command = this.cache.commands[existing_name];
                 const existing_priority =
-                    existing_command.priority || get_command_priority(existing_command.name);
+                    existing_command.priority
+                    || get_command_priority(existing_command.name);
                 if (my_priority < existing_priority) {
                     this.resolved_abbreviations[abbrev] = normalized_name;
                 }

--- a/src/command-database/index.ts
+++ b/src/command-database/index.ts
@@ -15,6 +15,7 @@ export { CommandDatabase };
 class CommandDatabase {
     private cache: CommandCache | null = null;
     private cache_version: number = 0;
+    private resolved_abbreviations: Record<string, string> = Object.create(null);
     
     // Pre-computed static completions (computed once, reused on every request)
     private all_commands_cached: ProviderCommandInfo[] | null = null;
@@ -39,6 +40,7 @@ class CommandDatabase {
             commands: commands_safe,
             abbreviations: abbreviations_safe,
         };
+        this.recompute_resolved_abbreviations();
         this.all_commands_cached = null; // Invalidate cached array
         this.cache_version++;
     }
@@ -58,17 +60,8 @@ class CommandDatabase {
         for (const addon_cmd of ADDON_COMMANDS) {
             const normalized = addon_cmd.name.toLowerCase();
             this.cache.commands[normalized] = addon_cmd;
-            
-            // Generate abbreviations for this command
-            const min_len = addon_cmd.min_abbreviation;
-            for (let i = min_len; i < addon_cmd.name.length; i++) {
-                const abbrev = addon_cmd.name.substring(0, i).toLowerCase();
-                if (!this.cache.abbreviations[abbrev]) {
-                    this.cache.abbreviations[abbrev] = normalized;
-                }
-            }
         }
-        
+        this.recompute_resolved_abbreviations();
         this.all_commands_cached = null; // Invalidate cached array
         this.cache_version++;
     }
@@ -94,9 +87,9 @@ class CommandDatabase {
             return this.to_provider_command_info(cmd);
         }
 
-        // Try abbreviation expansion
-        if (Object.prototype.hasOwnProperty.call(this.cache.abbreviations, normalized)) {
-            const full_name = this.cache.abbreviations[normalized];
+        // Try abbreviation expansion using the collision-aware resolution map.
+        if (Object.prototype.hasOwnProperty.call(this.resolved_abbreviations, normalized)) {
+            const full_name = this.resolved_abbreviations[normalized];
             if (Object.prototype.hasOwnProperty.call(this.cache.commands, full_name)) {
                 return this.to_provider_command_info(this.cache.commands[full_name]);
             }
@@ -117,8 +110,8 @@ class CommandDatabase {
             return this.cache.commands[normalized];
         }
 
-        if (Object.prototype.hasOwnProperty.call(this.cache.abbreviations, normalized)) {
-            const full_name = this.cache.abbreviations[normalized];
+        if (Object.prototype.hasOwnProperty.call(this.resolved_abbreviations, normalized)) {
+            const full_name = this.resolved_abbreviations[normalized];
             if (Object.prototype.hasOwnProperty.call(this.cache.commands, full_name)) {
                 return this.cache.commands[full_name];
             }
@@ -140,8 +133,8 @@ class CommandDatabase {
             return this.cache.commands[normalized];
         }
 
-        if (Object.prototype.hasOwnProperty.call(this.cache.abbreviations, normalized)) {
-            const full_name = this.cache.abbreviations[normalized];
+        if (Object.prototype.hasOwnProperty.call(this.resolved_abbreviations, normalized)) {
+            const full_name = this.resolved_abbreviations[normalized];
             if (Object.prototype.hasOwnProperty.call(this.cache.commands, full_name)) {
                 return this.cache.commands[full_name];
             }
@@ -289,6 +282,7 @@ class CommandDatabase {
         };
         
         this.cache.commands[normalized] = my_command_info;
+        this.recompute_resolved_abbreviations();
         this.all_commands_cached = null; // Invalidate cached array
         this.cache_version++;
     }
@@ -322,8 +316,70 @@ class CommandDatabase {
      */
     clear(): void {
         this.cache = null;
+        this.resolved_abbreviations = Object.create(null);
         this.all_commands_cached = null;
         this.cache_version++;
+    }
+
+    private recompute_resolved_abbreviations(): void {
+        this.resolved_abbreviations = Object.create(null);
+        if (!this.cache) return;
+
+        const exact_command_names = new Set(Object.keys(this.cache.commands));
+        for (const [abbrev, full_name] of Object.entries(this.cache.abbreviations)) {
+            if (exact_command_names.has(abbrev)) {
+                continue;
+            }
+            if (Object.prototype.hasOwnProperty.call(this.cache.commands, full_name)) {
+                this.resolved_abbreviations[abbrev] = full_name;
+            }
+        }
+        const the_sorted_commands = Object.values(this.cache.commands).sort(
+            (cmd_a, cmd_b) => {
+                const priority_a = cmd_a.priority || get_command_priority(cmd_a.name);
+                const priority_b = cmd_b.priority || get_command_priority(cmd_b.name);
+                if (priority_a !== priority_b) {
+                    return priority_a - priority_b;
+                }
+                if (cmd_a.min_abbreviation !== cmd_b.min_abbreviation) {
+                    return cmd_a.min_abbreviation - cmd_b.min_abbreviation;
+                }
+                if (cmd_a.name.length !== cmd_b.name.length) {
+                    return cmd_a.name.length - cmd_b.name.length;
+                }
+                return cmd_a.name.localeCompare(cmd_b.name);
+            }
+        );
+
+        for (const my_command of the_sorted_commands) {
+            const normalized_name = my_command.name.toLowerCase();
+            const my_priority =
+                my_command.priority || get_command_priority(my_command.name);
+            const min_len = Math.max(1, my_command.min_abbreviation);
+            for (let i = min_len; i < normalized_name.length; i++) {
+                const abbrev = normalized_name.substring(0, i);
+                if (exact_command_names.has(abbrev)) {
+                    continue;
+                }
+                if (!Object.prototype.hasOwnProperty.call(this.resolved_abbreviations, abbrev)) {
+                    this.resolved_abbreviations[abbrev] = normalized_name;
+                    continue;
+                }
+
+                const existing_name = this.resolved_abbreviations[abbrev];
+                if (!Object.prototype.hasOwnProperty.call(this.cache.commands, existing_name)) {
+                    this.resolved_abbreviations[abbrev] = normalized_name;
+                    continue;
+                }
+
+                const existing_command = this.cache.commands[existing_name];
+                const existing_priority =
+                    existing_command.priority || get_command_priority(existing_command.name);
+                if (my_priority < existing_priority) {
+                    this.resolved_abbreviations[abbrev] = normalized_name;
+                }
+            }
+        }
     }
 
     /**

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1874,9 +1874,11 @@ export class HoverProvider {
     private get_command_hover(word: string): MarkupContent | null {
         const command = this.command_db.lookup(word);
         if (command) {
+            const is_abbrev =
+                word.toLowerCase() !== command.name.toLowerCase();
             return this.format_builtin_command_hover(
                 command,
-                word !== command.name ? word : undefined
+                is_abbrev ? word : undefined
             );
         }
 

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1874,7 +1874,10 @@ export class HoverProvider {
     private get_command_hover(word: string): MarkupContent | null {
         const command = this.command_db.lookup(word);
         if (command) {
-            return this.format_builtin_command_hover(command);
+            return this.format_builtin_command_hover(
+                command,
+                word !== command.name ? word : undefined
+            );
         }
 
         // Try broadening the search to abbreviations

--- a/tests/property/abbreviation-expansion-preservation.prop.test.ts
+++ b/tests/property/abbreviation-expansion-preservation.prop.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, expect } from 'bun:test';
 import * as fc from 'fast-check';
 import { CommandDatabase } from '../../src/command-database';
+import { get_command_priority } from '../../src/command-database/priority-tiers';
 import type {
     CommandCache,
     CommandInfo,
@@ -43,8 +44,10 @@ describe('Abbreviation Expansion Preservation Property Tests', () => {
 
         const the_sorted_commands = Object.values(cache.commands).sort(
             (cmd_a, cmd_b) => {
-                const priority_a = cmd_a.priority ?? 3;
-                const priority_b = cmd_b.priority ?? 3;
+                const priority_a =
+                    cmd_a.priority ?? get_command_priority(cmd_a.name);
+                const priority_b =
+                    cmd_b.priority ?? get_command_priority(cmd_b.name);
                 if (priority_a !== priority_b) {
                     return priority_a - priority_b;
                 }
@@ -60,7 +63,8 @@ describe('Abbreviation Expansion Preservation Property Tests', () => {
 
         for (const my_command of the_sorted_commands) {
             const normalized_name = my_command.name.toLowerCase();
-            const my_priority = my_command.priority ?? 3;
+            const my_priority =
+                my_command.priority ?? get_command_priority(normalized_name);
             const min_len = Math.max(1, my_command.min_abbreviation);
             for (let i = min_len; i < normalized_name.length; i++) {
                 const abbrev = normalized_name.substring(0, i);
@@ -73,7 +77,19 @@ describe('Abbreviation Expansion Preservation Property Tests', () => {
                 }
 
                 const existing_name = resolved_abbreviations[abbrev];
-                const existing_priority = cache.commands[existing_name]?.priority ?? 3;
+                if (
+                    !Object.prototype.hasOwnProperty.call(
+                        cache.commands,
+                        existing_name
+                    )
+                ) {
+                    resolved_abbreviations[abbrev] = normalized_name;
+                    continue;
+                }
+
+                const existing_priority =
+                    cache.commands[existing_name]?.priority
+                    ?? get_command_priority(existing_name);
                 if (my_priority < existing_priority) {
                     resolved_abbreviations[abbrev] = normalized_name;
                 }
@@ -227,12 +243,13 @@ describe('Abbreviation Expansion Preservation Property Tests', () => {
                     my_database.load_cache(cache);
 
                     for (const my_str of the_random_strings) {
-                        const is_command = cache.commands[my_str] !== undefined;
                         const expected_name = compute_expected_lookup(cache, my_str);
                         const result = my_database.lookup_command(my_str);
-
-                        if (!is_command && expected_name === null) {
+                        if (expected_name === null) {
                             expect(result).toBeNull();
+                        } else {
+                            expect(result).not.toBeNull();
+                            expect(result?.name).toBe(expected_name);
                         }
                     }
 

--- a/tests/property/abbreviation-expansion-preservation.prop.test.ts
+++ b/tests/property/abbreviation-expansion-preservation.prop.test.ts
@@ -45,9 +45,9 @@ describe('Abbreviation Expansion Preservation Property Tests', () => {
         const the_sorted_commands = Object.values(cache.commands).sort(
             (cmd_a, cmd_b) => {
                 const priority_a =
-                    cmd_a.priority ?? get_command_priority(cmd_a.name);
+                    cmd_a.priority || get_command_priority(cmd_a.name);
                 const priority_b =
-                    cmd_b.priority ?? get_command_priority(cmd_b.name);
+                    cmd_b.priority || get_command_priority(cmd_b.name);
                 if (priority_a !== priority_b) {
                     return priority_a - priority_b;
                 }
@@ -64,7 +64,7 @@ describe('Abbreviation Expansion Preservation Property Tests', () => {
         for (const my_command of the_sorted_commands) {
             const normalized_name = my_command.name.toLowerCase();
             const my_priority =
-                my_command.priority ?? get_command_priority(normalized_name);
+                my_command.priority || get_command_priority(normalized_name);
             const min_len = Math.max(1, my_command.min_abbreviation);
             for (let i = min_len; i < normalized_name.length; i++) {
                 const abbrev = normalized_name.substring(0, i);
@@ -88,8 +88,8 @@ describe('Abbreviation Expansion Preservation Property Tests', () => {
                 }
 
                 const existing_priority =
-                    cache.commands[existing_name]?.priority
-                    ?? get_command_priority(existing_name);
+                    cache.commands[existing_name].priority
+                    || get_command_priority(existing_name);
                 if (my_priority < existing_priority) {
                     resolved_abbreviations[abbrev] = normalized_name;
                 }

--- a/tests/property/abbreviation-expansion-preservation.prop.test.ts
+++ b/tests/property/abbreviation-expansion-preservation.prop.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, beforeEach, expect } from 'bun:test';
 import * as fc from 'fast-check';
 import { CommandDatabase } from '../../src/command-database';
-import type { CommandCache, CommandInfo, OptionInfo, StataVersion } from '../../src/command-database/types';
+import type {
+    CommandCache,
+    CommandInfo,
+    OptionInfo,
+    StataVersion,
+} from '../../src/command-database/types';
 
 /**
  * Property Test: Abbreviation Expansion Preservation
  * Feature: command-database-cleanup, Property 2: Abbreviation Expansion Preservation
  * Validates: Requirements 3.4, 6.2
- * 
- * This test verifies that for any abbreviation in the cache's abbreviation dictionary,
- * expanding that abbreviation returns the correct full command name.
  */
 describe('Abbreviation Expansion Preservation Property Tests', () => {
     let my_database: CommandDatabase;
@@ -18,255 +20,219 @@ describe('Abbreviation Expansion Preservation Property Tests', () => {
         my_database = new CommandDatabase();
     });
 
-    // Generator for valid command names (lowercase alphabetic)
+    function compute_expected_lookup(
+        cache: CommandCache,
+        query: string
+    ): string | null {
+        const normalized = query.toLowerCase();
+        if (Object.prototype.hasOwnProperty.call(cache.commands, normalized)) {
+            return cache.commands[normalized].name;
+        }
+
+        const exact_command_names = new Set(Object.keys(cache.commands));
+        const resolved_abbreviations: Record<string, string> = Object.create(null);
+
+        for (const [abbrev, full_name] of Object.entries(cache.abbreviations)) {
+            if (exact_command_names.has(abbrev)) {
+                continue;
+            }
+            if (Object.prototype.hasOwnProperty.call(cache.commands, full_name)) {
+                resolved_abbreviations[abbrev] = full_name;
+            }
+        }
+
+        const the_sorted_commands = Object.values(cache.commands).sort(
+            (cmd_a, cmd_b) => {
+                const priority_a = cmd_a.priority ?? 3;
+                const priority_b = cmd_b.priority ?? 3;
+                if (priority_a !== priority_b) {
+                    return priority_a - priority_b;
+                }
+                if (cmd_a.min_abbreviation !== cmd_b.min_abbreviation) {
+                    return cmd_a.min_abbreviation - cmd_b.min_abbreviation;
+                }
+                if (cmd_a.name.length !== cmd_b.name.length) {
+                    return cmd_a.name.length - cmd_b.name.length;
+                }
+                return cmd_a.name.localeCompare(cmd_b.name);
+            }
+        );
+
+        for (const my_command of the_sorted_commands) {
+            const normalized_name = my_command.name.toLowerCase();
+            const my_priority = my_command.priority ?? 3;
+            const min_len = Math.max(1, my_command.min_abbreviation);
+            for (let i = min_len; i < normalized_name.length; i++) {
+                const abbrev = normalized_name.substring(0, i);
+                if (exact_command_names.has(abbrev)) {
+                    continue;
+                }
+                if (!Object.prototype.hasOwnProperty.call(resolved_abbreviations, abbrev)) {
+                    resolved_abbreviations[abbrev] = normalized_name;
+                    continue;
+                }
+
+                const existing_name = resolved_abbreviations[abbrev];
+                const existing_priority = cache.commands[existing_name]?.priority ?? 3;
+                if (my_priority < existing_priority) {
+                    resolved_abbreviations[abbrev] = normalized_name;
+                }
+            }
+        }
+
+        return resolved_abbreviations[normalized] ?? null;
+    }
+
     const command_name_generator: fc.Arbitrary<string> = fc.string({
         minLength: 3,
-        maxLength: 12
+        maxLength: 12,
     }).filter(s => /^[a-z]+$/.test(s));
 
-    // Generator for option info
     const option_info_generator: fc.Arbitrary<OptionInfo> = fc.record({
-        name: fc.string({ minLength: 2, maxLength: 10 }).filter(s => /^[a-z]+$/.test(s)),
+        name: fc.string({ minLength: 2, maxLength: 10 }).filter(
+            s => /^[a-z]+$/.test(s)
+        ),
         min_abbreviation: fc.integer({ min: 1, max: 10 }),
         description: fc.string({ minLength: 5, maxLength: 50 }),
-        has_argument: fc.boolean()
+        has_argument: fc.boolean(),
     }).map(info => ({
         ...info,
-        min_abbreviation: Math.min(info.min_abbreviation, info.name.length)
+        min_abbreviation: Math.min(info.min_abbreviation, info.name.length),
     }));
 
-    // Generator for command info (minimal type)
     const command_info_generator: fc.Arbitrary<CommandInfo> = fc.record({
         name: command_name_generator,
         syntax: fc.string({ minLength: 5, maxLength: 100 }),
         description: fc.string({ minLength: 10, maxLength: 100 }),
         min_abbreviation: fc.integer({ min: 1, max: 12 }),
-        options: fc.array(option_info_generator, { minLength: 0, maxLength: 5 })
+        options: fc.array(option_info_generator, { minLength: 0, maxLength: 5 }),
+        priority: fc.option(fc.integer({ min: 1, max: 3 })),
     }).map(info => ({
         ...info,
-        // Ensure min_abbreviation doesn't exceed name length
-        min_abbreviation: Math.min(info.min_abbreviation, info.name.length)
+        min_abbreviation: Math.min(info.min_abbreviation, info.name.length),
     }));
 
-    // Generator for command cache with proper abbreviation mappings
-    // Uses distinct prefixes to avoid abbreviation conflicts
-    const command_cache_generator: fc.Arbitrary<CommandCache> = fc.tuple(
-        fc.constantFrom('reg', 'sum', 'tab', 'gen', 'des', 'lis', 'mer', 'app', 'sor', 'dro'),
-        fc.constantFrom('ress', 'marize', 'ulate', 'erate', 'cribe', 't', 'ge', 'end', 't', 'p')
-    ).chain(([prefix1, suffix1]) => {
-        // Generate commands with distinct prefixes to avoid conflicts
-        const the_prefixes = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'];
-        return fc.array(
-            fc.tuple(
-                fc.constantFrom(...the_prefixes),
-                fc.string({ minLength: 2, maxLength: 6 }).filter(s => /^[a-z]+$/.test(s)),
-                fc.string({ minLength: 5, maxLength: 50 }),
-                fc.string({ minLength: 10, maxLength: 50 }),
-                fc.integer({ min: 2, max: 5 })
-            ),
-            { minLength: 3, maxLength: 5 }
-        ).map(the_tuples => {
-            const commands: Record<string, CommandInfo> = {};
-            const abbreviations: Record<string, string> = {};
-            const used_names = new Set<string>();
+    const command_cache_generator: fc.Arbitrary<CommandCache> = fc.array(
+        command_info_generator,
+        { minLength: 3, maxLength: 6 }
+    ).map(the_commands => {
+        const commands: Record<string, CommandInfo> = Object.create(null);
+        const abbreviations: Record<string, string> = Object.create(null);
 
-            for (let idx = 0; idx < the_tuples.length; idx++) {
-                const [prefix, suffix, syntax, description, min_abbrev_base] = the_tuples[idx];
-                // Create unique name by appending index
-                const name = `${prefix}${suffix}${idx}`.toLowerCase();
-                
-                if (used_names.has(name)) continue;
-                used_names.add(name);
+        for (let i = 0; i < the_commands.length; i++) {
+            const my_command = the_commands[i];
+            const normalized_name = `${my_command.name}${i}`.toLowerCase();
+            commands[normalized_name] = {
+                ...my_command,
+                name: normalized_name,
+                min_abbreviation: Math.min(
+                    my_command.min_abbreviation,
+                    normalized_name.length
+                ),
+            };
 
-                const min_abbreviation = Math.min(min_abbrev_base, name.length);
-                
-                commands[name] = {
-                    name,
-                    syntax,
-                    description,
-                    min_abbreviation,
-                    options: []
-                };
-
-                // Generate abbreviations - only add if not conflicting
-                for (let i = min_abbreviation; i < name.length; i++) {
-                    const abbrev = name.substring(0, i);
-                    // Only add if not already used as a command or abbreviation
-                    if (!commands[abbrev] && !abbreviations[abbrev]) {
-                        abbreviations[abbrev] = name;
-                    }
+            for (
+                let j = commands[normalized_name].min_abbreviation;
+                j < normalized_name.length;
+                j++
+            ) {
+                const abbrev = normalized_name.substring(0, j);
+                if (!Object.prototype.hasOwnProperty.call(abbreviations, abbrev)) {
+                    abbreviations[abbrev] = normalized_name;
                 }
             }
+        }
 
-            return {
-                version: 18 as StataVersion,
-                commands,
-                abbreviations
-            };
-        });
+        return {
+            version: 18 as StataVersion,
+            commands,
+            abbreviations,
+        };
     });
 
-    /**
-     * Property 2: Abbreviation Expansion Preservation
-     * 
-     * For any abbreviation in the cache's abbreviation dictionary,
-     * expanding that abbreviation SHALL return the correct full command name.
-     * 
-     * Feature: command-database-cleanup, Property 2: Abbreviation Expansion Preservation
-     * Validates: Requirements 3.4, 6.2
-     */
-    it('should expand every abbreviation to its correct full command name', () => {
+    it('should resolve abbreviations according to the precedence oracle', () => {
         fc.assert(
-            fc.property(
-                command_cache_generator,
-                (cache) => {
-                    // Load the cache
-                    my_database.load_cache(cache);
+            fc.property(command_cache_generator, cache => {
+                my_database.load_cache(cache);
 
-                    // For every abbreviation in the cache
-                    for (const [abbrev, expected_full_name] of Object.entries(cache.abbreviations)) {
-                        // Expand the abbreviation via lookup
-                        const result = my_database.lookup_command(abbrev);
+                for (const abbrev of Object.keys(cache.abbreviations)) {
+                    const result = my_database.lookup_command(abbrev);
+                    const expected_name = compute_expected_lookup(cache, abbrev);
 
-                        // The result should not be null
-                        expect(result).not.toBeNull();
-
-                        if (result !== null) {
-                            // The expanded command name should match the expected full name
-                            expect(result.name.toLowerCase()).toBe(expected_full_name.toLowerCase());
-
-                            // The result should have all required fields
-                            expect(result.name).toBeDefined();
-                            expect(result.syntax).toBeDefined();
-                            expect(result.description).toBeDefined();
-                            expect(result.min_abbreviation).toBeDefined();
-                        }
-                    }
-
-                    return true;
+                    expect(expected_name).not.toBeNull();
+                    expect(result).not.toBeNull();
+                    expect(result?.name.toLowerCase()).toBe(
+                        expected_name!.toLowerCase()
+                    );
                 }
-            ),
+
+                return true;
+            }),
             { numRuns: 100 }
         );
     });
 
-    /**
-     * Property: Abbreviation Length Validity
-     * 
-     * For any command, all abbreviations from min_abbreviation length up to
-     * full name length should resolve to that command (when no conflicts exist).
-     * 
-     * Feature: command-database-cleanup, Property 2: Abbreviation Expansion Preservation
-     * Validates: Requirements 3.4, 6.2
-     */
-    it('should resolve all valid abbreviation lengths to the correct command', () => {
+    it('should resolve exact command names to themselves even with overlapping abbreviations', () => {
         fc.assert(
-            fc.property(
-                command_cache_generator,
-                (cache) => {
-                    my_database.load_cache(cache);
+            fc.property(command_cache_generator, cache => {
+                my_database.load_cache(cache);
 
-                    // For each abbreviation in the cache, verify it resolves correctly
-                    for (const [abbrev, expected_cmd] of Object.entries(cache.abbreviations)) {
-                        const result = my_database.lookup_command(abbrev);
-
-                        // Should resolve to some command
-                        expect(result).not.toBeNull();
-
-                        if (result !== null) {
-                            // Should resolve to the expected command
-                            expect(result.name.toLowerCase()).toBe(expected_cmd.toLowerCase());
-                        }
-                    }
-
-                    // Also verify full command names resolve to themselves
-                    for (const [cmd_name, cmd_info] of Object.entries(cache.commands)) {
-                        const result = my_database.lookup_command(cmd_name);
-                        expect(result).not.toBeNull();
-                        if (result !== null) {
-                            expect(result.name.toLowerCase()).toBe(cmd_name.toLowerCase());
-                        }
-                    }
-
-                    return true;
+                for (const cmd_name of Object.keys(cache.commands)) {
+                    const result = my_database.lookup_command(cmd_name);
+                    expect(result).not.toBeNull();
+                    expect(result?.name.toLowerCase()).toBe(cmd_name);
                 }
-            ),
+
+                return true;
+            }),
             { numRuns: 100 }
         );
     });
 
-    /**
-     * Property: Abbreviation Expansion Consistency
-     * 
-     * For any abbreviation, expanding it multiple times should always
-     * return the same result (deterministic behavior).
-     * 
-     * Feature: command-database-cleanup, Property 2: Abbreviation Expansion Preservation
-     * Validates: Requirements 3.4, 6.2
-     */
     it('should consistently expand the same abbreviation to the same command', () => {
         fc.assert(
-            fc.property(
-                command_cache_generator,
-                (cache) => {
-                    my_database.load_cache(cache);
+            fc.property(command_cache_generator, cache => {
+                my_database.load_cache(cache);
 
-                    // For every abbreviation in the cache
-                    for (const abbrev of Object.keys(cache.abbreviations)) {
-                        // Expand multiple times
-                        const result_1 = my_database.lookup_command(abbrev);
-                        const result_2 = my_database.lookup_command(abbrev);
-                        const result_3 = my_database.lookup_command(abbrev);
+                for (const abbrev of Object.keys(cache.abbreviations)) {
+                    const result_1 = my_database.lookup_command(abbrev);
+                    const result_2 = my_database.lookup_command(abbrev);
+                    const result_3 = my_database.lookup_command(abbrev);
 
-                        // All results should be identical
-                        if (result_1 !== null && result_2 !== null && result_3 !== null) {
-                            expect(result_1.name).toBe(result_2.name);
-                            expect(result_2.name).toBe(result_3.name);
-                            expect(result_1.syntax).toBe(result_2.syntax);
-                            expect(result_2.syntax).toBe(result_3.syntax);
-                        }
+                    if (result_1 !== null && result_2 !== null && result_3 !== null) {
+                        expect(result_1.name).toBe(result_2.name);
+                        expect(result_2.name).toBe(result_3.name);
+                        expect(result_1.syntax).toBe(result_2.syntax);
+                        expect(result_2.syntax).toBe(result_3.syntax);
                     }
-
-                    return true;
                 }
-            ),
+
+                return true;
+            }),
             { numRuns: 100 }
         );
     });
 
-    /**
-     * Property: Invalid Abbreviation Rejection
-     * 
-     * For any string that is not in the abbreviations dictionary and not
-     * a command name, lookup should return null.
-     * 
-     * Feature: command-database-cleanup, Property 2: Abbreviation Expansion Preservation
-     * Validates: Requirements 3.4, 6.2
-     */
     it('should return null for invalid abbreviations', () => {
         fc.assert(
             fc.property(
                 command_cache_generator,
                 fc.array(
-                    fc.string({ minLength: 1, maxLength: 10 }).filter(s => /^[a-z]+$/.test(s)),
+                    fc.string({ minLength: 1, maxLength: 10 }).filter(
+                        s => /^[a-z]+$/.test(s)
+                    ),
                     { minLength: 5, maxLength: 10 }
                 ),
                 (cache, the_random_strings) => {
                     my_database.load_cache(cache);
 
-                    // Test random strings that are not valid commands or abbreviations
                     for (const my_str of the_random_strings) {
                         const is_command = cache.commands[my_str] !== undefined;
-                        const is_abbreviation = cache.abbreviations[my_str] !== undefined;
-
+                        const expected_name = compute_expected_lookup(cache, my_str);
                         const result = my_database.lookup_command(my_str);
 
-                        if (!is_command && !is_abbreviation) {
-                            // Should return null for invalid lookups
+                        if (!is_command && expected_name === null) {
                             expect(result).toBeNull();
-                        } else {
-                            // Should return a valid result for valid lookups
-                            expect(result).not.toBeNull();
                         }
                     }
 

--- a/tests/property/command-database-lookup.prop.test.ts
+++ b/tests/property/command-database-lookup.prop.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, expect } from 'bun:test';
 import * as fc from 'fast-check';
 import { CommandDatabase } from '../../src/command-database';
+import { get_command_priority } from '../../src/command-database/priority-tiers';
 import type {
     CommandCache,
     CommandInfo,
@@ -25,10 +26,22 @@ describe('Command Database Property Tests', () => {
         }
 
         const exact_command_names = new Set(Object.keys(cache.commands));
+        const resolved_abbreviations: Record<string, string> = Object.create(null);
+
+        for (const [abbrev, full_name] of Object.entries(cache.abbreviations)) {
+            if (exact_command_names.has(abbrev)) {
+                continue;
+            }
+            if (Object.prototype.hasOwnProperty.call(cache.commands, full_name)) {
+                resolved_abbreviations[abbrev] = full_name;
+            }
+        }
         const the_sorted_commands = Object.values(cache.commands).sort(
             (cmd_a, cmd_b) => {
-                const priority_a = cmd_a.priority ?? 3;
-                const priority_b = cmd_b.priority ?? 3;
+                const priority_a =
+                    cmd_a.priority ?? get_command_priority(cmd_a.name);
+                const priority_b =
+                    cmd_b.priority ?? get_command_priority(cmd_b.name);
                 if (priority_a !== priority_b) {
                     return priority_a - priority_b;
                 }
@@ -44,19 +57,46 @@ describe('Command Database Property Tests', () => {
 
         for (const my_command of the_sorted_commands) {
             const normalized_name = my_command.name.toLowerCase();
-            if (normalized.length < Math.max(1, my_command.min_abbreviation)) {
-                continue;
+            const my_priority =
+                my_command.priority ?? get_command_priority(normalized_name);
+            const min_len = Math.max(1, my_command.min_abbreviation);
+            for (let i = min_len; i < normalized_name.length; i++) {
+                const abbrev = normalized_name.substring(0, i);
+                if (exact_command_names.has(abbrev)) {
+                    continue;
+                }
+                if (
+                    !Object.prototype.hasOwnProperty.call(
+                        resolved_abbreviations,
+                        abbrev
+                    )
+                ) {
+                    resolved_abbreviations[abbrev] = normalized_name;
+                    continue;
+                }
+
+                const existing_name = resolved_abbreviations[abbrev];
+                if (
+                    !Object.prototype.hasOwnProperty.call(
+                        cache.commands,
+                        existing_name
+                    )
+                ) {
+                    resolved_abbreviations[abbrev] = normalized_name;
+                    continue;
+                }
+
+                const existing_command = cache.commands[existing_name];
+                const existing_priority =
+                    existing_command.priority
+                    ?? get_command_priority(existing_command.name);
+                if (my_priority < existing_priority) {
+                    resolved_abbreviations[abbrev] = normalized_name;
+                }
             }
-            if (!normalized_name.startsWith(normalized)) {
-                continue;
-            }
-            if (exact_command_names.has(normalized)) {
-                continue;
-            }
-            return my_command.name;
         }
 
-        return null;
+        return resolved_abbreviations[normalized] ?? null;
     }
 
     const option_info_generator: fc.Arbitrary<OptionInfo> = fc.record({
@@ -198,23 +238,13 @@ describe('Command Database Property Tests', () => {
 
                 for (const [abbrev, full_name] of Object.entries(cache.abbreviations)) {
                     const result = my_database.lookup_command(abbrev);
+                    const expected_name = compute_expected_lookup(cache, abbrev);
+                    expect(expected_name).not.toBeNull();
                     expect(result).not.toBeNull();
-                    if (result !== null) {
-                        const abbrev_is_command =
-                            Object.prototype.hasOwnProperty.call(
-                                cache.commands,
-                                abbrev
-                            );
-
-                        if (abbrev_is_command) {
-                            expect(result.name.toLowerCase()).toBe(
-                                abbrev.toLowerCase()
-                            );
-                        } else {
-                            expect(result.name.toLowerCase()).toBe(
-                                full_name.toLowerCase()
-                            );
-                        }
+                    if (result !== null && expected_name !== null) {
+                        expect(result.name.toLowerCase()).toBe(
+                            expected_name.toLowerCase()
+                        );
                     }
                 }
 

--- a/tests/property/command-database-lookup.prop.test.ts
+++ b/tests/property/command-database-lookup.prop.test.ts
@@ -119,6 +119,7 @@ describe('Command Database Property Tests', () => {
         description: fc.string({ minLength: 10, maxLength: 100 }),
         min_abbreviation: fc.integer({ min: 1, max: 12 }),
         options: fc.array(option_info_generator, { minLength: 0, maxLength: 5 }),
+        priority: fc.option(fc.integer({ min: 1, max: 3 })),
     }).map(info => ({
         ...info,
         min_abbreviation: Math.min(info.min_abbreviation, info.name.length),
@@ -129,8 +130,17 @@ describe('Command Database Property Tests', () => {
         { minLength: 5, maxLength: 15 }
     ).map(the_commands => {
         const unique_commands = new Map<string, CommandInfo>();
-        for (const my_command of the_commands) {
-            unique_commands.set(my_command.name.toLowerCase(), my_command);
+        for (let i = 0; i < the_commands.length; i++) {
+            const my_command = the_commands[i];
+            const normalized_name = `${my_command.name}${i}`.toLowerCase();
+            unique_commands.set(normalized_name, {
+                ...my_command,
+                name: normalized_name,
+                min_abbreviation: Math.min(
+                    my_command.min_abbreviation,
+                    normalized_name.length
+                ),
+            });
         }
 
         const commands: Record<string, CommandInfo> = {};

--- a/tests/property/command-database-lookup.prop.test.ts
+++ b/tests/property/command-database-lookup.prop.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, beforeEach, expect } from 'bun:test';
 import * as fc from 'fast-check';
 import { CommandDatabase } from '../../src/command-database';
-import type { CommandCache, CommandInfo, OptionInfo, StataVersion } from '../../src/command-database/types';
+import type {
+    CommandCache,
+    CommandInfo,
+    OptionInfo,
+    StataVersion,
+} from '../../src/command-database/types';
 
 describe('Command Database Property Tests', () => {
     let my_database: CommandDatabase;
@@ -10,97 +15,171 @@ describe('Command Database Property Tests', () => {
         my_database = new CommandDatabase();
     });
 
-    // Generator for option info
+    function compute_expected_lookup(
+        cache: CommandCache,
+        query: string
+    ): string | null {
+        const normalized = query.toLowerCase();
+        if (Object.prototype.hasOwnProperty.call(cache.commands, normalized)) {
+            return cache.commands[normalized].name;
+        }
+
+        const exact_command_names = new Set(Object.keys(cache.commands));
+        const the_sorted_commands = Object.values(cache.commands).sort(
+            (cmd_a, cmd_b) => {
+                const priority_a = cmd_a.priority ?? 3;
+                const priority_b = cmd_b.priority ?? 3;
+                if (priority_a !== priority_b) {
+                    return priority_a - priority_b;
+                }
+                if (cmd_a.min_abbreviation !== cmd_b.min_abbreviation) {
+                    return cmd_a.min_abbreviation - cmd_b.min_abbreviation;
+                }
+                if (cmd_a.name.length !== cmd_b.name.length) {
+                    return cmd_a.name.length - cmd_b.name.length;
+                }
+                return cmd_a.name.localeCompare(cmd_b.name);
+            }
+        );
+
+        for (const my_command of the_sorted_commands) {
+            const normalized_name = my_command.name.toLowerCase();
+            if (normalized.length < Math.max(1, my_command.min_abbreviation)) {
+                continue;
+            }
+            if (!normalized_name.startsWith(normalized)) {
+                continue;
+            }
+            if (exact_command_names.has(normalized)) {
+                continue;
+            }
+            return my_command.name;
+        }
+
+        return null;
+    }
+
     const option_info_generator: fc.Arbitrary<OptionInfo> = fc.record({
-        name: fc.string({ minLength: 2, maxLength: 10 }).filter(s => /^[a-z]+$/.test(s)),
+        name: fc.string({ minLength: 2, maxLength: 10 }).filter(
+            s => /^[a-z]+$/.test(s)
+        ),
         min_abbreviation: fc.integer({ min: 1, max: 10 }),
         description: fc.string({ minLength: 5, maxLength: 50 }),
-        has_argument: fc.boolean()
+        has_argument: fc.boolean(),
     }).map(info => ({
         ...info,
-        min_abbreviation: Math.min(info.min_abbreviation, info.name.length)
+        min_abbreviation: Math.min(info.min_abbreviation, info.name.length),
     }));
 
-    // Generator for command info (minimal type)
     const command_info_generator: fc.Arbitrary<CommandInfo> = fc.record({
-        name: fc.string({ minLength: 3, maxLength: 12 }).filter(s => /^[a-z]+$/.test(s)),
+        name: fc.string({ minLength: 3, maxLength: 12 }).filter(
+            s => /^[a-z]+$/.test(s)
+        ),
         syntax: fc.string({ minLength: 5, maxLength: 100 }),
         description: fc.string({ minLength: 10, maxLength: 100 }),
         min_abbreviation: fc.integer({ min: 1, max: 12 }),
-        options: fc.array(option_info_generator, { minLength: 0, maxLength: 5 })
+        options: fc.array(option_info_generator, { minLength: 0, maxLength: 5 }),
     }).map(info => ({
         ...info,
-        min_abbreviation: Math.min(info.min_abbreviation, info.name.length)
+        min_abbreviation: Math.min(info.min_abbreviation, info.name.length),
     }));
 
-    // Generator for command cache
     const command_cache_generator: fc.Arbitrary<CommandCache> = fc.array(
         command_info_generator,
         { minLength: 5, maxLength: 15 }
     ).map(the_commands => {
-        // Ensure unique command names
         const unique_commands = new Map<string, CommandInfo>();
         for (const my_command of the_commands) {
             unique_commands.set(my_command.name.toLowerCase(), my_command);
         }
-        
+
         const commands: Record<string, CommandInfo> = {};
         const abbreviations: Record<string, string> = {};
-        
+
         for (const [name, info] of unique_commands) {
             commands[name] = info;
-            // Add abbreviations based on min_abbreviation
             for (let i = info.min_abbreviation; i <= info.name.length; i++) {
                 const abbrev = info.name.substring(0, i).toLowerCase();
                 abbreviations[abbrev] = name;
             }
         }
-        
+
         return {
             version: 18 as StataVersion,
             commands,
-            abbreviations
+            abbreviations,
         };
     });
 
-    /**
-     * Property: Command Lookup Completeness
-     * For any valid command name (full or abbreviated) in the loaded cache, 
-     * looking up the command should return complete info including syntax 
-     * and description. For invalid command names, lookup should return null 
-     * without error.
-     * Feature: command-database-cleanup, Property 1: Command Lookup Preservation
-     * Validates: Requirements 6.1
-     */
+    const overlapping_command_cache_generator: fc.Arbitrary<CommandCache> = fc.array(
+        fc.record({
+            name: fc.string({ minLength: 3, maxLength: 10 }).filter(
+                s => /^[a-z]+$/.test(s)
+            ),
+            min_abbreviation: fc.integer({ min: 1, max: 5 }),
+            priority: fc.integer({ min: 1, max: 3 }),
+        }),
+        { minLength: 4, maxLength: 8 }
+    ).map(the_commands => {
+        const commands: Record<string, CommandInfo> = Object.create(null);
+
+        for (const my_command of the_commands) {
+            const normalized_name = my_command.name.toLowerCase();
+            if (Object.prototype.hasOwnProperty.call(commands, normalized_name)) {
+                continue;
+            }
+            commands[normalized_name] = {
+                name: normalized_name,
+                syntax: `${normalized_name} syntax`,
+                description: `${normalized_name} description`,
+                min_abbreviation: Math.min(
+                    my_command.min_abbreviation,
+                    normalized_name.length
+                ),
+                options: [],
+                priority: my_command.priority as 1 | 2 | 3,
+            };
+        }
+
+        return {
+            version: 18 as StataVersion,
+            commands,
+            abbreviations: Object.create(null),
+        };
+    }).filter(cache => Object.keys(cache.commands).length >= 3);
+
     it('should provide complete info for valid commands and null for invalid ones', () => {
         fc.assert(
             fc.property(
                 command_cache_generator,
-                fc.array(fc.string({ minLength: 2, maxLength: 10 }), { minLength: 3, maxLength: 8 }),
+                fc.array(fc.string({ minLength: 2, maxLength: 10 }), {
+                    minLength: 3,
+                    maxLength: 8,
+                }),
                 (cache, the_invalid_names) => {
-                    // Load the cache
                     my_database.load_cache(cache);
 
-                    // Test valid command lookups
                     for (const [name, info] of Object.entries(cache.commands)) {
                         const result = my_database.lookup_command(name);
-                        
-                        // Should return complete info
                         expect(result).not.toBeNull();
                         if (result !== null) {
                             expect(result.name).toBe(info.name);
                             expect(result.syntax).toBe(info.syntax);
                             expect(result.description).toBe(info.description);
-                            expect(result.min_abbreviation).toBe(info.min_abbreviation);
+                            expect(result.min_abbreviation).toBe(
+                                info.min_abbreviation
+                            );
                         }
                     }
 
-                    // Test invalid command lookups
                     for (const my_invalid_name of the_invalid_names) {
                         const normalized = my_invalid_name.toLowerCase();
-                        if (!cache.commands[normalized] && !cache.abbreviations[normalized]) {
-                            const result = my_database.lookup_command(my_invalid_name);
-                            // Should return null for non-existent commands
+                        if (
+                            !cache.commands[normalized]
+                            && !cache.abbreviations[normalized]
+                        ) {
+                            const result =
+                                my_database.lookup_command(my_invalid_name);
                             expect(result).toBeNull();
                         }
                     }
@@ -112,80 +191,62 @@ describe('Command Database Property Tests', () => {
         );
     });
 
-    /**
-     * Property: Abbreviation Expansion
-     * For any valid abbreviation in the cache, expanding it should return 
-     * the correct full command name (unless the abbreviation is itself a command name).
-     * Feature: command-database-cleanup, Property 2: Abbreviation Expansion Preservation
-     * Validates: Requirements 3.4, 6.2
-     */
     it('should correctly expand abbreviations to full command names', () => {
         fc.assert(
-            fc.property(
-                command_cache_generator,
-                (cache) => {
-                    // Load the cache
-                    my_database.load_cache(cache);
+            fc.property(command_cache_generator, cache => {
+                my_database.load_cache(cache);
 
-                    // Test abbreviation expansion
-                    for (const [abbrev, full_name] of Object.entries(cache.abbreviations)) {
-                        const result = my_database.lookup_command(abbrev);
-                        
-                        // Should resolve to some command
-                        expect(result).not.toBeNull();
-                        if (result !== null) {
-                            // If the abbreviation is itself a command name, it should resolve to that command
-                            // Otherwise, it should resolve to the abbreviated command
-                            const abbrev_is_command = Object.prototype.hasOwnProperty.call(
+                for (const [abbrev, full_name] of Object.entries(cache.abbreviations)) {
+                    const result = my_database.lookup_command(abbrev);
+                    expect(result).not.toBeNull();
+                    if (result !== null) {
+                        const abbrev_is_command =
+                            Object.prototype.hasOwnProperty.call(
                                 cache.commands,
                                 abbrev
                             );
 
-                            if (abbrev_is_command) {
-                                expect(result.name.toLowerCase()).toBe(abbrev.toLowerCase());
-                            } else {
-                                expect(result.name.toLowerCase()).toBe(full_name.toLowerCase());
-                            }
+                        if (abbrev_is_command) {
+                            expect(result.name.toLowerCase()).toBe(
+                                abbrev.toLowerCase()
+                            );
+                        } else {
+                            expect(result.name.toLowerCase()).toBe(
+                                full_name.toLowerCase()
+                            );
                         }
                     }
-
-                    return true;
                 }
-            ),
+
+                return true;
+            }),
             { numRuns: 50 }
         );
     });
 
-    /**
-     * Property: Search Prefix Matching
-     * For any prefix, search should return all commands that start with 
-     * that prefix.
-     * Feature: command-database-cleanup, Property: Search Prefix Matching
-     * Validates: Requirements 6.1
-     */
     it('should return all commands matching a prefix', () => {
         fc.assert(
             fc.property(
                 command_cache_generator,
-                fc.string({ minLength: 1, maxLength: 3 }).filter(s => /^[a-z]+$/.test(s)),
+                fc.string({ minLength: 1, maxLength: 3 }).filter(
+                    s => /^[a-z]+$/.test(s)
+                ),
                 (cache, prefix) => {
-                    // Load the cache
                     my_database.load_cache(cache);
 
-                    // Get search results
                     const results = my_database.search(prefix);
-                    
-                    // Count expected matches
                     const expected_matches = Object.values(cache.commands).filter(
                         cmd => cmd.name.toLowerCase().startsWith(prefix.toLowerCase())
                     );
 
-                    // Should return all matching commands
                     expect(results.length).toBe(expected_matches.length);
 
-                    // All results should start with the prefix
                     for (const my_result of results) {
-                        expect(my_result.name.toLowerCase().startsWith(prefix.toLowerCase())).toBe(true);
+                        expect(
+                            my_result.name.toLowerCase().startsWith(
+                                prefix.toLowerCase()
+                            )
+                        ).toBe(true);
                     }
 
                     return true;
@@ -195,38 +256,74 @@ describe('Command Database Property Tests', () => {
         );
     });
 
-    /**
-     * Property: Cache Loading Idempotence
-     * Loading the same cache multiple times should produce the same results.
-     * Feature: command-database-cleanup, Property: Cache Loading Idempotence
-     * Validates: Requirements 6.1
-     */
     it('should produce consistent results after multiple cache loads', () => {
         fc.assert(
-            fc.property(
-                command_cache_generator,
-                (cache) => {
-                    // Load cache first time
-                    my_database.load_cache(cache);
-                    const first_all = my_database.get_all_commands();
-                    
-                    // Load cache second time
-                    my_database.load_cache(cache);
-                    const second_all = my_database.get_all_commands();
+            fc.property(command_cache_generator, cache => {
+                my_database.load_cache(cache);
+                const first_all = my_database.get_all_commands();
 
-                    // Results should be identical
-                    expect(first_all.length).toBe(second_all.length);
-                    
-                    for (let i = 0; i < first_all.length; i++) {
-                        expect(first_all[i].name).toBe(second_all[i].name);
-                        expect(first_all[i].syntax).toBe(second_all[i].syntax);
-                        expect(first_all[i].description).toBe(second_all[i].description);
+                my_database.load_cache(cache);
+                const second_all = my_database.get_all_commands();
+
+                expect(first_all.length).toBe(second_all.length);
+
+                for (let i = 0; i < first_all.length; i++) {
+                    expect(first_all[i].name).toBe(second_all[i].name);
+                    expect(first_all[i].syntax).toBe(second_all[i].syntax);
+                    expect(first_all[i].description).toBe(
+                        second_all[i].description
+                    );
+                }
+
+                return true;
+            }),
+            { numRuns: 50 }
+        );
+    });
+
+    it('should always resolve exact command names to themselves', () => {
+        fc.assert(
+            fc.property(overlapping_command_cache_generator, cache => {
+                my_database.load_cache(cache);
+
+                for (const cmd_name of Object.keys(cache.commands)) {
+                    const result = my_database.lookup_command(cmd_name);
+                    expect(result).not.toBeNull();
+                    expect(result?.name.toLowerCase()).toBe(cmd_name);
+                }
+
+                return true;
+            }),
+            { numRuns: 100 }
+        );
+    });
+
+    it('should match the precedence oracle for overlapping abbreviations', () => {
+        fc.assert(
+            fc.property(
+                overlapping_command_cache_generator,
+                fc.string({ minLength: 1, maxLength: 8 }).filter(
+                    s => /^[a-z]+$/.test(s)
+                ),
+                (cache, query) => {
+                    my_database.load_cache(cache);
+
+                    const expected_name = compute_expected_lookup(cache, query);
+                    const result = my_database.lookup_command(query);
+
+                    if (expected_name === null) {
+                        expect(result).toBeNull();
+                    } else {
+                        expect(result).not.toBeNull();
+                        expect(result?.name.toLowerCase()).toBe(
+                            expected_name.toLowerCase()
+                        );
                     }
 
                     return true;
                 }
             ),
-            { numRuns: 50 }
+            { numRuns: 200 }
         );
     });
 });

--- a/tests/property/completion-detail-options.prop.test.ts
+++ b/tests/property/completion-detail-options.prop.test.ts
@@ -65,6 +65,20 @@ function create_test_command_db(): CommandDatabase {
         options: [],
         category: 'programming',
         isBuiltin: true,
+        priority: 1,
+    });
+
+    // Lower-priority colliding command used to verify abbreviation resolution
+    db.register({
+        name: 'dir',
+        minAbbreviation: 'd',
+        syntax: 'dir [, wide]',
+        options: [
+            { name: 'wide', minAbbreviation: 'wide', hasArgument: false },
+        ],
+        category: 'programming',
+        isBuiltin: true,
+        priority: 3,
     });
     
     return db;
@@ -115,6 +129,40 @@ describe('Completion Detail Options Tests', () => {
         if (my_display_completion!.detail) {
             expect(my_display_completion!.detail.startsWith('Options:')).toBe(false);
         }
+    });
+
+    it('abbreviated command names should resolve option completions via the precedence-aware lookup', async () => {
+        const my_local_db = new CommandDatabase();
+        my_local_db.register({
+            name: 'display',
+            minAbbreviation: 'di',
+            syntax: 'display ...',
+            options: [
+                { name: 'newline', minAbbreviation: 'newline', hasArgument: true },
+            ],
+            category: 'programming',
+            isBuiltin: true,
+            priority: 1,
+        });
+        my_local_db.register({
+            name: 'dir',
+            minAbbreviation: 'd',
+            syntax: 'dir [, wide]',
+            options: [
+                { name: 'wide', minAbbreviation: 'wide', hasArgument: false },
+            ],
+            category: 'programming',
+            isBuiltin: true,
+            priority: 3,
+        });
+        const my_local_provider = new CompletionProvider(my_local_db, { snippet_support: false });
+
+        const my_document = create_test_document('di, n');
+        const my_position = { line: 0, character: 5 };
+        const my_completions = await my_local_provider.get_completions(my_document, my_position);
+
+        expect(my_completions.some(c => c.label === 'newline')).toBe(true);
+        expect(my_completions.some(c => c.label === 'wide')).toBe(false);
     });
 
     it('no completion detail contains SMCL tags', async () => {

--- a/tests/property/hover-command-expression-position.prop.test.ts
+++ b/tests/property/hover-command-expression-position.prop.test.ts
@@ -171,17 +171,11 @@ function index_inside_word(content: string, word: string): number {
     return start + Math.floor(word.length / 2);
 }
 
-function command_hover_name(command_name: string): string {
-    if (command_name === 'int') {
-        return 'interval';
-    }
-    if (command_name === 'mod') {
-        return 'models';
-    }
-    if (command_name === 'trunc') {
-        return 'truncate';
-    }
-    return command_name;
+function command_hover_name(
+    command_db: CommandDatabase,
+    command_name: string
+): string | null {
+    return command_db.lookup(command_name)?.name ?? null;
 }
 
 describe('Hover Command vs Expression Position Property Tests', () => {
@@ -248,10 +242,19 @@ describe('Hover Command vs Expression Position Property Tests', () => {
                             character: index_inside_word(content, command_name),
                         }
                     );
+                    const expected_hover_name = command_hover_name(
+                        command_db,
+                        command_name
+                    );
+                    if (expected_hover_name === null) {
+                        expect(hover).toBeNull();
+                        return;
+                    }
+
                     const value = hover_value(hover);
 
                     expect(value).toContain(
-                        `**${command_hover_name(command_name)}**`
+                        `**${expected_hover_name}**`
                     );
                     expect(value).toContain('**Options:**');
                     expect(value).not.toContain('**Function:**');

--- a/tests/property/variable-extraction-preservation.prop.test.ts
+++ b/tests/property/variable-extraction-preservation.prop.test.ts
@@ -3,7 +3,9 @@ import * as fc from 'fast-check';
 import { StataLexer } from '../../src/lexer';
 import { StataParser } from '../../src/parser';
 import { SemanticAnalyzer } from '../../src/analyzer';
-import { arbitrary_identifier } from './generators';
+import {
+  arbitrary_non_reserved_identifier,
+} from './generators';
 
 describe('Variable Extraction Preservation Property Tests', () => {
   let lexer: StataLexer;
@@ -23,11 +25,11 @@ describe('Variable Extraction Preservation Property Tests', () => {
     return fc
       .tuple(
         fc.constantFrom('gen', 'generate'),
-        arbitrary_identifier(),
+        arbitrary_non_reserved_identifier(),
         fc.oneof(
           fc.integer({ min: 1, max: 100 }).map(n => n.toString()),
           fc.string({ minLength: 1, maxLength: 10 }).map(s => `"${s}"`),
-          arbitrary_identifier()
+          arbitrary_non_reserved_identifier()
         )
       )
       .map(([cmd, varname, expr]) => ({
@@ -42,9 +44,9 @@ describe('Variable Extraction Preservation Property Tests', () => {
   function arbitrary_egen_command(): fc.Arbitrary<{ source: string; varname: string }> {
     return fc
       .tuple(
-        arbitrary_identifier(),
+        arbitrary_non_reserved_identifier(),
         fc.constantFrom('sum', 'mean', 'max', 'min', 'count'),
-        arbitrary_identifier()
+        arbitrary_non_reserved_identifier()
       )
       .map(([varname, func, arg]) => ({
         source: `egen ${varname} = ${func}(${arg})`,

--- a/tests/unit/command-database-abbreviation-priority.test.ts
+++ b/tests/unit/command-database-abbreviation-priority.test.ts
@@ -1,0 +1,166 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { CommandDatabase } from '../../src/command-database';
+import { get_command_priority } from '../../src/command-database/priority-tiers';
+import type { CommandCache } from '../../src/command-database/types';
+
+function load_v18_database(): { db: CommandDatabase; cache: CommandCache } {
+    const cache_path = join(
+        __dirname,
+        '../../src/command-database/caches/v18.json'
+    );
+    const cache = JSON.parse(readFileSync(cache_path, 'utf-8')) as CommandCache;
+    const db = new CommandDatabase();
+    db.load_cache(cache);
+    return { db, cache };
+}
+
+function collect_all_abbreviations(
+    cache: CommandCache
+): Map<string, string[]> {
+    const the_abbreviations = new Map<string, string[]>();
+
+    for (const my_info of Object.values(cache.commands)) {
+        const my_name = my_info.name;
+        const my_name_lower = my_name.toLowerCase();
+        const my_min = my_info.min_abbreviation;
+
+        for (let i = my_min; i <= my_name_lower.length; i++) {
+            const my_abbrev = my_name_lower.substring(0, i);
+            const the_matches = the_abbreviations.get(my_abbrev);
+            if (the_matches) {
+                the_matches.push(my_name);
+            } else {
+                the_abbreviations.set(my_abbrev, [my_name]);
+            }
+        }
+    }
+
+    return the_abbreviations;
+}
+
+describe('CommandDatabase abbreviation priority resolution', () => {
+    let database: CommandDatabase;
+    let cache: CommandCache;
+
+    beforeAll(() => {
+        const loaded = load_v18_database();
+        database = loaded.db;
+        cache = loaded.cache;
+    });
+
+    it('lookup APIs agree on key real-cache abbreviations and exact names', () => {
+        const the_expected_resolutions: Array<[string, string]> = [
+            ['di', 'display'],
+            ['l', 'list'],
+            ['li', 'list'],
+            ['sca', 'scalar'],
+            ['display', 'display'],
+            ['label', 'label'],
+            ['local', 'local'],
+        ];
+
+        for (const [my_abbrev, my_expected_name] of the_expected_resolutions) {
+            expect(database.lookup(my_abbrev)?.name).toBe(my_expected_name);
+            expect(database.lookup_command(my_abbrev)?.name).toBe(
+                my_expected_name
+            );
+            expect(database.get_command(my_abbrev)?.name).toBe(
+                my_expected_name
+            );
+        }
+    });
+
+    it('direct names win over any abbreviation-table collision for every command', () => {
+        const the_failures: string[] = [];
+
+        for (const command_name of Object.keys(cache.commands)) {
+            const lookup_command = database.lookup_command(command_name);
+            const lookup = database.lookup(command_name);
+            const get_command = database.get_command(command_name);
+
+            if (
+                lookup_command?.name.toLowerCase() !== command_name
+                || lookup?.name.toLowerCase() !== command_name
+                || get_command?.name.toLowerCase() !== command_name
+            ) {
+                the_failures.push(command_name);
+            }
+        }
+
+        expect(the_failures).toEqual([]);
+    });
+
+    it('every ambiguous abbreviation resolves to the highest-priority candidate', () => {
+        const the_all_abbrevs = collect_all_abbreviations(cache);
+        const the_failures: string[] = [];
+
+        for (const [my_abbrev, the_candidates] of the_all_abbrevs) {
+            if (the_candidates.length < 2) continue;
+            if (cache.commands[my_abbrev]) continue;
+
+            const the_best_tier = Math.min(
+                ...the_candidates.map(my_name => get_command_priority(my_name))
+            );
+            const the_result = database.lookup(my_abbrev);
+            const the_result_tier = the_result
+                ? get_command_priority(the_result.name)
+                : 3;
+
+            if (!the_result || the_result_tier !== the_best_tier) {
+                the_failures.push(
+                    `${my_abbrev} -> ${the_result?.name ?? 'undefined'} `
+                    + `(tier ${the_result_tier}; best tier ${the_best_tier}; `
+                    + `candidates: ${the_candidates.join(', ')})`
+                );
+            }
+        }
+
+        expect(the_failures).toEqual([]);
+    });
+
+    it('cache preserves and exposes expected prefix subcommands', () => {
+        expect(database.get_subcommands('file')?.map(sub => sub.name)).toEqual([
+            'open',
+            'read',
+            'write',
+            'close',
+            'seek',
+            'query',
+            'set',
+        ]);
+        expect(database.get_subcommands('frame')?.map(sub => sub.name)).toEqual([
+            'create',
+            'change',
+            'copy',
+            'drop',
+            'rename',
+            'put',
+            'post',
+            'dir',
+            'reset',
+            'list',
+            'prefix',
+        ]);
+        expect(database.get_subcommands('mi')?.map(sub => sub.name)).toEqual([
+            'set',
+            'describe',
+            'estimate',
+            'impute',
+            'register',
+            'unregister',
+            'passive',
+            'varying',
+            'convert',
+            'export',
+            'import',
+            'merge',
+            'append',
+            'expand',
+            'reshape',
+            'update',
+            'xeq',
+        ]);
+    });
+});

--- a/tests/unit/command-database-abbreviation-priority.test.ts
+++ b/tests/unit/command-database-abbreviation-priority.test.ts
@@ -74,18 +74,18 @@ describe('CommandDatabase abbreviation priority resolution', () => {
 
     it('direct names win over any abbreviation-table collision for every command', () => {
         const the_failures: string[] = [];
-
-        for (const command_name of Object.keys(cache.commands)) {
-            const lookup_command = database.lookup_command(command_name);
-            const lookup = database.lookup(command_name);
-            const get_command = database.get_command(command_name);
+        for (const my_command_name of Object.keys(cache.commands)) {
+            const lookup_command_result =
+                database.lookup_command(my_command_name);
+            const lookup_result = database.lookup(my_command_name);
+            const get_command_result = database.get_command(my_command_name);
 
             if (
-                lookup_command?.name.toLowerCase() !== command_name
-                || lookup?.name.toLowerCase() !== command_name
-                || get_command?.name.toLowerCase() !== command_name
+                lookup_command_result?.name.toLowerCase() !== my_command_name
+                || lookup_result?.name.toLowerCase() !== my_command_name
+                || get_command_result?.name.toLowerCase() !== my_command_name
             ) {
-                the_failures.push(command_name);
+                the_failures.push(my_command_name);
             }
         }
 
@@ -164,7 +164,7 @@ describe('CommandDatabase abbreviation priority resolution', () => {
         ]);
     });
 
-    it('register_all preserves lookup semantics while recomputing once per batch', () => {
+    it('register_all preserves lookup semantics after batched registration', () => {
         const db = new CommandDatabase();
         db.register_all([
             {
@@ -196,6 +196,33 @@ describe('CommandDatabase abbreviation priority resolution', () => {
         expect(db.lookup('di')?.name).toBe('display');
         expect(db.lookup('dir')?.name).toBe('dir');
         expect(db.lookup('sca')?.name).toBe('scalar');
+    });
+
+    it('same-priority seeded abbreviations preserve curated cache mappings', () => {
+        const db = new CommandDatabase();
+        db.load_cache({
+            version: 18,
+            commands: {
+                alpha: {
+                    name: 'alpha',
+                    min_abbreviation: 1,
+                    options: [],
+                    priority: 3,
+                },
+                alpine: {
+                    name: 'alpine',
+                    min_abbreviation: 1,
+                    options: [],
+                    priority: 3,
+                },
+            },
+            abbreviations: {
+                al: 'alpine',
+            },
+        });
+        expect(db.lookup('al')?.name).toBe('alpine');
+        expect(db.lookup_command('al')?.name).toBe('alpine');
+        expect(db.get_command('al')?.name).toBe('alpine');
     });
 
     it('later low-priority registration does not displace a higher-priority abbreviation winner', () => {

--- a/tests/unit/command-database-abbreviation-priority.test.ts
+++ b/tests/unit/command-database-abbreviation-priority.test.ts
@@ -163,4 +163,62 @@ describe('CommandDatabase abbreviation priority resolution', () => {
             'xeq',
         ]);
     });
+
+    it('register_all preserves lookup semantics while recomputing once per batch', () => {
+        const db = new CommandDatabase();
+        db.register_all([
+            {
+                name: 'display',
+                minAbbreviation: 'di',
+                options: [],
+                category: 'builtin',
+                isBuiltin: true,
+                priority: 1,
+            },
+            {
+                name: 'dir',
+                minAbbreviation: 'd',
+                options: [],
+                category: 'builtin',
+                isBuiltin: true,
+                priority: 3,
+            },
+            {
+                name: 'scalar',
+                minAbbreviation: 'sca',
+                options: [],
+                category: 'builtin',
+                isBuiltin: true,
+                priority: 1,
+            },
+        ]);
+
+        expect(db.lookup('di')?.name).toBe('display');
+        expect(db.lookup('dir')?.name).toBe('dir');
+        expect(db.lookup('sca')?.name).toBe('scalar');
+    });
+
+    it('later low-priority registration does not displace a higher-priority abbreviation winner', () => {
+        const db = new CommandDatabase();
+        db.register({
+            name: 'display',
+            minAbbreviation: 'di',
+            options: [],
+            category: 'builtin',
+            isBuiltin: true,
+            priority: 1,
+        });
+        db.register({
+            name: 'dir',
+            minAbbreviation: 'd',
+            options: [],
+            category: 'builtin',
+            isBuiltin: true,
+            priority: 3,
+        });
+
+        expect(db.lookup('di')?.name).toBe('display');
+        expect(db.lookup_command('di')?.name).toBe('display');
+        expect(db.get_command('di')?.name).toBe('display');
+    });
 });

--- a/tests/unit/command-database.test.ts
+++ b/tests/unit/command-database.test.ts
@@ -100,3 +100,58 @@ test('CommandDatabase get_all cache invalidates on register', () => {
     expect(before_register).not.toBe(after_register);
     expect(after_register.length).toBe(before_register.length + 1);
 });
+
+test('CommandDatabase lookup_command prefers exact command names over longer command prefixes', () => {
+    const db = new CommandDatabase();
+    db.load_cache({
+        version: 18,
+        commands: {
+            'display': {
+                name: 'display',
+                min_abbreviation: 2,
+                options: [],
+                priority: 1
+            },
+            'displayknots': {
+                name: 'displayknots',
+                min_abbreviation: 2,
+                options: [],
+                priority: 3
+            }
+        },
+        abbreviations: {
+            'display': 'displayknots',
+            'displayk': 'displayknots'
+        }
+    });
+
+    expect(db.lookup_command('display')?.name).toBe('display');
+});
+
+test('CommandDatabase lookup_command resolves overlapping abbreviations by precedence', () => {
+    const db = new CommandDatabase();
+    db.load_cache({
+        version: 18,
+        commands: {
+            'dir': {
+                name: 'dir',
+                min_abbreviation: 1,
+                options: [],
+                priority: 3
+            },
+            'display': {
+                name: 'display',
+                min_abbreviation: 2,
+                options: [],
+                priority: 1
+            }
+        },
+        abbreviations: {
+            'di': 'dir',
+            'dis': 'display'
+        }
+    });
+
+    expect(db.lookup_command('di')?.name).toBe('display');
+    expect(db.lookup('di')?.name).toBe('display');
+});

--- a/tests/unit/generate-cache.test.ts
+++ b/tests/unit/generate-cache.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test';
+import {
+    apply_builtin_metadata_fallback,
+    build_abbreviations,
+} from '../../scripts/generate-cache';
+import type { CommandInfo } from '../../src/command-database/types';
+
+function command(name: string, min_abbreviation: number): CommandInfo {
+    return {
+        name,
+        min_abbreviation,
+        options: [],
+        priority: 3,
+    };
+}
+
+describe('generate-cache build_abbreviations', () => {
+    test('uses explicit override for di when dir is inserted first', () => {
+        const abbreviations = build_abbreviations({
+            dir: command('dir', 1),
+            display: command('display', 2),
+        });
+
+        expect(abbreviations.di).toBe('display');
+        expect(abbreviations.d).toBe('dir');
+    });
+
+    test('keeps first command for ordinary abbreviation collisions', () => {
+        const abbreviations = build_abbreviations({
+            detail: command('detail', 1),
+            describe: command('describe', 1),
+        });
+
+        expect(abbreviations.d).toBe('detail');
+    });
+
+    test('does not let documented-minimum claims rewrite stable collisions', () => {
+        const abbreviations = build_abbreviations({
+            display: command('display', 2),
+            dissimilarity: command('dissimilarity', 3),
+        });
+
+        expect(abbreviations.dis).toBe('display');
+    });
+});
+
+describe('generate-cache apply_builtin_metadata_fallback', () => {
+    test('adds builtin subcommands when SMCL extraction omits them', () => {
+        const commands: Record<string, CommandInfo> = {
+            frame: command('frame', 5),
+            mi: command('mi', 2),
+        };
+
+        const result = apply_builtin_metadata_fallback(commands);
+
+        expect(result.subcommands_fallback_count).toBe(2);
+        expect(commands.frame.subcommands?.map(sub => sub.name)).toEqual([
+            'create',
+            'change',
+            'copy',
+            'drop',
+            'rename',
+            'put',
+            'post',
+            'dir',
+            'reset',
+            'list',
+            'prefix',
+        ]);
+        expect(commands.mi.subcommands?.map(sub => sub.name)).toEqual([
+            'set',
+            'describe',
+            'estimate',
+            'impute',
+            'register',
+            'unregister',
+            'passive',
+            'varying',
+            'convert',
+            'export',
+            'import',
+            'merge',
+            'append',
+            'expand',
+            'reshape',
+            'update',
+            'xeq',
+        ]);
+    });
+
+    test('does not overwrite extracted subcommands', () => {
+        const commands: Record<string, CommandInfo> = {
+            file: {
+                ...command('file', 1),
+                subcommands: [{ name: 'custom', min_abbreviation: 3 }],
+            },
+        };
+
+        const result = apply_builtin_metadata_fallback(commands);
+
+        expect(result.subcommands_fallback_count).toBe(0);
+        expect(commands.file.subcommands).toEqual([
+            { name: 'custom', min_abbreviation: 3 },
+        ]);
+    });
+});

--- a/tests/unit/hover-abbreviation-priority.test.ts
+++ b/tests/unit/hover-abbreviation-priority.test.ts
@@ -134,5 +134,6 @@ describe('HoverProvider abbreviation priority', () => {
         const my_text = get_hover_text(my_hover);
         expect(my_text).toContain('**display**');
         expect(my_text).not.toContain('displayknots');
+        expect(my_text).not.toContain('abbreviated as');
     });
 });

--- a/tests/unit/hover-abbreviation-priority.test.ts
+++ b/tests/unit/hover-abbreviation-priority.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { HoverProvider } from '../../src/providers/hover';
+import { CommandDatabase } from '../../src/command-database';
+import type { CommandCache } from '../../src/command-database/types';
+import { ContextTracker } from '../../src/context-tracker';
+import { DocumentState } from '../../src/document-store';
+import { StataLexer } from '../../src/lexer';
+import { init_tracker_from_source } from '../test-context-helper';
+
+function load_v18_database(): CommandDatabase {
+    const cache_path = join(
+        __dirname,
+        '../../src/command-database/caches/v18.json'
+    );
+    const cache = JSON.parse(readFileSync(cache_path, 'utf-8')) as CommandCache;
+    const db = new CommandDatabase();
+    db.load_cache(cache);
+    return db;
+}
+
+function create_test_document(content: string): DocumentState {
+    const my_lexer = new StataLexer();
+    const my_lex_result = my_lexer.tokenize(content);
+    return {
+        uri: 'file:///test.do',
+        version: 1,
+        content,
+        tokens: my_lex_result.tokens,
+        ast: null,
+        symbols: {
+            programs: new Map(),
+            localMacros: new Map(),
+            globalMacros: new Map(),
+            variables: new Map(),
+        },
+        diagnostics: [],
+    } as unknown as DocumentState;
+}
+
+function get_hover_text(value: unknown): string {
+    if (
+        value
+        && typeof value === 'object'
+        && 'contents' in (value as object)
+    ) {
+        const the_contents = (value as { contents: unknown }).contents;
+        if (
+            the_contents
+            && typeof the_contents === 'object'
+            && 'value' in (the_contents as object)
+        ) {
+            return String((the_contents as { value: unknown }).value);
+        }
+    }
+    return '';
+}
+
+describe('HoverProvider abbreviation priority', () => {
+    it('hover on di shows display and notes the abbreviation', async () => {
+        const command_db = load_v18_database();
+        const context_tracker = new ContextTracker();
+        const hover_provider = new HoverProvider(command_db, context_tracker);
+
+        const my_content = 'di "hello"';
+        const my_doc = create_test_document(my_content);
+        init_tracker_from_source(context_tracker, my_content);
+
+        const my_hover = await hover_provider.get_hover(
+            my_doc,
+            { line: 0, character: 1 }
+        );
+
+        const my_text = get_hover_text(my_hover);
+        expect(my_text).toContain('**display**');
+        expect(my_text).toContain('abbreviated as');
+        expect(my_text).toContain('`di`');
+        expect(my_text).not.toContain('**dir**');
+    });
+
+    it('hover on l shows list, not left', async () => {
+        const command_db = load_v18_database();
+        const context_tracker = new ContextTracker();
+        const hover_provider = new HoverProvider(command_db, context_tracker);
+
+        const my_content = 'l var1 var2';
+        const my_doc = create_test_document(my_content);
+        init_tracker_from_source(context_tracker, my_content);
+
+        const my_hover = await hover_provider.get_hover(
+            my_doc,
+            { line: 0, character: 0 }
+        );
+
+        const my_text = get_hover_text(my_hover);
+        expect(my_text).toContain('list');
+        expect(my_text).not.toContain('**left**');
+    });
+
+    it('hover on sca shows scalar, not scatter', async () => {
+        const command_db = load_v18_database();
+        const context_tracker = new ContextTracker();
+        const hover_provider = new HoverProvider(command_db, context_tracker);
+
+        const my_content = 'sca x = 5';
+        const my_doc = create_test_document(my_content);
+        init_tracker_from_source(context_tracker, my_content);
+
+        const my_hover = await hover_provider.get_hover(
+            my_doc,
+            { line: 0, character: 1 }
+        );
+
+        const my_text = get_hover_text(my_hover);
+        expect(my_text).toContain('scalar');
+        expect(my_text).not.toContain('**scatter**');
+    });
+
+    it('hover on display still shows the exact command, not displayknots', async () => {
+        const command_db = load_v18_database();
+        const context_tracker = new ContextTracker();
+        const hover_provider = new HoverProvider(command_db, context_tracker);
+
+        const my_content = 'display "hi"';
+        const my_doc = create_test_document(my_content);
+        init_tracker_from_source(context_tracker, my_content);
+
+        const my_hover = await hover_provider.get_hover(
+            my_doc,
+            { line: 0, character: 3 }
+        );
+
+        const my_text = get_hover_text(my_hover);
+        expect(my_text).toContain('**display**');
+        expect(my_text).not.toContain('displayknots');
+    });
+});

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -139,6 +139,54 @@ function create_frame_command_db(): CommandDatabase {
     return db;
 }
 
+
+function create_abbreviation_collision_command_db(): CommandDatabase {
+    const db = new CommandDatabase();
+    const cache: CommandCache = {
+        version: 18,
+        commands: {
+            dir: {
+                name: 'dir',
+                min_abbreviation: 1,
+                options: [
+                    {
+                        name: 'wide',
+                        min_abbreviation: 4,
+                        has_argument: false,
+                    },
+                ],
+                priority: 3,
+            },
+            display: {
+                name: 'display',
+                min_abbreviation: 2,
+                options: [
+                    {
+                        name: 'newline',
+                        min_abbreviation: 7,
+                        has_argument: true,
+                    },
+                ],
+                priority: 1,
+            },
+            displayknots: {
+                name: 'displayknots',
+                min_abbreviation: 2,
+                options: [],
+                priority: 3,
+            },
+        },
+        abbreviations: {
+            di: 'dir',
+            dis: 'display',
+            display: 'displayknots',
+            displayk: 'displayknots',
+        },
+    };
+    db.load_cache(cache);
+    return db;
+}
+
 describe('HoverProvider - Context-Aware Behavior', () => {
     let hover_provider: HoverProvider;
     let context_tracker: ContextTracker;
@@ -452,6 +500,59 @@ describe('HoverProvider - Context-Aware Behavior', () => {
                 }
             }
         );
+
+        it(
+            'should resolve di hover to display instead of dir when abbreviations collide',
+            async () => {
+                command_db = create_abbreviation_collision_command_db();
+                hover_provider = new HoverProvider(command_db, context_tracker);
+
+                const my_content = 'di 1';
+                const my_doc = create_test_document(my_content);
+                init_tracker_from_source(context_tracker, my_content);
+
+                const my_hover = await hover_provider.get_hover(
+                    my_doc,
+                    { line: 0, character: 1 }
+                );
+
+                expect(my_hover).not.toBeNull();
+                if (
+                    typeof my_hover?.contents === 'object'
+                    && 'value' in my_hover.contents
+                ) {
+                    expect(my_hover.contents.value).toContain('**display**');
+                    expect(my_hover.contents.value).not.toContain('help dir');
+                }
+            }
+        );
+
+        it(
+            'should keep exact display hover on display instead of displayknots',
+            async () => {
+                command_db = create_abbreviation_collision_command_db();
+                hover_provider = new HoverProvider(command_db, context_tracker);
+
+                const my_content = 'display 1';
+                const my_doc = create_test_document(my_content);
+                init_tracker_from_source(context_tracker, my_content);
+
+                const my_hover = await hover_provider.get_hover(
+                    my_doc,
+                    { line: 0, character: 2 }
+                );
+
+                expect(my_hover).not.toBeNull();
+                if (
+                    typeof my_hover?.contents === 'object'
+                    && 'value' in my_hover.contents
+                ) {
+                    expect(my_hover.contents.value).toContain('**display**');
+                    expect(my_hover.contents.value).not.toContain('displayknots');
+                }
+            }
+        );
+
     });
 
     describe('Comment Context Hover', () => {


### PR DESCRIPTION
## Summary
- stabilize the variable extraction property test by excluding reserved qualifier identifiers from generated varnames and identifier expressions
- tighten hover regression coverage for exact command names and make the abbreviation annotation comparison case-tolerant
- batch command registration recomputation and add regression coverage for bulk registration and collision priority

## Validation
- bun test tests/property/variable-extraction-preservation.prop.test.ts (10 consecutive runs)
- bun test tests/unit/hover-abbreviation-priority.test.ts tests/unit/command-database-abbreviation-priority.test.ts tests/property/variable-extraction-preservation.prop.test.ts
- bun run test

## Artifacts
- Conversation: https://app.warp.dev/conversation/21bd8ebe-5a4d-4a82-8f4e-078ee6ef0ee0
- Plan: https://app.warp.dev/drive/notebook/vZosj8eRJOXuTuFAUFTJuR

Co-Authored-By: Oz <oz-agent@warp.dev>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hover now shows resolved command names for abbreviations (with an “abbreviated as …” note) and enriched subcommand metadata for frame and other commands.

* **Bug Fixes**
  * Deterministic, priority-aware abbreviation resolution to pick correct commands for ambiguous prefixes (e.g., di → display) and preserve cached mappings.

* **Tests**
  * Added comprehensive unit and property tests covering abbreviation resolution, hover behavior, cache generation, and builtin metadata fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->