### PR TITLE
feat(help-viewer): open .sthlp pages from hovers, completions, and palette

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -404,6 +404,10 @@
         "title": "Open SMCL Preview (Full Width)"
       },
       {
+        "command": "sight.openHelpTopic",
+        "title": "Sight: Open Help Topic"
+      },
+      {
         "command": "sight.resetDepthColors",
         "title": "Sight: Reset Depth Colors Configuration"
       },
@@ -557,6 +561,10 @@
       "commandPalette": [
         {
           "command": "sight.openInStata",
+          "when": "false"
+        },
+        {
+          "command": "sight.openHelpTopic",
           "when": "false"
         },
         {

--- a/client/package.json
+++ b/client/package.json
@@ -564,6 +564,10 @@
           "when": "false"
         },
         {
+          "command": "sight.openHelpTopic",
+          "when": "false"
+        },
+        {
           "command": "sight.openSmclPreview",
           "when": "resourceExtname =~ /\\.(smcl|sthlp)/i"
         },

--- a/client/package.json
+++ b/client/package.json
@@ -564,10 +564,6 @@
           "when": "false"
         },
         {
-          "command": "sight.openHelpTopic",
-          "when": "false"
-        },
-        {
           "command": "sight.openSmclPreview",
           "when": "resourceExtname =~ /\\.(smcl|sthlp)/i"
         },

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -30,6 +30,10 @@ import {
     apply_language_configuration,
     read_line_comment_style,
 } from './language-config';
+import {
+    trust_hover,
+    trust_completion_item,
+} from './help-link-middleware';
 
 let client: LanguageClient | null = null;
 let output_channel: OutputChannel | null = window.createOutputChannel(
@@ -199,6 +203,46 @@ export function activate(context: ExtensionContext) {
             fileEvents: file_watcher,
             // Synchronize the 'sight' configuration section with the server
             configurationSection: 'sight'
+        },
+        // Trust the `sight.openHelpTopic` command link that the server
+        // emits in hover and completion markdown. VS Code strips
+        // command URIs from LSP-provided markdown by default; this
+        // middleware narrowly re-enables the single Sight command.
+        middleware: {
+            provideHover: async (document, position, token, next) => {
+                const my_hover = await next(document, position, token);
+                if (!my_hover) {
+                    return my_hover;
+                }
+                return trust_hover(my_hover);
+            },
+            provideCompletionItem: async (
+                document, position, context, token, next
+            ) => {
+                const my_result = await next(
+                    document, position, context, token
+                );
+                if (!my_result) {
+                    return my_result;
+                }
+                if (Array.isArray(my_result)) {
+                    for (const my_item of my_result) {
+                        trust_completion_item(my_item);
+                    }
+                    return my_result;
+                }
+                for (const my_item of my_result.items) {
+                    trust_completion_item(my_item);
+                }
+                return my_result;
+            },
+            resolveCompletionItem: async (item, token, next) => {
+                const my_resolved = await next(item, token);
+                if (!my_resolved) {
+                    return my_resolved;
+                }
+                return trust_completion_item(my_resolved);
+            },
         }
     };
 

--- a/client/src/help-link-middleware.ts
+++ b/client/src/help-link-middleware.ts
@@ -1,0 +1,71 @@
+/**
+ * Help link middleware
+ *
+ * LSP-provided markdown (from hover and completion) is rendered as
+ * untrusted by default, which strips `command:` URIs. Sight emits
+ * `command:sight.openHelpTopic?...` links from the server in hover and
+ * completion documentation, so we must wrap those payloads as trusted
+ * MarkdownString on the client side.
+ *
+ * We narrowly enable only the `sight.openHelpTopic` command rather than
+ * trusting every command URI the server might emit.
+ */
+
+import * as vscode from 'vscode';
+
+const TRUSTED_COMMANDS: { enabledCommands: string[] } = {
+    enabledCommands: ['sight.openHelpTopic'],
+};
+
+function trust_markdown(value: string): vscode.MarkdownString {
+    const my_md = new vscode.MarkdownString(value);
+    my_md.isTrusted = TRUSTED_COMMANDS;
+    return my_md;
+}
+
+/**
+ * Return a trusted copy of a hover content entry when it carries
+ * markdown. Plain strings and MarkedString code blocks (`{language,
+ * value}`) have no command URIs to guard, so they pass through
+ * unchanged.
+ */
+function trust_hover_entry(
+    entry: vscode.MarkdownString | vscode.MarkedString
+): vscode.MarkdownString | vscode.MarkedString {
+    if (entry instanceof vscode.MarkdownString) {
+        entry.isTrusted = TRUSTED_COMMANDS;
+        return entry;
+    }
+    if (typeof entry === 'string') {
+        return trust_markdown(entry);
+    }
+    // `{ language, value }` plain code block.
+    return entry;
+}
+
+/**
+ * Wrap the `contents` of a VS Code Hover so any markdown entries are
+ * trusted for the `sight.openHelpTopic` command link.
+ */
+export function trust_hover(hover: vscode.Hover): vscode.Hover {
+    const the_new_contents = hover.contents.map(trust_hover_entry);
+    return new vscode.Hover(the_new_contents, hover.range);
+}
+
+/**
+ * Wrap a CompletionItem's `documentation` (if any) as a trusted
+ * MarkdownString so command links in the server-provided markdown are
+ * clickable. Plain-string documentation is left as-is.
+ */
+export function trust_completion_item(
+    item: vscode.CompletionItem
+): vscode.CompletionItem {
+    const my_doc = item.documentation;
+    if (!my_doc || typeof my_doc === 'string') {
+        return item;
+    }
+    if (my_doc instanceof vscode.MarkdownString) {
+        my_doc.isTrusted = TRUSTED_COMMANDS;
+    }
+    return item;
+}

--- a/client/src/smcl-preview/index.ts
+++ b/client/src/smcl-preview/index.ts
@@ -67,17 +67,18 @@ export function register_smcl_preview(
         )
     );
 
-    // Help topic preview (invoked from hover/completion markdown links).
-    // Accepts either a raw topic string or an object with a `topic` field.
+    // Help topic preview. Invoked from hover/completion markdown
+    // links (topic passed as argument) or from the command palette
+    // (no argument — we prompt the user for a topic).
     context.subscriptions.push(
         vscode.commands.registerCommand(
             'sight.openHelpTopic',
             async (arg: unknown) => {
-                const my_topic = extract_topic(arg);
+                let my_topic = extract_topic(arg);
                 if (!my_topic) {
-                    vscode.window.showErrorMessage(
-                        'No help topic provided.'
-                    );
+                    my_topic = await prompt_for_topic();
+                }
+                if (!my_topic) {
                     return;
                 }
                 await my_manager.open_topic(
@@ -87,6 +88,22 @@ export function register_smcl_preview(
             }
         )
     );
+}
+
+async function prompt_for_topic(): Promise<string | null> {
+    const my_input = await vscode.window.showInputBox({
+        title: 'Sight: Open Help Topic',
+        prompt: 'Enter a Stata help topic (e.g. regress, frame create, display)',
+        placeHolder: 'regress',
+        ignoreFocusOut: true,
+        validateInput: value => {
+            if (!value || value.trim().length === 0) {
+                return 'Please enter a help topic.';
+            }
+            return null;
+        },
+    });
+    return my_input ? my_input.trim() : null;
 }
 
 function extract_topic(arg: unknown): string | null {

--- a/client/src/smcl-preview/index.ts
+++ b/client/src/smcl-preview/index.ts
@@ -107,8 +107,9 @@ async function prompt_for_topic(): Promise<string | null> {
 }
 
 function extract_topic(arg: unknown): string | null {
-    if (typeof arg === 'string' && arg.length > 0) {
-        return arg;
+    if (typeof arg === 'string') {
+        const my_topic = arg.trim();
+        return my_topic.length > 0 ? my_topic : null;
     }
     if (
         arg
@@ -116,7 +117,7 @@ function extract_topic(arg: unknown): string | null {
         && 'topic' in arg
         && typeof (arg as { topic: unknown }).topic === 'string'
     ) {
-        const my_topic = (arg as { topic: string }).topic;
+        const my_topic = (arg as { topic: string }).topic.trim();
         return my_topic.length > 0 ? my_topic : null;
     }
     return null;

--- a/client/src/smcl-preview/index.ts
+++ b/client/src/smcl-preview/index.ts
@@ -66,4 +66,41 @@ export function register_smcl_preview(
             }
         )
     );
+
+    // Help topic preview (invoked from hover/completion markdown links).
+    // Accepts either a raw topic string or an object with a `topic` field.
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'sight.openHelpTopic',
+            async (arg: unknown) => {
+                const my_topic = extract_topic(arg);
+                if (!my_topic) {
+                    vscode.window.showErrorMessage(
+                        'No help topic provided.'
+                    );
+                    return;
+                }
+                await my_manager.open_topic(
+                    my_topic,
+                    vscode.ViewColumn.Beside
+                );
+            }
+        )
+    );
+}
+
+function extract_topic(arg: unknown): string | null {
+    if (typeof arg === 'string' && arg.length > 0) {
+        return arg;
+    }
+    if (
+        arg
+        && typeof arg === 'object'
+        && 'topic' in arg
+        && typeof (arg as { topic: unknown }).topic === 'string'
+    ) {
+        const my_topic = (arg as { topic: string }).topic;
+        return my_topic.length > 0 ? my_topic : null;
+    }
+    return null;
 }

--- a/client/src/smcl-preview/panel-manager.ts
+++ b/client/src/smcl-preview/panel-manager.ts
@@ -57,7 +57,17 @@ export class SmclPanelManager implements vscode.Disposable {
         this.panels.set(my_key, my_preview);
     }
 
-    private async handle_navigate(topic: string): Promise<void> {
+    /**
+     * Resolve a Stata help topic to a .sthlp file path via the LSP and
+     * open the SMCL preview panel in the given column. Shows an
+     * actionable info message when the topic cannot be resolved,
+     * pointing the user at the `sight.adoPaths` setting which
+     * controls the server-side help file search path.
+     */
+    async open_topic(
+        topic: string,
+        column: vscode.ViewColumn
+    ): Promise<void> {
         const my_client = this.get_client();
         if (!my_client) {
             vscode.window.showInformationMessage(
@@ -73,21 +83,44 @@ export class SmclPanelManager implements vscode.Disposable {
 
             if (my_result?.file_path) {
                 const my_uri = vscode.Uri.file(my_result.file_path);
-                this.open_or_reveal(my_uri, vscode.ViewColumn.Beside);
+                this.open_or_reveal(my_uri, column);
             } else {
-                vscode.window.showInformationMessage(
-                    `Help file not found for: ${topic}`
-                );
+                await this.show_not_found_message(topic);
             }
         } catch (err) {
             console.error(
-                `handle_navigate: sendRequest sight/resolveSthlpFile` +
+                `open_topic: sendRequest sight/resolveSthlpFile` +
                 ` failed for topic="${topic}":`, err
             );
             vscode.window.showInformationMessage(
                 `Could not resolve help file for: ${topic}`
             );
         }
+    }
+
+    private async show_not_found_message(topic: string): Promise<void> {
+        const my_open_settings_label = 'Open Settings';
+        const my_message =
+            `Couldn't find a help file for '${topic}'.` +
+            ` Sight searched your workspace and common Stata install` +
+            ` locations (e.g. /Applications/Stata/ado, /usr/local/stata,` +
+            ` C:\\Program Files\\Stata, and ~/ado). Add the directory` +
+            ` containing the .sthlp file to sight.adoPaths if Sight is` +
+            ` missing it.`;
+        const my_choice = await vscode.window.showInformationMessage(
+            my_message,
+            my_open_settings_label
+        );
+        if (my_choice === my_open_settings_label) {
+            await vscode.commands.executeCommand(
+                'workbench.action.openSettings',
+                'sight.adoPaths'
+            );
+        }
+    }
+
+    private handle_navigate(topic: string): Promise<void> {
+        return this.open_topic(topic, vscode.ViewColumn.Beside);
     }
 
     dispose(): void {

--- a/client/src/smcl-preview/panel-manager.ts
+++ b/client/src/smcl-preview/panel-manager.ts
@@ -46,7 +46,8 @@ export class SmclPanelManager implements vscode.Disposable {
         const my_preview = new SmclPreviewPanel(
             source_uri,
             my_panel,
-            topic => this.handle_navigate(topic)
+            topic => this.handle_navigate(topic),
+            () => this.get_client()
         );
 
         my_preview.on_did_dispose(() => {

--- a/client/src/smcl-preview/panel-manager.ts
+++ b/client/src/smcl-preview/panel-manager.ts
@@ -93,8 +93,18 @@ export class SmclPanelManager implements vscode.Disposable {
                 `open_topic: sendRequest sight/resolveSthlpFile` +
                 ` failed for topic="${topic}":`, err
             );
-            await this.show_not_found_message(topic);
+            await this.show_server_error_message(topic);
         }
+    }
+
+    private async show_server_error_message(
+        topic: string
+    ): Promise<void> {
+        await vscode.window.showWarningMessage(
+            `The language server encountered an error resolving` +
+            ` help for '${topic}'. The server may still be` +
+            ` starting up — try again in a moment.`
+        );
     }
 
     private async show_not_found_message(topic: string): Promise<void> {

--- a/client/src/smcl-preview/panel-manager.ts
+++ b/client/src/smcl-preview/panel-manager.ts
@@ -93,9 +93,7 @@ export class SmclPanelManager implements vscode.Disposable {
                 `open_topic: sendRequest sight/resolveSthlpFile` +
                 ` failed for topic="${topic}":`, err
             );
-            vscode.window.showInformationMessage(
-                `Could not resolve help file for: ${topic}`
-            );
+            await this.show_not_found_message(topic);
         }
     }
 

--- a/client/src/smcl-preview/preview-panel.ts
+++ b/client/src/smcl-preview/preview-panel.ts
@@ -90,6 +90,18 @@ export class SmclPreviewPanel implements vscode.Disposable {
             })
         );
 
+        // Clear findalias cache when ado-path configuration changes
+        // so stale null-misses don't persist after new .maint files
+        // become available.
+        this.disposables.push(
+            vscode.workspace.onDidChangeConfiguration(event => {
+                if (event.affectsConfiguration('sight.adoPaths')) {
+                    this.findalias_cache.clear();
+                    this.schedule_update();
+                }
+            })
+        );
+
         // Initial render
         void this.refresh();
     }

--- a/client/src/smcl-preview/preview-panel.ts
+++ b/client/src/smcl-preview/preview-panel.ts
@@ -272,13 +272,9 @@ export class SmclPreviewPanel implements vscode.Disposable {
                         };
                     } catch {
                         // Server unavailable / handler unregistered:
-                        // treat like a miss. Don't cache so we retry
-                        // next refresh.
-                        return {
-                            alias: my_alias,
-                            smcl: null,
-                            skip_cache: true
-                        };
+                        // treat like a miss (smcl: null). Not cached,
+                        // so we retry next refresh.
+                        return { alias: my_alias, smcl: null };
                     }
                 })
             );
@@ -288,12 +284,10 @@ export class SmclPreviewPanel implements vscode.Disposable {
             const the_new_smcl: string[] = [];
             for (const my_result of the_results) {
                 if (my_result.smcl !== null) {
-                    if (!('skip_cache' in my_result)) {
-                        this.findalias_cache.set(
-                            my_result.alias,
-                            my_result.smcl
-                        );
-                    }
+                    this.findalias_cache.set(
+                        my_result.alias,
+                        my_result.smcl
+                    );
                     my_map.set(my_result.alias, my_result.smcl);
                     the_new_smcl.push(my_result.smcl);
                 }

--- a/client/src/smcl-preview/preview-panel.ts
+++ b/client/src/smcl-preview/preview-panel.ts
@@ -33,9 +33,13 @@ export class SmclPreviewPanel implements vscode.Disposable {
     private get_client: () => LanguageClient | null;
     private disposed = false;
 
-    // Cache of `{findalias}` resolutions (alias → SMCL substitution or
-    // `null` for misses). Shared across refreshes for a given panel so
-    // debounced edits and scroll-sync redraws don't re-query the LSP.
+    // Monotonically increasing token so that a slow older refresh
+    // cannot overwrite HTML produced by a newer one.
+    private refresh_seq = 0;
+
+    // Cache of `{findalias}` resolutions (alias → SMCL substitution).
+    // Only hits are cached; misses re-query the LSP on each refresh so
+    // newly installed .maint files are detected without reopening.
     private findalias_cache: Map<string, string> = new Map();
 
     // Scroll sync state
@@ -156,11 +160,17 @@ export class SmclPreviewPanel implements vscode.Disposable {
         const my_content = this.read_content();
         if (my_content === null) return;
 
+        // Capture a token before any async work. If a newer refresh
+        // starts while we're awaiting LSP responses, it will bump the
+        // sequence and we'll discard our stale result.
+        const my_token = ++this.refresh_seq;
+
         const my_findalias_map = await this.resolve_findalias_map(my_content);
 
-        // If the panel was disposed while we were awaiting LSP
-        // responses, bail out rather than writing to a dead webview.
-        if (this.disposed) return;
+        // If the panel was disposed or a newer refresh has started
+        // while we were awaiting, bail out to avoid overwriting
+        // fresher content with stale HTML.
+        if (this.disposed || my_token !== this.refresh_seq) return;
 
         const my_result = smcl_to_html(my_content, {
             findalias_map: my_findalias_map,

--- a/client/src/smcl-preview/preview-panel.ts
+++ b/client/src/smcl-preview/preview-panel.ts
@@ -9,11 +9,20 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
+import { LanguageClient } from 'vscode-languageclient/node';
 import { smcl_to_html } from './smcl-to-html';
 import { build_webview_html } from './webview-html';
 
 const UPDATE_DEBOUNCE_MS = 300;
 const SCROLL_SYNC_SUPPRESSION_MS = 80;
+
+/**
+ * Regex used to extract `{findalias <alias>}` directives from raw
+ * SMCL before handing off to the renderer. We only need a best-effort
+ * scan to collect unique aliases for parallel LSP resolution; the
+ * canonical parse happens later inside `smcl_to_html`.
+ */
+const FINDALIAS_RE = /\{\s*findalias\s+([^}]+?)\s*\}/g;
 
 export class SmclPreviewPanel implements vscode.Disposable {
     private panel: vscode.WebviewPanel;
@@ -21,7 +30,13 @@ export class SmclPreviewPanel implements vscode.Disposable {
     private disposables: vscode.Disposable[] = [];
     private debounce_timer: ReturnType<typeof setTimeout> | undefined;
     private on_navigate: (topic: string) => void;
+    private get_client: () => LanguageClient | null;
     private disposed = false;
+
+    // Cache of `{findalias}` resolutions (alias → SMCL substitution or
+    // `null` for misses). Shared across refreshes for a given panel so
+    // debounced edits and scroll-sync redraws don't re-query the LSP.
+    private findalias_cache: Map<string, string | null> = new Map();
 
     // Scroll sync state
     private scroll_sync_source: 'editor' | 'preview' | null = null;
@@ -30,11 +45,13 @@ export class SmclPreviewPanel implements vscode.Disposable {
     constructor(
         source_uri: vscode.Uri,
         panel: vscode.WebviewPanel,
-        on_navigate: (topic: string) => void
+        on_navigate: (topic: string) => void,
+        get_client: () => LanguageClient | null
     ) {
         this.source_uri = source_uri;
         this.panel = panel;
         this.on_navigate = on_navigate;
+        this.get_client = get_client;
 
         // Handle messages from the webview
         this.disposables.push(
@@ -74,7 +91,7 @@ export class SmclPreviewPanel implements vscode.Disposable {
         );
 
         // Initial render
-        this.refresh();
+        void this.refresh();
     }
 
     get uri_string(): string {
@@ -118,16 +135,24 @@ export class SmclPreviewPanel implements vscode.Disposable {
         }
         this.debounce_timer = setTimeout(() => {
             this.debounce_timer = undefined;
-            this.refresh();
+            void this.refresh();
         }, UPDATE_DEBOUNCE_MS);
     }
 
-    private refresh(): void {
+    private async refresh(): Promise<void> {
         // Try to get content from open editor first; fall back to disk
         const my_content = this.read_content();
         if (my_content === null) return;
 
-        const my_result = smcl_to_html(my_content);
+        const my_findalias_map = await this.resolve_findalias_map(my_content);
+
+        // If the panel was disposed while we were awaiting LSP
+        // responses, bail out rather than writing to a dead webview.
+        if (this.disposed) return;
+
+        const my_result = smcl_to_html(my_content, {
+            findalias_map: my_findalias_map,
+        });
         const my_nonce = crypto.randomBytes(16).toString('hex');
         const my_title = this.get_title();
 
@@ -144,6 +169,67 @@ export class SmclPreviewPanel implements vscode.Disposable {
         if (my_editor) {
             this.sync_editor_to_preview(my_editor.visibleRanges);
         }
+    }
+
+    /**
+     * Collect unique `{findalias X}` aliases in the source and resolve
+     * them via the LSP. Returns a map of alias → SMCL substitution
+     * containing only successful resolutions (misses are omitted so
+     * the renderer can fall back to its empty-string behavior).
+     *
+     * Resolutions are cached for the lifetime of the panel so repeat
+     * renders caused by debounced edits or scroll sync don't re-hit
+     * the LSP.
+     */
+    private async resolve_findalias_map(
+        content: string
+    ): Promise<Map<string, string>> {
+        const the_aliases = collect_findalias_names(content);
+        const my_map = new Map<string, string>();
+        if (the_aliases.size === 0) return my_map;
+
+        const my_client = this.get_client();
+        // Pull cached hits up-front so we only query the LSP for misses.
+        const the_unresolved: string[] = [];
+        for (const my_alias of the_aliases) {
+            if (this.findalias_cache.has(my_alias)) {
+                const my_cached = this.findalias_cache.get(my_alias)!;
+                if (my_cached !== null) {
+                    my_map.set(my_alias, my_cached);
+                }
+                continue;
+            }
+            the_unresolved.push(my_alias);
+        }
+
+        if (the_unresolved.length === 0 || !my_client) {
+            return my_map;
+        }
+
+        const the_results = await Promise.all(
+            the_unresolved.map(async (my_alias) => {
+                try {
+                    const my_response = await my_client.sendRequest<{
+                        smcl: string | null;
+                    }>('sight/resolveFindalias', { alias: my_alias });
+                    return { alias: my_alias, smcl: my_response?.smcl ?? null };
+                } catch {
+                    // Server unavailable / handler unregistered: treat
+                    // like a miss. Don't cache so we retry next refresh.
+                    return { alias: my_alias, smcl: null, skip_cache: true };
+                }
+            })
+        );
+
+        for (const my_result of the_results) {
+            if (!('skip_cache' in my_result)) {
+                this.findalias_cache.set(my_result.alias, my_result.smcl);
+            }
+            if (my_result.smcl !== null) {
+                my_map.set(my_result.alias, my_result.smcl);
+            }
+        }
+        return my_map;
     }
 
     private read_content(): string | null {
@@ -239,4 +325,26 @@ export class SmclPreviewPanel implements vscode.Disposable {
                 break;
         }
     }
+}
+
+/**
+ * Best-effort extraction of unique `{findalias <alias>}` arguments
+ * from raw SMCL text. Returns a set so duplicates trigger only one
+ * LSP lookup per alias.
+ *
+ * Exported for tests. We rely on the pattern being non-nested (Stata
+ * never puts `{` inside `{findalias …}` args), which matches every
+ * real-world occurrence in the ado base tree.
+ */
+export function collect_findalias_names(source: string): Set<string> {
+    const the_names = new Set<string>();
+    FINDALIAS_RE.lastIndex = 0;
+    let my_match: RegExpExecArray | null;
+    while ((my_match = FINDALIAS_RE.exec(source)) !== null) {
+        const my_alias = my_match[1].trim();
+        if (my_alias.length > 0) {
+            the_names.add(my_alias);
+        }
+    }
+    return the_names;
 }

--- a/client/src/smcl-preview/preview-panel.ts
+++ b/client/src/smcl-preview/preview-panel.ts
@@ -226,18 +226,39 @@ export class SmclPreviewPanel implements vscode.Disposable {
             my_round++
         ) {
             const the_unresolved: string[] = [];
+            const the_cached_smcl: string[] = [];
             for (const my_alias of the_pending) {
                 if (the_seen.has(my_alias)) continue;
                 the_seen.add(my_alias);
                 const my_cached = this.findalias_cache.get(my_alias);
                 if (my_cached !== undefined) {
                     my_map.set(my_alias, my_cached);
+                    the_cached_smcl.push(my_cached);
                     continue;
                 }
                 the_unresolved.push(my_alias);
             }
 
-            if (the_unresolved.length === 0 || !my_client) break;
+            // Scan cached SMCL for nested aliases so transitive
+            // references discovered from cache hits are resolved in
+            // subsequent rounds.
+            const the_next = new Set<string>();
+            for (const my_smcl of the_cached_smcl) {
+                for (const my_alias of collect_findalias_names(my_smcl)) {
+                    if (!the_seen.has(my_alias)) {
+                        the_next.add(my_alias);
+                    }
+                }
+            }
+
+            // If nothing needs an LSP call, carry forward any nested
+            // aliases discovered from cached hits and continue (or
+            // break if there are none).
+            if (the_unresolved.length === 0 || !my_client) {
+                the_pending = the_next;
+                if (the_next.size === 0) break;
+                continue;
+            }
 
             const the_results = await Promise.all(
                 the_unresolved.map(async (my_alias) => {
@@ -278,8 +299,8 @@ export class SmclPreviewPanel implements vscode.Disposable {
                 }
             }
 
-            // Scan newly resolved SMCL for transitive aliases.
-            const the_next = new Set<string>();
+            // Scan newly resolved SMCL for transitive aliases,
+            // merging with any nested aliases from cached hits.
             for (const my_smcl of the_new_smcl) {
                 for (const my_alias of collect_findalias_names(my_smcl)) {
                     if (!the_seen.has(my_alias)) {

--- a/client/src/smcl-preview/preview-panel.ts
+++ b/client/src/smcl-preview/preview-panel.ts
@@ -206,52 +206,90 @@ export class SmclPreviewPanel implements vscode.Disposable {
     private async resolve_findalias_map(
         content: string
     ): Promise<Map<string, string>> {
-        const the_aliases = collect_findalias_names(content);
         const my_map = new Map<string, string>();
-        if (the_aliases.size === 0) return my_map;
-
         const my_client = this.get_client();
-        // Pull cached hits up-front so we only query the LSP for misses.
-        const the_unresolved: string[] = [];
-        for (const my_alias of the_aliases) {
-            const my_cached = this.findalias_cache.get(my_alias);
-            if (my_cached !== undefined) {
-                my_map.set(my_alias, my_cached);
-                continue;
-            }
-            the_unresolved.push(my_alias);
-        }
 
-        if (the_unresolved.length === 0 || !my_client) {
-            return my_map;
-        }
+        // Resolve transitively: an alias's SMCL substitution may
+        // itself contain `{findalias X}`, so we iterate until no new
+        // aliases are discovered. A depth cap prevents runaway loops
+        // from circular alias chains.
+        const MAX_RESOLVE_ROUNDS = 5;
+        // Seed the first round with aliases found in the source.
+        let the_pending = collect_findalias_names(content);
+        // Track every alias we've already attempted (hit or miss) so
+        // we never re-request the same alias in a later round.
+        const the_seen = new Set<string>();
 
-        const the_results = await Promise.all(
-            the_unresolved.map(async (my_alias) => {
-                try {
-                    const my_response = await my_client.sendRequest<{
-                        smcl: string | null;
-                    }>('sight/resolveFindalias', { alias: my_alias });
-                    return { alias: my_alias, smcl: my_response?.smcl ?? null };
-                } catch {
-                    // Server unavailable / handler unregistered: treat
-                    // like a miss. Don't cache so we retry next refresh.
-                    return { alias: my_alias, smcl: null, skip_cache: true };
+        for (
+            let my_round = 0;
+            my_round < MAX_RESOLVE_ROUNDS && the_pending.size > 0;
+            my_round++
+        ) {
+            const the_unresolved: string[] = [];
+            for (const my_alias of the_pending) {
+                if (the_seen.has(my_alias)) continue;
+                the_seen.add(my_alias);
+                const my_cached = this.findalias_cache.get(my_alias);
+                if (my_cached !== undefined) {
+                    my_map.set(my_alias, my_cached);
+                    continue;
                 }
-            })
-        );
-
-        for (const my_result of the_results) {
-            // Only cache hits — null misses are intentionally not
-            // cached so that newly installed .maint files are picked
-            // up on the next refresh without reopening the panel.
-            if (my_result.smcl !== null) {
-                if (!('skip_cache' in my_result)) {
-                    this.findalias_cache.set(my_result.alias, my_result.smcl);
-                }
-                my_map.set(my_result.alias, my_result.smcl);
+                the_unresolved.push(my_alias);
             }
+
+            if (the_unresolved.length === 0 || !my_client) break;
+
+            const the_results = await Promise.all(
+                the_unresolved.map(async (my_alias) => {
+                    try {
+                        const my_response = await my_client.sendRequest<{
+                            smcl: string | null;
+                        }>('sight/resolveFindalias', { alias: my_alias });
+                        return {
+                            alias: my_alias,
+                            smcl: my_response?.smcl ?? null
+                        };
+                    } catch {
+                        // Server unavailable / handler unregistered:
+                        // treat like a miss. Don't cache so we retry
+                        // next refresh.
+                        return {
+                            alias: my_alias,
+                            smcl: null,
+                            skip_cache: true
+                        };
+                    }
+                })
+            );
+
+            // Collect newly resolved SMCL so we can scan it for
+            // nested aliases.
+            const the_new_smcl: string[] = [];
+            for (const my_result of the_results) {
+                if (my_result.smcl !== null) {
+                    if (!('skip_cache' in my_result)) {
+                        this.findalias_cache.set(
+                            my_result.alias,
+                            my_result.smcl
+                        );
+                    }
+                    my_map.set(my_result.alias, my_result.smcl);
+                    the_new_smcl.push(my_result.smcl);
+                }
+            }
+
+            // Scan newly resolved SMCL for transitive aliases.
+            const the_next = new Set<string>();
+            for (const my_smcl of the_new_smcl) {
+                for (const my_alias of collect_findalias_names(my_smcl)) {
+                    if (!the_seen.has(my_alias)) {
+                        the_next.add(my_alias);
+                    }
+                }
+            }
+            the_pending = the_next;
         }
+
         return my_map;
     }
 

--- a/client/src/smcl-preview/preview-panel.ts
+++ b/client/src/smcl-preview/preview-panel.ts
@@ -36,7 +36,7 @@ export class SmclPreviewPanel implements vscode.Disposable {
     // Cache of `{findalias}` resolutions (alias → SMCL substitution or
     // `null` for misses). Shared across refreshes for a given panel so
     // debounced edits and scroll-sync redraws don't re-query the LSP.
-    private findalias_cache: Map<string, string | null> = new Map();
+    private findalias_cache: Map<string, string> = new Map();
 
     // Scroll sync state
     private scroll_sync_source: 'editor' | 'preview' | null = null;
@@ -204,11 +204,9 @@ export class SmclPreviewPanel implements vscode.Disposable {
         // Pull cached hits up-front so we only query the LSP for misses.
         const the_unresolved: string[] = [];
         for (const my_alias of the_aliases) {
-            if (this.findalias_cache.has(my_alias)) {
-                const my_cached = this.findalias_cache.get(my_alias)!;
-                if (my_cached !== null) {
-                    my_map.set(my_alias, my_cached);
-                }
+            const my_cached = this.findalias_cache.get(my_alias);
+            if (my_cached !== undefined) {
+                my_map.set(my_alias, my_cached);
                 continue;
             }
             the_unresolved.push(my_alias);
@@ -234,10 +232,13 @@ export class SmclPreviewPanel implements vscode.Disposable {
         );
 
         for (const my_result of the_results) {
-            if (!('skip_cache' in my_result)) {
-                this.findalias_cache.set(my_result.alias, my_result.smcl);
-            }
+            // Only cache hits — null misses are intentionally not
+            // cached so that newly installed .maint files are picked
+            // up on the next refresh without reopening the panel.
             if (my_result.smcl !== null) {
+                if (!('skip_cache' in my_result)) {
+                    this.findalias_cache.set(my_result.alias, my_result.smcl);
+                }
                 my_map.set(my_result.alias, my_result.smcl);
             }
         }

--- a/client/src/smcl-preview/smcl-to-html.ts
+++ b/client/src/smcl-preview/smcl-to-html.ts
@@ -1357,11 +1357,28 @@ export function smcl_to_html(
     options?: SmclToHtmlOptions
 ): SmclHtmlResult {
     const the_raw_nodes = parse_smcl(smcl);
+    // Drop the `{title:Title}` placeholder many Stata help files put
+    // at the top of the file (368 occurrences in the base ado tree as
+    // of Stata 18). The word "Title" is not meaningful content — it
+    // labels the upcoming title section, which is either a
+    // `{p2colset}…{p2colreset}` block (handled below) or a
+    // `{pstd}{findalias X}` block (resolved via the findalias_map).
+    // Stripping the stand-alone heading avoids a useless "Title"
+    // <h2> above the real title info.
+    const the_stripped_nodes = strip_placeholder_title(the_raw_nodes);
     // Collapse the `.sthlp` header's `{p2colset}…{p2colreset}` title
     // block into a single synthetic directive so we can render it as
     // a proper heading with a PDF-manual link, rather than a narrow
     // 2-column table row.
-    const the_nodes = transform_help_title(the_raw_nodes);
+    const the_p2col_nodes = transform_help_title(the_stripped_nodes);
+    // Files that substitute a manlink via `{pstd}{findalias X}` for
+    // their title block (e.g. `exp.sthlp`, `operator.sthlp`) get the
+    // same `__help_title__` treatment so they render as a proper
+    // heading + PDF link instead of a small inline blue reference.
+    const the_nodes = transform_findalias_help_title(
+        the_p2col_nodes,
+        options?.findalias_map
+    );
     const ctx = create_context(options?.findalias_map);
     let html = render_nodes(the_nodes, ctx);
     // Close any trailing persistent formats and style span
@@ -1388,6 +1405,57 @@ export function smcl_to_html(
 // ---------------------------------------------------------------------------
 // Help-title preprocessor
 // ---------------------------------------------------------------------------
+
+/**
+ * Remove the leading `{title:Title}` directive many Stata help files
+ * use as a placeholder label for their title section.
+ *
+ * Across the Stata 18 base ado tree, `{title:Title}` appears 368
+ * times with this exact placeholder text, always immediately followed
+ * by either a `{p2colset}…{p2colreset}` header block or a
+ * `{pstd}{findalias X}` block that supplies the real title content.
+ * Rendering the literal word "Title" as an `<h2>` adds a noisy,
+ * meaningless heading; Stata's native viewer tolerates it but we can
+ * do better by skipping it.
+ *
+ * We only strip the FIRST top-level `{title:...}` directive, and only
+ * when its content text is exactly "Title". Every other title
+ * (`Syntax`, `Description`, `Remarks`, …) is meaningful and must
+ * survive intact.
+ */
+function strip_placeholder_title(nodes: SmclNode[]): SmclNode[] {
+    for (let i = 0; i < nodes.length; i++) {
+        const my_node = nodes[i];
+        if (!is_directive(my_node)) continue;
+        if (my_node.name.toLowerCase() !== 'title') continue;
+        const my_text = extract_title_plain_text(my_node).trim();
+        if (my_text === 'Title') {
+            return [...nodes.slice(0, i), ...nodes.slice(i + 1)];
+        }
+        // First title encountered was something meaningful; leave it
+        // and every subsequent title alone.
+        return nodes;
+    }
+    return nodes;
+}
+
+/**
+ * Flatten a `{title:…}` directive's content into plain text so we can
+ * check for the `Title` placeholder. Non-text children contribute
+ * nothing (no real help file decorates the title content with
+ * directives; being conservative here only means we leave such a
+ * title in place).
+ */
+function extract_title_plain_text(directive: SmclDirective): string {
+    if (directive.args) return directive.args;
+    const the_parts: string[] = [];
+    for (const my_child of directive.content) {
+        if ('text' in my_child) {
+            the_parts.push(my_child.text);
+        }
+    }
+    return the_parts.join('');
+}
 
 interface HelpTitleInfo {
     /** Command / entry name, e.g. "display" or "frame create". */
@@ -1557,6 +1625,162 @@ function try_match_help_title(
             mansection_text,
         },
     };
+}
+
+/**
+ * Paragraph directives that can open a title-style block. When a help
+ * file substitutes its title via `{pstd}{findalias X}`, the outer
+ * paragraph wrapper is almost always `{pstd}`, but we accept the full
+ * family so layout-variant files still benefit.
+ */
+const PARAGRAPH_DIRECTIVE_NAMES: ReadonlySet<string> = new Set([
+    'p', 'pstd', 'pin', 'pin2', 'pin3',
+    'phang', 'phang2', 'phang3',
+    'pmore', 'pmore2', 'pmore3',
+    'psee',
+]);
+
+/**
+ * Directive names that mark the end of the preamble / title area.
+ * Hitting any of these during the findalias-title scan means the
+ * title block has already been rendered (or this file doesn't follow
+ * the pattern), so we leave the tree untouched.
+ */
+const PREAMBLE_TERMINATOR_NAMES: ReadonlySet<string> = new Set([
+    'marker', 'title', 'p2colset', '__help_title__',
+]);
+
+/**
+ * Walk the top-level nodes and, if the preamble contains a title-
+ * style `{findalias X}` block whose substitution resolves to a
+ * `{manlink A B…}` (the convention used by files like `exp.sthlp`
+ * and `operator.sthlp`), collapse the whole block into a synthetic
+ * `__help_title__` directive carrying the manual-reference heading.
+ *
+ * Without this pass the findalias resolves inline as a small bold
+ * blue link inside a regular paragraph, which hides the fact that
+ * the paragraph is actually the document's title.
+ *
+ * The scan is intentionally cheap and bails to the original node
+ * list the moment it encounters any signal that the preamble is
+ * already done (e.g. a `{marker}`, `{title:…}`, `{p2colset}`, or an
+ * already-synthesized `__help_title__`).
+ */
+function transform_findalias_help_title(
+    nodes: SmclNode[],
+    findalias_map: Map<string, string> | undefined
+): SmclNode[] {
+    if (!findalias_map || findalias_map.size === 0) return nodes;
+
+    // Remember the earliest paragraph directive we've seen so the
+    // replacement range swallows the opening `{pstd}` along with the
+    // `{findalias}` it contains.
+    let paragraph_start = -1;
+
+    for (let i = 0; i < nodes.length; i++) {
+        const my_node = nodes[i];
+
+        if (!is_directive(my_node)) {
+            // Any non-whitespace text before a findalias means we've
+            // moved into real body content; leave the tree alone.
+            if (!/^\s*$/.test(my_node.text)) return nodes;
+            continue;
+        }
+
+        const my_name = my_node.name.toLowerCase();
+        if (PREAMBLE_TERMINATOR_NAMES.has(my_name)) {
+            return nodes;
+        }
+
+        if (my_name === 'findalias') {
+            const my_alias = (my_node.args ?? '').trim();
+            if (my_alias.length === 0) continue;
+            const my_smcl = findalias_map.get(my_alias);
+            if (!my_smcl) continue;
+            const my_info = extract_manlink_help_title(my_smcl);
+            if (!my_info) continue;
+
+            const my_start = paragraph_start >= 0 ? paragraph_start : i;
+            // Consume through the end of the title paragraph: stop at
+            // the next hard boundary (marker/title/p2colset) or EOF.
+            let my_end = i + 1;
+            while (my_end < nodes.length) {
+                const my_next = nodes[my_end];
+                if (is_directive(my_next)) {
+                    const my_next_name = my_next.name.toLowerCase();
+                    if (PREAMBLE_TERMINATOR_NAMES.has(my_next_name)) {
+                        break;
+                    }
+                }
+                my_end++;
+            }
+
+            const my_synthetic: SmclDirective = {
+                name: '__help_title__',
+                args: JSON.stringify(my_info),
+                content: [],
+                line: nodes[my_start].line,
+            };
+            return [
+                ...nodes.slice(0, my_start),
+                my_synthetic,
+                ...nodes.slice(my_end),
+            ];
+        }
+
+        if (
+            paragraph_start < 0
+            && PARAGRAPH_DIRECTIVE_NAMES.has(my_name)
+        ) {
+            paragraph_start = i;
+        }
+    }
+
+    return nodes;
+}
+
+/**
+ * Parse a findalias substitution and, if it contains a `{manlink A B}`
+ * as its primary content, derive help-title metadata from it.
+ *
+ * The heading drops any leading section-number prefix (e.g. `13.2 `)
+ * so topics like `{manlink U 13.2 Operators}` render with a clean
+ * `Operators` heading. The full `[U] 13.2 Operators` reference is
+ * kept as the subtitle, and the mansection target is formatted so
+ * `build_manual_url` produces the canonical `u13.pdf#u13.2Operators`
+ * style URL.
+ */
+function extract_manlink_help_title(
+    smcl: string
+): HelpTitleInfo | null {
+    const the_nodes = parse_smcl(smcl);
+    for (const my_node of the_nodes) {
+        if (!is_directive(my_node)) continue;
+        const my_name = my_node.name.toLowerCase();
+        if (my_name !== 'manlink' && my_name !== 'manlinki') continue;
+
+        const my_args = (my_node.args ?? '').trim();
+        if (my_args.length === 0) return null;
+        const my_space = my_args.indexOf(' ');
+        if (my_space < 0) return null;
+        const my_manual = my_args.substring(0, my_space).trim();
+        const my_entry = my_args.substring(my_space + 1).trim();
+        if (my_manual.length === 0 || my_entry.length === 0) return null;
+
+        // Strip a leading section number like `13 `, `13.2 `, or
+        // `11.1.3 `. Falls back to the raw entry when there's nothing
+        // to strip (e.g. `regress postestimation`).
+        const my_heading = my_entry.replace(/^\d+(?:\.\d+)*\s+/, '').trim()
+            || my_entry;
+
+        return {
+            name: my_heading,
+            description: `[${my_manual}] ${my_entry}`,
+            mansection_target: `${my_manual} ${my_entry}`,
+            mansection_text: 'View complete PDF manual entry',
+        };
+    }
+    return null;
 }
 
 function extract_title_ref_from_p2col(

--- a/client/src/smcl-preview/smcl-to-html.ts
+++ b/client/src/smcl-preview/smcl-to-html.ts
@@ -462,6 +462,19 @@ function render_directive(
         // -- Text formatting (scoped: {bf:text}) --
         case 'bf':
             if (directive.content.length > 0) {
+                // Detect inline manual references like `{bf:[R] regress}`
+                // or `{bf:[U] 12.5 Formats}` and route them through the
+                // same help-link / PDF-link machinery as `{manlink}`.
+                const my_ref = detect_bracketed_manual_ref(directive);
+                if (my_ref) {
+                    const my_inner = build_manlink_anchor_inner(
+                        my_ref.manual,
+                        my_ref.entry,
+                        escape_html(my_ref.display_text),
+                        ctx
+                    );
+                    return `<strong>${my_inner}</strong>`;
+                }
                 return `<strong>${render_content(directive, ctx)}</strong>`;
             }
             return push_format(ctx, 'bf');
@@ -983,18 +996,68 @@ function render_manlink(
     ctx: RenderContext,
     italic: boolean
 ): string {
-    // {manlink MANUAL entry}
-    const the_parts = (directive.args || '').split(/\s+/);
+    // {manlink MANUAL entry} — e.g. {manlink R display} or
+    // {manlink U 12.5FormatsControllinghowdataaredisplayed}. Stata's
+    // native viewer opens these in the manual, so we emit a clickable
+    // link: topic-shaped entries go through the help viewer (same
+    // mechanism as `{help}`); manual-section refs link to stata.com
+    // PDFs via `build_manual_url`. Fall back to the plain bold/italic
+    // span when neither path applies.
+    const the_parts = (directive.args || '').trim().split(/\s+/);
     const my_manual = the_parts[0] || '';
-    const my_entry = the_parts.slice(1).join(' ') || '';
+    const my_entry = the_parts.slice(1).join(' ').trim();
     const my_display = directive.content.length > 0
         ? render_content(directive, ctx)
         : `[${escape_html(my_manual)}] ${escape_html(my_entry)}`;
 
-    let my_html = `<span class="smcl-manlink">${my_display}</span>`;
+    const my_inner = build_manlink_anchor_inner(
+        my_manual,
+        my_entry,
+        my_display,
+        ctx
+    );
+
+    let my_html = my_inner;
     if (italic) my_html = `<em>${my_html}</em>`;
     else my_html = `<strong>${my_html}</strong>`;
     return my_html;
+}
+
+/**
+ * Shared anchor / span rendering for `{manlink}` and inline-bold
+ * `[X] name` references. Returns either an `<a>` (when we can route
+ * to a help topic or a stata.com PDF) or a plain span with the
+ * existing `.smcl-manlink` styling when we can't classify the target.
+ */
+function build_manlink_anchor_inner(
+    manual: string,
+    entry: string,
+    display_html: string,
+    _ctx: RenderContext
+): string {
+    if (manual.length === 0 || entry.length === 0) {
+        return `<span class="smcl-manlink">${display_html}</span>`;
+    }
+
+    if (looks_like_help_topic(entry)) {
+        // Route to our SMCL help viewer via the same message path as
+        // `{help}` links. The topic is the entry without the bracket.
+        return (
+            `<a class="smcl-help-link smcl-manlink-topic" `
+            + `href="#" data-smcl-topic="${escape_html(entry)}">`
+            + `${display_html}</a>`
+        );
+    }
+
+    const my_url = build_manual_url(`${manual} ${entry.replace(/\s+/g, '')}`);
+    if (my_url) {
+        return (
+            `<a class="smcl-browse smcl-mansection smcl-manlink-pdf" `
+            + `href="${escape_html(my_url)}">${display_html}</a>`
+        );
+    }
+
+    return `<span class="smcl-manlink">${display_html}</span>`;
 }
 
 function render_mansection(directive: SmclDirective): string {
@@ -1036,46 +1099,50 @@ function parse_mansection_args(args: string): MansectionParsed | null {
 function build_manual_url(target: string): string | null {
     // Stata's online manual URLs follow a predictable convention that
     // was reverse-engineered by inspecting the per-entry PDFs on
-    // stata.com (e.g. /manuals/pdisplay.pdf, /manuals/rregress.pdf):
+    // stata.com (e.g. /manuals/pdisplay.pdf, /manuals/rregress.pdf,
+    // /manuals/u12.pdf):
     //
     //   * Filename: `<letter_lower><root_lower>.pdf`, where `root` is
-    //     the lowercase prefix of the sthlp `{mansection}` target
-    //     (everything up to the first uppercase letter).
+    //     the lowercase/digit prefix of the sthlp `{mansection}` target
+    //     (everything up to the first uppercase letter or period).
     //   * Named destinations inside the PDF preserve the original
     //     case of the target. The destination name is the lowercase
     //     manual letter concatenated with the target verbatim.
     //
     // Examples (all verified against actual PDFs on stata.com):
-    //   "P display"                     → pdisplay.pdf
-    //   "P displayRemarksandexamples"   → pdisplay.pdf#pdisplayRemarksandexamples
-    //   "R regressMethodsandformulas"   → rregress.pdf#rregressMethodsandformulas
+    //   "P display"                              → pdisplay.pdf
+    //   "P displayRemarksandexamples"            → pdisplay.pdf#pdisplayRemarksandexamples
+    //   "R regressMethodsandformulas"            → rregress.pdf#rregressMethodsandformulas
+    //   "U 12.5FormatsControllinghowdataaredisplayed"
+    //                                            → u12.pdf#u12.5FormatsControllinghowdataaredisplayed
     //
-    // We only construct URLs for the common `<MANUAL> <entry>` shape;
-    // anything else (section numbers like "U 11.3") returns null so
-    // the caller falls back to plain text.
-    const my_match = target.trim().match(/^([A-Z]+)\s+([A-Za-z][A-Za-z0-9_ ]*)$/);
+    // The entry may start with a digit (User's Guide section refs) and
+    // may contain periods. Anything that fails to produce a root
+    // returns null so the caller falls back to plain text.
+    const my_match = target.trim().match(
+        /^([A-Z]+)\s+([A-Za-z0-9][A-Za-z0-9_. ]*)$/
+    );
     if (!my_match) return null;
     const my_letter = my_match[1].toLowerCase();
     const my_entry_raw = my_match[2].replace(/\s+/g, '');
     if (my_entry_raw.length === 0) return null;
 
-    // Root = lowercase/digit/underscore prefix; the rest (if any,
-    // starting with an uppercase letter) is the PDF subsection.
+    // Root = longest lowercase/digit/underscore prefix. Anything after
+    // (a period or an uppercase letter) is the PDF subsection.
+    const my_root_match = my_entry_raw.match(/^([a-z0-9_]+)/);
     let my_root: string;
     let my_has_subsection: boolean;
-    if (/^[a-z]/.test(my_entry_raw)) {
-        const my_split = my_entry_raw.match(/^([a-z0-9_]+)([A-Z].*)$/);
-        if (my_split) {
-            my_root = my_split[1];
-            my_has_subsection = true;
-        } else {
-            my_root = my_entry_raw;
-            my_has_subsection = false;
-        }
+    if (my_root_match && my_root_match[1].length < my_entry_raw.length) {
+        my_root = my_root_match[1];
+        my_has_subsection = true;
+    } else if (my_root_match) {
+        // Entire entry is lowercase/digit/underscore; no subsection.
+        my_root = my_entry_raw;
+        my_has_subsection = false;
     } else {
         // Entry starts with uppercase (rare; e.g. "SEM Intro5").
         // Treat the entire entry as the root and skip the anchor.
-        my_root = my_entry_raw;
+        my_root = my_entry_raw.toLowerCase();
         my_has_subsection = false;
     }
 
@@ -1087,6 +1154,45 @@ function build_manual_url(target: string): string | null {
     // Destination name is `<letter_lower><target_case_preserved>`,
     // matching what Stata embeds in the PDF's /Names tree.
     return `${my_base}#${my_letter}${my_entry_raw}`;
+}
+
+/**
+ * Check whether an entry name looks like a Stata command / help topic
+ * (all-lowercase identifier words, optionally space-separated — e.g.
+ * "display", "frame create", "regress postestimation") rather than a
+ * manual section reference. Topics route through the sthlp viewer;
+ * non-topics go to the PDF manual.
+ */
+function looks_like_help_topic(entry: string): boolean {
+    return /^[a-z_][a-z0-9_]*(?: [a-z_][a-z0-9_]*)*$/.test(entry.trim());
+}
+
+/**
+ * Detect a `{bf:[X] name}` pattern in a directive's content and
+ * extract the manual code / entry / original text. Returns null when
+ * the content has nested markup or doesn't match the shape — in that
+ * case the caller should render a plain `<strong>` as before.
+ *
+ * The content must be a single text node (with optional surrounding
+ * whitespace) of the form `[MANUAL] entry` where MANUAL is one or
+ * more uppercase letters and entry is non-empty.
+ */
+function detect_bracketed_manual_ref(
+    directive: SmclDirective
+): { manual: string; entry: string; display_text: string } | null {
+    if (directive.content.length !== 1) return null;
+    const my_node = directive.content[0];
+    if (is_directive(my_node)) return null;
+    const my_raw = my_node.text;
+    const my_match = my_raw.match(/^\s*\[([A-Z]+)\]\s+(.+?)\s*$/);
+    if (!my_match) return null;
+    const my_entry = my_match[2].trim();
+    if (my_entry.length === 0) return null;
+    return {
+        manual: my_match[1],
+        entry: my_entry,
+        display_text: my_raw.trim(),
+    };
 }
 
 function is_safe_url(url: string): boolean {

--- a/client/src/smcl-preview/smcl-to-html.ts
+++ b/client/src/smcl-preview/smcl-to-html.ts
@@ -85,7 +85,7 @@ function is_directive(node: SmclNode): node is SmclDirective {
  */
 const ARGS_ONLY_DIRECTIVES = new Set([
     'opt', 'opth', 'cmdab', 'browse', 'c', 'char',
-    'viewerjumpto', 'viewerdialog', 'mansection',
+    'viewerjumpto', 'viewerdialog', 'vieweralsosee', 'mansection',
     'marker', 'col', 'space', 'hline', 'dup',
     'p', 'p2colset',
 ]);
@@ -389,6 +389,21 @@ function render_nodes(
                 my_text = my_text.replace(/^\n/, '');
                 ctx.pending_continuation = false;
             }
+            // Drop whitespace-only text between table rows. HTML
+            // parsing foster-parents any text-child of <table> that
+            // isn't inside a cell, which would hoist the newlines
+            // between our {synopt} rows up in front of the table and
+            // render them as tall blank gaps via `white-space:
+            // pre-wrap`. When we're inside a synopt / p2col table but
+            // not inside a row, swallow blank text so the table stays
+            // contiguous.
+            if (
+                (ctx.in_synopt_table || ctx.in_p2col)
+                && !ctx.in_table_row
+                && /^\s*$/.test(my_text)
+            ) {
+                continue;
+            }
             // Wrap text with data-line for scroll sync anchors
             if (my_node.line !== undefined) {
                 the_parts.push(
@@ -659,13 +674,20 @@ function render_directive(
             return render_manlink(directive, ctx, true);
         case 'mansection':
             return render_mansection(directive);
+        case '__help_title__':
+            return render_help_title(directive);
         case 'browse':
             return render_browse(directive, ctx);
         case 'marker':
             return render_marker(directive);
+        // Preamble metadata directives that Stata's native viewer uses
+        // to populate a top nav / "See Also" sidebar. We suppress them
+        // for now so the help file starts at its actual title.
+        // Tracking enhancement:
+        // https://github.com/jbearak/sight/issues/156
         case 'viewerjumpto':
-            return render_viewerjumpto(directive);
         case 'viewerdialog':
+        case 'vieweralsosee':
             return '';
         case 'stata':
             return render_stata_link(directive, ctx);
@@ -976,9 +998,95 @@ function render_manlink(
 }
 
 function render_mansection(directive: SmclDirective): string {
-    const my_text = directive.args ||
-        directive.content.map(n => 'text' in n ? n.text : '').join('');
-    return `<span class="smcl-mansection">${escape_html(my_text)}</span>`;
+    // Args format: `<manual_section>:<display_text>`, e.g.
+    // `P display:View complete PDF manual entry`. When we can build
+    // a stata.com URL from the target, emit a browse-style link so the
+    // existing webview click handler opens it externally. We
+    // deliberately omit `target="_blank"` so VS Code's webview link
+    // interception doesn't race with our `postMessage('openExternal')`
+    // handler — otherwise the PDF opens twice / prompts twice.
+    const my_args = directive.args
+        || directive.content.map(n => 'text' in n ? n.text : '').join('');
+    const my_parsed = parse_mansection_args(my_args);
+    const my_display_text = my_parsed?.display ?? my_args;
+    const my_url = my_parsed
+        ? build_manual_url(my_parsed.target)
+        : null;
+    const my_display_safe = escape_html(my_display_text);
+    if (my_url) {
+        return `<a class="smcl-browse smcl-mansection" href="${escape_html(my_url)}">${my_display_safe}</a>`;
+    }
+    return `<span class="smcl-mansection">${my_display_safe}</span>`;
+}
+
+interface MansectionParsed {
+    target: string;   // e.g. "P display"
+    display: string;  // e.g. "View complete PDF manual entry"
+}
+
+function parse_mansection_args(args: string): MansectionParsed | null {
+    const my_colon = args.indexOf(':');
+    if (my_colon <= 0) return null;
+    const my_target = args.substring(0, my_colon).trim();
+    const my_display = args.substring(my_colon + 1).trim();
+    if (my_target.length === 0 || my_display.length === 0) return null;
+    return { target: my_target, display: my_display };
+}
+
+function build_manual_url(target: string): string | null {
+    // Stata's online manual URLs follow a predictable convention that
+    // was reverse-engineered by inspecting the per-entry PDFs on
+    // stata.com (e.g. /manuals/pdisplay.pdf, /manuals/rregress.pdf):
+    //
+    //   * Filename: `<letter_lower><root_lower>.pdf`, where `root` is
+    //     the lowercase prefix of the sthlp `{mansection}` target
+    //     (everything up to the first uppercase letter).
+    //   * Named destinations inside the PDF preserve the original
+    //     case of the target. The destination name is the lowercase
+    //     manual letter concatenated with the target verbatim.
+    //
+    // Examples (all verified against actual PDFs on stata.com):
+    //   "P display"                     → pdisplay.pdf
+    //   "P displayRemarksandexamples"   → pdisplay.pdf#pdisplayRemarksandexamples
+    //   "R regressMethodsandformulas"   → rregress.pdf#rregressMethodsandformulas
+    //
+    // We only construct URLs for the common `<MANUAL> <entry>` shape;
+    // anything else (section numbers like "U 11.3") returns null so
+    // the caller falls back to plain text.
+    const my_match = target.trim().match(/^([A-Z]+)\s+([A-Za-z][A-Za-z0-9_ ]*)$/);
+    if (!my_match) return null;
+    const my_letter = my_match[1].toLowerCase();
+    const my_entry_raw = my_match[2].replace(/\s+/g, '');
+    if (my_entry_raw.length === 0) return null;
+
+    // Root = lowercase/digit/underscore prefix; the rest (if any,
+    // starting with an uppercase letter) is the PDF subsection.
+    let my_root: string;
+    let my_has_subsection: boolean;
+    if (/^[a-z]/.test(my_entry_raw)) {
+        const my_split = my_entry_raw.match(/^([a-z0-9_]+)([A-Z].*)$/);
+        if (my_split) {
+            my_root = my_split[1];
+            my_has_subsection = true;
+        } else {
+            my_root = my_entry_raw;
+            my_has_subsection = false;
+        }
+    } else {
+        // Entry starts with uppercase (rare; e.g. "SEM Intro5").
+        // Treat the entire entry as the root and skip the anchor.
+        my_root = my_entry_raw;
+        my_has_subsection = false;
+    }
+
+    const my_base =
+        `https://www.stata.com/manuals/${my_letter}${my_root.toLowerCase()}.pdf`;
+    if (!my_has_subsection) {
+        return my_base;
+    }
+    // Destination name is `<letter_lower><target_case_preserved>`,
+    // matching what Stata embeds in the PDF's /Names tree.
+    return `${my_base}#${my_letter}${my_entry_raw}`;
 }
 
 function is_safe_url(url: string): boolean {
@@ -1008,7 +1116,11 @@ function render_browse(
     }
 
     const my_url = escape_html(my_split.url);
-    return `<a class="smcl-browse" href="${my_url}" target="_blank">${my_display}</a>`;
+    // No `target="_blank"`: the webview click handler calls
+    // `vscode.env.openExternal` via postMessage. Emitting target=_blank
+    // would make VS Code's native link interception open the URL a
+    // second time and trigger a duplicate trust prompt.
+    return `<a class="smcl-browse" href="${my_url}">${my_display}</a>`;
 }
 
 function split_browse_args(
@@ -1044,23 +1156,6 @@ function split_browse_args(
 function render_marker(directive: SmclDirective): string {
     const my_name = directive.args || '';
     return `<a id="${escape_html(my_name)}"></a>`;
-}
-
-function render_viewerjumpto(directive: SmclDirective): string {
-    // {viewerjumpto "Display" "topic##anchor"}
-    // Args are typically two quoted strings
-    const my_match = directive.args.match(
-        /"([^"]*)"[\s,]*"([^"]*)"/
-    );
-    if (my_match) {
-        const my_display = escape_html(my_match[1]);
-        const my_target = my_match[2];
-        const my_anchor = my_target.includes('##')
-            ? my_target.split('##')[1]
-            : my_target;
-        return `<a class="smcl-jumpto" href="#${escape_html(my_anchor)}">${my_display}</a>`;
-    }
-    return escape_html(directive.args);
 }
 
 function render_stata_link(
@@ -1117,7 +1212,12 @@ function parse_first_number(args: string): number | null {
 // ---------------------------------------------------------------------------
 
 export function smcl_to_html(smcl: string): SmclHtmlResult {
-    const the_nodes = parse_smcl(smcl);
+    const the_raw_nodes = parse_smcl(smcl);
+    // Collapse the `.sthlp` header's `{p2colset}…{p2colreset}` title
+    // block into a single synthetic directive so we can render it as
+    // a proper heading with a PDF-manual link, rather than a narrow
+    // 2-column table row.
+    const the_nodes = transform_help_title(the_raw_nodes);
     const ctx = create_context();
     let html = render_nodes(the_nodes, ctx);
     // Close any trailing persistent formats and style span
@@ -1139,4 +1239,246 @@ export function smcl_to_html(smcl: string): SmclHtmlResult {
         html,
         cross_references: ctx.cross_references,
     };
+}
+
+// ---------------------------------------------------------------------------
+// Help-title preprocessor
+// ---------------------------------------------------------------------------
+
+interface HelpTitleInfo {
+    /** Command / entry name, e.g. "display" or "frame create". */
+    name: string;
+    /** One-line description from the title row. */
+    description: string;
+    /** `{mansection}` target, e.g. "P display". Optional. */
+    mansection_target?: string;
+    /** `{mansection}` display text. Optional. */
+    mansection_text?: string;
+}
+
+/**
+ * Walk the top-level node list and, if the first `{p2colset}…
+ * {p2colreset}` block matches Stata's help-title convention, replace
+ * it with a single synthetic `__help_title__` directive carrying the
+ * structured heading info.
+ *
+ * The title convention at the top of every Stata `.sthlp` file is:
+ *   {p2colset N N N N}{...}
+ *   {p2col:{bf:[X] name} {hline N}}description{p_end}
+ *   {p2col:}({mansection X entry:display text}){p_end}
+ *   {p2colreset}{...}
+ *
+ * We only match the first `{p2colset}` we encounter, since body-level
+ * 2-col tables should continue rendering as tables.
+ */
+function transform_help_title(nodes: SmclNode[]): SmclNode[] {
+    for (let i = 0; i < nodes.length; i++) {
+        const my_node = nodes[i];
+        if (!is_directive(my_node)) continue;
+        if (my_node.name.toLowerCase() !== 'p2colset') continue;
+
+        const my_match = try_match_help_title(nodes, i);
+        if (!my_match) {
+            // Only the first p2colset is inspected; if it isn't a
+            // title, fall through and render everything normally.
+            return nodes;
+        }
+        const my_synthetic: SmclDirective = {
+            name: '__help_title__',
+            args: JSON.stringify(my_match.info),
+            content: [],
+            line: my_node.line,
+        };
+        return [
+            ...nodes.slice(0, i),
+            my_synthetic,
+            ...nodes.slice(i + my_match.consumed),
+        ];
+    }
+    return nodes;
+}
+
+function try_match_help_title(
+    nodes: SmclNode[],
+    start: number
+): { consumed: number; info: HelpTitleInfo } | null {
+    let i = start;
+
+    const skip_filler = (): void => {
+        while (i < nodes.length) {
+            const my_node = nodes[i];
+            if (!is_directive(my_node)) {
+                if (/^\s*$/.test(my_node.text)) { i++; continue; }
+                break;
+            }
+            if (my_node.name === '...' || my_node.name === '.-') {
+                i++;
+                continue;
+            }
+            break;
+        }
+    };
+
+    // {p2colset ...}
+    if (
+        i >= nodes.length
+        || !is_directive(nodes[i])
+        || (nodes[i] as SmclDirective).name.toLowerCase() !== 'p2colset'
+    ) {
+        return null;
+    }
+    i++;
+    skip_filler();
+
+    // {p2col:{bf:[X] name} ...}description{p_end}
+    if (
+        i >= nodes.length
+        || !is_directive(nodes[i])
+        || (nodes[i] as SmclDirective).name.toLowerCase() !== 'p2col'
+    ) {
+        return null;
+    }
+    const my_title_p2col = nodes[i] as SmclDirective;
+    const my_title_ref = extract_title_ref_from_p2col(my_title_p2col);
+    if (!my_title_ref) return null;
+    i++;
+
+    // Collect the description as the sibling text nodes up to {p_end}.
+    // We keep this conservative: if we see a non-trivial directive in
+    // the description slot, bail out and render as a regular table.
+    const the_description_parts: string[] = [];
+    while (i < nodes.length) {
+        const my_node = nodes[i];
+        if (is_directive(my_node)) {
+            const my_name = my_node.name.toLowerCase();
+            if (my_name === 'p_end') { i++; break; }
+            if (my_name === '...' || my_name === '.-') { i++; continue; }
+            // Description contains unsupported markup; bail.
+            return null;
+        }
+        the_description_parts.push(my_node.text);
+        i++;
+    }
+    const my_description = the_description_parts.join('').trim();
+    if (my_description.length === 0) return null;
+    skip_filler();
+
+    // Optional: {p2col:}({mansection X name:text}){p_end}
+    let mansection_target: string | undefined;
+    let mansection_text: string | undefined;
+    if (
+        i < nodes.length
+        && is_directive(nodes[i])
+        && (nodes[i] as SmclDirective).name.toLowerCase() === 'p2col'
+        && (nodes[i] as SmclDirective).content.length === 0
+    ) {
+        i++;
+        while (i < nodes.length) {
+            const my_node = nodes[i];
+            if (is_directive(my_node) && my_node.name.toLowerCase() === 'p_end') {
+                i++;
+                break;
+            }
+            if (
+                is_directive(my_node)
+                && my_node.name.toLowerCase() === 'mansection'
+            ) {
+                const my_parsed = parse_mansection_args(my_node.args);
+                if (my_parsed) {
+                    mansection_target = my_parsed.target;
+                    mansection_text = my_parsed.display;
+                }
+            }
+            i++;
+        }
+        skip_filler();
+    }
+
+    // {p2colreset}
+    if (
+        i >= nodes.length
+        || !is_directive(nodes[i])
+        || (nodes[i] as SmclDirective).name.toLowerCase() !== 'p2colreset'
+    ) {
+        return null;
+    }
+    i++;
+
+    return {
+        consumed: i - start,
+        info: {
+            name: my_title_ref.name,
+            description: my_description,
+            mansection_target,
+            mansection_text,
+        },
+    };
+}
+
+function extract_title_ref_from_p2col(
+    p2col: SmclDirective
+): { name: string } | null {
+    // Expected content: [{bf:[X] name}, optional text/whitespace,
+    // optional {hline}]. We only look at the first directive to
+    // decide whether this row is a title; trailing space + {hline} is
+    // purely decorative. The leading [X] manual-reference is a
+    // convention most users don't recognize, so we strip it and only
+    // keep the command / entry name.
+    const my_first = p2col.content[0];
+    if (!my_first || !is_directive(my_first)) return null;
+    if (my_first.name.toLowerCase() !== 'bf') return null;
+
+    const my_inner_text = my_first.args
+        || my_first.content
+            .map(n => 'text' in n ? n.text : '')
+            .join('');
+    const my_match = my_inner_text.trim().match(/^\[[A-Z]+\]\s+(.+)$/);
+    if (!my_match) return null;
+    return { name: my_match[1].trim() };
+}
+
+function render_help_title(directive: SmclDirective): string {
+    let the_info: HelpTitleInfo;
+    try {
+        the_info = JSON.parse(directive.args) as HelpTitleInfo;
+    } catch {
+        return '';
+    }
+    const my_name = escape_html(the_info.name);
+    const my_desc = escape_html(the_info.description);
+
+    let my_manlink_html = '';
+    if (the_info.mansection_target && the_info.mansection_text) {
+        const my_url = build_manual_url(the_info.mansection_target);
+        // Override Stata's raw "View complete PDF manual entry" text
+        // with a label that is accurate in our context: the link leaves
+        // VS Code and opens the canonical ("complete") Reference Manual
+        // entry as a PDF on stata.com. We intentionally do NOT override
+        // `render_mansection` callers outside the title block, since
+        // those may legitimately use different display text.
+        const my_label = my_url
+            ? 'View the complete manual entry (PDF, opens in browser)'
+            : the_info.mansection_text;
+        const my_label_safe = escape_html(my_label);
+        if (my_url) {
+            // See render_browse / render_mansection: no `target="_blank"`
+            // — the webview click handler routes to openExternal once.
+            my_manlink_html =
+                `<p class="smcl-help-manlink">` +
+                `<a class="smcl-browse smcl-mansection" ` +
+                `href="${escape_html(my_url)}">` +
+                `${my_label_safe}</a></p>`;
+        } else {
+            my_manlink_html =
+                `<p class="smcl-help-manlink">${my_label_safe}</p>`;
+        }
+    }
+
+    return (
+        `<header class="smcl-help-title"${data_line_attr(directive)}>` +
+        `<h1 class="smcl-help-title-heading">${my_name}</h1>` +
+        `<p class="smcl-help-subtitle">${my_desc}</p>` +
+        my_manlink_html +
+        `</header>`
+    );
 }

--- a/client/src/smcl-preview/smcl-to-html.ts
+++ b/client/src/smcl-preview/smcl-to-html.ts
@@ -21,6 +21,18 @@ export interface SmclCrossRef {
     element_id: string;
 }
 
+export interface SmclToHtmlOptions {
+    /**
+     * Resolved `{findalias X}` substitutions keyed by the alias name
+     * (the argument passed to `{findalias}`). Values are raw SMCL that
+     * replace the directive in place and are rendered through the same
+     * parser / renderer. When the map is absent or a lookup misses,
+     * `{findalias}` renders as nothing — matching the pre-resolver
+     * behavior so diffs on unresolved files stay empty.
+     */
+    findalias_map?: Map<string, string>;
+}
+
 // ---------------------------------------------------------------------------
 // Character escape table for {c ...} directives
 // ---------------------------------------------------------------------------
@@ -304,9 +316,16 @@ interface RenderContext {
     active_style: string | null;
     active_formats: string[];
     in_asis: boolean;
+    findalias_map?: Map<string, string>;
+    // Guard against infinite recursion when a `{findalias X}`
+    // substitution itself contains another `{findalias Y}`
+    // (or loops back to `X`).
+    findalias_stack: string[];
 }
 
-function create_context(): RenderContext {
+function create_context(
+    findalias_map?: Map<string, string>
+): RenderContext {
     return {
         cross_references: [],
         ref_counter: 0,
@@ -319,6 +338,8 @@ function create_context(): RenderContext {
         active_style: null,
         active_formats: [],
         in_asis: false,
+        findalias_map,
+        findalias_stack: [],
     };
 }
 
@@ -711,7 +732,7 @@ function render_directive(
         case 'search':
             return render_content(directive, ctx);
         case 'findalias':
-            return '';
+            return render_findalias(directive, ctx);
 
         // -- Special characters --
         case 'c':
@@ -1245,6 +1266,39 @@ function render_marker(directive: SmclDirective): string {
     return `<a id="${escape_html(my_name)}"></a>`;
 }
 
+/**
+ * Render `{findalias X}` by looking up the alias in the current
+ * render context's `findalias_map` and rendering the resulting SMCL
+ * substitution in place. When no map is present or the alias is not
+ * in the map, emit nothing (matching pre-resolver behavior).
+ *
+ * Substitutions are parsed and rendered through the same pipeline as
+ * the outer document so nested directives (`{manlink …}`,
+ * `{vieweralsosee …}`, etc.) render identically to how they would if
+ * they had been inlined by hand.
+ */
+function render_findalias(
+    directive: SmclDirective,
+    ctx: RenderContext
+): string {
+    if (!ctx.findalias_map) return '';
+    const my_alias = (directive.args ?? '').trim();
+    if (my_alias.length === 0) return '';
+    const my_smcl = ctx.findalias_map.get(my_alias);
+    if (my_smcl === undefined) return '';
+    if (ctx.findalias_stack.includes(my_alias)) {
+        // Recursive substitution — bail to avoid infinite expansion.
+        return '';
+    }
+    ctx.findalias_stack.push(my_alias);
+    try {
+        const the_sub_nodes = parse_smcl(my_smcl);
+        return render_nodes(the_sub_nodes, ctx);
+    } finally {
+        ctx.findalias_stack.pop();
+    }
+}
+
 function render_stata_link(
     directive: SmclDirective,
     ctx: RenderContext
@@ -1298,14 +1352,17 @@ function parse_first_number(args: string): number | null {
 // Entry point
 // ---------------------------------------------------------------------------
 
-export function smcl_to_html(smcl: string): SmclHtmlResult {
+export function smcl_to_html(
+    smcl: string,
+    options?: SmclToHtmlOptions
+): SmclHtmlResult {
     const the_raw_nodes = parse_smcl(smcl);
     // Collapse the `.sthlp` header's `{p2colset}…{p2colreset}` title
     // block into a single synthetic directive so we can render it as
     // a proper heading with a PDF-manual link, rather than a narrow
     // 2-column table row.
     const the_nodes = transform_help_title(the_raw_nodes);
-    const ctx = create_context();
+    const ctx = create_context(options?.findalias_map);
     let html = render_nodes(the_nodes, ctx);
     // Close any trailing persistent formats and style span
     html += close_asis(ctx);

--- a/client/src/smcl-preview/smcl-to-html.ts
+++ b/client/src/smcl-preview/smcl-to-html.ts
@@ -1133,7 +1133,7 @@ function build_manual_url(target: string): string | null {
     // may contain periods. Anything that fails to produce a root
     // returns null so the caller falls back to plain text.
     const my_match = target.trim().match(
-        /^([A-Z]+)\s+([A-Za-z0-9][A-Za-z0-9_. ]*)$/
+        /^([A-Z]+(?:-\d+)?)\s+([A-Za-z0-9][A-Za-z0-9_. ]*)$/
     );
     if (!my_match) return null;
     const my_letter = my_match[1].toLowerCase();
@@ -1186,7 +1186,7 @@ function detect_bracketed_manual_ref(
     const my_node = directive.content[0];
     if (is_directive(my_node)) return null;
     const my_raw = my_node.text;
-    const my_match = my_raw.match(/^\s*\[([A-Z]+)\]\s+(.+?)\s*$/);
+    const my_match = my_raw.match(/^\s*\[([A-Z]+(?:-\d+)?)\]\s+(.+?)\s*$/);
     if (!my_match) return null;
     const my_entry = my_match[2].trim();
     if (my_entry.length === 0) return null;
@@ -1701,13 +1701,18 @@ function transform_findalias_help_title(
             if (!my_info) continue;
 
             const my_start = paragraph_start >= 0 ? paragraph_start : i;
-            // Consume through the end of the title paragraph: stop at
-            // the next hard boundary (marker/title/p2colset) or EOF.
+            // Consume through the end of the title paragraph only:
+            // stop at (and include) the first {p_end}, or bail at a
+            // hard preamble boundary / EOF.
             let my_end = i + 1;
             while (my_end < nodes.length) {
                 const my_next = nodes[my_end];
                 if (is_directive(my_next)) {
                     const my_next_name = my_next.name.toLowerCase();
+                    if (my_next_name === 'p_end') {
+                        my_end++;
+                        break;
+                    }
                     if (PREAMBLE_TERMINATOR_NAMES.has(my_next_name)) {
                         break;
                     }
@@ -1800,7 +1805,7 @@ function extract_title_ref_from_p2col(
         || my_first.content
             .map(n => 'text' in n ? n.text : '')
             .join('');
-    const my_match = my_inner_text.trim().match(/^\[[A-Z]+\]\s+(.+)$/);
+    const my_match = my_inner_text.trim().match(/^\[[A-Z]+(?:-\d+)?\]\s+(.+)$/);
     if (!my_match) return null;
     return { name: my_match[1].trim() };
 }

--- a/client/src/smcl-preview/smcl-to-html.ts
+++ b/client/src/smcl-preview/smcl-to-html.ts
@@ -1025,9 +1025,11 @@ function render_manlink(
 
 /**
  * Shared anchor / span rendering for `{manlink}` and inline-bold
- * `[X] name` references. Returns either an `<a>` (when we can route
- * to a help topic or a stata.com PDF) or a plain span with the
- * existing `.smcl-manlink` styling when we can't classify the target.
+ * `[X] name` references. Matches Stata's native viewer behavior: these
+ * references always target the Reference Manual PDF on stata.com, not
+ * the sthlp help file for a similarly-named command. Falls back to a
+ * plain `.smcl-manlink` span when we can't build a manual URL (e.g.
+ * the target doesn't match the `<MANUAL> <entry>` shape).
  */
 function build_manlink_anchor_inner(
     manual: string,
@@ -1037,16 +1039,6 @@ function build_manlink_anchor_inner(
 ): string {
     if (manual.length === 0 || entry.length === 0) {
         return `<span class="smcl-manlink">${display_html}</span>`;
-    }
-
-    if (looks_like_help_topic(entry)) {
-        // Route to our SMCL help viewer via the same message path as
-        // `{help}` links. The topic is the entry without the bracket.
-        return (
-            `<a class="smcl-help-link smcl-manlink-topic" `
-            + `href="#" data-smcl-topic="${escape_html(entry)}">`
-            + `${display_html}</a>`
-        );
     }
 
     const my_url = build_manual_url(`${manual} ${entry.replace(/\s+/g, '')}`);
@@ -1154,17 +1146,6 @@ function build_manual_url(target: string): string | null {
     // Destination name is `<letter_lower><target_case_preserved>`,
     // matching what Stata embeds in the PDF's /Names tree.
     return `${my_base}#${my_letter}${my_entry_raw}`;
-}
-
-/**
- * Check whether an entry name looks like a Stata command / help topic
- * (all-lowercase identifier words, optionally space-separated — e.g.
- * "display", "frame create", "regress postestimation") rather than a
- * manual section reference. Topics route through the sthlp viewer;
- * non-topics go to the PDF manual.
- */
-function looks_like_help_topic(entry: string): boolean {
-    return /^[a-z_][a-z0-9_]*(?: [a-z_][a-z0-9_]*)*$/.test(entry.trim());
 }
 
 /**

--- a/client/src/smcl-preview/webview-html.ts
+++ b/client/src/smcl-preview/webview-html.ts
@@ -57,6 +57,28 @@ body {
     max-width: 100ch;
 }
 
+/* Help-file title block (first {p2colset} block). */
+.smcl-help-title {
+    margin: 0.2em 0 1.2em 0;
+    padding-bottom: 0.6em;
+    border-bottom: 1px solid var(--vscode-panel-border);
+}
+.smcl-help-title-heading {
+    font-size: 1.6em;
+    font-weight: bold;
+    margin: 0 0 0.2em 0;
+}
+.smcl-help-subtitle {
+    margin: 0;
+    font-size: 1.05em;
+    color: var(--vscode-descriptionForeground, var(--vscode-foreground));
+}
+.smcl-help-manlink {
+    margin: 0.5em 0 0 0;
+    font-size: 0.9em;
+    opacity: 0.85;
+}
+
 /* Headings */
 .smcl-title {
     font-size: 1.3em;
@@ -250,10 +272,16 @@ const WEBVIEW_SCRIPT = `
     // Cross-reference link clicks
     // ----------------------------------------------------------
 
+    // Capture phase: run before VS Code's native link interception
+    // picks up the click. Combined with preventDefault +
+    // stopPropagation, this keeps an .smcl-browse click from being
+    // handled twice (once by the webview native handler and once by
+    // our postMessage route).
     document.addEventListener('click', function(e) {
         const link = e.target.closest('a[data-smcl-topic]');
         if (link) {
             e.preventDefault();
+            e.stopPropagation();
             const topic = link.getAttribute('data-smcl-topic');
             if (topic) {
                 vscode.postMessage({ type: 'navigate', topic: topic });
@@ -266,6 +294,7 @@ const WEBVIEW_SCRIPT = `
             var href = anchor.getAttribute('href');
             if (href && href.startsWith('#')) {
                 e.preventDefault();
+                e.stopPropagation();
                 var target = document.getElementById(href.substring(1));
                 if (target) {
                     target.scrollIntoView({ behavior: 'smooth' });
@@ -277,13 +306,14 @@ const WEBVIEW_SCRIPT = `
         var browse = e.target.closest('a.smcl-browse');
         if (browse) {
             e.preventDefault();
+            e.stopPropagation();
             var url = browse.getAttribute('href');
             if (url) {
                 vscode.postMessage({ type: 'openExternal', url: url });
             }
             return;
         }
-    });
+    }, true);
 
     // ----------------------------------------------------------
     // Scroll sync

--- a/client/src/smcl-preview/webview-html.ts
+++ b/client/src/smcl-preview/webview-html.ts
@@ -191,10 +191,17 @@ table.smcl-synopt-table th {
     padding: 2px 8px;
     vertical-align: top;
     text-align: left;
+    /* Override the document-level white-space:pre-wrap inside table
+     * cells so the newline + spaces continuations in Stata's SMCL
+     * source collapse into normal word-wrap. Without this, wrapped
+     * descriptions are forced to a deep, confusing indent. */
+    white-space: normal;
+    overflow-wrap: break-word;
 }
 .smcl-synopt-col1 {
     width: 30%;
-    white-space: nowrap;
+    /* Allow wide option labels (compound strings, etc.) to wrap to
+     * a second line instead of overflowing into col2. */
     padding-left: 4ch;
 }
 .smcl-synopt-col2 {
@@ -230,6 +237,11 @@ table.smcl-p2col-table {
 table.smcl-p2col-table td {
     padding: 2px 8px;
     vertical-align: top;
+    /* Same rationale as synopt cells: collapse source whitespace so
+     * wrapped text wraps naturally and doesn't inherit the deep
+     * indent from the raw SMCL source. */
+    white-space: normal;
+    overflow-wrap: break-word;
 }
 .smcl-p2col-col1 {
     width: 40%;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,6 +154,17 @@ Example:
 }
 ```
 
+### Auto-detected Stata install paths
+
+In addition to the paths you configure, Sight automatically consults the standard Stata install and user ado directories when resolving help topics for the SMCL help viewer:
+
+- **macOS:** `/Applications/Stata/ado/{base,site,updates}`, its `StataMP` / `StataSE` / `StataBE` / `StataIC` variants, and `~/Library/Application Support/Stata/ado/{personal,plus}`.
+- **Linux:** `/usr/local/stata<version>/ado/{base,site,updates}` and `/opt/stata<version>/…` for versions 13–20, plus unversioned `stata` directories.
+- **Windows:** `Stata<version>\ado\{base,site,updates}` under each `Program Files` / `Program Files (x86)` directory that Windows reports via its environment variables.
+- All platforms: the legacy `~/ado`, `~/ado/personal`, and `~/ado/plus` conventions.
+
+Only directories that actually exist are used, and the auto-detected paths are only consulted for `.sthlp` lookups — they are not scanned into the workspace symbol index. Use `sight.adoPaths` to override or supplement this list when you install Stata in a non-standard location.
+
 ## Comments
 
 Configure the line comment character used by VS Code's toggle comment shortcut.

--- a/docs/smcl-viewer.md
+++ b/docs/smcl-viewer.md
@@ -17,3 +17,20 @@ The preview renders SMCL markup as formatted HTML in a VS Code webview panel, sh
 The viewer renders both:
 - **Log files** (`.smcl`): Stata session output with formatted results, tables, and error messages
 - **Help files** (`.sthlp`): Stata help documentation with cross-references and formatted syntax
+
+## Help links in hovers and completions
+
+Hovering over a built-in command (e.g. `generate`), an expression
+function (e.g. `mi()`), or a prefix-command subcommand (e.g. `frame
+create`) shows a clickable `help <topic>` link. Clicking the link opens
+the matching `.sthlp` file in the SMCL preview to the right of the
+editor. The same link appears in the completion popup for built-in
+commands and their abbreviations.
+
+Sight resolves the topic to a file by searching, in order:
+
+1. Every directory listed in the `sight.adoPaths` setting.
+2. Your workspace folders.
+3. Auto-detected Stata install locations (e.g. `/Applications/Stata/ado/base` on macOS, `/usr/local/stata<version>/ado/base` on Linux, `C:\Program Files\Stata<version>\ado\base` on Windows), plus the usual `~/ado/personal` and `~/ado/plus` conventions.
+
+This means `help regress`, `help include`, and other built-in topics generally work out of the box without any configuration. If a `.sthlp` still isn't found, Sight shows a notification with an **Open Settings** button that jumps straight to `sight.adoPaths` so you can point it at the directory containing the help file.

--- a/scripts/generate-cache.ts
+++ b/scripts/generate-cache.ts
@@ -321,9 +321,9 @@ async function extract_minimal_metadata(file_path: string): Promise<ExtractedCom
  *       inside another command's syntax (`{c -(}{cmdab:loc:al} | ...`).
  *   0 - No structural signal — fall back to first-extracted.
  *
- * Prefer the record whose file basename matches the command name: this
- * is a strong tiebreaker because `macro.sthlp` is always more
- * authoritative than any other file that happens to mention `macro`.
+ * A small fractional bonus (+0.1) is added when the file basename
+ * matches the command name, acting as a tiebreaker within the same
+ * rank category (e.g. `macro.sthlp` for the `macro` command).
  */
 function rank_record(record: ExtractedCommandRecord): number {
     let my_rank = 0;
@@ -331,7 +331,9 @@ function rank_record(record: ExtractedCommandRecord): number {
     else if (record.has_viewerdialog) my_rank = 2;
     else if (record.is_paragraph_lead) my_rank = 1;
     // Bump records whose file is literally named after the command.
-    if (record.help_file_basename === record.key) my_rank += 10;
+    // Use a small fractional bonus so it only breaks ties within
+    // the same primary rank category (0–3).
+    if (record.help_file_basename === record.key) my_rank += 0.1;
     return my_rank;
 }
 

--- a/scripts/generate-cache.ts
+++ b/scripts/generate-cache.ts
@@ -431,7 +431,7 @@ export async function generate_cache(options: GenerateOptions): Promise<{ cache:
     for (const my_letter of 'abcdefghijklmnopqrstuvwxyz_'.split('')) {
         const letter_dir = join(base_path, my_letter);
         try {
-            const the_files = readdirSync(letter_dir).filter(f => f.endsWith('.sthlp'));
+            const the_files = readdirSync(letter_dir).filter(f => f.endsWith('.sthlp')).sort();
             for (const my_file of the_files) {
                 the_all_files.push(join(letter_dir, my_file));
                 if (options.max_files && the_all_files.length >= options.max_files) break;

--- a/scripts/generate-cache.ts
+++ b/scripts/generate-cache.ts
@@ -264,7 +264,7 @@ async function extract_minimal_metadata(file_path: string): Promise<ExtractedCom
             console.warn(my_warning);
         }
 
-        const the_help_file_basename = basename(file_path, '.sthlp');
+        const the_help_file_basename = basename(file_path, '.sthlp').toLowerCase();
 
         // Convert ExtractedCommand to provenance-carrying records.
         const the_records: ExtractedCommandRecord[] = [];

--- a/scripts/generate-cache.ts
+++ b/scripts/generate-cache.ts
@@ -2,7 +2,7 @@
 
 // Manual cache generation script - run when needed, commit results
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'fs';
-import { join } from 'path';
+import { join, basename } from 'path';
 import { CommandCache, CommandInfo, OptionInfo, StataVersion } from '../src/command-database/types.js';
 import { extract_commands_from_file, ExtractedCommand } from '../src/command-database/smcl-extractor.js';
 import { BUILTIN_COMMANDS } from '../src/commands/builtin-commands.js';
@@ -171,21 +171,37 @@ export function merge_options(
 }
 
 /**
+ * A single command extracted from a single help file, along with the
+ * provenance flags we need to pick the right `help_file` when the same
+ * command appears in multiple files.
+ */
+interface ExtractedCommandRecord {
+    key: string;
+    command_info: CommandInfo;
+    is_primary: boolean;
+    has_viewerdialog: boolean;
+    is_paragraph_lead: boolean;
+    /** Basename of the source help file without the `.sthlp` extension. */
+    help_file_basename: string;
+}
+
+/**
  * Process a single file and extract all commands from it.
  * Uses the SMCL extractor to properly handle multi-command files.
- * Returns an array of [name, CommandInfo] tuples.
  */
-async function extract_minimal_metadata(file_path: string): Promise<Array<[string, CommandInfo]>> {
+async function extract_minimal_metadata(file_path: string): Promise<ExtractedCommandRecord[]> {
     try {
         const result = extract_commands_from_file(file_path);
-        
+
         // Log any warnings
         for (const my_warning of result.warnings) {
             console.warn(my_warning);
         }
-        
-        // Convert ExtractedCommand to [name, CommandInfo] tuples
-        const the_tuples: Array<[string, CommandInfo]> = [];
+
+        const the_help_file_basename = basename(file_path, '.sthlp');
+
+        // Convert ExtractedCommand to provenance-carrying records.
+        const the_records: ExtractedCommandRecord[] = [];
         for (const my_cmd of result.commands) {
             // Skip invalid command names (e.g., "kap (2 raters)" documentation entries)
             if (!/^[a-z_][a-z0-9_]*$/i.test(my_cmd.name)) {
@@ -198,27 +214,59 @@ async function extract_minimal_metadata(file_path: string): Promise<Array<[strin
                 min_abbreviation: opt.min_abbreviation,
                 has_argument: opt.has_argument
             }));
-            
+
             // Normalize command name to lowercase for cache key
             const normalized_key = my_cmd.name.toLowerCase();
-            
-            the_tuples.push([
-                normalized_key,
-                {
+
+            the_records.push({
+                key: normalized_key,
+                command_info: {
                     name: my_cmd.name,
                     // syntax field removed - see smcl-syntax-cleanup spec
                     min_abbreviation: my_cmd.min_abbreviation,
                     options: cache_options,
                     priority: get_command_priority(my_cmd.name)
-                }
-            ]);
+                },
+                is_primary: my_cmd.is_primary,
+                has_viewerdialog: my_cmd.has_viewerdialog,
+                is_paragraph_lead: my_cmd.is_paragraph_lead,
+                help_file_basename: the_help_file_basename
+            });
         }
-        
-        return the_tuples;
+
+        return the_records;
     } catch (error) {
         console.warn(`Failed to process ${file_path}: ${error}`);
         return [];
     }
+}
+
+/**
+ * Rank a provenance record so we can pick the best source when the same
+ * command appears in multiple files. Higher is better; ties fall back to
+ * first-extracted wins.
+ *
+ * Hierarchy of signals:
+ *   3 - The command is the file's primary (`[P] macro` → `macro`).
+ *   2 - The command has a `{viewerdialog}` tag in the file.
+ *   1 - The command leads a syntax paragraph (e.g., `{cmdab:loc:al}` at
+ *       the start of a `{p ...}` line in `macro.sthlp`), which
+ *       distinguishes canonical documentation from incidental mentions
+ *       inside another command's syntax (`{c -(}{cmdab:loc:al} | ...`).
+ *   0 - No structural signal — fall back to first-extracted.
+ *
+ * Prefer the record whose file basename matches the command name: this
+ * is a strong tiebreaker because `macro.sthlp` is always more
+ * authoritative than any other file that happens to mention `macro`.
+ */
+function rank_record(record: ExtractedCommandRecord): number {
+    let my_rank = 0;
+    if (record.is_primary) my_rank = 3;
+    else if (record.has_viewerdialog) my_rank = 2;
+    else if (record.is_paragraph_lead) my_rank = 1;
+    // Bump records whose file is literally named after the command.
+    if (record.help_file_basename === record.key) my_rank += 10;
+    return my_rank;
 }
 
 /**
@@ -333,33 +381,55 @@ export async function generate_cache(options: GenerateOptions): Promise<{ cache:
     // Process files in parallel batches of BATCH_SIZE
     let files_processed = 0;
     let commands_extracted = 0;
-    
+
+    // Track the best provenance record we've seen for each command so
+    // that, when a command appears in multiple files, we prefer the one
+    // where it's the primary command or has a viewerdialog tag. This is
+    // what turns `local` into a pointer at `macro.sthlp` instead of the
+    // first (semi-arbitrary) file that happened to mention it.
+    const best_records: Record<string, ExtractedCommandRecord> = Object.create(null);
+
     for (let i = 0; i < the_all_files.length; i += BATCH_SIZE) {
         const my_batch = the_all_files.slice(i, i + BATCH_SIZE);
         const my_batch_results = await Promise.all(
             my_batch.map(file => extract_minimal_metadata(file))
         );
-        
+
         // Collect results from this batch - now handles multiple commands per file
         for (const my_result of my_batch_results) {
-            for (const [command_name, command_info] of my_result) {
-                // Only add if not already present (first occurrence wins)
-                if (!commands[command_name]) {
-                    commands[command_name] = command_info;
+            for (const my_record of my_result) {
+                const my_existing = best_records[my_record.key];
+                if (!my_existing) {
+                    best_records[my_record.key] = my_record;
                     commands_extracted++;
+                    continue;
+                }
+                if (rank_record(my_record) > rank_record(my_existing)) {
+                    best_records[my_record.key] = my_record;
                 }
             }
             if (my_result.length > 0) {
                 files_processed++;
             }
         }
-        
+
         // Progress reporting
         if (files_processed % 100 === 0 || i + BATCH_SIZE >= the_all_files.length) {
             console.log(`Processed ${files_processed} files, extracted ${commands_extracted} commands...`);
         }
     }
-    
+
+    // Promote best_records into the `commands` map, stamping `help_file`
+    // only when it diverges from the command name (keeps cache churn
+    // small and the diff easy to review).
+    for (const [my_key, my_record] of Object.entries(best_records)) {
+        const my_command_info = my_record.command_info;
+        if (my_record.help_file_basename !== my_key) {
+            my_command_info.help_file = my_record.help_file_basename;
+        }
+        commands[my_key] = my_command_info;
+    }
+
     console.log(`Extracted ${commands_extracted} commands from ${files_processed} files`);
     
     // Add fundamental commands that may be missing

--- a/src/command-database/caches/v18.json
+++ b/src/command-database/caches/v18.json
@@ -5,7 +5,8 @@
       "name": "glossary",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adapt_glossary"
     },
     "asroprobit": {
       "name": "asroprobit",
@@ -196,6 +197,90 @@
       ],
       "priority": 3
     },
+    "predict": {
+      "name": "predict",
+      "min_abbreviation": 7,
+      "options": [
+        {
+          "name": "stddp",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "equation",
+          "min_abbreviation": 8,
+          "has_argument": true
+        },
+        {
+          "name": "score",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "scores",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "xb",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "stdp",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "nooffset",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "predict",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "offset",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "exposure",
+          "min_abbreviation": 8,
+          "has_argument": true
+        }
+      ],
+      "priority": 2
+    },
+    "psdensity": {
+      "name": "psdensity",
+      "min_abbreviation": 9,
+      "options": [
+        {
+          "name": "pspectrum",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "range",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "cycle",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "smemory",
+          "min_abbreviation": 4,
+          "has_argument": false
+        }
+      ],
+      "priority": 3
+    },
     "append": {
       "name": "append",
       "min_abbreviation": 2,
@@ -345,6 +430,18 @@
       ],
       "priority": 3
     },
+    "estat": {
+      "name": "estat",
+      "min_abbreviation": 5,
+      "options": [
+        {
+          "name": "n",
+          "min_abbreviation": 1,
+          "has_argument": true
+        }
+      ],
+      "priority": 2
+    },
     "assertnested": {
       "name": "assertnested",
       "min_abbreviation": 12,
@@ -359,24 +456,24 @@
     },
     "missing": {
       "name": "missing",
-      "min_abbreviation": 4,
-      "options": [
-        {
-          "name": "within",
-          "min_abbreviation": 6,
-          "has_argument": true
-        }
-      ],
-      "priority": 3
+      "min_abbreviation": 1,
+      "options": [],
+      "priority": 3,
+      "help_file": "egen"
     },
     "by": {
       "name": "by",
       "min_abbreviation": 2,
       "options": [
         {
-          "name": "within",
-          "min_abbreviation": 6,
-          "has_argument": true
+          "name": "sort",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "rc0",
+          "min_abbreviation": 3,
+          "has_argument": false
         }
       ],
       "priority": 3
@@ -406,7 +503,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adoupdate"
     },
     "areg": {
       "name": "areg",
@@ -475,9 +573,44 @@
       "min_abbreviation": 9,
       "options": [
         {
-          "name": "vce",
+          "name": "reps",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "strata",
           "min_abbreviation": 3,
           "has_argument": true
+        },
+        {
+          "name": "size",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "cluster",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "idcluster",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "bca",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "ties",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "mse",
+          "min_abbreviation": 3,
+          "has_argument": false
         },
         {
           "name": "level",
@@ -485,49 +618,109 @@
           "has_argument": true
         },
         {
-          "name": "clustertable",
-          "min_abbreviation": 8,
+          "name": "notable",
+          "min_abbreviation": 7,
           "has_argument": false
         },
         {
-          "name": "absorb",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "ols",
+          "name": "noheader",
           "min_abbreviation": 3,
           "has_argument": false
         },
         {
-          "name": "robust",
+          "name": "nolegend",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "verbose",
           "min_abbreviation": 1,
           "has_argument": false
         },
         {
-          "name": "cluster",
+          "name": "nodots",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "dots",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "noisily",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "trace",
           "min_abbreviation": 2,
           "has_argument": false
         },
         {
-          "name": "bootstrap",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "jackknife",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "tolerance",
-          "min_abbreviation": 3,
+          "name": "title",
+          "min_abbreviation": 2,
           "has_argument": true
         },
         {
-          "name": "iterate",
+          "name": "nodrop",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "nowarn",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "force",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "reject",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "seed",
           "min_abbreviation": 4,
           "has_argument": true
+        },
+        {
+          "name": "group",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "jackknifeopts",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "eform",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "eclass",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "rclass",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "n",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "coeflegend",
+          "min_abbreviation": 10,
+          "has_argument": false
         }
       ],
       "priority": 3
@@ -592,7 +785,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "areg"
     },
     "pr": {
       "name": "pr",
@@ -734,7 +928,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adjust"
     },
     "vertical": {
       "name": "vertical",
@@ -876,7 +1071,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adjust"
     },
     "nooffset": {
       "name": "nooffset",
@@ -1018,7 +1214,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adjust"
     },
     "noheader": {
       "name": "noheader",
@@ -1160,7 +1357,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adjust"
     },
     "center": {
       "name": "center",
@@ -1302,7 +1500,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adjust"
     },
     "left": {
       "name": "left",
@@ -1444,7 +1643,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adjust"
     },
     "adjust": {
       "name": "adjust",
@@ -1592,7 +1792,8 @@
       "name": "showorder",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "anovadef"
     },
     "anovadef": {
       "name": "anovadef",
@@ -1732,13 +1933,33 @@
       "min_abbreviation": 2,
       "options": [
         {
-          "name": "yoverhangs",
-          "min_abbreviation": 10,
-          "has_argument": false
+          "name": "msymbol",
+          "min_abbreviation": 7,
+          "has_argument": true
         },
         {
-          "name": "xoverhangs",
-          "min_abbreviation": 10,
+          "name": "mcolor",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "msize",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "mlabel",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "connect",
+          "min_abbreviation": 7,
+          "has_argument": true
+        },
+        {
+          "name": "sort",
+          "min_abbreviation": 4,
           "has_argument": false
         }
       ],
@@ -1746,17 +1967,32 @@
     },
     "line": {
       "name": "line",
-      "min_abbreviation": 2,
+      "min_abbreviation": 4,
       "options": [
         {
-          "name": "yoverhangs",
-          "min_abbreviation": 10,
+          "name": "sort",
+          "min_abbreviation": 4,
           "has_argument": false
         },
         {
-          "name": "xoverhangs",
-          "min_abbreviation": 10,
-          "has_argument": false
+          "name": "connect",
+          "min_abbreviation": 7,
+          "has_argument": true
+        },
+        {
+          "name": "lpattern",
+          "min_abbreviation": 8,
+          "has_argument": true
+        },
+        {
+          "name": "lwidth",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "lcolor",
+          "min_abbreviation": 6,
+          "has_argument": true
         }
       ],
       "priority": 2
@@ -1776,7 +2012,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "advanced_options"
     },
     "dot": {
       "name": "dot",
@@ -1793,7 +2030,8 @@
           "has_argument": false
         }
       ],
-      "priority": 2
+      "priority": 2,
+      "help_file": "advanced_options"
     },
     "pcscatter": {
       "name": "pcscatter",
@@ -1810,7 +2048,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "advanced_options"
     },
     "alpha": {
       "name": "alpha",
@@ -1894,7 +2133,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "axis_scale_options"
     },
     "fextend": {
       "name": "fextend",
@@ -1916,7 +2156,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "axis_scale_options"
     },
     "extend": {
       "name": "extend",
@@ -1938,7 +2179,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "axis_scale_options"
     },
     "noextend": {
       "name": "noextend",
@@ -1960,7 +2202,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "axis_scale_options"
     },
     "noline": {
       "name": "noline",
@@ -1982,7 +2225,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "axis_scale_options"
     },
     "assert": {
       "name": "assert",
@@ -2026,7 +2270,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "assert"
     },
     "fast": {
       "name": "fast",
@@ -2048,35 +2293,131 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "assert"
     },
     "stcurve": {
       "name": "stcurve",
       "min_abbreviation": 7,
       "options": [
         {
-          "name": "atmeans",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
           "name": "atomeans",
           "min_abbreviation": 8,
           "has_argument": false
         },
         {
-          "name": "atzeros",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "atbase",
-          "min_abbreviation": 6,
+          "name": "attmeans",
+          "min_abbreviation": 8,
           "has_argument": false
         },
         {
           "name": "at",
           "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "atframe",
+          "min_abbreviation": 7,
+          "has_argument": true
+        },
+        {
+          "name": "alpha1",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "fixedonly",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "unconditional",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "marginal",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "range",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "width",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "kernel",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "noboundary",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "name",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "saving",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "opts",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "survival",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "failure",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "hazard",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "cumhaz",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "cif",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "events",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "sepevents",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "replace",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "byopts",
+          "min_abbreviation": 6,
           "has_argument": true
         }
       ],
@@ -2112,7 +2453,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adjustfor_option"
     },
     "atomeans": {
       "name": "atomeans",
@@ -2144,7 +2486,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adjustfor_option"
     },
     "atzeros": {
       "name": "atzeros",
@@ -2176,27 +2519,13 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "adjustfor_option"
     },
     "anova": {
       "name": "anova",
-      "min_abbreviation": 2,
+      "min_abbreviation": 5,
       "options": [
-        {
-          "name": "category",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "class",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "continuous",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
         {
           "name": "repeated",
           "min_abbreviation": 3,
@@ -2218,6 +2547,11 @@
           "has_argument": false
         },
         {
+          "name": "dropemptycells",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
           "name": "bse",
           "min_abbreviation": 3,
           "has_argument": true
@@ -2233,28 +2567,13 @@
           "has_argument": true
         },
         {
-          "name": "regress",
-          "min_abbreviation": 1,
-          "has_argument": false
-        },
-        {
-          "name": "detail",
-          "min_abbreviation": 1,
-          "has_argument": false
-        },
-        {
           "name": "anova",
           "min_abbreviation": 5,
           "has_argument": false
         },
         {
-          "name": "noanova",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "no",
-          "min_abbreviation": 2,
+          "name": "bootstrap",
+          "min_abbreviation": 9,
           "has_argument": false
         },
         {
@@ -2263,12 +2582,22 @@
           "has_argument": false
         },
         {
-          "name": "aweight",
+          "name": "collect",
           "min_abbreviation": 7,
           "has_argument": false
         },
         {
-          "name": "fweight",
+          "name": "fp",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "jackknife",
+          "min_abbreviation": 9,
+          "has_argument": false
+        },
+        {
+          "name": "statsby",
           "min_abbreviation": 7,
           "has_argument": false
         }
@@ -2396,13 +2725,100 @@
       "name": "permanently",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "autotabgraphs"
     },
     "anova_terms": {
       "name": "anova_terms",
       "min_abbreviation": 11,
       "options": [],
       "priority": 3
+    },
+    "test": {
+      "name": "test",
+      "min_abbreviation": 4,
+      "options": [
+        {
+          "name": "accumulate",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "notest",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "mtest",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "coef",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "common",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "constant",
+          "min_abbreviation": 8,
+          "has_argument": false
+        }
+      ],
+      "priority": 2
+    },
+    "dfbeta": {
+      "name": "dfbeta",
+      "min_abbreviation": 6,
+      "options": [],
+      "priority": 3,
+      "help_file": "anova_postestimation"
+    },
+    "acprplot": {
+      "name": "acprplot",
+      "min_abbreviation": 8,
+      "options": [],
+      "priority": 3,
+      "help_file": "anova_postestimation"
+    },
+    "avplots": {
+      "name": "avplots",
+      "min_abbreviation": 7,
+      "options": [],
+      "priority": 3,
+      "help_file": "anova_postestimation"
+    },
+    "cprplot": {
+      "name": "cprplot",
+      "min_abbreviation": 7,
+      "options": [],
+      "priority": 3,
+      "help_file": "anova_postestimation"
+    },
+    "lvr2plot": {
+      "name": "lvr2plot",
+      "min_abbreviation": 8,
+      "options": [],
+      "priority": 3,
+      "help_file": "anova_postestimation"
+    },
+    "rvfplot": {
+      "name": "rvfplot",
+      "min_abbreviation": 7,
+      "options": [],
+      "priority": 3,
+      "help_file": "anova_postestimation"
+    },
+    "rvpplot": {
+      "name": "rvpplot",
+      "min_abbreviation": 7,
+      "options": [],
+      "priority": 3,
+      "help_file": "anova_postestimation"
     },
     "args": {
       "name": "args",
@@ -2567,7 +2983,8 @@
       "name": "appendix",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "appendix_for_collect_style_cell"
     },
     "asclogit": {
       "name": "asclogit",
@@ -3153,7 +3570,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "arch"
     },
     "normal": {
       "name": "normal",
@@ -3390,7 +3808,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "arch"
     },
     "arfimasoc": {
       "name": "arfimasoc",
@@ -3529,17 +3948,7 @@
       "min_abbreviation": 6,
       "options": [
         {
-          "name": "noconstant",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "link",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "slink",
+          "name": "het",
           "min_abbreviation": 3,
           "has_argument": true
         },
@@ -3554,42 +3963,18 @@
           "has_argument": true
         },
         {
-          "name": "nocnsreport",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
           "name": "constraints",
           "min_abbreviation": 11,
           "has_argument": true
         },
         {
-          "name": "oim",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "robust",
-          "min_abbreviation": 1,
-          "has_argument": false
-        },
-        {
-          "name": "cluster",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
           "name": "bootstrap",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "jackknife",
           "min_abbreviation": 4,
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "churdle"
     },
     "bitest": {
       "name": "bitest",
@@ -3597,58 +3982,79 @@
       "options": [],
       "priority": 3
     },
-    "detail": {
-      "name": "detail",
-      "min_abbreviation": 1,
-      "options": [],
-      "priority": 3
-    },
     "bitesti": {
       "name": "bitesti",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bitest"
+    },
+    "detail": {
+      "name": "detail",
+      "min_abbreviation": 1,
+      "options": [],
+      "priority": 3,
+      "help_file": "bitest"
     },
     "bayes": {
       "name": "bayes",
       "min_abbreviation": 5,
-      "options": [
-        {
-          "name": "noconstant",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "offset",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "asis",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "level",
-          "min_abbreviation": 1,
-          "has_argument": true
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "generate": {
       "name": "generate",
-      "min_abbreviation": 3,
+      "min_abbreviation": 1,
       "options": [
+        {
+          "name": "before",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
         {
           "name": "after",
           "min_abbreviation": 5,
           "has_argument": true
         },
         {
-          "name": "before",
+          "name": "nopromote",
+          "min_abbreviation": 9,
+          "has_argument": false
+        },
+        {
+          "name": "replace",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "byte",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "int",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "long",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "float",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "double",
           "min_abbreviation": 6,
-          "has_argument": true
+          "has_argument": false
+        },
+        {
+          "name": "permanently",
+          "min_abbreviation": 11,
+          "has_argument": false
         }
       ],
       "priority": 1
@@ -3667,42 +4073,47 @@
     },
     "graph": {
       "name": "graph",
-      "min_abbreviation": 1,
+      "min_abbreviation": 2,
       "options": [
         {
-          "name": "irf",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "oirf",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "dm",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "cirf",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "coirf",
+          "name": "title",
           "min_abbreviation": 5,
-          "has_argument": false
+          "has_argument": true
         },
         {
-          "name": "cdm",
-          "min_abbreviation": 3,
-          "has_argument": false
+          "name": "subtitle",
+          "min_abbreviation": 8,
+          "has_argument": true
         },
         {
-          "name": "fevd",
+          "name": "note",
           "min_abbreviation": 4,
-          "has_argument": false
+          "has_argument": true
+        },
+        {
+          "name": "caption",
+          "min_abbreviation": 7,
+          "has_argument": true
+        },
+        {
+          "name": "legend",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "scheme",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "name",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "saving",
+          "min_abbreviation": 6,
+          "has_argument": true
         }
       ],
       "priority": 2
@@ -3710,43 +4121,7 @@
     "bayesirf": {
       "name": "bayesirf",
       "min_abbreviation": 8,
-      "options": [
-        {
-          "name": "irf",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "oirf",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "dm",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "cirf",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "coirf",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "cdm",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "fevd",
-          "min_abbreviation": 4,
-          "has_argument": false
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "bicplot": {
@@ -4061,13 +4436,15 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bicplot"
     },
     "ctable": {
       "name": "ctable",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bayesirf_ctable"
     },
     "bitowt": {
       "name": "bitowt",
@@ -4137,7 +4514,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bmagraph_pmp"
     },
     "compute": {
       "name": "compute",
@@ -4169,38 +4547,13 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bayesfcast_compute"
     },
     "bayesfcast": {
       "name": "bayesfcast",
       "min_abbreviation": 10,
-      "options": [
-        {
-          "name": "step",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "dynamic",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "estimate",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "replace",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "median",
-          "min_abbreviation": 6,
-          "has_argument": false
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "jointness": {
@@ -4233,7 +4586,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bmastats_jointness"
     },
     "frequency": {
       "name": "frequency",
@@ -4265,7 +4619,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bmastats_jointness"
     },
     "bayespredict": {
       "name": "bayespredict",
@@ -4333,7 +4688,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bootstrap_options"
     },
     "bstat": {
       "name": "bstat",
@@ -4497,7 +4853,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bstat"
     },
     "inflate": {
       "name": "inflate",
@@ -4544,7 +4901,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bayes_zinb"
     },
     "bysort": {
       "name": "bysort",
@@ -4561,20 +4919,16 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "by"
     },
     "sort": {
       "name": "sort",
-      "min_abbreviation": 1,
+      "min_abbreviation": 2,
       "options": [
         {
-          "name": "sort",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "rc0",
-          "min_abbreviation": 3,
+          "name": "stable",
+          "min_abbreviation": 6,
           "has_argument": false
         }
       ],
@@ -4635,7 +4989,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bayes_binreg"
     },
     "boxcox": {
       "name": "boxcox",
@@ -4698,7 +5053,8 @@
       "name": "ograph",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bayesirf_ograph"
     },
     "models": {
       "name": "models",
@@ -4805,7 +5161,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bmastats_models"
     },
     "bmapredict": {
       "name": "bmapredict",
@@ -4817,37 +5174,43 @@
       "name": "colfirst",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "by_option"
     },
     "compact": {
       "name": "compact",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "by_option"
     },
     "edgelabel": {
       "name": "edgelabel",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "by_option"
     },
     "rescale": {
       "name": "rescale",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "by_option"
     },
     "yrescale": {
       "name": "yrescale",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "by_option"
     },
     "xrescale": {
       "name": "xrescale",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "by_option"
     },
     "binreg": {
       "name": "binreg",
@@ -5061,7 +5424,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bayestest_interval"
     },
     "create": {
       "name": "create",
@@ -5113,18 +5477,32 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bayesirf_create"
     },
     "coefdensity": {
       "name": "coefdensity",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bmagraph_coefdensity"
     },
     "bayesgraph": {
       "name": "bayesgraph",
       "min_abbreviation": 10,
       "options": [],
+      "priority": 3
+    },
+    "bayesmh": {
+      "name": "bayesmh",
+      "min_abbreviation": 7,
+      "options": [
+        {
+          "name": "noconstant",
+          "min_abbreviation": 10,
+          "has_argument": false
+        }
+      ],
       "priority": 3
     },
     "select": {
@@ -5152,7 +5530,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bayes_heckman"
     },
     "biplot": {
       "name": "biplot",
@@ -5271,7 +5650,8 @@
       "name": "check",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bcal"
     },
     "describe": {
       "name": "describe",
@@ -5332,19 +5712,8 @@
       "name": "nobreak",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
-    },
-    "bayesmh": {
-      "name": "bayesmh",
-      "min_abbreviation": 7,
-      "options": [
-        {
-          "name": "noconstant",
-          "min_abbreviation": 10,
-          "has_argument": false
-        }
-      ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "break"
     },
     "bmaregress": {
       "name": "bmaregress",
@@ -5392,7 +5761,8 @@
       "name": "cgraph",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bayesirf_cgraph"
     },
     "bsample": {
       "name": "bsample",
@@ -5494,62 +5864,133 @@
       "min_abbreviation": 3,
       "options": [
         {
-          "name": "notable",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "noheader",
-          "min_abbreviation": 8,
-          "has_argument": false
-        },
-        {
-          "name": "nolegend",
-          "min_abbreviation": 8,
-          "has_argument": false
-        },
-        {
-          "name": "verbose",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "level",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "title",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "stat",
+          "name": "predict",
           "min_abbreviation": 4,
           "has_argument": true
         },
         {
-          "name": "mse",
+          "name": "varlist",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "dydx",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "eyex",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "dyex",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "eydx",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "nodiscrete",
           "min_abbreviation": 3,
           "has_argument": false
         },
         {
-          "name": "brrstat",
-          "min_abbreviation": 7,
+          "name": "nose",
+          "min_abbreviation": 3,
           "has_argument": false
         },
         {
-          "name": "jkstat",
+          "name": "at",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "noesample",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nowght",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nonlinear",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "force",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "level",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "tracelvl",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "help",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "mean",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "median",
           "min_abbreviation": 6,
           "has_argument": false
+        },
+        {
+          "name": "zero",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "mfx",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "diagnostics",
+          "min_abbreviation": 11,
+          "has_argument": true
         }
       ],
       "priority": 3
     },
     "table": {
       "name": "table",
-      "min_abbreviation": 1,
-      "options": [],
+      "min_abbreviation": 5,
+      "options": [
+        {
+          "name": "totals",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "nototals",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "table",
+          "min_abbreviation": 5,
+          "has_argument": false
+        }
+      ],
       "priority": 1
     },
     "grubin": {
@@ -5562,48 +6003,20 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bayesstats_grubin"
     },
     "byable": {
       "name": "byable",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "byprog"
     },
     "program": {
       "name": "program",
       "min_abbreviation": 2,
       "options": [
-        {
-          "name": "nclass",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "rclass",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "eclass",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "sclass",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "sortpreserve",
-          "min_abbreviation": 12,
-          "has_argument": false
-        },
-        {
-          "name": "byable",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
         {
           "name": "properties",
           "min_abbreviation": 10,
@@ -5616,25 +6029,29 @@
       "name": "define",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scalar"
     },
     "recall": {
       "name": "recall",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "byprog"
     },
     "onecall": {
       "name": "onecall",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "byprog"
     },
     "constant": {
       "name": "constant",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "bmastats_msize"
     },
     "biprobit": {
       "name": "biprobit",
@@ -5743,79 +6160,92 @@
       "name": "recurse",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "classutil"
     },
     "newok": {
       "name": "newok",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "classutil"
     },
     "top": {
       "name": "top",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "right": {
       "name": "right",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "bottom": {
       "name": "bottom",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "north": {
       "name": "north",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "neast": {
       "name": "neast",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "east": {
       "name": "east",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "seast": {
       "name": "seast",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "south": {
       "name": "south",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "swest": {
       "name": "swest",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "west": {
       "name": "west",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "nwest": {
       "name": "nwest",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "compassdirstyle"
     },
     "cttost": {
       "name": "cttost",
@@ -6025,7 +6455,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "churdle"
     },
     "exponential": {
       "name": "exponential",
@@ -6057,7 +6488,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "churdle"
     },
     "robust": {
       "name": "robust",
@@ -6089,53 +6521,53 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "churdle"
     },
     "cluster": {
       "name": "cluster",
-      "min_abbreviation": 2,
-      "options": [
-        {
-          "name": "het",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "vce",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "level",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "constraints",
-          "min_abbreviation": 11,
-          "has_argument": true
-        },
-        {
-          "name": "bootstrap",
-          "min_abbreviation": 4,
-          "has_argument": false
-        }
-      ],
+      "min_abbreviation": 7,
+      "options": [],
       "priority": 3
     },
     "jackknife": {
       "name": "jackknife",
-      "min_abbreviation": 4,
+      "min_abbreviation": 9,
       "options": [
         {
-          "name": "het",
-          "min_abbreviation": 3,
+          "name": "eclass",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "rclass",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "n",
+          "min_abbreviation": 1,
           "has_argument": true
         },
         {
-          "name": "vce",
-          "min_abbreviation": 3,
+          "name": "cluster",
+          "min_abbreviation": 2,
           "has_argument": true
+        },
+        {
+          "name": "idcluster",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "keep",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "mse",
+          "min_abbreviation": 3,
+          "has_argument": false
         },
         {
           "name": "level",
@@ -6143,13 +6575,83 @@
           "has_argument": true
         },
         {
-          "name": "constraints",
-          "min_abbreviation": 11,
+          "name": "notable",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "noheader",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nolegend",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "verbose",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "nodots",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "dots",
+          "min_abbreviation": 4,
           "has_argument": true
         },
         {
-          "name": "bootstrap",
-          "min_abbreviation": 4,
+          "name": "noisily",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "trace",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "title",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "nodrop",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "reject",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "jackknife",
+          "min_abbreviation": 9,
+          "has_argument": false
+        },
+        {
+          "name": "myreg",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "x3",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "eform",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "coeflegend",
+          "min_abbreviation": 10,
           "has_argument": false
         }
       ],
@@ -6185,7 +6687,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "churdle"
     },
     "epitab": {
       "name": "epitab",
@@ -6203,7 +6706,8 @@
       "name": "csi",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cs"
     },
     "creturn": {
       "name": "creturn",
@@ -6216,13 +6720,58 @@
       "min_abbreviation": 1,
       "options": [
         {
+          "name": "compress",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "nocompress",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "fast",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "abbreviate",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "string",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
           "name": "noobs",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "fvall",
           "min_abbreviation": 5,
           "has_argument": false
         },
         {
-          "name": "nolabel",
-          "min_abbreviation": 7,
+          "name": "table",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "display",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "header",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "noheader",
+          "min_abbreviation": 3,
           "has_argument": false
         },
         {
@@ -6231,42 +6780,149 @@
           "has_argument": false
         },
         {
+          "name": "divider",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
           "name": "separator",
           "min_abbreviation": 3,
           "has_argument": true
         },
         {
-          "name": "abbreviate",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "string",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "table",
+          "name": "sepby",
           "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "divider",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "header",
-          "min_abbreviation": 6,
           "has_argument": true
         },
         {
-          "name": "noheader",
+          "name": "ds",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "nolabel",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "labvar",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "notrim",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "absolute",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nodotz",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "subvarname",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "linesize",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "footer",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "sepbyexp",
           "min_abbreviation": 8,
+          "has_argument": true
+        },
+        {
+          "name": "mean",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "sum",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "n",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "constant",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "x",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "relative",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "by",
+          "min_abbreviation": 2,
           "has_argument": false
         }
       ],
       "priority": 1
+    },
+    "screeplot": {
+      "name": "screeplot",
+      "min_abbreviation": 9,
+      "options": [
+        {
+          "name": "neigen",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "mean",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "meanlopts",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "ci",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "heteroskedastic",
+          "min_abbreviation": 15,
+          "has_argument": false
+        },
+        {
+          "name": "homoskedastic",
+          "min_abbreviation": 13,
+          "has_argument": false
+        },
+        {
+          "name": "addplot",
+          "min_abbreviation": 7,
+          "has_argument": true
+        }
+      ],
+      "priority": 3
     },
     "cls": {
       "name": "cls",
@@ -6453,7 +7109,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cmrologit"
     },
     "clustermat": {
       "name": "clustermat",
@@ -6695,7 +7352,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ci"
     },
     "proportions": {
       "name": "proportions",
@@ -6732,7 +7390,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ci"
     },
     "variances": {
       "name": "variances",
@@ -6769,24 +7428,90 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ci"
     },
     "poisson": {
       "name": "poisson",
-      "min_abbreviation": 4,
+      "min_abbreviation": 7,
       "options": [
+        {
+          "name": "noconstant",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "exposure",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "offset",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "vce",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
         {
           "name": "level",
           "min_abbreviation": 1,
           "has_argument": true
         },
         {
-          "name": "separator",
+          "name": "irr",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "nocnsreport",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "collinear",
           "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "constraints",
+          "min_abbreviation": 11,
           "has_argument": true
         },
         {
-          "name": "total",
+          "name": "oim",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "robust",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "cluster",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "opg",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "bootstrap",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "jackknife",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "bayes",
           "min_abbreviation": 5,
           "has_argument": false
         },
@@ -6796,13 +7521,43 @@
           "has_argument": false
         },
         {
-          "name": "collect",
+          "name": "fmm",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "fp",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "mfp",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nestreg",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "rolling",
           "min_abbreviation": 7,
           "has_argument": false
         },
         {
           "name": "statsby",
           "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "stepwise",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "svy",
+          "min_abbreviation": 3,
           "has_argument": false
         }
       ],
@@ -6843,7 +7598,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ci"
     },
     "cii": {
       "name": "cii",
@@ -6880,19 +7636,80 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ci"
+    },
+    "cabiplot": {
+      "name": "cabiplot",
+      "min_abbreviation": 8,
+      "options": [],
+      "priority": 3,
+      "help_file": "ca_postestimation_plots"
+    },
+    "caprojection": {
+      "name": "caprojection",
+      "min_abbreviation": 12,
+      "options": [],
+      "priority": 3,
+      "help_file": "ca_postestimation_plots"
     },
     "replace": {
       "name": "replace",
       "min_abbreviation": 7,
       "options": [
         {
-          "name": "name",
-          "min_abbreviation": 4,
+          "name": "before",
+          "min_abbreviation": 6,
           "has_argument": true
+        },
+        {
+          "name": "after",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "nopromote",
+          "min_abbreviation": 9,
+          "has_argument": false
+        },
+        {
+          "name": "replace",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "byte",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "int",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "long",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "float",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "double",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "permanently",
+          "min_abbreviation": 11,
+          "has_argument": false
         }
       ],
-      "priority": 1
+      "priority": 1,
+      "help_file": "generate"
     },
     "contrast": {
       "name": "contrast",
@@ -6929,13 +7746,7 @@
     "clear": {
       "name": "clear",
       "min_abbreviation": 5,
-      "options": [
-        {
-          "name": "name",
-          "min_abbreviation": 4,
-          "has_argument": true
-        }
-      ],
+      "options": [],
       "priority": 1
     },
     "copy": {
@@ -7222,7 +8033,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cmmprobit"
     },
     "collapse": {
       "name": "collapse",
@@ -7276,7 +8088,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collapse"
     },
     "sebinomial": {
       "name": "sebinomial",
@@ -7303,7 +8116,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collapse"
     },
     "sepoisson": {
       "name": "sepoisson",
@@ -7330,7 +8144,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collapse"
     },
     "cmmixlogit": {
       "name": "cmmixlogit",
@@ -7461,50 +8276,15 @@
       "name": "style",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
-    },
-    "test": {
-      "name": "test",
-      "min_abbreviation": 1,
-      "options": [
-        {
-          "name": "accumulate",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "notest",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "mtest",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "coef",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "common",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "constant",
-          "min_abbreviation": 8,
-          "has_argument": false
-        }
-      ],
-      "priority": 2
+      "priority": 3,
+      "help_file": "conren"
     },
     "result": {
       "name": "result",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "conren"
     },
     "input": {
       "name": "input",
@@ -7512,7 +8292,7 @@
       "options": [
         {
           "name": "automatic",
-          "min_abbreviation": 4,
+          "min_abbreviation": 9,
           "has_argument": false
         },
         {
@@ -7539,19 +8319,22 @@
       "name": "link",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "conren"
     },
     "hilite": {
       "name": "hilite",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "conren"
     },
     "uloff": {
       "name": "uloff",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "conren"
     },
     "set": {
       "name": "set",
@@ -7599,34 +8382,8 @@
     },
     "format": {
       "name": "format",
-      "min_abbreviation": 1,
-      "options": [
-        {
-          "name": "altwise",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "longstub",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "time",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "choice",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "statistics",
-          "min_abbreviation": 10,
-          "has_argument": true
-        }
-      ],
+      "min_abbreviation": 4,
+      "options": [],
       "priority": 3
     },
     "variables": {
@@ -7659,7 +8416,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cmsummarize"
     },
     "statistics": {
       "name": "statistics",
@@ -7691,7 +8449,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cmsummarize"
     },
     "centile": {
       "name": "centile",
@@ -7808,7 +8567,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collect_label"
     },
     "comments": {
       "name": "comments",
@@ -7820,13 +8580,15 @@
       "name": "system",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "checkhlpfiles"
     },
     "check_help": {
       "name": "check_help",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "checkhlpfiles"
     },
     "checkhlpfiles": {
       "name": "checkhlpfiles",
@@ -7838,17 +8600,19 @@
       "name": "stata",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m4_stata"
     },
     "doublebang": {
       "name": "doublebang",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "checkhlpfiles"
     },
     "help": {
       "name": "help",
-      "min_abbreviation": 4,
+      "min_abbreviation": 1,
       "options": [
         {
           "name": "nonew",
@@ -7872,7 +8636,8 @@
       "name": "dialog",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "checkhlpfiles"
     },
     "cvplot": {
       "name": "cvplot",
@@ -7949,7 +8714,7 @@
     },
     "dir": {
       "name": "dir",
-      "min_abbreviation": 1,
+      "min_abbreviation": 3,
       "options": [
         {
           "name": "wide",
@@ -8057,7 +8822,8 @@
       "name": "adofiles",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cscript"
     },
     "cscript": {
       "name": "cscript",
@@ -8302,7 +9068,8 @@
       "name": "notable",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ciwidth_opttable"
     },
     "cmxtmixlogit": {
       "name": "cmxtmixlogit",
@@ -8493,7 +9260,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ca"
     },
     "chelp": {
       "name": "chelp",
@@ -8553,7 +9321,8 @@
       "name": "cci",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cc"
     },
     "clonevar": {
       "name": "clonevar",
@@ -8695,7 +9464,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ctset"
     },
     "show": {
       "name": "show",
@@ -8722,7 +9492,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ctset"
     },
     "cmsample": {
       "name": "cmsample",
@@ -8962,7 +9733,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collect_export"
     },
     "html": {
       "name": "html",
@@ -8984,7 +9756,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collect_export"
     },
     "pdf": {
       "name": "pdf",
@@ -9006,7 +9779,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collect_export"
     },
     "xlsx": {
       "name": "xlsx",
@@ -9028,7 +9802,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collect_export"
     },
     "xls": {
       "name": "xls",
@@ -9050,7 +9825,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collect_export"
     },
     "tex": {
       "name": "tex",
@@ -9072,28 +9848,13 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collect_export"
     },
     "smcl": {
       "name": "smcl",
       "min_abbreviation": 4,
-      "options": [
-        {
-          "name": "name",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "as",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "replace",
-          "min_abbreviation": 7,
-          "has_argument": false
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "txt": {
@@ -9116,26 +9877,22 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collect_export"
     },
     "markdown": {
       "name": "markdown",
       "min_abbreviation": 8,
       "options": [
         {
-          "name": "name",
-          "min_abbreviation": 4,
+          "name": "saving",
+          "min_abbreviation": 6,
           "has_argument": true
         },
         {
-          "name": "as",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "replace",
+          "name": "basedir",
           "min_abbreviation": 7,
-          "has_argument": false
+          "has_argument": true
         }
       ],
       "priority": 3
@@ -9160,7 +9917,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collect_export"
     },
     "cpoisson": {
       "name": "cpoisson",
@@ -9283,7 +10041,8 @@
       "name": "onevariance",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ciwidth_onevariance"
     },
     "checkdlgfiles": {
       "name": "checkdlgfiles",
@@ -9295,7 +10054,8 @@
       "name": "ado",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_ado"
     },
     "char": {
       "name": "char",
@@ -9349,27 +10109,24 @@
       "name": "local",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 1
+      "priority": 1,
+      "help_file": "macro"
     },
     "global": {
       "name": "global",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 1
+      "priority": 1,
+      "help_file": "macro"
     },
     "quietly": {
       "name": "quietly",
-      "min_abbreviation": 7,
+      "min_abbreviation": 3,
       "options": [
         {
-          "name": "name",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "tags",
-          "min_abbreviation": 4,
-          "has_argument": true
+          "name": "noisily",
+          "min_abbreviation": 7,
+          "has_argument": false
         }
       ],
       "priority": 1
@@ -9498,7 +10255,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "correlate"
     },
     "cumul": {
       "name": "cumul",
@@ -9689,36 +10447,22 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cmset"
     },
     "margins": {
       "name": "margins",
       "min_abbreviation": 7,
       "options": [
         {
-          "name": "alternative",
-          "min_abbreviation": 3,
+          "name": "predict",
+          "min_abbreviation": 7,
           "has_argument": true
         },
         {
-          "name": "contrast",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "noesample",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "outcomejoint",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "alternativejoint",
-          "min_abbreviation": 3,
-          "has_argument": false
+          "name": "expression",
+          "min_abbreviation": 10,
+          "has_argument": true
         }
       ],
       "priority": 2
@@ -9753,37 +10497,43 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cm_margins"
     },
     "none": {
       "name": "none",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "connectstyle"
     },
     "direct": {
       "name": "direct",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "connectstyle"
     },
     "ascending": {
       "name": "ascending",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "connectstyle"
     },
     "stairstep": {
       "name": "stairstep",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "connectstyle"
     },
     "stepstair": {
       "name": "stepstair",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "connectstyle"
     },
     "nolabels": {
       "name": "nolabels",
@@ -9825,7 +10575,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cat_axis_label_options"
     },
     "alternate": {
       "name": "alternate",
@@ -9867,7 +10618,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cat_axis_label_options"
     },
     "outside": {
       "name": "outside",
@@ -9909,7 +10661,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cat_axis_label_options"
     },
     "crossing": {
       "name": "crossing",
@@ -9951,7 +10704,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cat_axis_label_options"
     },
     "confirm": {
       "name": "confirm",
@@ -9963,59 +10717,32 @@
       "name": "existence",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "confirm"
     },
     "file": {
       "name": "file",
-      "min_abbreviation": 1,
+      "min_abbreviation": 4,
       "options": [],
-      "priority": 3,
-      "subcommands": [
-        {
-          "name": "open",
-          "min_abbreviation": 1
-        },
-        {
-          "name": "read",
-          "min_abbreviation": 1
-        },
-        {
-          "name": "write",
-          "min_abbreviation": 1
-        },
-        {
-          "name": "close",
-          "min_abbreviation": 1
-        },
-        {
-          "name": "seek",
-          "min_abbreviation": 3
-        },
-        {
-          "name": "query",
-          "min_abbreviation": 1
-        },
-        {
-          "name": "set",
-          "min_abbreviation": 3
-        }
-      ]
+      "priority": 3
     },
     "names": {
       "name": "names",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "confirm"
     },
     "number": {
       "name": "number",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "confirm"
     },
     "matrix": {
       "name": "matrix",
-      "min_abbreviation": 3,
+      "min_abbreviation": 6,
       "options": [],
       "priority": 1
     },
@@ -10029,25 +10756,29 @@
       "name": "variable",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "confirm"
     },
     "exact": {
       "name": "exact",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "confirm"
     },
     "alias": {
       "name": "alias",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "confirm"
     },
     "float": {
       "name": "float",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "confirm"
     },
     "candisc": {
       "name": "candisc",
@@ -10148,7 +10879,8 @@
       "name": "pwd",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cd"
     },
     "cumsp": {
       "name": "cumsp",
@@ -10459,7 +11191,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cmroprobit"
     },
     "corrgram": {
       "name": "corrgram",
@@ -10471,13 +11204,15 @@
       "name": "ac",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "corrgram"
     },
     "pac": {
       "name": "pac",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "corrgram"
     },
     "copyright": {
       "name": "copyright",
@@ -10510,7 +11245,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "collect_style_header"
     },
     "cf": {
       "name": "cf",
@@ -10544,7 +11280,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "cf"
     },
     "coefpath": {
       "name": "coefpath",
@@ -11019,7 +11756,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "duplicates"
     },
     "examples": {
       "name": "examples",
@@ -11151,7 +11889,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "duplicates"
     },
     "tag": {
       "name": "tag",
@@ -11283,7 +12022,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "duplicates"
     },
     "db": {
       "name": "db",
@@ -11394,13 +12134,15 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "didregress"
     },
     "wide": {
       "name": "wide",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "dir"
     },
     "dfactor": {
       "name": "dfactor",
@@ -11444,19 +12186,15 @@
       "name": "labels",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "discrim_estat"
     },
     "noweights": {
       "name": "noweights",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
-    },
-    "estat": {
-      "name": "estat",
-      "min_abbreviation": 5,
-      "options": [],
-      "priority": 2
+      "priority": 3,
+      "help_file": "discrim_estat"
     },
     "dfgls": {
       "name": "dfgls",
@@ -11526,71 +12264,96 @@
       "name": "as",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
-    },
-    "logistic": {
-      "name": "logistic",
-      "min_abbreviation": 4,
-      "options": [
-        {
-          "name": "priors",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "ties",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "notable",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "group",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "statsby",
-          "min_abbreviation": 7,
-          "has_argument": false
-        }
-      ],
-      "priority": 2
+      "priority": 3,
+      "help_file": "display"
     },
     "discrim": {
       "name": "discrim",
       "min_abbreviation": 7,
+      "options": [],
+      "priority": 3
+    },
+    "logistic": {
+      "name": "logistic",
+      "min_abbreviation": 8,
       "options": [
         {
-          "name": "priors",
+          "name": "noconstant",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "offset",
           "min_abbreviation": 3,
           "has_argument": true
         },
         {
-          "name": "ties",
+          "name": "asis",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "vce",
           "min_abbreviation": 3,
           "has_argument": true
         },
         {
-          "name": "notable",
+          "name": "level",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "coef",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "nocnsreport",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "collinear",
           "min_abbreviation": 3,
           "has_argument": false
         },
         {
-          "name": "group",
-          "min_abbreviation": 5,
+          "name": "constraints",
+          "min_abbreviation": 11,
           "has_argument": true
         },
         {
-          "name": "statsby",
-          "min_abbreviation": 7,
+          "name": "oim",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "opg",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "robust",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "cluster",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "bootstrap",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "jackknife",
+          "min_abbreviation": 4,
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 2
     },
     "di_g": {
       "name": "di_g",
@@ -11600,7 +12363,7 @@
     },
     "label": {
       "name": "label",
-      "min_abbreviation": 1,
+      "min_abbreviation": 2,
       "options": [
         {
           "name": "add",
@@ -11621,6 +12384,16 @@
           "name": "nofix",
           "min_abbreviation": 5,
           "has_argument": false
+        },
+        {
+          "name": "myvar",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "mylab",
+          "min_abbreviation": 5,
+          "has_argument": false
         }
       ],
       "priority": 1
@@ -11629,13 +12402,15 @@
       "name": "nomemory",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "dialog_undocumented"
     },
     "treeview": {
       "name": "treeview",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "dialog_undocumented"
     },
     "varlabel": {
       "name": "varlabel",
@@ -11657,7 +12432,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "dataex"
     },
     "elsewhere": {
       "name": "elsewhere",
@@ -11679,7 +12455,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "dataex"
     },
     "dataex": {
       "name": "dataex",
@@ -11765,7 +12542,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "dydx"
     },
     "dotplot": {
       "name": "dotplot",
@@ -11920,7 +12698,8 @@
       "name": "keep",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 1
+      "priority": 1,
+      "help_file": "drop"
     },
     "datetime": {
       "name": "datetime",
@@ -11983,6 +12762,12 @@
           "has_argument": true
         }
       ],
+      "priority": 3
+    },
+    "irt": {
+      "name": "irt",
+      "min_abbreviation": 3,
+      "options": [],
       "priority": 3
     },
     "discard": {
@@ -12077,6 +12862,50 @@
           "name": "no",
           "min_abbreviation": 2,
           "has_argument": false
+        }
+      ],
+      "priority": 3
+    },
+    "loadingplot": {
+      "name": "loadingplot",
+      "min_abbreviation": 11,
+      "options": [],
+      "priority": 3,
+      "help_file": "discrim_lda_postestimation"
+    },
+    "scoreplot": {
+      "name": "scoreplot",
+      "min_abbreviation": 9,
+      "options": [
+        {
+          "name": "factors",
+          "min_abbreviation": 7,
+          "has_argument": true
+        },
+        {
+          "name": "norotated",
+          "min_abbreviation": 9,
+          "has_argument": false
+        },
+        {
+          "name": "matrix",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "combined",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "scoreopt",
+          "min_abbreviation": 8,
+          "has_argument": true
+        },
+        {
+          "name": "maxlength",
+          "min_abbreviation": 9,
+          "has_argument": true
         }
       ],
       "priority": 3
@@ -12266,7 +13095,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "drawnorm"
     },
     "dspoisson": {
       "name": "dspoisson",
@@ -12356,7 +13186,8 @@
       "name": "run",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 1
+      "priority": 1,
+      "help_file": "do"
     },
     "diflogistic": {
       "name": "diflogistic",
@@ -12528,7 +13359,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "dsgenl"
     },
     "destring": {
       "name": "destring",
@@ -12602,7 +13434,8 @@
           "has_argument": false
         }
       ],
-      "priority": 1
+      "priority": 1,
+      "help_file": "destring"
     },
     "dsregress": {
       "name": "dsregress",
@@ -12672,7 +13505,8 @@
       "name": "q",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_conversion"
     },
     "dyngen": {
       "name": "dyngen",
@@ -12683,7 +13517,33 @@
     "update": {
       "name": "update",
       "min_abbreviation": 6,
-      "options": [],
+      "options": [
+        {
+          "name": "from",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "update",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "detail",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "force",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "exit",
+          "min_abbreviation": 4,
+          "has_argument": false
+        }
+      ],
       "priority": 3
     },
     "ds": {
@@ -12780,11 +13640,12 @@
       "name": "leave",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "dirstats"
     },
     "version": {
       "name": "version",
-      "min_abbreviation": 7,
+      "min_abbreviation": 4,
       "options": [],
       "priority": 3
     },
@@ -12792,37 +13653,43 @@
       "name": "dateformat",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "ydm": {
       "name": "ydm",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "myd": {
       "name": "myd",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "mdy": {
       "name": "mdy",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "dym": {
       "name": "dym",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "dmy": {
       "name": "dmy",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "range": {
       "name": "range",
@@ -12834,31 +13701,36 @@
       "name": "centerdate",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "omit": {
       "name": "omit",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "date": {
       "name": "date",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "dayofweek": {
       "name": "dayofweek",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "dowinmonth": {
       "name": "dowinmonth",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_business_calendars_creation"
     },
     "dstdize": {
       "name": "dstdize",
@@ -12870,7 +13742,8 @@
       "name": "istdize",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "dstdize"
     },
     "dyntext": {
       "name": "dyntext",
@@ -12909,139 +13782,162 @@
       "name": "reset",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datasignature"
     },
     "strict": {
       "name": "strict",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datasignature"
     },
     "yy": {
       "name": "yy",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "jjj": {
       "name": "jjj",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "mon": {
       "name": "mon",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "month": {
       "name": "month",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "nn": {
       "name": "nn",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "dd": {
       "name": "dd",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "dayname": {
       "name": "dayname",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "day": {
       "name": "day",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "da": {
       "name": "da",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "ww": {
       "name": "ww",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "hh": {
       "name": "hh",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "mm": {
       "name": "mm",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "ss": {
       "name": "ss",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "am": {
       "name": "am",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "datetime_display_formats"
     },
     "symplot": {
       "name": "symplot",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "diagnostic_plots"
     },
     "quantile": {
       "name": "quantile",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "diagnostic_plots"
     },
     "qqplot": {
       "name": "qqplot",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "diagnostic_plots"
     },
     "qnorm": {
       "name": "qnorm",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "diagnostic_plots"
     },
     "pnorm": {
       "name": "pnorm",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "diagnostic_plots"
     },
     "qchi": {
       "name": "qchi",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "diagnostic_plots"
     },
     "pchi": {
       "name": "pchi",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "diagnostic_plots"
     },
     "dsge": {
       "name": "dsge",
@@ -13110,30 +14006,33 @@
       "name": "nostop",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "estimates_for"
     },
     "store": {
       "name": "store",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "estimates"
     },
     "restore": {
       "name": "restore",
-      "min_abbreviation": 3,
+      "min_abbreviation": 7,
       "options": [
         {
-          "name": "not",
-          "min_abbreviation": 3,
+          "name": "permanently",
+          "min_abbreviation": 11,
           "has_argument": false
         },
         {
-          "name": "preserve",
-          "min_abbreviation": 8,
+          "name": "once",
+          "min_abbreviation": 4,
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "preserve"
     },
     "query": {
       "name": "query",
@@ -13145,13 +14044,15 @@
       "name": "replay",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "estimates"
     },
     "selected": {
       "name": "selected",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "estimates"
     },
     "expoisson": {
       "name": "expoisson",
@@ -13220,13 +14121,15 @@
       "name": "twostep",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "etregress"
     },
     "cfunction": {
       "name": "cfunction",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "etregress"
     },
     "etable": {
       "name": "etable",
@@ -13243,81 +14146,8 @@
     "meta": {
       "name": "meta",
       "min_abbreviation": 4,
-      "options": [
-        {
-          "name": "reweighted",
-          "min_abbreviation": 10,
-          "has_argument": false
-        },
-        {
-          "name": "regline",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "noregline",
-          "min_abbreviation": 9,
-          "has_argument": false
-        },
-        {
-          "name": "ci",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "noci",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "level",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "n",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "lineopts",
-          "min_abbreviation": 8,
-          "has_argument": true
-        }
-      ],
+      "options": [],
       "priority": 3
-    },
-    "predict": {
-      "name": "predict",
-      "min_abbreviation": 7,
-      "options": [
-        {
-          "name": "pomean",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "te",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "tet",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "tlevel",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "outlevel",
-          "min_abbreviation": 8,
-          "has_argument": true
-        }
-      ],
-      "priority": 2
     },
     "expr_query": {
       "name": "expr_query",
@@ -13340,7 +14170,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "estat_df"
     },
     "exit": {
       "name": "exit",
@@ -13352,7 +14183,7 @@
           "has_argument": false
         },
         {
-          "name": "stata",
+          "name": "STATA",
           "min_abbreviation": 5,
           "has_argument": false
         }
@@ -13581,7 +14412,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "etpoisson"
     },
     "ereturn": {
       "name": "ereturn",
@@ -13602,20 +14434,10 @@
     },
     "first": {
       "name": "first",
-      "min_abbreviation": 1,
-      "options": [
-        {
-          "name": "buildfvinfo",
-          "min_abbreviation": 11,
-          "has_argument": false
-        },
-        {
-          "name": "findomitted",
-          "min_abbreviation": 11,
-          "has_argument": false
-        }
-      ],
-      "priority": 3
+      "min_abbreviation": 5,
+      "options": [],
+      "priority": 3,
+      "help_file": "m1_first"
     },
     "plus": {
       "name": "plus",
@@ -13632,7 +14454,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ereturn"
     },
     "buildfvinfo": {
       "name": "buildfvinfo",
@@ -13649,7 +14472,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ereturn"
     },
     "whatever": {
       "name": "whatever",
@@ -13681,7 +14505,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "examplehelpfile"
     },
     "fweight": {
       "name": "fweight",
@@ -13713,7 +14538,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "examplehelpfile"
     },
     "eivreg": {
       "name": "eivreg",
@@ -13777,13 +14603,15 @@
       "name": "nolabel",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "edit"
     },
     "browse": {
       "name": "browse",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 1
+      "priority": 1,
+      "help_file": "edit"
     },
     "egen": {
       "name": "egen",
@@ -13801,35 +14629,40 @@
       "name": "trim",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "head": {
       "name": "head",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "last": {
       "name": "last",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "tail": {
       "name": "tail",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "values": {
       "name": "values",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "decode": {
       "name": "decode",
-      "min_abbreviation": 1,
+      "min_abbreviation": 3,
       "options": [
         {
           "name": "generate",
@@ -13842,43 +14675,50 @@
           "has_argument": true
         }
       ],
-      "priority": 1
+      "priority": 1,
+      "help_file": "encode"
     },
     "punct": {
       "name": "punct",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "group": {
       "name": "group",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "icodes": {
       "name": "icodes",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "truncate": {
       "name": "truncate",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "autotype": {
       "name": "autotype",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "byte": {
       "name": "byte",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "egen"
     },
     "esize": {
       "name": "esize",
@@ -13992,7 +14832,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "esize"
     },
     "twosample": {
       "name": "twosample",
@@ -14049,7 +14890,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "esize"
     },
     "unpaired": {
       "name": "unpaired",
@@ -14106,7 +14948,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "esize"
     },
     "expandcl": {
       "name": "expandcl",
@@ -14186,7 +15029,8 @@
       "name": "nocopy",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "estimates_store"
     },
     "erase": {
       "name": "erase",
@@ -14226,7 +15070,8 @@
       "name": "maxlength",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "encode"
     },
     "eoprobit": {
       "name": "eoprobit",
@@ -14310,7 +15155,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "eoprobit"
     },
     "elasticnet": {
       "name": "elasticnet",
@@ -14369,7 +15215,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "estimates_save"
     },
     "eteffects": {
       "name": "eteffects",
@@ -14455,7 +15302,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "estimates_stats"
     },
     "eprobit": {
       "name": "eprobit",
@@ -14467,7 +15315,8 @@
       "name": "xteprobit",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "eprobit"
     },
     "eregress": {
       "name": "eregress",
@@ -14479,19 +15328,22 @@
       "name": "xteregress",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "eregress"
     },
     "default": {
       "name": "default",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_sortmethod"
     },
     "eps": {
       "name": "eps",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "eps_options"
     },
     "eintreg": {
       "name": "eintreg",
@@ -14503,7 +15355,8 @@
       "name": "xteintreg",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "eintreg"
     },
     "frames": {
       "name": "frames",
@@ -14515,32 +15368,24 @@
       "name": "frame",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "frame_pwf"
     },
     "pwf": {
       "name": "pwf",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "frame_pwf"
     },
     "fmm": {
       "name": "fmm",
       "min_abbreviation": 3,
       "options": [
         {
-          "name": "noconstant",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "offset",
-          "min_abbreviation": 3,
+          "name": "lcinvariant",
+          "min_abbreviation": 11,
           "has_argument": true
-        },
-        {
-          "name": "asis",
-          "min_abbreviation": 4,
-          "has_argument": false
         }
       ],
       "priority": 3
@@ -14549,7 +15394,8 @@
       "name": "cwf",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "frames"
     },
     "frlink": {
       "name": "frlink",
@@ -14560,7 +15406,23 @@
     "frget": {
       "name": "frget",
       "min_abbreviation": 5,
-      "options": [],
+      "options": [
+        {
+          "name": "prefix",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "suffix",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "exclude",
+          "min_abbreviation": 7,
+          "has_argument": true
+        }
+      ],
       "priority": 3
     },
     "frunalias": {
@@ -14577,14 +15439,8 @@
     },
     "forecast": {
       "name": "forecast",
-      "min_abbreviation": 4,
-      "options": [
-        {
-          "name": "notrim",
-          "min_abbreviation": 4,
-          "has_argument": false
-        }
-      ],
+      "min_abbreviation": 8,
+      "options": [],
       "priority": 3
     },
     "findfile": {
@@ -14597,6 +15453,69 @@
       "name": "nodescend",
       "min_abbreviation": 5,
       "options": [],
+      "priority": 3,
+      "help_file": "findfile"
+    },
+    "rotate": {
+      "name": "rotate",
+      "min_abbreviation": 3,
+      "options": [
+        {
+          "name": "orthogonal",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "oblique",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "normalize",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "factors",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "components",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "blanks",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "detail",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "format",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "noloading",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "norotation",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "clear",
+          "min_abbreviation": 5,
+          "has_argument": false
+        }
+      ],
       "priority": 3
     },
     "fdasave": {
@@ -14609,13 +15528,15 @@
       "name": "fdadescribe",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "fdasave"
     },
     "fdause": {
       "name": "fdause",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "fdasave"
     },
     "frontier": {
       "name": "frontier",
@@ -14824,7 +15745,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "fcast_compute"
     },
     "fvrevar": {
       "name": "fvrevar",
@@ -14888,7 +15810,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "fvrevar"
     },
     "tsonly": {
       "name": "tsonly",
@@ -14920,7 +15843,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "fvrevar"
     },
     "fralias": {
       "name": "fralias",
@@ -14953,37 +15877,43 @@
       "name": "read",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "file"
     },
     "write": {
       "name": "write",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "file"
     },
     "text": {
       "name": "text",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "file"
     },
     "binary": {
       "name": "binary",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "file"
     },
     "byteorder": {
       "name": "byteorder",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "file"
     },
     "exogenous": {
       "name": "exogenous",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "forecast_exogenous"
     },
     "solve": {
       "name": "solve",
@@ -15150,7 +16080,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "forecast_solve"
     },
     "foreach": {
       "name": "foreach",
@@ -15162,7 +16093,8 @@
       "name": "newlist",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "foreach"
     },
     "identity": {
       "name": "identity",
@@ -15179,7 +16111,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "forecast_identity"
     },
     "findit": {
       "name": "findit",
@@ -15339,7 +16272,22 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "factor"
+    },
+    "fracplot": {
+      "name": "fracplot",
+      "min_abbreviation": 8,
+      "options": [],
+      "priority": 3,
+      "help_file": "fracpoly_postestimation"
+    },
+    "fracpred": {
+      "name": "fracpred",
+      "min_abbreviation": 8,
+      "options": [],
+      "priority": 3,
+      "help_file": "fracpoly_postestimation"
     },
     "coefvector": {
       "name": "coefvector",
@@ -15356,25 +16304,29 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "forecast_coefvector"
     },
     "mkf": {
       "name": "mkf",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "frame_create"
     },
     "comma": {
       "name": "comma",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "format"
     },
     "period": {
       "name": "period",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "format"
     },
     "fp": {
       "name": "fp",
@@ -15418,12 +16370,47 @@
     },
     "probit": {
       "name": "probit",
-      "min_abbreviation": 2,
+      "min_abbreviation": 6,
       "options": [
         {
-          "name": "offset",
+          "name": "noconstant",
           "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "offset",
+          "min_abbreviation": 3,
           "has_argument": true
+        },
+        {
+          "name": "asis",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "vce",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "level",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "nocnsreport",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "nocoef",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "collinear",
+          "min_abbreviation": 3,
+          "has_argument": false
         },
         {
           "name": "constraints",
@@ -15431,21 +16418,86 @@
           "has_argument": true
         },
         {
-          "name": "level",
-          "min_abbreviation": 5,
-          "has_argument": true
+          "name": "oim",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "opg",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "robust",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "cluster",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "bootstrap",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "jackknife",
+          "min_abbreviation": 4,
+          "has_argument": false
         }
       ],
       "priority": 2
     },
     "logit": {
       "name": "logit",
-      "min_abbreviation": 3,
+      "min_abbreviation": 5,
       "options": [
         {
-          "name": "offset",
+          "name": "noconstant",
           "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "offset",
+          "min_abbreviation": 3,
           "has_argument": true
+        },
+        {
+          "name": "asis",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "vce",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "level",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "or",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "nocnsreport",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "nocoef",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "collinear",
+          "min_abbreviation": 3,
+          "has_argument": false
         },
         {
           "name": "constraints",
@@ -15453,9 +16505,34 @@
           "has_argument": true
         },
         {
-          "name": "level",
-          "min_abbreviation": 5,
-          "has_argument": true
+          "name": "oim",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "opg",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "robust",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "cluster",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "bootstrap",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "jackknife",
+          "min_abbreviation": 4,
+          "has_argument": false
         }
       ],
       "priority": 2
@@ -15562,7 +16639,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "fvset"
     },
     "design": {
       "name": "design",
@@ -15614,7 +16692,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "fvset"
     },
     "filefilter": {
       "name": "filefilter",
@@ -15658,13 +16737,15 @@
       "name": "fracgen",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "fracpoly"
     },
     "pie": {
       "name": "pie",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 2
+      "priority": 2,
+      "help_file": "graph_pie"
     },
     "ycommon": {
       "name": "ycommon",
@@ -15676,7 +16757,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_combine"
     },
     "xcommon": {
       "name": "xcommon",
@@ -15688,7 +16770,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_combine"
     },
     "commonscheme": {
       "name": "commonscheme",
@@ -15700,7 +16783,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_combine"
     },
     "bar": {
       "name": "bar",
@@ -15747,32 +16831,74 @@
           "has_argument": true
         }
       ],
-      "priority": 2
+      "priority": 2,
+      "help_file": "graph_bar"
     },
     "hbar": {
       "name": "hbar",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_bar"
     },
     "mean": {
       "name": "mean",
       "min_abbreviation": 4,
       "options": [
         {
+          "name": "stdize",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "stdweight",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "nostdrescale",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
           "name": "over",
           "min_abbreviation": 4,
           "has_argument": true
         },
         {
-          "name": "level",
-          "min_abbreviation": 5,
+          "name": "vce",
+          "min_abbreviation": 3,
           "has_argument": true
         },
         {
-          "name": "cluster",
-          "min_abbreviation": 7,
+          "name": "level",
+          "min_abbreviation": 1,
           "has_argument": true
+        },
+        {
+          "name": "noheader",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "analytic",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "cluster",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "bootstrap",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "jackknife",
+          "min_abbreviation": 4,
+          "has_argument": false
         }
       ],
       "priority": 3
@@ -15780,44 +16906,62 @@
     "median": {
       "name": "median",
       "min_abbreviation": 6,
-      "options": [],
-      "priority": 3
+      "options": [
+        {
+          "name": "exact",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "porder",
+          "min_abbreviation": 6,
+          "has_argument": false
+        }
+      ],
+      "priority": 3,
+      "help_file": "ranksum"
     },
     "p1": {
       "name": "p1",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_bar"
     },
     "p2": {
       "name": "p2",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_bar"
     },
     "sum": {
       "name": "sum",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_bar"
     },
     "percent": {
       "name": "percent",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_bar"
     },
     "min": {
       "name": "min",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_bar"
     },
     "max": {
       "name": "max",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_bar"
     },
     "gmm": {
       "name": "gmm",
@@ -15876,152 +17020,13 @@
       "min_abbreviation": 4,
       "options": [
         {
-          "name": "family",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "link",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "cloglog",
+          "name": "permute",
           "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "exponential",
-          "min_abbreviation": 11,
-          "has_argument": false
-        },
-        {
-          "name": "gamma",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "logit",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "loglogistic",
-          "min_abbreviation": 11,
-          "has_argument": false
-        },
-        {
-          "name": "lognormal",
-          "min_abbreviation": 9,
-          "has_argument": false
-        },
-        {
-          "name": "llogistic",
-          "min_abbreviation": 9,
-          "has_argument": false
-        },
-        {
-          "name": "lnormal",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "mlogit",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "nbreg",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "ocloglog",
-          "min_abbreviation": 8,
-          "has_argument": false
-        },
-        {
-          "name": "ologit",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "oprobit",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "poisson",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "probit",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "regress",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "weibull",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "exposure",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "offset",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "ldepvar",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "udepvar",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "rcensored",
-          "min_abbreviation": 9,
-          "has_argument": true
-        },
-        {
-          "name": "lcensored",
-          "min_abbreviation": 9,
-          "has_argument": true
-        },
-        {
-          "name": "ltruncated",
-          "min_abbreviation": 10,
-          "has_argument": true
-        },
-        {
-          "name": "failure",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "ph",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "aft",
-          "min_abbreviation": 3,
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "gsem_command"
     },
     "gs_filetype": {
       "name": "gs_filetype",
@@ -16033,7 +17038,8 @@
       "name": "suffix",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "gs_filetype"
     },
     "gs_fileinfo": {
       "name": "gs_fileinfo",
@@ -16045,7 +17051,8 @@
       "name": "schemes",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_query"
     },
     "nopromote": {
       "name": "nopromote",
@@ -16102,61 +17109,37 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "generate"
     },
     "type": {
       "name": "type",
       "min_abbreviation": 2,
       "options": [
         {
-          "name": "before",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "after",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "nopromote",
-          "min_abbreviation": 9,
+          "name": "asis",
+          "min_abbreviation": 1,
           "has_argument": false
         },
         {
-          "name": "replace",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "byte",
+          "name": "smcl",
           "min_abbreviation": 4,
           "has_argument": false
         },
         {
-          "name": "int",
-          "min_abbreviation": 3,
+          "name": "showtabs",
+          "min_abbreviation": 1,
           "has_argument": false
         },
         {
-          "name": "long",
+          "name": "starbang",
           "min_abbreviation": 4,
           "has_argument": false
         },
         {
-          "name": "float",
+          "name": "lines",
           "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "double",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "permanently",
-          "min_abbreviation": 11,
-          "has_argument": false
+          "has_argument": true
         }
       ],
       "priority": 2
@@ -16241,7 +17224,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "gsem_estimation_options"
     },
     "gs_graphinfo": {
       "name": "gs_graphinfo",
@@ -16295,7 +17279,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "gsdesign_twoproportions"
     },
     "logrank": {
       "name": "logrank",
@@ -16327,19 +17312,22 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "gsdesign_logrank"
     },
     "blogit": {
       "name": "blogit",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "glogit"
     },
     "bprobit": {
       "name": "bprobit",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "glogit"
     },
     "glogit": {
       "name": "glogit",
@@ -16351,7 +17339,8 @@
       "name": "gprobit",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "glogit"
     },
     "gs": {
       "name": "gs",
@@ -16433,49 +17422,57 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "gsbounds"
     },
     "ps": {
       "name": "ps",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_set"
     },
     "svg": {
       "name": "svg",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_export"
     },
     "emf": {
       "name": "emf",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_export"
     },
     "png": {
       "name": "png",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_export"
     },
     "tif": {
       "name": "tif",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_export"
     },
     "gif": {
       "name": "gif",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_export"
     },
     "jpg": {
       "name": "jpg",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_export"
     },
     "glm": {
       "name": "glm",
@@ -16653,7 +17650,8 @@
       "name": "oneproportion",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "gsdesign_oneproportion"
     },
     "grmeanby": {
       "name": "grmeanby",
@@ -16748,19 +17746,32 @@
           "has_argument": true
         }
       ],
-      "priority": 2
+      "priority": 2,
+      "help_file": "graph_twoway"
     },
     "memory": {
       "name": "memory",
-      "min_abbreviation": 1,
-      "options": [],
+      "min_abbreviation": 6,
+      "options": [
+        {
+          "name": "permanently",
+          "min_abbreviation": 11,
+          "has_argument": false
+        },
+        {
+          "name": "once",
+          "min_abbreviation": 4,
+          "has_argument": false
+        }
+      ],
       "priority": 3
     },
     "gph": {
       "name": "gph",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_dir"
     },
     "gettoken": {
       "name": "gettoken",
@@ -16798,25 +17809,29 @@
       "name": "quotes",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "gettoken"
     },
     "bind": {
       "name": "bind",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "gettoken"
     },
     "box": {
       "name": "box",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_box"
     },
     "hbox": {
       "name": "hbox",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "graph_box"
     },
     "gsort": {
       "name": "gsort",
@@ -16850,7 +17865,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "gsort"
     },
     "hsearch": {
       "name": "hsearch",
@@ -16860,6 +17876,13 @@
     },
     "build": {
       "name": "build",
+      "min_abbreviation": 5,
+      "options": [],
+      "priority": 3,
+      "help_file": "hsearch"
+    },
+    "h2oml": {
+      "name": "h2oml",
       "min_abbreviation": 5,
       "options": [],
       "priority": 3
@@ -16899,7 +17922,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "h2omlestat_metrics"
     },
     "hetprobit": {
       "name": "hetprobit",
@@ -17310,7 +18334,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "hotel"
     },
     "h2omlgof": {
       "name": "h2omlgof",
@@ -17456,12 +18481,6 @@
           "has_argument": false
         }
       ],
-      "priority": 3
-    },
-    "h2oml": {
-      "name": "h2oml",
-      "min_abbreviation": 5,
-      "options": [],
       "priority": 3
     },
     "hexdump": {
@@ -17727,7 +18746,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "help"
     },
     "hadimvo": {
       "name": "hadimvo",
@@ -17739,13 +18759,15 @@
       "name": "haverdirect",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "import_haverdirect"
     },
     "frommemory": {
       "name": "frommemory",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "import_haverdirect"
     },
     "import": {
       "name": "import",
@@ -17789,11 +18811,106 @@
       ],
       "priority": 2
     },
+    "lroc": {
+      "name": "lroc",
+      "min_abbreviation": 4,
+      "options": [
+        {
+          "name": "all",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nograph",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "beta",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "rlopts",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "if",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "in",
+          "min_abbreviation": 2,
+          "has_argument": false
+        }
+      ],
+      "priority": 3
+    },
+    "lsens": {
+      "name": "lsens",
+      "min_abbreviation": 5,
+      "options": [
+        {
+          "name": "all",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "genprob",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "gensens",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "genspec",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "replace",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "nograph",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "beta",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "if",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "in",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "addplot",
+          "min_abbreviation": 7,
+          "has_argument": true
+        }
+      ],
+      "priority": 3
+    },
     "regression": {
       "name": "regression",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "is_svy"
     },
     "is_svy": {
       "name": "is_svy",
@@ -17972,7 +19089,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "icd9p"
     },
     "category": {
       "name": "category",
@@ -18029,7 +19147,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "icd9p"
     },
     "description": {
       "name": "description",
@@ -18086,7 +19205,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "icd9p"
     },
     "lookup": {
       "name": "lookup",
@@ -18143,60 +19263,71 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "icd9p"
     },
     "search": {
       "name": "search",
-      "min_abbreviation": 3,
+      "min_abbreviation": 6,
       "options": [
         {
-          "name": "generate",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "dots",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "pad",
+          "name": "all",
           "min_abbreviation": 3,
           "has_argument": false
         },
         {
-          "name": "category",
-          "min_abbreviation": 8,
-          "has_argument": false
-        },
-        {
-          "name": "description",
-          "min_abbreviation": 11,
-          "has_argument": false
-        },
-        {
-          "name": "range",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "icd9p",
+          "name": "local",
           "min_abbreviation": 5,
           "has_argument": false
         },
         {
-          "name": "clean",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "long",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "end",
+          "name": "net",
           "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "author",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "entry",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "exact",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "faq",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "historical",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "or",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "manual",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "sj",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "search",
+          "min_abbreviation": 6,
           "has_argument": false
         }
       ],
@@ -18232,7 +19363,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "irtgraph_icc"
     },
     "plocation": {
       "name": "plocation",
@@ -18264,6 +19396,84 @@
           "has_argument": true
         }
       ],
+      "priority": 3,
+      "help_file": "irtgraph_icc"
+    },
+    "ivsvar": {
+      "name": "ivsvar",
+      "min_abbreviation": 6,
+      "options": [
+        {
+          "name": "noconstant",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "nozconstant",
+          "min_abbreviation": 11,
+          "has_argument": false
+        },
+        {
+          "name": "lags",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "zlags",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "level",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "nocnsreport",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "scale",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "showgmm",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "gmm",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "quietly",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "norescale",
+          "min_abbreviation": 9,
+          "has_argument": false
+        },
+        {
+          "name": "qmatrix",
+          "min_abbreviation": 7,
+          "has_argument": true
+        },
+        {
+          "name": "showvar",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "showzvar",
+          "min_abbreviation": 8,
+          "has_argument": false
+        }
+      ],
       "priority": 3
     },
     "irf": {
@@ -18271,28 +19481,63 @@
       "min_abbreviation": 3,
       "options": [
         {
-          "name": "set",
+          "name": "irf",
           "min_abbreviation": 3,
-          "has_argument": true
+          "has_argument": false
         },
         {
-          "name": "using",
+          "name": "var",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "svar",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "ivsvar",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "vec",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "arima",
           "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "detail",
-          "min_abbreviation": 1,
           "has_argument": false
         },
         {
-          "name": "variables",
-          "min_abbreviation": 1,
+          "name": "arfima",
+          "min_abbreviation": 6,
           "has_argument": false
         },
         {
-          "name": "describe",
-          "min_abbreviation": 8,
+          "name": "lpirf",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "ivlpirf",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "dsge",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "dsgenl",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "xtvar",
+          "min_abbreviation": 5,
           "has_argument": false
         }
       ],
@@ -18400,7 +19645,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ir"
     },
     "icd": {
       "name": "icd",
@@ -18602,7 +19848,8 @@
       "name": "add",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "irf_add"
     },
     "ivtobit": {
       "name": "ivtobit",
@@ -18614,7 +19861,8 @@
       "name": "ll",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ivtobit"
     },
     "infile": {
       "name": "infile",
@@ -18641,7 +19889,8 @@
           "has_argument": false
         }
       ],
-      "priority": 2
+      "priority": 2,
+      "help_file": "infile1"
     },
     "automatic": {
       "name": "automatic",
@@ -18658,7 +19907,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "input"
     },
     "impute": {
       "name": "impute",
@@ -18779,19 +20029,15 @@
           "has_argument": false
         }
       ],
-      "priority": 3
-    },
-    "irt": {
-      "name": "irt",
-      "min_abbreviation": 3,
-      "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ivlpirf"
     },
     "delimited": {
       "name": "delimited",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "import_delimited"
     },
     "icc": {
       "name": "icc",
@@ -18809,7 +20055,8 @@
       "name": "short",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "icd10"
     },
     "ivregress": {
       "name": "ivregress",
@@ -19053,7 +20300,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ivregress"
     },
     "ivqregress": {
       "name": "ivqregress",
@@ -19116,25 +20364,29 @@
       "name": "pad",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "icd9_13"
     },
     "main": {
       "name": "main",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "icd9_13"
     },
     "long": {
       "name": "long",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "icd9_13"
     },
     "end": {
       "name": "end",
-      "min_abbreviation": 1,
+      "min_abbreviation": 3,
       "options": [],
-      "priority": 1
+      "priority": 1,
+      "help_file": "m3_end"
     },
     "insheet": {
       "name": "insheet",
@@ -19209,13 +20461,15 @@
       "name": "b1",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "irt_constraints"
     },
     "datafmt": {
       "name": "datafmt",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "import_dbase"
     },
     "icd9": {
       "name": "icd9",
@@ -19294,19 +20548,22 @@
       "name": "if",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 1
+      "priority": 1,
+      "help_file": "ifcmd"
     },
     "else": {
       "name": "else",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 1
+      "priority": 1,
+      "help_file": "ifcmd"
     },
     "inbase": {
       "name": "inbase",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "inten"
     },
     "inten": {
       "name": "inten",
@@ -19318,19 +20575,22 @@
       "name": "freddescribe",
       "min_abbreviation": 12,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "import_fred"
     },
     "fredsearch": {
       "name": "fredsearch",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "import_fred"
     },
     "excel": {
       "name": "excel",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "import_excel"
     },
     "isid": {
       "name": "isid",
@@ -19364,29 +20624,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
-    },
-    "firstlineoffile": {
-      "name": "firstlineoffile",
-      "min_abbreviation": 5,
-      "options": [
-        {
-          "name": "using",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "clear",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "infix",
-          "min_abbreviation": 5,
-          "has_argument": false
-        }
-      ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "isid"
     },
     "infix": {
       "name": "infix",
@@ -19410,6 +20649,29 @@
       ],
       "priority": 3
     },
+    "firstlineoffile": {
+      "name": "firstlineoffile",
+      "min_abbreviation": 5,
+      "options": [
+        {
+          "name": "using",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "clear",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "infix",
+          "min_abbreviation": 5,
+          "has_argument": false
+        }
+      ],
+      "priority": 3,
+      "help_file": "infix"
+    },
     "include": {
       "name": "include",
       "min_abbreviation": 7,
@@ -19418,9 +20680,10 @@
     },
     "adopath": {
       "name": "adopath",
-      "min_abbreviation": 3,
+      "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "sysdir"
     },
     "ipolate": {
       "name": "ipolate",
@@ -19454,7 +20717,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ipolate"
     },
     "nolegend": {
       "name": "nolegend",
@@ -19511,7 +20775,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "jkstat"
     },
     "jkstat": {
       "name": "jkstat",
@@ -19574,25 +20839,29 @@
       "name": "initialize",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "java_utilities"
     },
     "java": {
       "name": "java",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "java_utilities"
     },
     "home": {
       "name": "home",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "java_utilities"
     },
     "heapmax": {
       "name": "heapmax",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "java_utilities"
     },
     "jdbc": {
       "name": "jdbc",
@@ -19604,19 +20873,22 @@
       "name": "connect",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "jdbc"
     },
     "showdbs": {
       "name": "showdbs",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "jdbc"
     },
     "showtables": {
       "name": "showtables",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "jdbc"
     },
     "javacall": {
       "name": "javacall",
@@ -19782,28 +21054,6 @@
       ],
       "priority": 3
     },
-    "kap": {
-      "name": "kap",
-      "min_abbreviation": 3,
-      "options": [
-        {
-          "name": "tab",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "wgt",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "absolute",
-          "min_abbreviation": 8,
-          "has_argument": false
-        }
-      ],
-      "priority": 3
-    },
     "kapwgt": {
       "name": "kapwgt",
       "min_abbreviation": 6,
@@ -19824,7 +21074,31 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "kappa"
+    },
+    "kap": {
+      "name": "kap",
+      "min_abbreviation": 3,
+      "options": [
+        {
+          "name": "tab",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "wgt",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "absolute",
+          "min_abbreviation": 8,
+          "has_argument": false
+        }
+      ],
+      "priority": 3,
+      "help_file": "kappa"
     },
     "ksmirnov": {
       "name": "ksmirnov",
@@ -19893,53 +21167,7 @@
     "telasso": {
       "name": "telasso",
       "min_abbreviation": 7,
-      "options": [
-        {
-          "name": "display",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "format",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "sort",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "for",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "pred",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "xfold",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "xfolds",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "resample",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "tlevel",
-          "min_abbreviation": 6,
-          "has_argument": true
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "lasso": {
@@ -20036,43 +21264,6 @@
       "name": "lmbuild",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
-    },
-    "lroc": {
-      "name": "lroc",
-      "min_abbreviation": 4,
-      "options": [
-        {
-          "name": "all",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "nograph",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "beta",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "rlopts",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "if",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "in",
-          "min_abbreviation": 2,
-          "has_argument": false
-        }
-      ],
       "priority": 3
     },
     "lrtest": {
@@ -20267,7 +21458,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "list"
     },
     "loneway": {
       "name": "loneway",
@@ -20407,7 +21599,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "lassogof"
     },
     "postselection": {
       "name": "postselection",
@@ -20424,64 +21617,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
-    },
-    "lsens": {
-      "name": "lsens",
-      "min_abbreviation": 5,
-      "options": [
-        {
-          "name": "all",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "genprob",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "gensens",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "genspec",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "replace",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "nograph",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "beta",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "if",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "in",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "addplot",
-          "min_abbreviation": 7,
-          "has_argument": true
-        }
-      ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "lassogof"
     },
     "levelsof": {
       "name": "levelsof",
@@ -20566,19 +21703,22 @@
       "name": "close",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "log"
     },
     "off": {
       "name": "off",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "log"
     },
     "linesize": {
       "name": "linesize",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "log"
     },
     "cmdlog": {
       "name": "cmdlog",
@@ -20595,7 +21735,8 @@
           "has_argument": false
         }
       ],
-      "priority": 2
+      "priority": 2,
+      "help_file": "log"
     },
     "lpoly": {
       "name": "lpoly",
@@ -20753,7 +21894,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "lnskew0"
     },
     "ltable": {
       "name": "ltable",
@@ -20877,7 +22019,40 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "label"
+    },
+    "save": {
+      "name": "save",
+      "min_abbreviation": 2,
+      "options": [
+        {
+          "name": "replace",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "nolabel",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "orphans",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "all",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "emptyok",
+          "min_abbreviation": 7,
+          "has_argument": false
+        }
+      ],
+      "priority": 1
     },
     "language": {
       "name": "language",
@@ -20914,7 +22089,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "label"
     },
     "lookfor": {
       "name": "lookfor",
@@ -20926,7 +22102,8 @@
       "name": "new",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "label_language"
     },
     "lrecomp": {
       "name": "lrecomp",
@@ -20987,23 +22164,26 @@
       "options": [],
       "priority": 3
     },
-    "noadjust": {
-      "name": "noadjust",
-      "min_abbreviation": 3,
-      "options": [],
-      "priority": 3
-    },
     "gladder": {
       "name": "gladder",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ladder"
     },
     "qladder": {
       "name": "qladder",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ladder"
+    },
+    "noadjust": {
+      "name": "noadjust",
+      "min_abbreviation": 3,
+      "options": [],
+      "priority": 3,
+      "help_file": "ladder"
     },
     "lv": {
       "name": "lv",
@@ -21028,35 +22208,165 @@
       "options": [],
       "priority": 3
     },
-    "remove": {
-      "name": "remove",
-      "min_abbreviation": 1,
-      "options": [],
-      "priority": 3
-    },
-    "var": {
-      "name": "var",
-      "min_abbreviation": 1,
-      "options": [],
-      "priority": 3
-    },
     "numlabel": {
       "name": "numlabel",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "labelbook"
     },
     "uselabel": {
       "name": "uselabel",
       "min_abbreviation": 8,
       "options": [],
+      "priority": 3,
+      "help_file": "labelbook"
+    },
+    "remove": {
+      "name": "remove",
+      "min_abbreviation": 1,
+      "options": [],
+      "priority": 3,
+      "help_file": "labelbook"
+    },
+    "var": {
+      "name": "var",
+      "min_abbreviation": 3,
+      "options": [
+        {
+          "name": "noconstant",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "lags",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "exog",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "iterate",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "tolerance",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "noisure",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "dfk",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "small",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "nobigf",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "level",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "lutstats",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nocnsreport",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "constraints",
+          "min_abbreviation": 11,
+          "has_argument": true
+        },
+        {
+          "name": "log",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nolog",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "var",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "vce",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "unadjusted",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "robust",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "bayes",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "by",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "fp",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "rolling",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "statsby",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "coeflegend",
+          "min_abbreviation": 10,
+          "has_argument": false
+        }
+      ],
       "priority": 3
     },
     "p1box": {
       "name": "p1box",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "labelstyle"
     },
     "lassoselect": {
       "name": "lassoselect",
@@ -21066,12 +22376,19 @@
     },
     "noisily": {
       "name": "noisily",
-      "min_abbreviation": 3,
+      "min_abbreviation": 1,
       "options": [],
-      "priority": 1
+      "priority": 1,
+      "help_file": "quietly"
     },
     "ml": {
       "name": "ml",
+      "min_abbreviation": 2,
+      "options": [],
+      "priority": 3
+    },
+    "mi": {
+      "name": "mi",
       "min_abbreviation": 2,
       "options": [],
       "priority": 3
@@ -21111,7 +22428,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_import_nhanes1"
     },
     "mvreg": {
       "name": "mvreg",
@@ -21289,110 +22607,10 @@
     },
     "standard": {
       "name": "standard",
-      "min_abbreviation": 2,
-      "options": [
-        {
-          "name": "method",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "loss",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "transform",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "normalize",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "s2d",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "force",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "dimension",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "addconstant",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "initialize",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "tolerance",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "ltolerance",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "iterate",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "protect",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "trace",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "gradient",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "sdprotect",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "id",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "neigen",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "config",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "noplot",
-          "min_abbreviation": 4,
-          "has_argument": false
-        }
-      ],
-      "priority": 3
+      "min_abbreviation": 8,
+      "options": [],
+      "priority": 3,
+      "help_file": "m4_standard"
     },
     "oneminus": {
       "name": "oneminus",
@@ -21499,19 +22717,21 @@
           "has_argument": false
         }
       ],
-      "priority": 3
-    },
-    "correlations": {
-      "name": "correlations",
-      "min_abbreviation": 4,
-      "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mdslong"
     },
     "mvtest": {
       "name": "mvtest",
       "min_abbreviation": 6,
       "options": [],
       "priority": 3
+    },
+    "correlations": {
+      "name": "correlations",
+      "min_abbreviation": 4,
+      "options": [],
+      "priority": 3,
+      "help_file": "mvtest_correlations"
     },
     "mlogit": {
       "name": "mlogit",
@@ -21650,7 +22870,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_rowjoinbyname"
     },
     "coljoinbyname": {
       "name": "coljoinbyname",
@@ -21667,74 +22888,61 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_rowjoinbyname"
     },
-    "mi": {
-      "name": "mi",
-      "min_abbreviation": 2,
-      "options": [
-        {
-          "name": "offset",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "augment",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "conditional",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "bootstrap",
-          "min_abbreviation": 4,
-          "has_argument": false
-        }
-      ],
-      "priority": 3
+    "manovatest": {
+      "name": "manovatest",
+      "min_abbreviation": 10,
+      "options": [],
+      "priority": 3,
+      "help_file": "manova_postestimation"
     },
     "utility": {
       "name": "utility",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m4_utility"
     },
     "rclass": {
       "name": "rclass",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mkassert"
     },
     "nostripes": {
       "name": "nostripes",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mkassert"
     },
     "tmpnames": {
       "name": "tmpnames",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mkassert"
     },
     "eclass": {
       "name": "eclass",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mkassert"
     },
     "sclass": {
       "name": "sclass",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mkassert"
     },
     "obs": {
       "name": "obs",
-      "min_abbreviation": 1,
+      "min_abbreviation": 2,
       "options": [],
       "priority": 3
     },
@@ -21748,13 +22956,15 @@
       "name": "dta",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mkassert"
     },
     "matdescribe": {
       "name": "matdescribe",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_matsave"
     },
     "accum": {
       "name": "accum",
@@ -21766,7 +22976,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_accum"
     },
     "deviations": {
       "name": "deviations",
@@ -21778,7 +22989,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_accum"
     },
     "glsaccum": {
       "name": "glsaccum",
@@ -21790,7 +23002,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_accum"
     },
     "vecaccum": {
       "name": "vecaccum",
@@ -21802,7 +23015,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_accum"
     },
     "opaccum": {
       "name": "opaccum",
@@ -21814,7 +23028,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_accum"
     },
     "noupdate": {
       "name": "noupdate",
@@ -21826,79 +23041,170 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_stsplit"
     },
     "nopreserve": {
       "name": "nopreserve",
-      "min_abbreviation": 5,
-      "options": [
-        {
-          "name": "trim",
-          "min_abbreviation": 4,
-          "has_argument": false
-        }
-      ],
+      "min_abbreviation": 10,
+      "options": [],
       "priority": 3
     },
     "matacache": {
       "name": "matacache",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_set"
     },
     "matalnum": {
       "name": "matalnum",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_set"
     },
     "mataoptimize": {
       "name": "mataoptimize",
       "min_abbreviation": 12,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_set"
     },
     "matafavor": {
       "name": "matafavor",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_set"
     },
     "matastrict": {
       "name": "matastrict",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_set"
     },
     "matalibs": {
       "name": "matalibs",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_set"
     },
     "matamofirst": {
       "name": "matamofirst",
       "min_abbreviation": 11,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_set"
     },
     "matasolvetol": {
       "name": "matasolvetol",
       "min_abbreviation": 12,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_set"
     },
     "variance": {
       "name": "variance",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "meta_estat_sd"
     },
     "coeflegend": {
       "name": "coeflegend",
-      "min_abbreviation": 5,
-      "options": [],
-      "priority": 3
+      "min_abbreviation": 10,
+      "options": [
+        {
+          "name": "kernel",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "dkernel",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "predict",
+          "min_abbreviation": 7,
+          "has_argument": true
+        },
+        {
+          "name": "noderivatives",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "imaic",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "unidentsample",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "bwidth",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "meanbwidth",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "derivbwidth",
+          "min_abbreviation": 7,
+          "has_argument": true
+        },
+        {
+          "name": "reps",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "seed",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "bwreplace",
+          "min_abbreviation": 9,
+          "has_argument": false
+        },
+        {
+          "name": "level",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "citype",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "vce",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "none",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "bootstrap",
+          "min_abbreviation": 4,
+          "has_argument": false
+        }
+      ],
+      "priority": 3,
+      "help_file": "npregress_kernel"
     },
     "mkspline": {
       "name": "mkspline",
@@ -21962,7 +23268,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mkspline"
     },
     "displayknots": {
       "name": "displayknots",
@@ -21994,35 +23301,46 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mkspline"
     },
     "pctile": {
       "name": "pctile",
-      "min_abbreviation": 1,
+      "min_abbreviation": 6,
       "options": [
         {
-          "name": "marginal",
-          "min_abbreviation": 8,
-          "has_argument": false
-        },
-        {
-          "name": "displayknots",
-          "min_abbreviation": 12,
-          "has_argument": false
-        },
-        {
-          "name": "pctile",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "nknots",
-          "min_abbreviation": 6,
+          "name": "nquantiles",
+          "min_abbreviation": 10,
           "has_argument": true
         },
         {
-          "name": "knots",
+          "name": "altdef",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "cutpoints",
+          "min_abbreviation": 9,
+          "has_argument": true
+        },
+        {
+          "name": "xtile",
           "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "if",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "in",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "percentiles",
+          "min_abbreviation": 11,
           "has_argument": true
         }
       ],
@@ -22032,12 +23350,84 @@
       "name": "model",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ml"
     },
     "maximize": {
       "name": "maximize",
-      "min_abbreviation": 3,
-      "options": [],
+      "min_abbreviation": 8,
+      "options": [
+        {
+          "name": "difficult",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "technique",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "iterate",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "trace",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "gradient",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "showstep",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "hessian",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "tolerance",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "ltolerance",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "nrtolerance",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "qtolerance",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "nonrtolerance",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "from",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "log",
+          "min_abbreviation": 3,
+          "has_argument": false
+        }
+      ],
       "priority": 3
     },
     "plot": {
@@ -22050,7 +23440,8 @@
       "name": "footnote",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ml"
     },
     "mat_capp": {
       "name": "mat_capp",
@@ -22062,19 +23453,22 @@
       "name": "mat_rapp",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mat_capp"
     },
     "mat_order": {
       "name": "mat_order",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mat_capp"
     },
     "solvers": {
       "name": "solvers",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m4_solvers"
     },
     "mestreg": {
       "name": "mestreg",
@@ -22290,7 +23684,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_merge"
     },
     "mhodds": {
       "name": "mhodds",
@@ -22340,7 +23735,8 @@
       "name": "op_range",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_op_range"
     },
     "segment_size": {
       "name": "segment_size",
@@ -22357,7 +23753,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "memory"
     },
     "segmentsize": {
       "name": "segmentsize",
@@ -22374,7 +23771,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "memory"
     },
     "min_memory": {
       "name": "min_memory",
@@ -22391,7 +23789,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "memory"
     },
     "meologit": {
       "name": "meologit",
@@ -22516,7 +23915,8 @@
       "name": "workflow",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_workflow"
     },
     "macro": {
       "name": "macro",
@@ -22528,85 +23928,119 @@
       "name": "shift",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macro"
     },
     "tempvar": {
       "name": "tempvar",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macro"
     },
     "tempname": {
       "name": "tempname",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macro"
     },
     "tempfile": {
       "name": "tempfile",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macro"
     },
     "technical": {
       "name": "technical",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_technical"
     },
     "complete": {
       "name": "complete",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_mlib"
     },
     "lmath": {
       "name": "lmath",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_mlib"
     },
     "lmoremath": {
       "name": "lmoremath",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_mlib"
     },
     "lnjc": {
       "name": "lnjc",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata_mlib"
     },
     "intro": {
       "name": "intro",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mata"
     },
     "pwcompare": {
       "name": "pwcompare",
-      "min_abbreviation": 6,
-      "options": [],
+      "min_abbreviation": 9,
+      "options": [
+        {
+          "name": "mcompare",
+          "min_abbreviation": 8,
+          "has_argument": true
+        },
+        {
+          "name": "asobserved",
+          "min_abbreviation": 10,
+          "has_argument": false
+        },
+        {
+          "name": "equation",
+          "min_abbreviation": 8,
+          "has_argument": true
+        },
+        {
+          "name": "atequations",
+          "min_abbreviation": 11,
+          "has_argument": false
+        }
+      ],
       "priority": 2
     },
     "dissimilarity": {
       "name": "dissimilarity",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_dissimilarity"
     },
     "observations": {
       "name": "observations",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_dissimilarity"
     },
     "allbinary": {
       "name": "allbinary",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_dissimilarity"
     },
     "mkdir": {
       "name": "mkdir",
@@ -22624,13 +24058,15 @@
       "name": "public",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mkdir"
     },
     "goto": {
       "name": "goto",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_goto"
     },
     "melogit": {
       "name": "melogit",
@@ -22693,7 +24129,8 @@
       "name": "op_conditional",
       "min_abbreviation": 14,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_op_conditional"
     },
     "meqrlogit": {
       "name": "meqrlogit",
@@ -22831,32 +24268,17 @@
     },
     "return": {
       "name": "return",
-      "min_abbreviation": 6,
+      "min_abbreviation": 3,
       "options": [
         {
-          "name": "local",
-          "min_abbreviation": 5,
-          "has_argument": false
+          "name": "esample",
+          "min_abbreviation": 7,
+          "has_argument": true
         },
         {
-          "name": "scalar",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "matrix",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "add",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "clear",
-          "min_abbreviation": 5,
-          "has_argument": false
+          "name": "properties",
+          "min_abbreviation": 10,
+          "has_argument": true
         }
       ],
       "priority": 1
@@ -22999,31 +24421,36 @@
       "name": "pragma",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_pragma"
     },
     "unset": {
       "name": "unset",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_pragma"
     },
     "unused": {
       "name": "unused",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_pragma"
     },
     "op_kronecker": {
       "name": "op_kronecker",
       "min_abbreviation": 12,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_op_kronecker"
     },
     "op_transpose": {
       "name": "op_transpose",
       "min_abbreviation": 12,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_op_transpose"
     },
     "mlong": {
       "name": "mlong",
@@ -23035,7 +24462,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_convert"
     },
     "flong": {
       "name": "flong",
@@ -23047,7 +24475,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_convert"
     },
     "flongsep": {
       "name": "flongsep",
@@ -23059,19 +24488,22 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_convert"
     },
     "op_assignment": {
       "name": "op_assignment",
       "min_abbreviation": 13,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_op_assignment"
     },
     "how": {
       "name": "how",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_how"
     },
     "mdsmat": {
       "name": "mdsmat",
@@ -23355,7 +24787,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mdsmat"
     },
     "full": {
       "name": "full",
@@ -23497,7 +24930,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mdsmat"
     },
     "lower": {
       "name": "lower",
@@ -23639,7 +25073,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mdsmat"
     },
     "llower": {
       "name": "llower",
@@ -23781,7 +25216,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mdsmat"
     },
     "uupper": {
       "name": "uupper",
@@ -23923,7 +25359,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mdsmat"
     },
     "meintreg": {
       "name": "meintreg",
@@ -23976,7 +25413,22 @@
       "name": "eigenvalues",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_eigenvalues"
+    },
+    "mcaplot": {
+      "name": "mcaplot",
+      "min_abbreviation": 7,
+      "options": [],
+      "priority": 3,
+      "help_file": "mca_postestimation"
+    },
+    "mcaprojection": {
+      "name": "mcaprojection",
+      "min_abbreviation": 13,
+      "options": [],
+      "priority": 3,
+      "help_file": "mca_postestimation"
     },
     "mediate": {
       "name": "mediate",
@@ -24146,7 +25598,8 @@
       "name": "lapack",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_lapack"
     },
     "mswitch": {
       "name": "mswitch",
@@ -24230,7 +25683,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mswitch"
     },
     "ar": {
       "name": "ar",
@@ -24272,7 +25726,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mswitch"
     },
     "galbraithplot": {
       "name": "galbraithplot",
@@ -24339,7 +25794,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "meta_galbraithplot"
     },
     "mat_put_rr": {
       "name": "mat_put_rr",
@@ -24428,71 +25884,8 @@
       "name": "covariances",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
-    },
-    "nomissing": {
-      "name": "nomissing",
-      "min_abbreviation": 5,
-      "options": [
-        {
-          "name": "rownames",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "roweq",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "rowprefix",
-          "min_abbreviation": 9,
-          "has_argument": true
-        },
-        {
-          "name": "obs",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "nchar",
-          "min_abbreviation": 5,
-          "has_argument": true
-        }
-      ],
-      "priority": 3
-    },
-    "explicit": {
-      "name": "explicit",
-      "min_abbreviation": 1,
-      "options": [
-        {
-          "name": "rownames",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "roweq",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "rowprefix",
-          "min_abbreviation": 9,
-          "has_argument": true
-        },
-        {
-          "name": "obs",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "nchar",
-          "min_abbreviation": 5,
-          "has_argument": true
-        }
-      ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mvtest_covariances"
     },
     "mkmat": {
       "name": "mkmat",
@@ -24556,7 +25949,74 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mkmat"
+    },
+    "nomissing": {
+      "name": "nomissing",
+      "min_abbreviation": 5,
+      "options": [
+        {
+          "name": "rownames",
+          "min_abbreviation": 8,
+          "has_argument": true
+        },
+        {
+          "name": "roweq",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "rowprefix",
+          "min_abbreviation": 9,
+          "has_argument": true
+        },
+        {
+          "name": "obs",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nchar",
+          "min_abbreviation": 5,
+          "has_argument": true
+        }
+      ],
+      "priority": 3,
+      "help_file": "mkmat"
+    },
+    "explicit": {
+      "name": "explicit",
+      "min_abbreviation": 1,
+      "options": [
+        {
+          "name": "rownames",
+          "min_abbreviation": 8,
+          "has_argument": true
+        },
+        {
+          "name": "roweq",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "rowprefix",
+          "min_abbreviation": 9,
+          "has_argument": true
+        },
+        {
+          "name": "obs",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nchar",
+          "min_abbreviation": 5,
+          "has_argument": true
+        }
+      ],
+      "priority": 3,
+      "help_file": "mkmat"
     },
     "merge": {
       "name": "merge",
@@ -24629,37 +26089,57 @@
       "name": "optargs",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_optargs"
     },
     "function": {
       "name": "function",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_optargs"
     },
     "imputed": {
       "name": "imputed",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_set"
     },
     "passive": {
       "name": "passive",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_set"
     },
     "regular": {
       "name": "regular",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_set"
+    },
+    "mdsconfig": {
+      "name": "mdsconfig",
+      "min_abbreviation": 9,
+      "options": [],
+      "priority": 3,
+      "help_file": "mds_postestimation"
+    },
+    "mdsshepard": {
+      "name": "mdsshepard",
+      "min_abbreviation": 10,
+      "options": [],
+      "priority": 3,
+      "help_file": "mds_postestimation"
     },
     "op_logical": {
       "name": "op_logical",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_op_logical"
     },
     "normality": {
       "name": "normality",
@@ -24696,13 +26176,15 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mvtest_normality"
     },
     "transmorphic": {
       "name": "transmorphic",
       "min_abbreviation": 12,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mf_ghkfast"
     },
     "noblank": {
       "name": "noblank",
@@ -24714,7 +26196,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_utility"
     },
     "nohalf": {
       "name": "nohalf",
@@ -24726,7 +26209,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_utility"
     },
     "nonames": {
       "name": "nonames",
@@ -24738,7 +26222,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_utility"
     },
     "nodotz": {
       "name": "nodotz",
@@ -24750,7 +26235,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_utility"
     },
     "menl": {
       "name": "menl",
@@ -24773,25 +26259,29 @@
       "name": "reswords",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_reswords"
     },
     "io": {
       "name": "io",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m4_io"
     },
     "styles": {
       "name": "styles",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_styles"
     },
     "dates": {
       "name": "dates",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m4_dates"
     },
     "multiplicative": {
       "name": "multiplicative",
@@ -24803,7 +26293,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "meta_bias"
     },
     "traditional": {
       "name": "traditional",
@@ -24815,7 +26306,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "meta_bias"
     },
     "random": {
       "name": "random",
@@ -24827,7 +26319,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "meta_bias"
     },
     "common": {
       "name": "common",
@@ -24839,7 +26332,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "meta_bias"
     },
     "fixed": {
       "name": "fixed",
@@ -24851,13 +26345,15 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "meta_bias"
     },
     "namelists": {
       "name": "namelists",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m3_namelists"
     },
     "meoprobit": {
       "name": "meoprobit",
@@ -24910,7 +26406,8 @@
       "name": "for",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_for"
     },
     "menbreg": {
       "name": "menbreg",
@@ -24977,7 +26474,7 @@
     },
     "summarize": {
       "name": "summarize",
-      "min_abbreviation": 3,
+      "min_abbreviation": 2,
       "options": [
         {
           "name": "detail",
@@ -24998,6 +26495,31 @@
           "name": "separator",
           "min_abbreviation": 3,
           "has_argument": true
+        },
+        {
+          "name": "g",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "by",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "collect",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "rolling",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "statsby",
+          "min_abbreviation": 7,
+          "has_argument": false
         }
       ],
       "priority": 1
@@ -25006,13 +26528,15 @@
       "name": "patterns",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "misstable"
     },
     "nested": {
       "name": "nested",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "misstable"
     },
     "multilevel": {
       "name": "multilevel",
@@ -25024,7 +26548,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "meta_multilevel"
     },
     "mca": {
       "name": "mca",
@@ -25117,13 +26642,15 @@
       "name": "str",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mf_st_addvar"
     },
     "statistical": {
       "name": "statistical",
       "min_abbreviation": 11,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m4_statistical"
     },
     "me": {
       "name": "me",
@@ -25135,19 +26662,22 @@
       "name": "score",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_score"
     },
     "op_increment": {
       "name": "op_increment",
       "min_abbreviation": 12,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_op_increment"
     },
     "tolerance": {
       "name": "tolerance",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_tolerance"
     },
     "custom": {
       "name": "custom",
@@ -25164,19 +26694,22 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_impute_monotone"
     },
     "struct": {
       "name": "struct",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_struct"
     },
     "quoted": {
       "name": "quoted",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matmacfunc"
     },
     "makespline": {
       "name": "makespline",
@@ -25336,31 +26869,36 @@
       "name": "subscripts",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_subscripts"
     },
     "symeigen": {
       "name": "symeigen",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_symeigen"
     },
     "pointers": {
       "name": "pointers",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_pointers"
     },
     "pointer": {
       "name": "pointer",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_pointers"
     },
     "exp": {
       "name": "exp",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_exp"
     },
     "maxbezierpath": {
       "name": "maxbezierpath",
@@ -25372,7 +26910,8 @@
       "name": "mata",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m3_mata"
     },
     "mcc": {
       "name": "mcc",
@@ -25384,13 +26923,15 @@
       "name": "mcci",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mcc"
     },
     "mathematical": {
       "name": "mathematical",
       "min_abbreviation": 12,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m4_mathematical"
     },
     "correlation": {
       "name": "correlation",
@@ -25402,13 +26943,15 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "meta_estat_recovariance"
     },
     "semicolons": {
       "name": "semicolons",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_semicolons"
     },
     "metobit": {
       "name": "metobit",
@@ -25470,43 +27013,7 @@
     "trace": {
       "name": "trace",
       "min_abbreviation": 2,
-      "options": [
-        {
-          "name": "range",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "from",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "arguments",
-          "min_abbreviation": 9,
-          "has_argument": true
-        },
-        {
-          "name": "tolerance",
-          "min_abbreviation": 9,
-          "has_argument": true
-        },
-        {
-          "name": "iterate",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "missing",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "trace",
-          "min_abbreviation": 5,
-          "has_argument": false
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "minbound": {
@@ -25555,7 +27062,8 @@
       "name": "op_join",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_op_join"
     },
     "multivariate": {
       "name": "multivariate",
@@ -25567,7 +27075,8 @@
       "name": "interactive",
       "min_abbreviation": 11,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_interactive"
     },
     "mfp": {
       "name": "mfp",
@@ -25642,7 +27151,8 @@
       "name": "source",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_source"
     },
     "viewsource": {
       "name": "viewsource",
@@ -25654,55 +27164,64 @@
       "name": "op_arith",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_op_arith"
     },
     "svd": {
       "name": "svd",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_svd"
     },
     "retokenize": {
       "name": "retokenize",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macrolists"
     },
     "uniq": {
       "name": "uniq",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macrolists"
     },
     "dups": {
       "name": "dups",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macrolists"
     },
     "rsort": {
       "name": "rsort",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macrolists"
     },
     "clean": {
       "name": "clean",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macrolists"
     },
     "sizeof": {
       "name": "sizeof",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macrolists"
     },
     "posof": {
       "name": "posof",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "macrolists"
     },
     "mark": {
       "name": "mark",
@@ -25714,43 +27233,50 @@
       "name": "novarlist",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mark"
     },
     "strok": {
       "name": "strok",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mark"
     },
     "sysmissok": {
       "name": "sysmissok",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mark"
     },
     "marksample": {
       "name": "marksample",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mark"
     },
     "noby": {
       "name": "noby",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mark"
     },
     "markout": {
       "name": "markout",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mark"
     },
     "markin": {
       "name": "markin",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mark"
     },
     "svymarkout": {
       "name": "svymarkout",
@@ -25762,13 +27288,15 @@
       "name": "errors",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_errors"
     },
     "permutation": {
       "name": "permutation",
       "min_abbreviation": 11,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_permutation"
     },
     "while": {
       "name": "while",
@@ -25780,25 +27308,29 @@
       "name": "rownames",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_rownames"
     },
     "colnames": {
       "name": "colnames",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_rownames"
     },
     "roweq": {
       "name": "roweq",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_rownames"
     },
     "coleq": {
       "name": "coleq",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_rownames"
     },
     "matlist": {
       "name": "matlist",
@@ -25810,31 +27342,136 @@
       "name": "manipulation",
       "min_abbreviation": 12,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m4_manipulation"
     },
     "marginsplot": {
       "name": "marginsplot",
       "min_abbreviation": 11,
-      "options": [],
+      "options": [
+        {
+          "name": "horizontal",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "noci",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "derivlabels",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "allxlabels",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "nolabels",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "allsimplelabels",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "nosimplelabels",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "separator",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "noseparator",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "recast",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "ciopts",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "recastci",
+          "min_abbreviation": 8,
+          "has_argument": true
+        },
+        {
+          "name": "mcompare",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "level",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "unique",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "csort",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "byopts",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "replace",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "pwcompare",
+          "min_abbreviation": 9,
+          "has_argument": false
+        },
+        {
+          "name": "addplot",
+          "min_abbreviation": 7,
+          "has_argument": true
+        }
+      ],
       "priority": 2
     },
     "void": {
       "name": "void",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_void"
     },
     "op_colon": {
       "name": "op_colon",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_op_colon"
     },
     "robust_result_": {
       "name": "robust_result_",
       "min_abbreviation": 14,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mf_robust"
     },
     "makecns": {
       "name": "makecns",
@@ -25878,13 +27515,15 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "makecns"
     },
     "estimation": {
       "name": "estimation",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_estimation"
     },
     "dupsok": {
       "name": "dupsok",
@@ -25901,7 +27540,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_import_wide"
     },
     "mgarch": {
       "name": "mgarch",
@@ -26048,31 +27688,36 @@
       "name": "dispcns",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "matrix_makecns"
     },
     "naming": {
       "name": "naming",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_naming"
     },
     "x2": {
       "name": "x2",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_naming"
     },
     "logarithm_of_x": {
       "name": "logarithm_of_x",
       "min_abbreviation": 14,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_naming"
     },
     "logofx": {
       "name": "logofx",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_naming"
     },
     "more": {
       "name": "more",
@@ -26084,19 +27729,22 @@
       "name": "pagesize",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "more"
     },
     "programming": {
       "name": "programming",
       "min_abbreviation": 11,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m4_programming"
     },
     "unregistered": {
       "name": "unregistered",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mi_varying"
     },
     "showtolerance": {
       "name": "showtolerance",
@@ -26173,7 +27821,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "maximize"
     },
     "dfp": {
       "name": "dfp",
@@ -26250,13 +27899,15 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "maximize"
     },
     "limits": {
       "name": "limits",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m1_limits"
     },
     "syntax": {
       "name": "syntax",
@@ -26274,28 +27925,12 @@
       "name": "string",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m4_string"
     },
     "mvencode": {
       "name": "mvencode",
       "min_abbreviation": 8,
-      "options": [
-        {
-          "name": "mv",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "override",
-          "min_abbreviation": 8,
-          "has_argument": false
-        }
-      ],
-      "priority": 3
-    },
-    "override": {
-      "name": "override",
-      "min_abbreviation": 1,
       "options": [
         {
           "name": "mv",
@@ -26325,31 +27960,54 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mvencode"
+    },
+    "override": {
+      "name": "override",
+      "min_abbreviation": 1,
+      "options": [
+        {
+          "name": "mv",
+          "min_abbreviation": 2,
+          "has_argument": true
+        },
+        {
+          "name": "override",
+          "min_abbreviation": 8,
+          "has_argument": false
+        }
+      ],
+      "priority": 3,
+      "help_file": "mvencode"
     },
     "mpg": {
       "name": "mpg",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "mf_st_data"
     },
     "declarations": {
       "name": "declarations",
       "min_abbreviation": 12,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_declarations"
     },
     "external": {
       "name": "external",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_declarations"
     },
     "ftof": {
       "name": "ftof",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "m2_ftof"
     },
     "newey": {
       "name": "newey",
@@ -26407,7 +28065,8 @@
       "name": "nodraw",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "nodraw_option"
     },
     "nptrend": {
       "name": "nptrend",
@@ -26470,25 +28129,36 @@
       "name": "numlist",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "nlist"
     },
     "descending": {
       "name": "descending",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "nlist"
     },
     "integer": {
       "name": "integer",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "nlist"
     },
     "missingokay": {
       "name": "missingokay",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "nlist"
+    },
+    "npgraph": {
+      "name": "npgraph",
+      "min_abbreviation": 7,
+      "options": [],
+      "priority": 3,
+      "help_file": "npregress_kernel_postestimation"
     },
     "nestreg": {
       "name": "nestreg",
@@ -26521,7 +28191,8 @@
       "name": "varabbrev",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "novarabbrev"
     },
     "novarabbrev": {
       "name": "novarabbrev",
@@ -26571,13 +28242,21 @@
       "name": "install",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "net"
     },
     "news": {
       "name": "news",
       "min_abbreviation": 4,
       "options": [],
       "priority": 3
+    },
+    "renumber": {
+      "name": "renumber",
+      "min_abbreviation": 8,
+      "options": [],
+      "priority": 3,
+      "help_file": "notes"
     },
     "nlsur": {
       "name": "nlsur",
@@ -26701,7 +28380,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "npregress_kernel"
     },
     "npregress": {
       "name": "npregress",
@@ -26793,7 +28473,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "npregress_kernel"
     },
     "nl": {
       "name": "nl",
@@ -26882,7 +28563,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "npregress_series"
     },
     "nbreg": {
       "name": "nbreg",
@@ -26935,7 +28617,8 @@
       "name": "gnbreg",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "nbreg"
     },
     "nlogit": {
       "name": "nlogit",
@@ -26943,17 +28626,26 @@
       "options": [],
       "priority": 3
     },
-    "estconst": {
-      "name": "estconst",
-      "min_abbreviation": 4,
-      "options": [],
-      "priority": 3
-    },
     "nlogitgen": {
       "name": "nlogitgen",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "nlogit"
+    },
+    "nlogittree": {
+      "name": "nlogittree",
+      "min_abbreviation": 10,
+      "options": [],
+      "priority": 3,
+      "help_file": "nlogit"
+    },
+    "estconst": {
+      "name": "estconst",
+      "min_abbreviation": 4,
+      "options": [],
+      "priority": 3,
+      "help_file": "nlogit"
     },
     "netio": {
       "name": "netio",
@@ -27325,7 +29017,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "odbc"
     },
     "load": {
       "name": "load",
@@ -27447,7 +29140,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "odbc"
     },
     "insert": {
       "name": "insert",
@@ -27569,7 +29263,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "odbc"
     },
     "odbcdriver": {
       "name": "odbcdriver",
@@ -27691,7 +29386,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "odbc"
     },
     "odbcmgr": {
       "name": "odbcmgr",
@@ -27813,7 +29509,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "odbc"
     },
     "outfile": {
       "name": "outfile",
@@ -28015,7 +29712,8 @@
       "name": "orthpoly",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "orthog"
     },
     "outsheet": {
       "name": "outsheet",
@@ -28163,11 +29861,18 @@
       ],
       "priority": 3
     },
+    "power": {
+      "name": "power",
+      "min_abbreviation": 5,
+      "options": [],
+      "priority": 3
+    },
     "double": {
       "name": "double",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "prefix_saving_option"
     },
     "twovariances": {
       "name": "twovariances",
@@ -28189,7 +29894,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "power_twovariances"
     },
     "pkcross": {
       "name": "pkcross",
@@ -28248,7 +29954,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "post"
     },
     "post": {
       "name": "post",
@@ -28272,7 +29979,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "post"
     },
     "projmanager": {
       "name": "projmanager",
@@ -28302,7 +30010,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "putexcel"
     },
     "overwritefmt": {
       "name": "overwritefmt",
@@ -28314,7 +30023,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "putexcel"
     },
     "twocorrelations": {
       "name": "twocorrelations",
@@ -28331,27 +30041,27 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "power_twocorrelations"
     },
     "sortpreserve": {
       "name": "sortpreserve",
       "min_abbreviation": 4,
-      "options": [
-        {
-          "name": "properties",
-          "min_abbreviation": 10,
-          "has_argument": true
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "plugin": {
       "name": "plugin",
-      "min_abbreviation": 6,
+      "min_abbreviation": 4,
       "options": [
         {
-          "name": "properties",
-          "min_abbreviation": 10,
+          "name": "plugin",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "using",
+          "min_abbreviation": 5,
           "has_argument": true
         }
       ],
@@ -28360,12 +30070,6 @@
     "postest": {
       "name": "postest",
       "min_abbreviation": 7,
-      "options": [],
-      "priority": 3
-    },
-    "power": {
-      "name": "power",
-      "min_abbreviation": 5,
       "options": [],
       "priority": 3
     },
@@ -28424,7 +30128,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "power_pairedmeans"
     },
     "profiler": {
       "name": "profiler",
@@ -28452,7 +30157,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "power_onecorrelation"
     },
     "xtile": {
       "name": "xtile",
@@ -28494,7 +30200,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "pctile"
     },
     "predictnl": {
       "name": "predictnl",
@@ -28660,7 +30367,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "procrustes"
     },
     "oblique": {
       "name": "oblique",
@@ -28707,7 +30415,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "procrustes"
     },
     "unrestricted": {
       "name": "unrestricted",
@@ -28754,7 +30463,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "procrustes"
     },
     "prais": {
       "name": "prais",
@@ -28905,6 +30615,13 @@
       ],
       "priority": 3
     },
+    "procoverlay": {
+      "name": "procoverlay",
+      "min_abbreviation": 11,
+      "options": [],
+      "priority": 3,
+      "help_file": "procrustes_postestimation"
+    },
     "postrtoe": {
       "name": "postrtoe",
       "min_abbreviation": 8,
@@ -28957,7 +30674,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "power_rsquared"
     },
     "prtest": {
       "name": "prtest",
@@ -28969,7 +30687,8 @@
       "name": "prtesti",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "prtest"
     },
     "pairedproportions": {
       "name": "pairedproportions",
@@ -29026,7 +30745,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "power_pairedproportions"
     },
     "preserve": {
       "name": "preserve",
@@ -29060,7 +30780,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "preserve"
     },
     "putmata": {
       "name": "putmata",
@@ -29072,7 +30793,8 @@
       "name": "getmata",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "putmata"
     },
     "putpdf": {
       "name": "putpdf",
@@ -29104,7 +30826,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "putpdf_collect"
     },
     "pergram": {
       "name": "pergram",
@@ -29154,33 +30877,6 @@
       "name": "printer",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
-    },
-    "psdensity": {
-      "name": "psdensity",
-      "min_abbreviation": 9,
-      "options": [
-        {
-          "name": "pspectrum",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "range",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "cycle",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "smemory",
-          "min_abbreviation": 4,
-          "has_argument": false
-        }
-      ],
       "priority": 3
     },
     "scores": {
@@ -29238,7 +30934,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "predict"
     },
     "pkequiv": {
       "name": "pkequiv",
@@ -29329,31 +31026,36 @@
       "name": "linepalette",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "palette"
     },
     "symbolpalette": {
       "name": "symbolpalette",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "palette"
     },
     "smclsymbolpalette": {
       "name": "smclsymbolpalette",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "palette"
     },
     "color": {
       "name": "color",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "palette"
     },
     "cmyk": {
       "name": "cmyk",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "palette"
     },
     "pkshape": {
       "name": "pkshape",
@@ -29446,52 +31148,27 @@
     },
     "sqrtlasso": {
       "name": "sqrtlasso",
-      "min_abbreviation": 4,
+      "min_abbreviation": 9,
       "options": [
+        {
+          "name": "noconstant",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
         {
           "name": "offset",
           "min_abbreviation": 3,
           "has_argument": true
         },
         {
-          "name": "exposure",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "level",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "irr",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "coef",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "verbose",
+          "name": "cluster",
           "min_abbreviation": 7,
-          "has_argument": false
+          "has_argument": true
         },
         {
           "name": "rseed",
           "min_abbreviation": 5,
           "has_argument": true
-        },
-        {
-          "name": "noheader",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "no",
-          "min_abbreviation": 2,
-          "has_argument": false
         }
       ],
       "priority": 3
@@ -29630,7 +31307,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "pca"
     },
     "proportion": {
       "name": "proportion",
@@ -29776,7 +31454,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "putdocx_collect"
     },
     "pcorr": {
       "name": "pcorr",
@@ -30089,7 +31768,8 @@
       "name": "totalpages",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "putdocx_paragraph"
     },
     "qby": {
       "name": "qby",
@@ -30101,37 +31781,43 @@
       "name": "qbys",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "qby"
     },
     "output": {
       "name": "output",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "query"
     },
     "interface": {
       "name": "interface",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "query"
     },
     "graphics": {
       "name": "graphics",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "query"
     },
     "network": {
       "name": "network",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "query"
     },
     "other": {
       "name": "other",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "query"
     },
     "quadchk": {
       "name": "quadchk",
@@ -30165,19 +31851,22 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "quadchk"
     },
     "proc": {
       "name": "proc",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "quietly"
     },
     "inform": {
       "name": "inform",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "quietly"
     },
     "qc": {
       "name": "qc",
@@ -30271,7 +31960,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "qc"
     },
     "pchart": {
       "name": "pchart",
@@ -30318,7 +32008,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "qc"
     },
     "rchart": {
       "name": "rchart",
@@ -30365,7 +32056,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "qc"
     },
     "xchart": {
       "name": "xchart",
@@ -30412,7 +32104,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "qc"
     },
     "shewhart": {
       "name": "shewhart",
@@ -30459,7 +32152,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "qc"
     },
     "qreg": {
       "name": "qreg",
@@ -30471,81 +32165,22 @@
       "name": "iqreg",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "qreg"
     },
     "sqreg": {
       "name": "sqreg",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "qreg"
     },
     "bsqreg": {
       "name": "bsqreg",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
-    },
-    "rotate": {
-      "name": "rotate",
-      "min_abbreviation": 3,
-      "options": [
-        {
-          "name": "orthogonal",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "oblique",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "normalize",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "factors",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "components",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "blanks",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "detail",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "format",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "noloading",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "norotation",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "clear",
-          "min_abbreviation": 5,
-          "has_argument": false
-        }
-      ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "qreg"
     },
     "rmsg": {
       "name": "rmsg",
@@ -30635,7 +32270,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "recode"
     },
     "rolling": {
       "name": "rolling",
@@ -31165,7 +32801,8 @@
       "name": "proper",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "rename_group"
     },
     "sreturn": {
       "name": "sreturn",
@@ -31182,7 +32819,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "return"
     },
     "repost": {
       "name": "repost",
@@ -31199,7 +32837,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "return"
     },
     "reg3": {
       "name": "reg3",
@@ -31307,6 +32946,13 @@
         }
       ],
       "priority": 3
+    },
+    "rocplot": {
+      "name": "rocplot",
+      "min_abbreviation": 7,
+      "options": [],
+      "priority": 3,
+      "help_file": "rocfit_postestimation"
     },
     "rcof": {
       "name": "rcof",
@@ -31468,7 +33114,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "roccomp"
     },
     "ranksum": {
       "name": "ranksum",
@@ -31639,43 +33286,12 @@
       ],
       "priority": 3
     },
-    "save": {
-      "name": "save",
-      "min_abbreviation": 2,
-      "options": [
-        {
-          "name": "replace",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "nolabel",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "orphans",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "all",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "emptyok",
-          "min_abbreviation": 7,
-          "has_argument": false
-        }
-      ],
-      "priority": 1
-    },
     "saveold": {
       "name": "saveold",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "save"
     },
     "serset": {
       "name": "serset",
@@ -31687,53 +33303,61 @@
       "name": "omitanymiss",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "omitallmiss": {
       "name": "omitallmiss",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "omitdupmiss": {
       "name": "omitdupmiss",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "omitnothing": {
       "name": "omitnothing",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "create_xmedians": {
       "name": "create_xmedians",
       "min_abbreviation": 15,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "logx": {
       "name": "logx",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "logy": {
       "name": "logy",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "create_cspline": {
       "name": "create_cspline",
       "min_abbreviation": 14,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "use": {
       "name": "use",
-      "min_abbreviation": 3,
+      "min_abbreviation": 1,
       "options": [
         {
           "name": "clear",
@@ -31752,19 +33376,22 @@
       "name": "reset_id",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "sersetwrite": {
       "name": "sersetwrite",
       "min_abbreviation": 11,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "sersetread": {
       "name": "sersetread",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "serset"
     },
     "statsby": {
       "name": "statsby",
@@ -31890,7 +33517,8 @@
       "name": "locale_ui",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_locale_ui"
     },
     "slogit": {
       "name": "slogit",
@@ -32009,7 +33637,8 @@
       "name": "scheme",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_sj"
     },
     "st": {
       "name": "st",
@@ -32065,37 +33694,43 @@
       "name": "printcolor",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_printcolor"
     },
     "asis": {
       "name": "asis",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_printcolor"
     },
     "gs1": {
       "name": "gs1",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_printcolor"
     },
     "gs2": {
       "name": "gs2",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_printcolor"
     },
     "gs3": {
       "name": "gs3",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_printcolor"
     },
     "copycolor": {
       "name": "copycolor",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_printcolor"
     },
     "spmatrix": {
       "name": "spmatrix",
@@ -32171,7 +33806,8 @@
       "name": "st_show",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "st_is"
     },
     "shell": {
       "name": "shell",
@@ -32183,13 +33819,15 @@
       "name": "xshell",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "shell"
     },
     "winexec": {
       "name": "winexec",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "shell"
     },
     "stepwise": {
       "name": "stepwise",
@@ -32237,7 +33875,8 @@
       "name": "prefix",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_prefix"
     },
     "suest": {
       "name": "suest",
@@ -32296,18 +33935,38 @@
       "min_abbreviation": 3,
       "options": [
         {
-          "name": "bsn",
+          "name": "subpop",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "dof",
           "min_abbreviation": 3,
           "has_argument": true
         },
         {
-          "name": "mse",
-          "min_abbreviation": 3,
+          "name": "level",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "nocnsreport",
+          "min_abbreviation": 11,
           "has_argument": false
         },
         {
-          "name": "verbose",
-          "min_abbreviation": 7,
+          "name": "noheader",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "nolegend",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "noadjust",
+          "min_abbreviation": 8,
           "has_argument": false
         },
         {
@@ -32316,154 +33975,205 @@
           "has_argument": false
         },
         {
-          "name": "nodots",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
           "name": "trace",
           "min_abbreviation": 5,
           "has_argument": false
         },
         {
-          "name": "title",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "nodrop",
-          "min_abbreviation": 6,
+          "name": "coeflegend",
+          "min_abbreviation": 10,
           "has_argument": false
-        },
-        {
-          "name": "reject",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "dof",
-          "min_abbreviation": 3,
-          "has_argument": true
         }
       ],
       "priority": 3
     },
     "tabulate": {
       "name": "tabulate",
-      "min_abbreviation": 3,
+      "min_abbreviation": 2,
       "options": [
         {
-          "name": "stdize",
-          "min_abbreviation": 6,
-          "has_argument": true
+          "name": "chi2",
+          "min_abbreviation": 2,
+          "has_argument": false
         },
         {
-          "name": "stdweight",
-          "min_abbreviation": 9,
-          "has_argument": true
+          "name": "gamma",
+          "min_abbreviation": 1,
+          "has_argument": false
         },
         {
-          "name": "tab",
+          "name": "lrchi2",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "taub",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "v",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "cchi2",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "column",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "row",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "clrchi2",
           "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "missing",
-          "min_abbreviation": 7,
           "has_argument": false
         },
         {
           "name": "cell",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "count",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "se",
           "min_abbreviation": 2,
           "has_argument": false
         },
         {
-          "name": "ci",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "deff",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "deft",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "cv",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "srssubpop",
-          "min_abbreviation": 9,
-          "has_argument": false
-        },
-        {
-          "name": "obs",
+          "name": "expected",
           "min_abbreviation": 3,
           "has_argument": false
         },
         {
-          "name": "level",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "proportion",
-          "min_abbreviation": 10,
+          "name": "nofreq",
+          "min_abbreviation": 3,
           "has_argument": false
         },
         {
-          "name": "percent",
+          "name": "rowsort",
           "min_abbreviation": 7,
           "has_argument": false
         },
         {
-          "name": "nomarginal",
-          "min_abbreviation": 10,
+          "name": "colsort",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "missing",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "wrap",
+          "min_abbreviation": 1,
           "has_argument": false
         },
         {
           "name": "nolabel",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nolog",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "matcell",
+          "min_abbreviation": 7,
+          "has_argument": true
+        },
+        {
+          "name": "matrow",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "matcol",
+          "min_abbreviation": 6,
+          "has_argument": true
+        },
+        {
+          "name": "all",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "aweight",
           "min_abbreviation": 7,
           "has_argument": false
         },
         {
-          "name": "cellwidth",
-          "min_abbreviation": 9,
-          "has_argument": true
+          "name": "iweight",
+          "min_abbreviation": 7,
+          "has_argument": false
         },
         {
-          "name": "csepwidth",
-          "min_abbreviation": 9,
-          "has_argument": true
+          "name": "exact",
+          "min_abbreviation": 5,
+          "has_argument": false
         },
         {
-          "name": "stubwidth",
-          "min_abbreviation": 9,
-          "has_argument": true
+          "name": "a",
+          "min_abbreviation": 1,
+          "has_argument": false
         },
         {
-          "name": "format",
-          "min_abbreviation": 6,
-          "has_argument": true
+          "name": "no",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "key",
+          "min_abbreviation": 3,
+          "has_argument": false
+        },
+        {
+          "name": "nokey",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "firstonly",
+          "min_abbreviation": 9,
+          "has_argument": false
+        },
+        {
+          "name": "replace",
+          "min_abbreviation": 7,
+          "has_argument": false
+        },
+        {
+          "name": "tabi",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "tabulate",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "by",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "tab2",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "collect",
+          "min_abbreviation": 7,
+          "has_argument": false
         }
       ],
-      "priority": 1
+      "priority": 1,
+      "help_file": "tabulate_twoway"
     },
     "risktable": {
       "name": "risktable",
@@ -32600,143 +34310,13 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "sts_graph"
     },
     "sts": {
       "name": "sts",
       "min_abbreviation": 3,
-      "options": [
-        {
-          "name": "survival",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "failure",
-          "min_abbreviation": 1,
-          "has_argument": false
-        },
-        {
-          "name": "cumhaz",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "hazard",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "by",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "strata",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "separate",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "ci",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "risktable",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "level",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "per",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "noshow",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "tmax",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "tmin",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "noorigin",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "kernel",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "noboundary",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "lost",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "enter",
-          "min_abbreviation": 1,
-          "has_argument": false
-        },
-        {
-          "name": "atrisk",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "censopts",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "lostopts",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "atriskopts",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "plotopts",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "ciopts",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "byopts",
-          "min_abbreviation": 4,
-          "has_argument": true
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "simulate": {
@@ -32794,129 +34374,20 @@
     "sem": {
       "name": "sem",
       "min_abbreviation": 3,
-      "options": [],
-      "priority": 3
+      "options": [
+        {
+          "name": "permute",
+          "min_abbreviation": 7,
+          "has_argument": false
+        }
+      ],
+      "priority": 3,
+      "help_file": "sem_command"
     },
     "stpower": {
       "name": "stpower",
       "min_abbreviation": 5,
-      "options": [
-        {
-          "name": "t",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "alpha",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "power",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "beta",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "n",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "hratio",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "onesided",
-          "min_abbreviation": 8,
-          "has_argument": false
-        },
-        {
-          "name": "p1",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "nratio",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "loghazard",
-          "min_abbreviation": 9,
-          "has_argument": false
-        },
-        {
-          "name": "unconditional",
-          "min_abbreviation": 13,
-          "has_argument": false
-        },
-        {
-          "name": "fperiod",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "aperiod",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "aprob",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "aptime",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "atime",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "ashape",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "lossprob",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "losstime",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "losshaz",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "detail",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "colwidth",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "separator",
-          "min_abbreviation": 9,
-          "has_argument": true
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "stbase": {
@@ -33096,123 +34567,7 @@
     "stset": {
       "name": "stset",
       "min_abbreviation": 5,
-      "options": [
-        {
-          "name": "estimate",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "strata",
-          "min_abbreviation": 6,
-          "has_argument": true
-        },
-        {
-          "name": "shared",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "offset",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "breslow",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "efron",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "exactm",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "exactp",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "tvc",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "texp",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "vce",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "noadjust",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "level",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "nohr",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "noshow",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "oim",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "robust",
-          "min_abbreviation": 1,
-          "has_argument": false
-        },
-        {
-          "name": "cluster",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "bootstrap",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "jackknife",
-          "min_abbreviation": 4,
-          "has_argument": false
-        },
-        {
-          "name": "fp",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "mfp",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "coeflegend",
-          "min_abbreviation": 10,
-          "has_argument": false
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "stintcox": {
@@ -33231,67 +34586,78 @@
       "name": "showbaselevels",
       "min_abbreviation": 14,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_showbaselevels"
     },
     "showemptycells": {
       "name": "showemptycells",
       "min_abbreviation": 14,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_showbaselevels"
     },
     "showomitted": {
       "name": "showomitted",
       "min_abbreviation": 11,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_showbaselevels"
     },
     "fvlabel": {
       "name": "fvlabel",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_showbaselevels"
     },
     "fvwrap": {
       "name": "fvwrap",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_showbaselevels"
     },
     "fvwrapon": {
       "name": "fvwrapon",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_showbaselevels"
     },
     "s1": {
       "name": "s1",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_s1"
     },
     "s1rcolor": {
       "name": "s1rcolor",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_s1"
     },
     "s1color": {
       "name": "s1color",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_s1"
     },
     "s1mono": {
       "name": "s1mono",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_s1"
     },
     "s1manual": {
       "name": "s1manual",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_s1"
     },
     "set_defaults": {
       "name": "set_defaults",
@@ -33303,19 +34669,22 @@
       "name": "cformat",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_cformat"
     },
     "pformat": {
       "name": "pformat",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_cformat"
     },
     "sformat": {
       "name": "sformat",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_cformat"
     },
     "svyset": {
       "name": "svyset",
@@ -33627,7 +34996,8 @@
       "name": "iterlog",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_iter"
     },
     "spshape2dta": {
       "name": "spshape2dta",
@@ -33655,13 +35025,15 @@
       "name": "stphplot",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stcox_diagnostics"
     },
     "stcoxkm": {
       "name": "stcoxkm",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stcox_diagnostics"
     },
     "signrank": {
       "name": "signrank",
@@ -33673,7 +35045,8 @@
       "name": "signtest",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "signrank"
     },
     "splitsample": {
       "name": "splitsample",
@@ -33746,19 +35119,22 @@
       "name": "emptycells",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_emptycells"
     },
     "docx_hardbreak": {
       "name": "docx_hardbreak",
       "min_abbreviation": 14,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_docx"
     },
     "docx_paramode": {
       "name": "docx_paramode",
       "min_abbreviation": 13,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_docx"
     },
     "sleep": {
       "name": "sleep",
@@ -33770,7 +35146,8 @@
       "name": "ctrlh",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_ctrlh"
     },
     "atrisk0": {
       "name": "atrisk0",
@@ -33862,21 +35239,62 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "sts_list"
     },
     "testnl": {
       "name": "testnl",
       "min_abbreviation": 6,
       "options": [
         {
-          "name": "mtest",
-          "min_abbreviation": 5,
+          "name": "iterate",
+          "min_abbreviation": 4,
           "has_argument": true
         },
         {
-          "name": "iterate",
-          "min_abbreviation": 7,
+          "name": "df",
+          "min_abbreviation": 2,
           "has_argument": true
+        },
+        {
+          "name": "nosvyadjust",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "mtest",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "bonferroni",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "holm",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "sidak",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "noadjust",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "testnl",
+          "min_abbreviation": 6,
+          "has_argument": false
+        },
+        {
+          "name": "svy",
+          "min_abbreviation": 3,
+          "has_argument": false
         }
       ],
       "priority": 3
@@ -33933,7 +35351,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "sdtest"
     },
     "robvar": {
       "name": "robvar",
@@ -33960,7 +35379,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "sdtest"
     },
     "storedresults": {
       "name": "storedresults",
@@ -33972,7 +35392,8 @@
       "name": "coeftabresults",
       "min_abbreviation": 14,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_coeftabresults"
     },
     "snapspan": {
       "name": "snapspan",
@@ -34001,13 +35422,15 @@
       "name": "fe",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "spxtregress"
     },
     "re": {
       "name": "re",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "spxtregress"
     },
     "poststratify": {
       "name": "poststratify",
@@ -34059,7 +35482,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "svygen"
     },
     "brr": {
       "name": "brr",
@@ -34111,7 +35535,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "svygen"
     },
     "svygen": {
       "name": "svygen",
@@ -34169,25 +35594,29 @@
       "name": "rng",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_rng"
     },
     "mt64": {
       "name": "mt64",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_rng"
     },
     "mt64s": {
       "name": "mt64s",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_rng"
     },
     "kiss32": {
       "name": "kiss32",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_rng"
     },
     "signestimationsample": {
       "name": "signestimationsample",
@@ -34199,19 +35628,22 @@
       "name": "checkestimationsample",
       "min_abbreviation": 21,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "signestimationsample"
     },
     "stgcolor": {
       "name": "stgcolor",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_st"
     },
     "builder": {
       "name": "builder",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "sem_builder"
     },
     "stci": {
       "name": "stci",
@@ -34371,18 +35803,7 @@
     "stteffects": {
       "name": "stteffects",
       "min_abbreviation": 10,
-      "options": [
-        {
-          "name": "noconstant",
-          "min_abbreviation": 10,
-          "has_argument": false
-        },
-        {
-          "name": "level",
-          "min_abbreviation": 5,
-          "has_argument": true
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "sspace": {
@@ -34427,13 +35848,15 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "sspace"
     },
     "fvbase": {
       "name": "fvbase",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_fvbase"
     },
     "stcrreg": {
       "name": "stcrreg",
@@ -34647,7 +36070,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stcrreg"
     },
     "iweight": {
       "name": "iweight",
@@ -34754,37 +36178,43 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stcrreg"
     },
     "nocmd": {
       "name": "nocmd",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stset"
     },
     "past": {
       "name": "past",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stset"
     },
     "future": {
       "name": "future",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stset"
     },
     "streset": {
       "name": "streset",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stset"
     },
     "insertmode": {
       "name": "insertmode",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_insertmode"
     },
     "spdistance": {
       "name": "spdistance",
@@ -34796,31 +36226,36 @@
       "name": "s2color",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_s2"
     },
     "s2mono": {
       "name": "s2mono",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_s2"
     },
     "s2gcolor": {
       "name": "s2gcolor",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_s2"
     },
     "s2manual": {
       "name": "s2manual",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_s2"
     },
     "s2gmanual": {
       "name": "s2gmanual",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_s2"
     },
     "sttocc": {
       "name": "sttocc",
@@ -34936,7 +36371,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stfill"
     },
     "forward": {
       "name": "forward",
@@ -34973,7 +36409,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stfill"
     },
     "streg": {
       "name": "streg",
@@ -35337,37 +36774,43 @@
       "name": "author",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ssc"
     },
     "saving": {
       "name": "saving",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ssc"
     },
     "personal": {
       "name": "personal",
-      "min_abbreviation": 1,
+      "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "sysdir"
     },
     "hot": {
       "name": "hot",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ssc"
     },
     "economist": {
       "name": "economist",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "scheme_economist"
     },
     "locale_functions": {
       "name": "locale_functions",
       "min_abbreviation": 16,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_locale_functions"
     },
     "stsplit": {
       "name": "stsplit",
@@ -35379,7 +36822,8 @@
       "name": "stjoin",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stsplit"
     },
     "stintphplot": {
       "name": "stintphplot",
@@ -35426,7 +36870,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stintcox_diagnostics"
     },
     "stintcoxnp": {
       "name": "stintcoxnp",
@@ -35473,7 +36918,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stintcox_diagnostics"
     },
     "stdescribe": {
       "name": "stdescribe",
@@ -35507,7 +36953,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stdescribe"
     },
     "spset": {
       "name": "spset",
@@ -35626,49 +37073,8 @@
       "name": "sfrancia",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
-    },
-    "screeplot": {
-      "name": "screeplot",
-      "min_abbreviation": 9,
-      "options": [
-        {
-          "name": "neigen",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "mean",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "meanlopts",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "ci",
-          "min_abbreviation": 2,
-          "has_argument": false
-        },
-        {
-          "name": "heteroskedastic",
-          "min_abbreviation": 15,
-          "has_argument": false
-        },
-        {
-          "name": "homoskedastic",
-          "min_abbreviation": 13,
-          "has_argument": false
-        },
-        {
-          "name": "addplot",
-          "min_abbreviation": 7,
-          "has_argument": true
-        }
-      ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "swilk"
     },
     "scree": {
       "name": "scree",
@@ -35710,7 +37116,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "screeplot"
     },
     "survey": {
       "name": "survey",
@@ -35843,7 +37250,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stcurve"
     },
     "cif": {
       "name": "cif",
@@ -35970,13 +37378,15 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "stcurve"
     },
     "fvtrack": {
       "name": "fvtrack",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_fvtrack"
     },
     "spbalance": {
       "name": "spbalance",
@@ -35988,139 +37398,162 @@
       "name": "circle",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "diamond": {
       "name": "diamond",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "triangle": {
       "name": "triangle",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "square": {
       "name": "square",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "arrowf": {
       "name": "arrowf",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "arrow": {
       "name": "arrow",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "pipe": {
       "name": "pipe",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smcircle": {
       "name": "smcircle",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smdiamond": {
       "name": "smdiamond",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smsquare": {
       "name": "smsquare",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smtriangle": {
       "name": "smtriangle",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smplus": {
       "name": "smplus",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smx": {
       "name": "smx",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smv": {
       "name": "smv",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "circle_hollow": {
       "name": "circle_hollow",
       "min_abbreviation": 13,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "diamond_hollow": {
       "name": "diamond_hollow",
       "min_abbreviation": 14,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "triangle_hollow": {
       "name": "triangle_hollow",
       "min_abbreviation": 15,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "square_hollow": {
       "name": "square_hollow",
       "min_abbreviation": 13,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smcircle_hollow": {
       "name": "smcircle_hollow",
       "min_abbreviation": 15,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smdiamond_hollow": {
       "name": "smdiamond_hollow",
       "min_abbreviation": 16,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smtriangle_hollow": {
       "name": "smtriangle_hollow",
       "min_abbreviation": 17,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "smsquare_hollow": {
       "name": "smsquare_hollow",
       "min_abbreviation": 15,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "point": {
       "name": "point",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symbolstyle"
     },
     "stptime": {
       "name": "stptime",
@@ -36214,7 +37647,8 @@
       "name": "gs2sls",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "spregress"
     },
     "sktest": {
       "name": "sktest",
@@ -36354,25 +37788,29 @@
       "name": "fsort",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_sortmethod"
     },
     "qsort": {
       "name": "qsort",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "set_sortmethod"
     },
     "contiguity": {
       "name": "contiguity",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "spmatrix_create"
     },
     "idistance": {
       "name": "idistance",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "spmatrix_create"
     },
     "symmetry": {
       "name": "symmetry",
@@ -36456,7 +37894,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "symmetry"
     },
     "smooth": {
       "name": "smooth",
@@ -36468,7 +37907,8 @@
       "name": "twice",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "smooth"
     },
     "split": {
       "name": "split",
@@ -36718,80 +38158,6 @@
       ],
       "priority": 3
     },
-    "scoreplot": {
-      "name": "scoreplot",
-      "min_abbreviation": 9,
-      "options": [
-        {
-          "name": "factors",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "norotated",
-          "min_abbreviation": 9,
-          "has_argument": false
-        },
-        {
-          "name": "matrix",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "combined",
-          "min_abbreviation": 8,
-          "has_argument": false
-        },
-        {
-          "name": "scoreopt",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "maxlength",
-          "min_abbreviation": 9,
-          "has_argument": true
-        }
-      ],
-      "priority": 3
-    },
-    "loadingplot": {
-      "name": "loadingplot",
-      "min_abbreviation": 11,
-      "options": [
-        {
-          "name": "factors",
-          "min_abbreviation": 7,
-          "has_argument": true
-        },
-        {
-          "name": "norotated",
-          "min_abbreviation": 9,
-          "has_argument": false
-        },
-        {
-          "name": "matrix",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "combined",
-          "min_abbreviation": 8,
-          "has_argument": false
-        },
-        {
-          "name": "scoreopt",
-          "min_abbreviation": 8,
-          "has_argument": true
-        },
-        {
-          "name": "maxlength",
-          "min_abbreviation": 9,
-          "has_argument": true
-        }
-      ],
-      "priority": 3
-    },
     "sysdir": {
       "name": "sysdir",
       "min_abbreviation": 6,
@@ -36802,7 +38168,8 @@
       "name": "adosize",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "sysdir"
     },
     "spearman": {
       "name": "spearman",
@@ -36814,7 +38181,8 @@
       "name": "ktau",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "spearman"
     },
     "stmgintcox": {
       "name": "stmgintcox",
@@ -36860,7 +38228,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ssd"
     },
     "unaddgroup": {
       "name": "unaddgroup",
@@ -36872,7 +38241,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ssd"
     },
     "status": {
       "name": "status",
@@ -36884,7 +38254,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ssd"
     },
     "serrbar": {
       "name": "serrbar",
@@ -36911,18 +38282,7 @@
     "teffects": {
       "name": "teffects",
       "min_abbreviation": 8,
-      "options": [
-        {
-          "name": "noconstant",
-          "min_abbreviation": 10,
-          "has_argument": false
-        },
-        {
-          "name": "level",
-          "min_abbreviation": 5,
-          "has_argument": true
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "tabstat": {
@@ -36996,19 +38356,22 @@
       "name": "headlabel",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_pcarrow"
     },
     "pcarrow": {
       "name": "pcarrow",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_pcarrow"
     },
     "pcbarrow": {
       "name": "pcbarrow",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_pcarrow"
     },
     "tetrachoric": {
       "name": "tetrachoric",
@@ -37076,13 +38439,15 @@
       "name": "rscatter",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_rscatter"
     },
     "horizontal": {
       "name": "horizontal",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_rscatter"
     },
     "truncreg": {
       "name": "truncreg",
@@ -37251,7 +38616,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_contour"
     },
     "tpoisson": {
       "name": "tpoisson",
@@ -37385,25 +38751,29 @@
       "name": "tsrline",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tsline"
     },
     "mspline": {
       "name": "mspline",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_mspline"
     },
     "rcapsym": {
       "name": "rcapsym",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_rcapsym"
     },
     "rconnected": {
       "name": "rconnected",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_rconnected"
     },
     "shwinters": {
       "name": "shwinters",
@@ -37490,112 +38860,35 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tssmooth_shwinters"
     },
     "tssmooth": {
       "name": "tssmooth",
       "min_abbreviation": 8,
-      "options": [
-        {
-          "name": "replace",
-          "min_abbreviation": 7,
-          "has_argument": false
-        },
-        {
-          "name": "parms",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "samp0",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "forecast",
-          "min_abbreviation": 1,
-          "has_argument": true
-        },
-        {
-          "name": "period",
-          "min_abbreviation": 3,
-          "has_argument": true
-        },
-        {
-          "name": "additive",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "sn0_0",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "sn0_v",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "snt_v",
-          "min_abbreviation": 5,
-          "has_argument": true
-        },
-        {
-          "name": "normalize",
-          "min_abbreviation": 1,
-          "has_argument": false
-        },
-        {
-          "name": "altstarts",
-          "min_abbreviation": 3,
-          "has_argument": false
-        },
-        {
-          "name": "from",
-          "min_abbreviation": 2,
-          "has_argument": true
-        },
-        {
-          "name": "daily",
-          "min_abbreviation": 5,
-          "has_argument": false
-        },
-        {
-          "name": "weekly",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "yearly",
-          "min_abbreviation": 6,
-          "has_argument": false
-        },
-        {
-          "name": "quarterly",
-          "min_abbreviation": 9,
-          "has_argument": false
-        }
-      ],
+      "options": [],
       "priority": 3
     },
     "translator": {
       "name": "translator",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "translate"
     },
     "transmap": {
       "name": "transmap",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "translate"
     },
     "noweight": {
       "name": "noweight",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_lowess"
     },
     "threshold": {
       "name": "threshold",
@@ -37698,7 +38991,8 @@
       "name": "mband",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_mband"
     },
     "tobit": {
       "name": "tobit",
@@ -37836,31 +39130,36 @@
       "name": "scatteri",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_scatteri"
     },
     "mwidth": {
       "name": "mwidth",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_rbar"
     },
     "rbar": {
       "name": "rbar",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_rbar"
     },
     "lfitci": {
       "name": "lfitci",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_lfitci"
     },
     "stdp": {
       "name": "stdp",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_lfitci"
     },
     "total": {
       "name": "total",
@@ -37913,25 +39212,29 @@
       "name": "fpfitci",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_fpfitci"
     },
     "discrete": {
       "name": "discrete",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway__histogram_gen"
     },
     "density": {
       "name": "density",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway__histogram_gen"
     },
     "fraction": {
       "name": "fraction",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway__histogram_gen"
     },
     "twoway__histogram_gen": {
       "name": "twoway__histogram_gen",
@@ -38045,7 +39348,8 @@
       "name": "dropline",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_dropline"
     },
     "tsfilter": {
       "name": "tsfilter",
@@ -38120,49 +39424,57 @@
       "name": "nodropbase",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_area"
     },
     "area": {
       "name": "area",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_area"
     },
     "tracedepth": {
       "name": "tracedepth",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "trace"
     },
     "traceexpand": {
       "name": "traceexpand",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "trace"
     },
     "tracesep": {
       "name": "tracesep",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "trace"
     },
     "traceindent": {
       "name": "traceindent",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "trace"
     },
     "tracenumber": {
       "name": "tracenumber",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "trace"
     },
     "tracehilite": {
       "name": "tracehilite",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "trace"
     },
     "smoother": {
       "name": "smoother",
@@ -38174,19 +39486,15 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tssmooth_nl"
     },
     "window": {
       "name": "window",
-      "min_abbreviation": 1,
-      "options": [
-        {
-          "name": "replace",
-          "min_abbreviation": 7,
-          "has_argument": false
-        }
-      ],
-      "priority": 3
+      "min_abbreviation": 6,
+      "options": [],
+      "priority": 3,
+      "help_file": "window_stopbox"
     },
     "weights": {
       "name": "weights",
@@ -38198,7 +39506,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tssmooth_ma"
     },
     "tebalance": {
       "name": "tebalance",
@@ -38210,19 +39519,22 @@
       "name": "rcap",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_rcap"
     },
     "qfit": {
       "name": "qfit",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_qfit"
     },
     "pcarrowi": {
       "name": "pcarrowi",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_pcarrowi"
     },
     "ttest": {
       "name": "ttest",
@@ -38306,7 +39618,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ttest"
     },
     "unequal": {
       "name": "unequal",
@@ -38348,7 +39661,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ttest"
     },
     "welch": {
       "name": "welch",
@@ -38390,7 +39704,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ttest"
     },
     "twoway__function_gen": {
       "name": "twoway__function_gen",
@@ -38419,6 +39734,13 @@
         }
       ],
       "priority": 2
+    },
+    "testparm": {
+      "name": "testparm",
+      "min_abbreviation": 8,
+      "options": [],
+      "priority": 3,
+      "help_file": "test"
     },
     "tsrevar": {
       "name": "tsrevar",
@@ -38461,7 +39783,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tssmooth_hwinters"
     },
     "tsfill": {
       "name": "tsfill",
@@ -38514,7 +39837,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_fpfit"
     },
     "tab2": {
       "name": "tab2",
@@ -38701,7 +40025,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tabulate_twoway"
     },
     "tabi": {
       "name": "tabi",
@@ -38888,37 +40213,43 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tabulate_twoway"
     },
     "qfitci": {
       "name": "qfitci",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_qfitci"
     },
     "pcspike": {
       "name": "pcspike",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_pcspike"
     },
     "rspike": {
       "name": "rspike",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_rspike"
     },
     "pccapsym": {
       "name": "pccapsym",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_pccapsym"
     },
     "bexpand": {
       "name": "bexpand",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "textbox_options"
     },
     "dexponential": {
       "name": "dexponential",
@@ -38950,7 +40281,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tssmooth_dexponential"
     },
     "timer": {
       "name": "timer",
@@ -39021,7 +40353,8 @@
       "name": "spike",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_spike"
     },
     "tabdisp": {
       "name": "tabdisp",
@@ -39045,7 +40378,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tabdisp"
     },
     "totals": {
       "name": "totals",
@@ -39057,7 +40391,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tabdisp"
     },
     "dotz": {
       "name": "dotz",
@@ -39069,7 +40404,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tabdisp"
     },
     "tab1": {
       "name": "tab1",
@@ -39131,19 +40467,22 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tabulate_oneway"
     },
     "bconly": {
       "name": "bconly",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tebalance_overid"
     },
     "nolog": {
       "name": "nolog",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "tebalance_overid"
     },
     "twoway__kdensity_gen": {
       "name": "twoway__kdensity_gen",
@@ -39155,7 +40494,8 @@
       "name": "pci",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_pci"
     },
     "tsreport": {
       "name": "tsreport",
@@ -39183,7 +40523,8 @@
       "name": "rarea",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_rarea"
     },
     "contourline": {
       "name": "contourline",
@@ -39245,7 +40586,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_contourline"
     },
     "tabodds": {
       "name": "tabodds",
@@ -39303,13 +40645,15 @@
       "name": "rline",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_rline"
     },
     "lfit": {
       "name": "lfit",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "twoway_lfit"
     },
     "unab": {
       "name": "unab",
@@ -39321,19 +40665,22 @@
       "name": "tsunab",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unab"
     },
     "fvunab": {
       "name": "fvunab",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unab"
     },
     "collator": {
       "name": "collator",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_collator"
     },
     "unicode": {
       "name": "unicode",
@@ -39351,7 +40698,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_convertfile"
     },
     "dstencoding": {
       "name": "dstencoding",
@@ -39363,7 +40711,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_convertfile"
     },
     "convertfile": {
       "name": "convertfile",
@@ -39375,7 +40724,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_convertfile"
     },
     "unabcmd": {
       "name": "unabcmd",
@@ -39387,37 +40737,43 @@
       "name": "encoding",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_encoding"
     },
     "redo": {
       "name": "redo",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_translate"
     },
     "retranslate": {
       "name": "retranslate",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_translate"
     },
     "nodata": {
       "name": "nodata",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_translate"
     },
     "invalid": {
       "name": "invalid",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_translate"
     },
     "transutf8": {
       "name": "transutf8",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_translate"
     },
     "ucm": {
       "name": "ucm",
@@ -39475,19 +40831,22 @@
       "name": "locale",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_locale"
     },
     "uipackage": {
       "name": "uipackage",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unicode_locale"
     },
     "nfractional": {
       "name": "nfractional",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "unbalanced_designs"
     },
     "varclassify": {
       "name": "varclassify",
@@ -39902,19 +41261,99 @@
       "min_abbreviation": 5,
       "options": [
         {
-          "name": "estimates",
-          "min_abbreviation": 9,
+          "name": "lags",
+          "min_abbreviation": 4,
           "has_argument": true
         },
         {
-          "name": "varwle",
-          "min_abbreviation": 6,
+          "name": "fodeviation",
+          "min_abbreviation": 3,
           "has_argument": false
         },
         {
-          "name": "separator",
-          "min_abbreviation": 9,
+          "name": "fd",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "minldep",
+          "min_abbreviation": 7,
           "has_argument": true
+        },
+        {
+          "name": "maxldep",
+          "min_abbreviation": 7,
+          "has_argument": true
+        },
+        {
+          "name": "collapse",
+          "min_abbreviation": 8,
+          "has_argument": false
+        },
+        {
+          "name": "exogenous",
+          "min_abbreviation": 4,
+          "has_argument": true
+        },
+        {
+          "name": "endogenous",
+          "min_abbreviation": 5,
+          "has_argument": true
+        },
+        {
+          "name": "predetermined",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "vce",
+          "min_abbreviation": 3,
+          "has_argument": true
+        },
+        {
+          "name": "level",
+          "min_abbreviation": 1,
+          "has_argument": true
+        },
+        {
+          "name": "winitial",
+          "min_abbreviation": 5,
+          "has_argument": false
+        },
+        {
+          "name": "onestep",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "wcrobust",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "robust",
+          "min_abbreviation": 1,
+          "has_argument": false
+        },
+        {
+          "name": "bootstrap",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "jackknife",
+          "min_abbreviation": 4,
+          "has_argument": false
+        },
+        {
+          "name": "xt",
+          "min_abbreviation": 2,
+          "has_argument": false
+        },
+        {
+          "name": "identity",
+          "min_abbreviation": 2,
+          "has_argument": false
         }
       ],
       "priority": 3
@@ -40095,7 +41534,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "vl_set"
     },
     "vecnorm": {
       "name": "vecnorm",
@@ -40234,7 +41674,8 @@
       "name": "manage",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "window_manage"
     },
     "wntestq": {
       "name": "wntestq",
@@ -40258,13 +41699,15 @@
       "name": "fopen",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "window_fopen"
     },
     "fsave": {
       "name": "fsave",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "window_fopen"
     },
     "wildbootstrap": {
       "name": "wildbootstrap",
@@ -40319,13 +41762,15 @@
       "name": "stopbox",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "window_stopbox"
     },
     "menu": {
       "name": "menu",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "window_menu"
     },
     "which": {
       "name": "which",
@@ -40521,17 +41966,19 @@
       "options": [],
       "priority": 3
     },
-    "freq": {
-      "name": "freq",
-      "min_abbreviation": 1,
-      "options": [],
-      "priority": 3
-    },
     "xttrans": {
       "name": "xttrans",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "xttab"
+    },
+    "freq": {
+      "name": "freq",
+      "min_abbreviation": 1,
+      "options": [],
+      "priority": 3,
+      "help_file": "xttab"
     },
     "xtregar": {
       "name": "xtregar",
@@ -40922,7 +42369,8 @@
       "name": "xmluse",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "xmlsave"
     },
     "xcorr": {
       "name": "xcorr",
@@ -41333,6 +42781,20 @@
         }
       ],
       "priority": 3
+    },
+    "xttest0": {
+      "name": "xttest0",
+      "min_abbreviation": 7,
+      "options": [],
+      "priority": 3,
+      "help_file": "xtreg_postestimation"
+    },
+    "xtvarsoc": {
+      "name": "xtvarsoc",
+      "min_abbreviation": 8,
+      "options": [],
+      "priority": 3,
+      "help_file": "xtvar_postestimation"
     },
     "xtfrontier": {
       "name": "xtfrontier",
@@ -42493,7 +43955,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "xtgls"
     },
     "xtline": {
       "name": "xtline",
@@ -42505,7 +43968,8 @@
       "name": "overlay",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "xtline"
     },
     "zip": {
       "name": "zip",
@@ -42995,7 +44459,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "ztest"
     },
     "ztnb": {
       "name": "ztnb",
@@ -43236,7 +44701,8 @@
       "name": "unzipfile",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "zipfile"
     },
     "zinb": {
       "name": "zinb",
@@ -43294,13 +44760,15 @@
       "name": "mtest",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_mtest"
     },
     "footer": {
       "name": "footer",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_mtest"
     },
     "_predict": {
       "name": "_predict",
@@ -43344,7 +44812,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_predict"
     },
     "cooksd": {
       "name": "cooksd",
@@ -43366,7 +44835,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_predict"
     },
     "residuals": {
       "name": "residuals",
@@ -43388,7 +44858,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_predict"
     },
     "rstandard": {
       "name": "rstandard",
@@ -43410,7 +44881,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_predict"
     },
     "rstudent": {
       "name": "rstudent",
@@ -43432,7 +44904,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_predict"
     },
     "execute": {
       "name": "execute",
@@ -43454,7 +44927,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_diparmopts"
     },
     "prob": {
       "name": "prob",
@@ -43481,7 +44955,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_diparm"
     },
     "eqlabel": {
       "name": "eqlabel",
@@ -43508,13 +44983,15 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_diparm"
     },
     "get": {
       "name": "get",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_check_omit"
     },
     "equal": {
       "name": "equal",
@@ -43546,7 +45023,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_sassert"
     },
     "nolist": {
       "name": "nolist",
@@ -43568,7 +45046,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_assert_mreldif"
     },
     "srssubpop": {
       "name": "srssubpop",
@@ -43600,7 +45079,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_svy_setup"
     },
     "_rmcoll": {
       "name": "_rmcoll",
@@ -43612,7 +45092,8 @@
       "name": "forcedrop",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_rmcoll"
     },
     "_frames": {
       "name": "_frames",
@@ -43680,7 +45161,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_coef_table_header"
     },
     "noomitted": {
       "name": "noomitted",
@@ -43717,115 +45199,134 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_ms_extract_varlist"
     },
     "canonicalize": {
       "name": "canonicalize",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_parse"
     },
     "rmquotes": {
       "name": "rmquotes",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_parse"
     },
     "opsin": {
       "name": "opsin",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_parse"
     },
     "rightmost": {
       "name": "rightmost",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_parse"
     },
     "gweight": {
       "name": "gweight",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_parse"
     },
     "factordot": {
       "name": "factordot",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_parse"
     },
     "combine": {
       "name": "combine",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_parse"
     },
     "combop": {
       "name": "combop",
       "min_abbreviation": 6,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_parse"
     },
     "expandarg": {
       "name": "expandarg",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_parse"
     },
     "asobserved": {
       "name": "asobserved",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_ms_at_parse"
     },
     "asbalanced": {
       "name": "asbalanced",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_ms_at_parse"
     },
     "p99": {
       "name": "p99",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_ms_at_parse"
     },
     "zero": {
       "name": "zero",
       "min_abbreviation": 4,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_ms_at_parse"
     },
     "totalallowed": {
       "name": "totalallowed",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_gropts"
     },
     "missingallowed": {
       "name": "missingallowed",
       "min_abbreviation": 7,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_gropts"
     },
     "nobycheck": {
       "name": "nobycheck",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_gropts"
     },
     "getcombine": {
       "name": "getcombine",
       "min_abbreviation": 10,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_gropts"
     },
     "gettwoway": {
       "name": "gettwoway",
       "min_abbreviation": 9,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_gropts"
     },
     "_datasignature": {
       "name": "_datasignature",
@@ -43876,7 +45377,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_estimates"
     },
     "nullok": {
       "name": "nullok",
@@ -43888,7 +45390,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_estimates"
     },
     "unhold": {
       "name": "unhold",
@@ -43900,7 +45403,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_estimates"
     },
     "nocolon": {
       "name": "nocolon",
@@ -43927,61 +45431,71 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_ms_split"
     },
     "nagar": {
       "name": "nagar",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_crcar1"
     },
     "theil": {
       "name": "theil",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_crcar1"
     },
     "tscorr": {
       "name": "tscorr",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_crcar1"
     },
     "dw": {
       "name": "dw",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_crcar1"
     },
     "eform": {
       "name": "eform",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_eformopts"
     },
     "irr": {
       "name": "irr",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_eformopts"
     },
     "rrr": {
       "name": "rrr",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_eformopts"
     },
     "soptions": {
       "name": "soptions",
       "min_abbreviation": 8,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_eformopts"
     },
     "hr": {
       "name": "hr",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_get_eformopts"
     },
     "_return": {
       "name": "_return",
@@ -44074,13 +45588,15 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_ms_display"
     },
     "find_hlp_file": {
       "name": "find_hlp_file",
       "min_abbreviation": 13,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_findhlpalias"
     },
     "singleok": {
       "name": "singleok",
@@ -44112,7 +45628,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_stubstar2names"
     },
     "nosubcommand": {
       "name": "nosubcommand",
@@ -44144,7 +45661,8 @@
           "has_argument": false
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_stubstar2names"
     },
     "nointegers": {
       "name": "nointegers",
@@ -44166,29 +45684,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
-    },
-    "renumber": {
-      "name": "renumber",
-      "min_abbreviation": 5,
-      "options": [
-        {
-          "name": "stub",
-          "min_abbreviation": 4,
-          "has_argument": true
-        },
-        {
-          "name": "indexfrom",
-          "min_abbreviation": 9,
-          "has_argument": true
-        },
-        {
-          "name": "namelist",
-          "min_abbreviation": 8,
-          "has_argument": true
-        }
-      ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_labels2names"
     },
     "_robust": {
       "name": "_robust",
@@ -44226,133 +45723,155 @@
       "name": "noreformat",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "middle": {
       "name": "middle",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "nocommas": {
       "name": "nocommas",
       "min_abbreviation": 5,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "commas": {
       "name": "commas",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "widths": {
       "name": "widths",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "tcolors": {
       "name": "tcolors",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "ncolors": {
       "name": "ncolors",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "scolors": {
       "name": "scolors",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "tfmts": {
       "name": "tfmts",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "nfmts": {
       "name": "nfmts",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "sfmts": {
       "name": "sfmts",
       "min_abbreviation": 2,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "paddings": {
       "name": "paddings",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "vseparators": {
       "name": "vseparators",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "rows": {
       "name": "rows",
       "min_abbreviation": 3,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "columns": {
       "name": "columns",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "fmts": {
       "name": "fmts",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tab"
     },
     "daily": {
       "name": "daily",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tsnatscale"
     },
     "weekly": {
       "name": "weekly",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tsnatscale"
     },
     "monthly": {
       "name": "monthly",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tsnatscale"
     },
     "quarterly": {
       "name": "quarterly",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tsnatscale"
     },
     "halfyearly": {
       "name": "halfyearly",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tsnatscale"
     },
     "yearly": {
       "name": "yearly",
       "min_abbreviation": 1,
       "options": [],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_tsnatscale"
     },
     "covariance": {
       "name": "covariance",
@@ -44434,7 +45953,8 @@
           "has_argument": true
         }
       ],
-      "priority": 3
+      "priority": 3,
+      "help_file": "_getcovcorr"
     }
   },
   "abbreviations": {
@@ -44442,6 +45962,9 @@
     "app": "append",
     "appe": "append",
     "appen": "append",
+    "m": "missing",
+    "mi": "missing",
+    "mis": "missing",
     "miss": "missing",
     "missi": "missing",
     "missin": "missing",
@@ -44472,8 +45995,6 @@
     "scat": "scatter",
     "scatt": "scatter",
     "scatte": "scatter",
-    "li": "line",
-    "lin": "line",
     "con": "connected",
     "conn": "connected",
     "conne": "connected",
@@ -44508,9 +46029,6 @@
     "f": "fast",
     "fa": "fast",
     "fas": "fast",
-    "an": "anova",
-    "ano": "anova",
-    "anov": "anova",
     "perm": "permanently",
     "perma": "permanently",
     "perman": "permanently",
@@ -44535,12 +46053,13 @@
     "det": "detail",
     "deta": "detail",
     "detai": "detail",
+    "g": "generate",
+    "ge": "generate",
     "gen": "generate",
     "gene": "generate",
     "gener": "generate",
     "genera": "generate",
     "generat": "generate",
-    "g": "graph",
     "gr": "graph",
     "gra": "graph",
     "grap": "graph",
@@ -44570,7 +46089,6 @@
     "bys": "bysort",
     "byso": "bysort",
     "bysor": "bysort",
-    "s": "sort",
     "so": "sort",
     "sor": "sort",
     "coef": "coefficients",
@@ -44644,10 +46162,6 @@
     "cgr": "cgraph",
     "cgra": "cgraph",
     "cgrap": "cgraph",
-    "t": "table",
-    "ta": "table",
-    "tab": "table",
-    "tabl": "table",
     "gru": "grubin",
     "grub": "grubin",
     "grubi": "grubin",
@@ -44678,6 +46192,7 @@
     "ne": "newok",
     "new": "newok",
     "newo": "newok",
+    "t": "top",
     "to": "top",
     "ri": "right",
     "rig": "right",
@@ -44689,6 +46204,7 @@
     "botto": "bottom",
     "cou": "count",
     "coun": "count",
+    "lin": "linear",
     "line": "linear",
     "linea": "linear",
     "exp": "exponential",
@@ -44703,16 +46219,6 @@
     "rob": "robust",
     "robu": "robust",
     "robus": "robust",
-    "cl": "cluster",
-    "clu": "cluster",
-    "clus": "cluster",
-    "clust": "cluster",
-    "cluste": "cluster",
-    "jack": "jackknife",
-    "jackk": "jackknife",
-    "jackkn": "jackknife",
-    "jackkni": "jackknife",
-    "jackknif": "jackknife",
     "nocnsr": "nocnsreport",
     "nocnsre": "nocnsreport",
     "nocnsrep": "nocnsreport",
@@ -44721,7 +46227,9 @@
     "cret": "creturn",
     "cretu": "creturn",
     "cretur": "creturn",
+    "li": "list",
     "lis": "list",
+    "cl": "clist",
     "cli": "clist",
     "clis": "clist",
     "mean": "means",
@@ -44738,9 +46246,6 @@
     "varian": "variances",
     "varianc": "variances",
     "variance": "variances",
-    "pois": "poisson",
-    "poiss": "poisson",
-    "poisso": "poisson",
     "bon": "bonett",
     "bone": "bonett",
     "bonet": "bonett",
@@ -44762,11 +46267,10 @@
     "sepois": "sepoisson",
     "sepoiss": "sepoisson",
     "sepoisso": "sepoisson",
+    "s": "style",
     "st": "style",
     "sty": "style",
     "styl": "style",
-    "te": "test",
-    "tes": "test",
     "resu": "result",
     "resul": "result",
     "inp": "input",
@@ -44778,8 +46282,6 @@
     "hili": "hilite",
     "hilit": "hilite",
     "ulof": "uloff",
-    "fo": "format",
-    "for": "format",
     "form": "format",
     "forma": "format",
     "v": "variables",
@@ -44798,11 +46300,13 @@
     "sys": "system",
     "syst": "system",
     "syste": "system",
+    "h": "help",
+    "he": "help",
+    "hel": "help",
     "constr": "constraint",
     "constra": "constraint",
     "constrai": "constraint",
     "constrain": "constraint",
-    "di": "dir",
     "cap": "capture",
     "capt": "capture",
     "captu": "capture",
@@ -44832,6 +46336,10 @@
     "glo": "global",
     "glob": "global",
     "globa": "global",
+    "qui": "quietly",
+    "quie": "quietly",
+    "quiet": "quietly",
+    "quietl": "quietly",
     "cor": "correlate",
     "corr": "correlate",
     "corre": "correlate",
@@ -44879,15 +46387,10 @@
     "existe": "existence",
     "existen": "existence",
     "existenc": "existence",
-    "fi": "file",
-    "fil": "file",
     "name": "names",
     "num": "number",
     "numb": "number",
     "numbe": "number",
-    "mat": "matrix",
-    "matr": "matrix",
-    "matri": "matrix",
     "scal": "scalar",
     "scala": "scalar",
     "exa": "exact",
@@ -44906,6 +46409,7 @@
     "examp": "examples",
     "exampl": "examples",
     "example": "examples",
+    "ta": "tag",
     "w": "wide",
     "wi": "wide",
     "wid": "wide",
@@ -44918,14 +46422,11 @@
     "noweig": "noweights",
     "noweigh": "noweights",
     "noweight": "noweights",
+    "di": "display",
     "dis": "display",
     "disp": "display",
     "displ": "display",
     "displa": "display",
-    "logi": "logistic",
-    "logis": "logistic",
-    "logist": "logistic",
-    "logisti": "logistic",
     "la": "label",
     "nomem": "nomemory",
     "nomemo": "nomemory",
@@ -44946,6 +46447,9 @@
     "upp": "upper",
     "uppe": "upper",
     "ru": "run",
+    "vers": "version",
+    "versi": "version",
+    "versio": "version",
     "datasig": "datasignature",
     "datasign": "datasignature",
     "datasigna": "datasignature",
@@ -44962,9 +46466,6 @@
     "nosto": "nostop",
     "sto": "store",
     "stor": "store",
-    "rest": "restore",
-    "resto": "restore",
-    "restor": "restore",
     "q": "query",
     "qu": "query",
     "que": "query",
@@ -44990,8 +46491,6 @@
     "eret": "ereturn",
     "eretu": "ereturn",
     "eretur": "ereturn",
-    "fir": "first",
-    "firs": "first",
     "pl": "plus",
     "plu": "plus",
     "buildfv": "buildfvinfo",
@@ -45013,8 +46512,6 @@
     "brow": "browse",
     "brows": "browse",
     "tri": "trim",
-    "h": "head",
-    "he": "head",
     "hea": "head",
     "las": "last",
     "tai": "tail",
@@ -45067,14 +46564,13 @@
     "forval": "forvalues",
     "forvalu": "forvalues",
     "forvalue": "forvalues",
-    "fore": "forecast",
-    "forec": "forecast",
-    "foreca": "forecast",
-    "forecas": "forecast",
     "nodes": "nodescend",
     "nodesc": "nodescend",
     "nodesce": "nodescend",
     "nodescen": "nodescend",
+    "rot": "rotate",
+    "rota": "rotate",
+    "rotat": "rotate",
     "fdasav": "fdasave",
     "fdades": "fdadescribe",
     "fdadesc": "fdadescribe",
@@ -45096,6 +46592,7 @@
     "wr": "write",
     "wri": "write",
     "writ": "write",
+    "te": "text",
     "tex": "text",
     "bi": "binary",
     "bin": "binary",
@@ -45131,9 +46628,6 @@
     "per": "period",
     "peri": "period",
     "perio": "period",
-    "prob": "probit",
-    "probi": "probit",
-    "log": "logit",
     "ba": "base",
     "bas": "base",
     "desi": "design",
@@ -45178,6 +46672,7 @@
     "twoproporti": "twoproportions",
     "twoproportio": "twoproportions",
     "twoproportion": "twoproportions",
+    "log": "logrank",
     "logr": "logrank",
     "logra": "logrank",
     "logran": "logrank",
@@ -45193,11 +46688,6 @@
     "tw": "twoway",
     "twow": "twoway",
     "twowa": "twoway",
-    "m": "memory",
-    "me": "memory",
-    "mem": "memory",
-    "memo": "memory",
-    "memor": "memory",
     "gp": "gph",
     "quo": "quotes",
     "quot": "quotes",
@@ -45235,9 +46725,6 @@
     "descriptio": "description",
     "look": "lookup",
     "looku": "lookup",
-    "sea": "search",
-    "sear": "search",
-    "searc": "search",
     "blo": "blocation",
     "bloc": "blocation",
     "bloca": "blocation",
@@ -45284,8 +46771,6 @@
     "datafm": "datafmt",
     "exc": "excel",
     "exce": "excel",
-    "mi": "missok",
-    "mis": "missok",
     "misso": "missok",
     "first": "firstlineoffile",
     "firstl": "firstlineoffile",
@@ -45297,10 +46782,6 @@
     "firstlineoff": "firstlineoffile",
     "firstlineoffi": "firstlineoffile",
     "firstlineoffil": "firstlineoffile",
-    "ado": "adopath",
-    "adop": "adopath",
-    "adopa": "adopath",
-    "adopat": "adopath",
     "ep": "epolate",
     "epo": "epolate",
     "epol": "epolate",
@@ -45352,6 +46833,8 @@
     "linesiz": "linesize",
     "da": "data",
     "dat": "data",
+    "sa": "save",
+    "sav": "save",
     "lang": "language",
     "langu": "language",
     "langua": "language",
@@ -45364,6 +46847,7 @@
     "rem": "remove",
     "remo": "remove",
     "remov": "remove",
+    "no": "noisily",
     "noi": "noisily",
     "nois": "noisily",
     "noisi": "noisily",
@@ -45372,10 +46856,6 @@
     "upperc": "uppercase",
     "upperca": "uppercase",
     "uppercas": "uppercase",
-    "stan": "standard",
-    "stand": "standard",
-    "standa": "standard",
-    "standar": "standard",
     "onem": "oneminus",
     "onemi": "oneminus",
     "onemin": "oneminus",
@@ -45442,16 +46922,6 @@
     "noupd": "noupdate",
     "noupda": "noupdate",
     "noupdat": "noupdate",
-    "nopre": "nopreserve",
-    "nopres": "nopreserve",
-    "noprese": "nopreserve",
-    "nopreser": "nopreserve",
-    "nopreserv": "nopreserve",
-    "coefl": "coeflegend",
-    "coefle": "coeflegend",
-    "coefleg": "coeflegend",
-    "coeflege": "coeflegend",
-    "coeflegen": "coeflegend",
     "mar": "marginal",
     "marg": "marginal",
     "margi": "marginal",
@@ -45462,15 +46932,6 @@
     "displaykn": "displayknots",
     "displaykno": "displayknots",
     "displayknot": "displayknots",
-    "pc": "pctile",
-    "pct": "pctile",
-    "pcti": "pctile",
-    "pctil": "pctile",
-    "max": "maximize",
-    "maxi": "maximize",
-    "maxim": "maximize",
-    "maximi": "maximize",
-    "maximiz": "maximize",
     "foot": "footnote",
     "footn": "footnote",
     "footno": "footnote",
@@ -45482,9 +46943,6 @@
     "macr": "macro",
     "shi": "shift",
     "shif": "shift",
-    "pwcomp": "pwcompare",
-    "pwcompa": "pwcompare",
-    "pwcompar": "pwcompare",
     "diss": "dissimilarity",
     "dissi": "dissimilarity",
     "dissim": "dissimilarity",
@@ -45511,6 +46969,9 @@
     "pub": "public",
     "publ": "public",
     "publi": "public",
+    "ret": "return",
+    "retu": "return",
+    "retur": "return",
     "ml": "mlong",
     "mlo": "mlong",
     "mlon": "mlong",
@@ -45601,6 +47062,7 @@
     "traditio": "traditional",
     "tradition": "traditional",
     "traditiona": "traditional",
+    "su": "summarize",
     "sum": "summarize",
     "summ": "summarize",
     "summa": "summarize",
@@ -45665,6 +47127,7 @@
     "cole": "coleq",
     "dups": "dupsok",
     "dupso": "dupsok",
+    "mat": "matsize",
     "mats": "matsize",
     "matsi": "matsize",
     "matsiz": "matsize",
@@ -45767,6 +47230,8 @@
     "sortprese": "sortpreserve",
     "sortpreser": "sortpreserve",
     "sortpreserv": "sortpreserve",
+    "plug": "plugin",
+    "plugi": "plugin",
     "pairedm": "pairedmeans",
     "pairedme": "pairedmeans",
     "pairedmea": "pairedmeans",
@@ -45851,11 +47316,6 @@
     "smclsymbolpale": "smclsymbolpalette",
     "smclsymbolpalet": "smclsymbolpalette",
     "smclsymbolpalett": "smclsymbolpalette",
-    "sqrt": "sqrtlasso",
-    "sqrtl": "sqrtlasso",
-    "sqrtla": "sqrtlasso",
-    "sqrtlas": "sqrtlasso",
-    "sqrtlass": "sqrtlasso",
     "outp": "output",
     "outpu": "output",
     "interf": "interface",
@@ -45876,9 +47336,6 @@
     "i": "inform",
     "info": "inform",
     "infor": "inform",
-    "rot": "rotate",
-    "rota": "rotate",
-    "rotat": "rotate",
     "rm": "rmsg",
     "rms": "rmsg",
     "nonm": "nonmissing",
@@ -45891,8 +47348,6 @@
     "sret": "sreturn",
     "sretu": "sreturn",
     "sretur": "sreturn",
-    "sa": "save",
-    "sav": "save",
     "omitanym": "omitanymiss",
     "omitanymi": "omitanymiss",
     "omitanymis": "omitanymiss",
@@ -45908,11 +47363,13 @@
     "omitnoth": "omitnothing",
     "omitnothi": "omitnothing",
     "omitnothin": "omitnothing",
+    "us": "use",
     "she": "shell",
     "shel": "shell",
     "xsh": "xshell",
     "xshe": "xshell",
     "xshel": "xshell",
+    "tab": "tabulate",
     "tabu": "tabulate",
     "tabul": "tabulate",
     "tabula": "tabulate",
@@ -45948,6 +47405,8 @@
     "basel": "baseline",
     "baseli": "baseline",
     "baselin": "baseline",
+    "fo": "forward",
+    "for": "forward",
     "forw": "forward",
     "forwa": "forward",
     "forwar": "forward",
@@ -45955,10 +47414,6 @@
     "autho": "author",
     "savi": "saving",
     "savin": "saving",
-    "pers": "personal",
-    "perso": "personal",
-    "person": "personal",
-    "persona": "personal",
     "we": "weight",
     "wei": "weight",
     "weig": "weight",
@@ -45979,6 +47434,7 @@
     "idistanc": "idistance",
     "twi": "twice",
     "twic": "twice",
+    "ado": "adosize",
     "ados": "adosize",
     "adosi": "adosize",
     "adosiz": "adosize",
@@ -46071,9 +47527,6 @@
     "smoot": "smoother",
     "smooth": "smoother",
     "smoothe": "smoother",
-    "win": "window",
-    "wind": "window",
-    "windo": "window",
     "weight": "weights",
     "une": "unequal",
     "uneq": "unequal",
@@ -46180,6 +47633,7 @@
     "stop": "stopbox",
     "stopb": "stopbox",
     "stopbo": "stopbox",
+    "me": "menu",
     "men": "menu",
     "fr": "freq",
     "fre": "freq",
@@ -46219,7 +47673,6 @@
     "execut": "execute",
     "eqlab": "eqlabel",
     "eqlabe": "eqlabel",
-    "ge": "get",
     "eq": "equal",
     "equ": "equal",
     "equa": "equal",
@@ -46323,9 +47776,6 @@
     "nointeg": "nointegers",
     "nointege": "nointegers",
     "nointeger": "nointegers",
-    "renum": "renumber",
-    "renumb": "renumber",
-    "renumbe": "renumber",
     "noref": "noreformat",
     "norefo": "noreformat",
     "norefor": "noreformat",

--- a/src/command-database/index.ts
+++ b/src/command-database/index.ts
@@ -317,6 +317,14 @@ class CommandDatabase {
     }
 
     /**
+     * Get all command names (normalized, lowercase keys).
+     */
+    get_all_command_names(): string[] {
+        if (!this.cache) return [];
+        return Object.keys(this.cache.commands);
+    }
+
+    /**
      * Clear all commands.
      */
     clear(): void {

--- a/src/command-database/index.ts
+++ b/src/command-database/index.ts
@@ -285,7 +285,8 @@ class CommandDatabase {
             min_abbreviation: info.minAbbreviation.length,
             options: the_cache_options,
             subcommands: the_cache_subcommands,
-            priority: info.priority || get_command_priority(info.name)
+            priority: info.priority || get_command_priority(info.name),
+            help_file: info.helpFile
         };
         
         this.cache.commands[normalized] = my_command_info;
@@ -351,7 +352,8 @@ class CommandDatabase {
             subcommands: the_provider_subcommands,
             category: 'builtin',
             isBuiltin: true,
-            priority: cmd.priority || get_command_priority(cmd.name)
+            priority: cmd.priority || get_command_priority(cmd.name),
+            helpFile: cmd.help_file
         };
 
         return my_provider_info;

--- a/src/command-database/smcl-extractor.ts
+++ b/src/command-database/smcl-extractor.ts
@@ -46,6 +46,22 @@ export interface ExtractedCommand {
     source_file: string;
     /** Whether this is the primary command documented in the file */
     is_primary: boolean;
+    /**
+     * Whether this command had a {viewerdialog} tag in the help file.
+     * Combined with `is_primary`, this is the strongest signal that the
+     * current file is the canonical home of the command's help page.
+     */
+    has_viewerdialog: boolean;
+    /**
+     * Whether this command appears as the first token of a syntax paragraph
+     * (i.e., `{p ...}{cmdab:...}` or `{p ...}{cmd:NAME}` with no intervening
+     * alternation delimiters like `{c -(}`). This distinguishes files that
+     * genuinely document the command (e.g. `macro.sthlp`'s `{cmdab:loc:al}`
+     * leading a syntax paragraph) from files that merely reference it as
+     * one alternative inside another command's syntax (e.g. `char.sthlp`'s
+     * `{c -(}{cmdab:loc:al} | {cmdab:gl:obal}{c )-}`).
+     */
+    is_paragraph_lead: boolean;
     /** Options available for this command */
     options: ExtractedOption[];
 }
@@ -220,10 +236,13 @@ export function should_exclude_command(
 // ============================================================================
 
 /**
- * Pattern 1: viewerdialog - indicates command has dialog interface
- * Example: {viewerdialog "replace" "dialog replace"}
+ * Pattern 1: viewerdialog - indicates command has dialog interface.
+ * Both quoted (`{viewerdialog "replace" "dialog replace"}`) and
+ * unquoted (`{viewerdialog encode "dialog encode"}`) first-name
+ * forms appear in the wild, and both are accepted here.
  */
-export const VIEWERDIALOG_PATTERN = /\{viewerdialog\s+"([^"]+)"\s+"dialog\s+[^"]+"\}/g;
+export const VIEWERDIALOG_PATTERN =
+    /\{viewerdialog\s+(?:"([^"]+)"|([a-z_][a-z0-9_]*(?:\s+[a-z_][a-z0-9_]*)*))\s+"dialog\s+[^"]+"\}/gi;
 
 /**
  * Pattern 2: cmdab - command with abbreviation
@@ -357,7 +376,8 @@ export function extract_viewerdialog_commands(content: string): string[] {
 
     let my_match: RegExpExecArray | null;
     while ((my_match = VIEWERDIALOG_REGEX.exec(content)) !== null) {
-        const my_command_name = my_match[1];
+        // my_match[1] captures the quoted form, my_match[2] the unquoted.
+        const my_command_name = my_match[1] ?? my_match[2];
         if (my_command_name && !the_commands.includes(my_command_name)) {
             the_commands.push(my_command_name);
         }
@@ -793,6 +813,77 @@ export function extract_primary_command(content: string): string | null {
 }
 
 /**
+ * Extract the set of command names that appear as the *first* command
+ * token of a syntax paragraph. Used as a "this file documents the
+ * command" signal so the cache generator can pick `macro.sthlp` over
+ * `char.sthlp` for `local`: macro.sthlp leads a paragraph with
+ * `{cmdab:loc:al}` while char.sthlp nests it inside `{c -(} | {c )-}`.
+ *
+ * A paragraph lead must follow optional `{p ...}` tags with no
+ * intervening alternation delimiter (`{c -(}` / `{c )-}`), bracket
+ * (`[`), or `{cmd:,}` separator. Multi-word subcommand syntax such as
+ * `{cmdab:ma:cro} {cmdab:di:r}` still returns `macro` as the lead.
+ */
+export function extract_paragraph_lead_commands(syntax_section: string): Set<string> {
+    const the_commands = new Set<string>();
+    const my_doc = { content: syntax_section, line_offsets: compute_line_offsets(syntax_section) };
+    const my_line_count = get_line_count(my_doc);
+
+    // Match a command token that is *directly* preceded by one or more
+    // `{p ...}` paragraph tags on the same line. This is the strongest
+    // signal of "this line starts a new syntax paragraph".
+    const the_inline_paragraph_lead_pattern =
+        /^\s*(?:\{p[^}]*\}\s*)+(?:\{cmdab:([a-z][a-z0-9_]*):([a-z0-9_]+)\}|\{cmd:([a-z_][a-z0-9_]*)\})/i;
+    // Match a command token with *no* leading `{p ...}` tag on the
+    // line. Used only when the previous non-empty line was itself a
+    // paragraph-start marker (`{p ...}`, `{phang}`, `{pstd}`), which is
+    // how help files like `generate.sthlp` split a syntax paragraph
+    // across lines:
+    //     {p 8 17 2}
+    //     {cmd:replace}
+    const the_standalone_cmd_pattern =
+        /^\s*(?:\{cmdab:([a-z][a-z0-9_]*):([a-z0-9_]+)\}|\{cmd:([a-z_][a-z0-9_]*)\})/i;
+    const the_p_marker_pattern = /^\s*(?:\{p[^}]*\}|\{phang[^}]*\}|\{pstd\})\s*$/i;
+    // Recognise the indented line layout used by files like
+    // `quietly.sthlp`, where syntax lines are simply tab-indented and
+    // separated by blank lines rather than paragraph tags. A command
+    // tag that begins at the start of such a line (after a blank
+    // separator) also counts as a paragraph lead.
+    let previous_line_was_blank = true;
+    let previous_was_paragraph_marker = false;
+    for (let i = 0; i < my_line_count; i++) {
+        const my_line = get_line_text(my_doc, i);
+
+        if (my_line.trim().length === 0) {
+            previous_was_paragraph_marker = false;
+            previous_line_was_blank = true;
+            continue;
+        }
+
+        const my_inline = my_line.match(the_inline_paragraph_lead_pattern);
+        if (my_inline) {
+            const my_command_name = my_inline[1]
+                ? (my_inline[1] + my_inline[2]).toLowerCase()
+                : my_inline[3].toLowerCase();
+            the_commands.add(my_command_name);
+        } else if (previous_was_paragraph_marker || previous_line_was_blank) {
+            const my_standalone = my_line.match(the_standalone_cmd_pattern);
+            if (my_standalone) {
+                const my_command_name = my_standalone[1]
+                    ? (my_standalone[1] + my_standalone[2]).toLowerCase()
+                    : my_standalone[3].toLowerCase();
+                the_commands.add(my_command_name);
+            }
+        }
+
+        previous_was_paragraph_marker = the_p_marker_pattern.test(my_line);
+        previous_line_was_blank = false;
+    }
+
+    return the_commands;
+}
+
+/**
  * Extract command names from {cmd:name} patterns in the syntax section.
  *
  * @param syntax_section - The syntax section content
@@ -1069,6 +1160,7 @@ export function extract_commands_from_file(file_path: string): ExtractionResult 
     );
 
     const cmd_commands = extract_cmd_patterns(syntax_section);
+    const paragraph_lead_commands = extract_paragraph_lead_commands(syntax_section);
 
     // Avoid scanning the full file for {cmdab:...} patterns.
     // Many help files use cmdab tags for non-command tokens (tables, labels,
@@ -1134,6 +1226,7 @@ export function extract_commands_from_file(file_path: string): ExtractionResult 
     for (const my_name of all_names) {
         const is_primary = my_name === primary_name;
         const has_viewerdialog = dialog_names.has(my_name);
+        const is_paragraph_lead = paragraph_lead_commands.has(my_name);
 
         // Filter out non-command tokens
         if (should_exclude_command(my_name, has_viewerdialog, is_primary)) {
@@ -1150,6 +1243,8 @@ export function extract_commands_from_file(file_path: string): ExtractionResult 
             description: my_description,
             source_file: file_path,
             is_primary: is_primary,
+            has_viewerdialog: has_viewerdialog,
+            is_paragraph_lead: is_paragraph_lead,
             options: extracted_options
         });
     }
@@ -1210,6 +1305,7 @@ export function extract_commands_from_content(
     );
 
     const cmd_commands = extract_cmd_patterns(syntax_section);
+    const paragraph_lead_commands = extract_paragraph_lead_commands(syntax_section);
 
     // Avoid scanning the full file for {cmdab:...} patterns.
     // Many help files use cmdab tags for non-command tokens (tables, labels,
@@ -1273,6 +1369,7 @@ export function extract_commands_from_content(
     for (const my_name of all_names) {
         const is_primary = my_name === primary_name;
         const has_viewerdialog = dialog_names.has(my_name);
+        const is_paragraph_lead = paragraph_lead_commands.has(my_name);
 
         // Filter out non-command tokens
         if (should_exclude_command(my_name, has_viewerdialog, is_primary)) {
@@ -1289,6 +1386,8 @@ export function extract_commands_from_content(
             description: my_description,
             source_file: source_file,
             is_primary: is_primary,
+            has_viewerdialog: has_viewerdialog,
+            is_paragraph_lead: is_paragraph_lead,
             options: extracted_options
         });
     }

--- a/src/command-database/smcl-extractor.ts
+++ b/src/command-database/smcl-extractor.ts
@@ -354,7 +354,7 @@ export const OPT_HYPERLINK_ARG_PATTERN =
 // Compiled RegExp Constants
 // ============================================================================
 
-const VIEWERDIALOG_REGEX = new RegExp(VIEWERDIALOG_PATTERN.source, 'g');
+const VIEWERDIALOG_REGEX = new RegExp(VIEWERDIALOG_PATTERN.source, 'gi');
 const CMDAB_REGEX = new RegExp(CMDAB_PATTERN.source, 'gi');
 const OPT_REGEX = new RegExp(OPT_PATTERN.source, 'gi');
 const SYNOPT_WRAPPER_REGEX = new RegExp(SYNOPT_WRAPPER_PATTERN.source, 'gi');
@@ -824,26 +824,20 @@ export function extract_primary_command(content: string): string | null {
  * (`[`), or `{cmd:,}` separator. Multi-word subcommand syntax such as
  * `{cmdab:ma:cro} {cmdab:di:r}` still returns `macro` as the lead.
  */
+// Module-level regexes for paragraph-lead detection (hoisted for
+// performance — avoids re-creating on every call during cache
+// generation across thousands of help files).
+const INLINE_PARAGRAPH_LEAD_PATTERN =
+    /^\s*(?:\{p[^}]*\}\s*)+(?:\{cmdab:([a-z][a-z0-9_]*):([a-z0-9_]+)\}|\{cmd:([a-z_][a-z0-9_]*)\})/i;
+const STANDALONE_CMD_PATTERN =
+    /^\s*(?:\{cmdab:([a-z][a-z0-9_]*):([a-z0-9_]+)\}|\{cmd:([a-z_][a-z0-9_]*)\})/i;
+const P_MARKER_PATTERN =
+    /^\s*(?:\{p[^}]*\}|\{phang[^}]*\}|\{pstd\})\s*$/i;
+
 export function extract_paragraph_lead_commands(syntax_section: string): Set<string> {
     const the_commands = new Set<string>();
     const my_doc = { content: syntax_section, line_offsets: compute_line_offsets(syntax_section) };
     const my_line_count = get_line_count(my_doc);
-
-    // Match a command token that is *directly* preceded by one or more
-    // `{p ...}` paragraph tags on the same line. This is the strongest
-    // signal of "this line starts a new syntax paragraph".
-    const the_inline_paragraph_lead_pattern =
-        /^\s*(?:\{p[^}]*\}\s*)+(?:\{cmdab:([a-z][a-z0-9_]*):([a-z0-9_]+)\}|\{cmd:([a-z_][a-z0-9_]*)\})/i;
-    // Match a command token with *no* leading `{p ...}` tag on the
-    // line. Used only when the previous non-empty line was itself a
-    // paragraph-start marker (`{p ...}`, `{phang}`, `{pstd}`), which is
-    // how help files like `generate.sthlp` split a syntax paragraph
-    // across lines:
-    //     {p 8 17 2}
-    //     {cmd:replace}
-    const the_standalone_cmd_pattern =
-        /^\s*(?:\{cmdab:([a-z][a-z0-9_]*):([a-z0-9_]+)\}|\{cmd:([a-z_][a-z0-9_]*)\})/i;
-    const the_p_marker_pattern = /^\s*(?:\{p[^}]*\}|\{phang[^}]*\}|\{pstd\})\s*$/i;
     // Recognise the indented line layout used by files like
     // `quietly.sthlp`, where syntax lines are simply tab-indented and
     // separated by blank lines rather than paragraph tags. A command
@@ -860,14 +854,14 @@ export function extract_paragraph_lead_commands(syntax_section: string): Set<str
             continue;
         }
 
-        const my_inline = my_line.match(the_inline_paragraph_lead_pattern);
+        const my_inline = my_line.match(INLINE_PARAGRAPH_LEAD_PATTERN);
         if (my_inline) {
             const my_command_name = my_inline[1]
                 ? (my_inline[1] + my_inline[2]).toLowerCase()
                 : my_inline[3].toLowerCase();
             the_commands.add(my_command_name);
         } else if (previous_was_paragraph_marker || previous_line_was_blank) {
-            const my_standalone = my_line.match(the_standalone_cmd_pattern);
+            const my_standalone = my_line.match(STANDALONE_CMD_PATTERN);
             if (my_standalone) {
                 const my_command_name = my_standalone[1]
                     ? (my_standalone[1] + my_standalone[2]).toLowerCase()
@@ -876,7 +870,7 @@ export function extract_paragraph_lead_commands(syntax_section: string): Set<str
             }
         }
 
-        previous_was_paragraph_marker = the_p_marker_pattern.test(my_line);
+        previous_was_paragraph_marker = P_MARKER_PATTERN.test(my_line);
         previous_line_was_blank = false;
     }
 

--- a/src/command-database/types.ts
+++ b/src/command-database/types.ts
@@ -32,6 +32,14 @@ export interface CommandInfo {
     subcommands?: SubcommandInfo[];
     /** Priority tier for completion ordering (1=highest, 3=lowest) */
     priority?: 1 | 2 | 3;
+    /**
+     * Basename (without `.sthlp`) of the help file that actually documents
+     * this command when different from `name`. Used by the
+     * `sight/resolveSthlpFile` handler so topics like `local` resolve to
+     * `macro.sthlp`. Left unset when the help file matches the command
+     * name to keep the cache compact.
+     */
+    help_file?: string;
 }
 
 export interface CommandCache {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -37,6 +37,10 @@ import { logger } from '../utils/logger';
 import { compute_line_offsets } from '../utils/line-utils';
 import { get_workspace_root_for_path } from '../utils/workspace-roots';
 import { discover_stata_ado_paths } from '../utils/stata-install-paths';
+import {
+    FindaliasResolver,
+    HelpAliasResolver,
+} from '../utils/findalias-resolver';
 
 const MAX_PARALLEL = 4;
 const YIELD_INTERVAL_MS = 100;
@@ -73,6 +77,15 @@ export class WorkspaceIndexer {
     // once during initialize and mutated via `set_help_search_paths`
     // for tests.
     private help_search_paths: string[] = [];
+    // Shared FindaliasResolver that consults the same search dirs used
+    // by `resolve_sthlp_file` (ado_paths ∪ workspace roots ∪ help_search_paths).
+    // Its `set_search_dirs` call is a no-op when the list is unchanged,
+    // so callers can refresh it cheaply on every lookup.
+    private findalias_resolver = new FindaliasResolver();
+    // Parallel HelpAliasResolver consulted inside `resolve_sthlp_file`
+    // to handle Stata's `<topic>` → `<other_topic>` redirects that
+    // ship in `*help_alias.maint` files (e.g. `operators` → `operator`).
+    private help_alias_resolver = new HelpAliasResolver();
     private dependency_graph?: DependencyGraph;
     private metrics: IndexerMetrics = {
         files_indexed: 0,
@@ -889,14 +902,61 @@ export class WorkspaceIndexer {
     }
 
     /**
+     * Return the shared `FindaliasResolver`, refreshed with the same
+     * search-path list that `resolve_sthlp_file` uses. The resolver
+     * caches `.maint` file reads internally so refreshing the search
+     * dirs here is effectively free when nothing has changed.
+     */
+    get_findalias_resolver(): FindaliasResolver {
+        this.findalias_resolver.set_search_dirs(this.maint_search_dirs());
+        return this.findalias_resolver;
+    }
+
+    /**
+     * Return the shared `HelpAliasResolver` used by
+     * `resolve_sthlp_file` to follow `*help_alias.maint` redirects
+     * (e.g. `operators` → `operator`). Refreshed on every access with
+     * the same search-path list as the SMCL-alias resolver.
+     */
+    get_help_alias_resolver(): HelpAliasResolver {
+        this.help_alias_resolver.set_search_dirs(this.maint_search_dirs());
+        return this.help_alias_resolver;
+    }
+
+    /**
+     * Shared search-path list fed to every `.maint` resolver. Matches
+     * the lookup order used by `resolve_sthlp_file`.
+     */
+    private maint_search_dirs(): string[] {
+        return [
+            ...this.ado_paths,
+            ...this.workspace_roots,
+            ...this.help_search_paths,
+        ];
+    }
+
+    /**
      * Resolve a `.sthlp` help file by topic name.
      *
      * Searches the user-configured `ado_paths`, then workspace roots,
      * then auto-discovered Stata install directories, following
      * Stata's letter-subdirectory convention (e.g., `r/regress.sthlp`).
      * Returns the absolute file path or null.
+     *
+     * When the filesystem lookup misses, consults Stata's
+     * `*help_alias.maint` redirects (e.g. `operators` → `operator`)
+     * and retries with the redirected topic. A per-call visited set
+     * guards against malformed alias chains that cycle back on
+     * themselves.
      */
     async resolve_sthlp_file(topic: string): Promise<string | null> {
+        return this.resolve_sthlp_file_with_visited(topic, new Set());
+    }
+
+    private async resolve_sthlp_file_with_visited(
+        topic: string,
+        visited: Set<string>
+    ): Promise<string | null> {
         // Stata convention: multi-word topics (e.g. `regress
         // postestimation`, `frame create`) live in files named with
         // underscores (`regress_postestimation.sthlp`,
@@ -909,6 +969,18 @@ export class WorkspaceIndexer {
         for (const my_candidate of the_basenames) {
             const my_resolved = await this.resolve_sthlp_basename(my_candidate);
             if (my_resolved) return my_resolved;
+        }
+
+        // Filesystem lookup missed. Try Stata's `*help_alias.maint`
+        // redirects (e.g. `operators` → `operator`) and retry the
+        // resolver on the redirected topic.
+        if (visited.has(topic)) return null;
+        visited.add(topic);
+        const my_alias_target = this.get_help_alias_resolver().lookup(topic);
+        if (my_alias_target && !visited.has(my_alias_target)) {
+            return this.resolve_sthlp_file_with_visited(
+                my_alias_target, visited
+            );
         }
         return null;
     }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -36,6 +36,7 @@ import { ContextTracker } from '../context-tracker';
 import { logger } from '../utils/logger';
 import { compute_line_offsets } from '../utils/line-utils';
 import { get_workspace_root_for_path } from '../utils/workspace-roots';
+import { discover_stata_ado_paths } from '../utils/stata-install-paths';
 
 const MAX_PARALLEL = 4;
 const YIELD_INTERVAL_MS = 100;
@@ -65,6 +66,13 @@ export class WorkspaceIndexer {
     private analyzer = new SemanticAnalyzer();
     private directive_parser = new DirectiveParser();
     private ado_paths: string[] = [];
+    // Auto-discovered Stata install / user ado directories used ONLY
+    // for `.sthlp` help-file lookup. Deliberately kept separate from
+    // `ado_paths` so the workspace scanner doesn't recursively index
+    // the thousands of built-in ado files under `ado/base`. Populated
+    // once during initialize and mutated via `set_help_search_paths`
+    // for tests.
+    private help_search_paths: string[] = [];
     private dependency_graph?: DependencyGraph;
     private metrics: IndexerMetrics = {
         files_indexed: 0,
@@ -235,6 +243,10 @@ export class WorkspaceIndexer {
         }
         this.ado_paths = ado_paths;
         this.workspace_roots = workspace_folders.map(f => path.resolve(f));
+        // Auto-detect Stata install / user ado directories for help
+        // lookup. The discovery is cheap (a handful of `fs.statSync`
+        // calls on well-known paths) and non-fatal if none exist.
+        this.help_search_paths = discover_stata_ado_paths();
         this.cancelled = false;
         const start_time = Date.now();
 
@@ -861,27 +873,43 @@ export class WorkspaceIndexer {
     }
 
     /**
-     * Resolve a program name to its definition location.
-     * Follows Stata resolution order:
-     * 1. Current directory of the referring file
-     * 2. PERSONAL
-     * 3. PLUS
-     * 4. SITE
+     * For tests and callers that want to override or inspect the
+     * auto-discovered help search paths. Accepts absolute directories.
      */
+    set_help_search_paths(paths: string[]): void {
+        this.help_search_paths = [...paths];
+    }
+
     /**
-     * Resolve a .sthlp help file by topic name.
+     * Read-only view of the auto-discovered help search paths.
+     * Exposed primarily for tests.
+     */
+    get_help_search_paths(): string[] {
+        return [...this.help_search_paths];
+    }
+
+    /**
+     * Resolve a `.sthlp` help file by topic name.
      *
-     * Searches ado_paths and workspace roots following Stata's
-     * letter-subdirectory convention (e.g., `r/regress.sthlp`).
+     * Searches the user-configured `ado_paths`, then workspace roots,
+     * then auto-discovered Stata install directories, following
+     * Stata's letter-subdirectory convention (e.g., `r/regress.sthlp`).
      * Returns the absolute file path or null.
      */
     async resolve_sthlp_file(topic: string): Promise<string | null> {
         const my_basename = `${topic}.sthlp`;
         const my_first_letter = topic.charAt(0).toLowerCase();
 
-        // Search ado_paths first (PERSONAL, PLUS, SITE, BASE order),
-        // then workspace roots
-        const the_search_dirs = [...this.ado_paths, ...this.workspace_roots];
+        // Search user-configured ado_paths first (highest priority),
+        // then workspace roots, then the auto-discovered Stata install
+        // directories. Auto-discovered paths come last so an explicit
+        // user override always wins, but they are still consulted so
+        // built-in help like `help include` works out of the box.
+        const the_search_dirs = [
+            ...this.ado_paths,
+            ...this.workspace_roots,
+            ...this.help_search_paths,
+        ];
 
         for (const my_dir of the_search_dirs) {
             // Check letter subdirectory: dir/r/regress.sthlp

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -897,6 +897,24 @@ export class WorkspaceIndexer {
      * Returns the absolute file path or null.
      */
     async resolve_sthlp_file(topic: string): Promise<string | null> {
+        // Stata convention: multi-word topics (e.g. `regress
+        // postestimation`, `frame create`) live in files named with
+        // underscores (`regress_postestimation.sthlp`,
+        // `frame_create.sthlp`). Try both forms so callers can pass
+        // whichever matches how the user typed the topic.
+        const the_basenames: string[] = [topic];
+        if (topic.includes(' ')) {
+            the_basenames.push(topic.replace(/\s+/g, '_'));
+        }
+        for (const my_candidate of the_basenames) {
+            const my_resolved = await this.resolve_sthlp_basename(my_candidate);
+            if (my_resolved) return my_resolved;
+        }
+        return null;
+    }
+
+    private async resolve_sthlp_basename(topic: string): Promise<string | null> {
+        if (topic.length === 0) return null;
         const my_basename = `${topic}.sthlp`;
         const my_first_letter = topic.charAt(0).toLowerCase();
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -54,15 +54,7 @@ import {
     MacroCompletionContext
 } from './completion/macro-completion';
 import { get_line_text, get_line_count } from '../utils/line-utils';
-
-/**
- * Render a markdown command link that opens the Sight help viewer for
- * the given topic. Kept in sync with `format_help_link` in `hover.ts`.
- */
-function format_help_link(topic: string): string {
-    const the_args = encodeURIComponent(JSON.stringify([topic]));
-    return `[help ${topic}](command:sight.openHelpTopic?${the_args})`;
-}
+import { format_help_link } from '../utils/help-link';
 
 /**
  * Map ForwardCallSite.effective_type to directive_type for ranking.

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -9,6 +9,7 @@ import {
     CompletionItem,
     CompletionItemKind,
     InsertTextFormat,
+    MarkupKind,
     Position,
     CancellationToken,
     TextEdit,
@@ -1372,7 +1373,10 @@ export class CompletionProvider {
                 label: my_subcommand.name,
                 kind: CompletionItemKind.Keyword,
                 detail: `${prefix_display} subcommand`,
-                documentation: `Subcommand of ${prefix_command}. See \`help ${prefix_command} ${my_subcommand.name}\``,
+                documentation: {
+                    kind: MarkupKind.Markdown,
+                    value: `Subcommand of \`${prefix_command}\`. See ${format_help_link(prefix_command + ' ' + my_subcommand.name)}`,
+                },
                 sortText: '0' + my_subcommand.name, // Sort before other completions
             });
         }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -56,6 +56,15 @@ import {
 import { get_line_text, get_line_count } from '../utils/line-utils';
 
 /**
+ * Render a markdown command link that opens the Sight help viewer for
+ * the given topic. Kept in sync with `format_help_link` in `hover.ts`.
+ */
+function format_help_link(topic: string): string {
+    const the_args = encodeURIComponent(JSON.stringify([topic]));
+    return `[help ${topic}](command:sight.openHelpTopic?${the_args})`;
+}
+
+/**
  * Map ForwardCallSite.effective_type to directive_type for ranking.
  * 'include' -> 'included-by', else 'done-by'
  */
@@ -2313,7 +2322,7 @@ export class CompletionProvider {
             value: help_content
         } : {
             kind: 'markdown' as const,
-            value: `See Stata documentation: \`help ${command.name}\``,
+            value: `See Stata documentation: ${format_help_link(command.name)}`,
         };
 
         return {
@@ -2336,7 +2345,7 @@ export class CompletionProvider {
             value: help_content + `\n\n*Abbreviation for \`${command.name}\`*`
         } : {
             kind: 'markdown' as const,
-            value: `See Stata documentation: \`help ${command.name}\`\n\n*Abbreviation for \`${command.name}\`*`,
+            value: `See Stata documentation: ${format_help_link(command.name)}\n\n*Abbreviation for \`${command.name}\`*`,
         };
 
         return {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -42,6 +42,7 @@ import {
 import { IContextTracker } from '../context-tracker/types';
 import { LanguageContext } from '../context-tracker/types';
 import { ScopeResolver } from '../scope-resolver';
+import { format_help_link } from '../utils/help-link';
 import type { WorkspaceIndexer } from '../indexer';
 import { build_scope_resolver_config } from '../scope-resolver';
 import { get_visible_symbols_at } from '../scope-resolver';
@@ -90,19 +91,6 @@ export const STATA_EXPRESSION_FUNCTION_ALIASES = new Map<string, string>([
     ['mi', 'missing'],
 ]);
 
-/**
- * Render a markdown command link that opens the Sight help viewer for
- * the given topic. The link label keeps the familiar `help <topic>`
- * shape so users coming from Stata's `help` command recognize it.
- *
- * VS Code requires command arguments to be a JSON array encoded with
- * `encodeURIComponent`. The client middleware trusts this specific
- * command URI so the link is clickable from LSP-provided markdown.
- */
-function format_help_link(topic: string): string {
-    const the_args = encodeURIComponent(JSON.stringify([topic]));
-    return `[help ${topic}](command:sight.openHelpTopic?${the_args})`;
-}
 
 /**
  * One entry in a symbol's `additional_definitions` array.

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -91,6 +91,20 @@ const STATA_EXPRESSION_FUNCTION_ALIASES = new Map<string, string>([
 ]);
 
 /**
+ * Render a markdown command link that opens the Sight help viewer for
+ * the given topic. The link label keeps the familiar `help <topic>`
+ * shape so users coming from Stata's `help` command recognize it.
+ *
+ * VS Code requires command arguments to be a JSON array encoded with
+ * `encodeURIComponent`. The client middleware trusts this specific
+ * command URI so the link is clickable from LSP-provided markdown.
+ */
+function format_help_link(topic: string): string {
+    const the_args = encodeURIComponent(JSON.stringify([topic]));
+    return `[help ${topic}](command:sight.openHelpTopic?${the_args})`;
+}
+
+/**
  * One entry in a symbol's `additional_definitions` array.
  *
  * Analyzer invariant (enforced by `add_or_append_definition` and the ad-hoc
@@ -1501,7 +1515,7 @@ export class HoverProvider {
                 const prefix_display = prefix.charAt(0).toUpperCase() + prefix.slice(1);
                 return {
                     kind: MarkupKind.Markdown,
-                    value: `**${prefix_display} Subcommand:** \`${sub.name}\`\n\nSubcommand of \`${prefix}\`.\n\nSee Stata documentation: \`help ${prefix} ${sub.name}\``
+                    value: `**${prefix_display} Subcommand:** \`${sub.name}\`\n\nSubcommand of \`${prefix}\`.\n\nSee Stata documentation: ${format_help_link(`${prefix} ${sub.name}`)}`
                 };
             }
         }
@@ -1935,7 +1949,7 @@ export class HoverProvider {
             hover_text += ` (abbreviated as \`${abbreviated_as}\`)`;
         }
 
-        hover_text += `\n\nSee Stata documentation: \`help ${function_name}()\``;
+        hover_text += `\n\nSee Stata documentation: ${format_help_link(function_name)}`;
 
         return {
             kind: MarkupKind.Markdown,
@@ -1957,7 +1971,7 @@ export class HoverProvider {
             hover_text += `\n\n**Options:** ${option_names}`;
         }
 
-        hover_text += `\n\nSee Stata documentation: \`help ${command.name}\``;
+        hover_text += `\n\nSee Stata documentation: ${format_help_link(command.name)}`;
 
         return {
             kind: MarkupKind.Markdown,

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -56,7 +56,7 @@ import { is_cursor_in_string_literal } from '../utils/string-literal-utils';
 const MARKDOWN_TEXT_ESCAPE_PATTERN =
     /([\\`*_{}\[\]()#+\-.!|])/g;
 
-const STATA_EXPRESSION_FUNCTIONS = new Set<string>([
+export const STATA_EXPRESSION_FUNCTIONS = new Set<string>([
     'byte',
     'date',
     'daily',
@@ -86,7 +86,7 @@ const STATA_EXPRESSION_FUNCTIONS = new Set<string>([
     'yearly',
 ]);
 
-const STATA_EXPRESSION_FUNCTION_ALIASES = new Map<string, string>([
+export const STATA_EXPRESSION_FUNCTION_ALIASES = new Map<string, string>([
     ['mi', 'missing'],
 ]);
 

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -61,6 +61,7 @@ import {
     create_execute_command_handler,
     create_get_working_directory_handler,
     create_resolve_sthlp_file_handler,
+    create_resolve_findalias_handler,
 } from './server-handlers';
 
 import type { TransportType } from './cli';
@@ -1131,6 +1132,9 @@ export async function create_server(options: ServerOptions): Promise<void> {
 
     const resolve_sthlp_handler = create_resolve_sthlp_file_handler(handler_deps);
     connection.onRequest('sight/resolveSthlpFile', resolve_sthlp_handler);
+
+    const resolve_findalias_handler = create_resolve_findalias_handler(handler_deps);
+    connection.onRequest('sight/resolveFindalias', resolve_findalias_handler);
 
     // Start listening
     documents.listen(connection);

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -1025,3 +1025,41 @@ export function create_resolve_sthlp_file_handler(
         return { file_path: null };
     };
 }
+
+// -----------------------------------------------------------------------
+// sight/resolveFindalias
+// -----------------------------------------------------------------------
+
+export interface ResolveFindaliasParams {
+    alias: string;
+}
+
+export interface ResolveFindaliasResult {
+    smcl: string | null;
+}
+
+/**
+ * Creates the custom request handler for `sight/resolveFindalias`.
+ *
+ * Resolves a `{findalias X}` SMCL alias to its substitution string by
+ * consulting `*smcl_alias.maint` files under the same directories
+ * `resolve_sthlp_file` searches (user `ado_paths` ∪ workspace roots
+ * ∪ auto-discovered Stata install paths). Returns `{ smcl: null }`
+ * when the alias is unknown or no workspace indexer is available.
+ */
+export function create_resolve_findalias_handler(
+    deps: HandlerDependencies
+): (params: ResolveFindaliasParams) => Promise<ResolveFindaliasResult> {
+    return async (params: ResolveFindaliasParams): Promise<ResolveFindaliasResult> => {
+        if (!deps.workspace_indexer) {
+            return { smcl: null };
+        }
+        const my_alias = (params.alias ?? '').trim();
+        if (my_alias.length === 0) {
+            return { smcl: null };
+        }
+        const my_resolver = deps.workspace_indexer.get_findalias_resolver();
+        const my_smcl = my_resolver.lookup(my_alias);
+        return { smcl: my_smcl };
+    };
+}

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -900,11 +900,9 @@ export function create_resolve_sthlp_file_handler(
             return { file_path: my_direct };
         }
 
-        // 2. Try expanding the first word of the topic via Stata's
-        //    abbreviation conventions (e.g. `reg` → `regress`, `di`
-        //    → `display` or `dir`, `gen` → `generate`), preserving
-        //    any trailing words so `reg postestimation` resolves via
-        //    `regress_postestimation.sthlp`.
+        // Split the topic into head (first word) + tail so we can work
+        // with the subcommand shape (`frame create`, `macro dir`, ...)
+        // the same way across all fallbacks below.
         const my_first_space = my_topic.search(/\s/);
         const my_head = my_first_space === -1
             ? my_topic
@@ -915,7 +913,47 @@ export function create_resolve_sthlp_file_handler(
         if (my_head.length === 0) {
             return { file_path: null };
         }
+        const my_head_lower = my_head.toLowerCase();
 
+        // 2. Redirect via `helpFile` when the command database knows the
+        //    canonical help page lives elsewhere (e.g. `local` →
+        //    `macro.sthlp`, `replace` → `generate.sthlp`). We try the
+        //    redirected topic both with the original tail (so
+        //    `replace postestimation`-style topics still work if they
+        //    ever exist) and — for multi-word topics — without the
+        //    tail, which handles subcommand links like `macro dir`
+        //    whose help lives inside the parent file.
+        const my_head_lookup = command_database.lookup(my_head);
+        if (my_head_lookup?.helpFile && my_head_lookup.helpFile.toLowerCase() !== my_head_lower) {
+            const my_redirected = await my_indexer.resolve_sthlp_file(
+                my_head_lookup.helpFile + my_tail
+            );
+            if (my_redirected) {
+                return { file_path: my_redirected };
+            }
+            if (my_tail.length > 0) {
+                const my_parent_only = await my_indexer.resolve_sthlp_file(
+                    my_head_lookup.helpFile
+                );
+                if (my_parent_only) {
+                    return { file_path: my_parent_only };
+                }
+            }
+        } else if (my_tail.length > 0 && my_head_lookup) {
+            // Subcommands (`macro dir`, `frame drop`) that aren't backed
+            // by a dedicated `<head>_<sub>.sthlp` should still open the
+            // parent's help page rather than surfacing "not found".
+            const my_parent_only = await my_indexer.resolve_sthlp_file(my_head);
+            if (my_parent_only) {
+                return { file_path: my_parent_only };
+            }
+        }
+
+        // 3. Try expanding the first word of the topic via Stata's
+        //    abbreviation conventions (e.g. `reg` → `regress`, `di`
+        //    → `display` or `dir`, `gen` → `generate`), preserving
+        //    any trailing words so `reg postestimation` resolves via
+        //    `regress_postestimation.sthlp`.
         // Gather candidate expansions in preference order. Stata's
         // command-database cache marks more commonly-used commands
         // with a lower `priority` value (1 = Tier 1 / most common),
@@ -924,27 +962,25 @@ export function create_resolve_sthlp_file_handler(
         // command, e.g. `regress` over `regression`). The cache's
         // explicit abbreviations map (`lookup`) is tried first as a
         // published short form.
-        interface Candidate { name: string; priority: number; }
+        interface Candidate { name: string; priority: number; help_file?: string; }
         const the_tried = new Set<string>();
         const the_candidates: Candidate[] = [];
-        const my_head_lower = my_head.toLowerCase();
-        const add_candidate = (name: string, priority: number | undefined): void => {
+        const add_candidate = (name: string, priority: number | undefined, help_file?: string): void => {
             const my_normalized = name.toLowerCase();
             if (my_normalized === my_head_lower) return;
             if (the_tried.has(my_normalized)) return;
             the_tried.add(my_normalized);
-            the_candidates.push({ name, priority: priority ?? 99 });
+            the_candidates.push({ name, priority: priority ?? 99, help_file });
         };
 
-        const my_lookup = command_database.lookup(my_head);
-        if (my_lookup) {
-            add_candidate(my_lookup.name, my_lookup.priority);
+        if (my_head_lookup) {
+            add_candidate(my_head_lookup.name, my_head_lookup.priority, my_head_lookup.helpFile);
         }
         for (const my_match of command_database.expand_abbreviation(my_head)) {
-            add_candidate(my_match.name, my_match.priority);
+            add_candidate(my_match.name, my_match.priority, my_match.helpFile);
         }
         for (const my_match of command_database.search(my_head)) {
-            add_candidate(my_match.name, my_match.priority);
+            add_candidate(my_match.name, my_match.priority, my_match.helpFile);
         }
 
         // Sort by priority ascending (1 = Tier 1 / most common), then
@@ -963,6 +999,27 @@ export function create_resolve_sthlp_file_handler(
             );
             if (my_resolved) {
                 return { file_path: my_resolved };
+            }
+            // If the expanded command itself has a help_file redirect
+            // (e.g. `loc` → `local` → `macro`), follow it.
+            if (
+                my_candidate.help_file
+                && my_candidate.help_file.toLowerCase() !== my_candidate.name.toLowerCase()
+            ) {
+                const my_redirected = await my_indexer.resolve_sthlp_file(
+                    my_candidate.help_file + my_tail
+                );
+                if (my_redirected) {
+                    return { file_path: my_redirected };
+                }
+                if (my_tail.length > 0) {
+                    const my_parent_only = await my_indexer.resolve_sthlp_file(
+                        my_candidate.help_file
+                    );
+                    if (my_parent_only) {
+                        return { file_path: my_parent_only };
+                    }
+                }
             }
         }
         return { file_path: null };

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -32,6 +32,7 @@ import {
 } from 'vscode-languageserver/node';
 
 import { DocumentStore } from './document-store';
+import { command_database } from './command-database';
 import { DiagnosticsProvider } from './providers/diagnostics';
 import { CompletionProvider, detect_completion_context } from './providers/completion';
 import { HoverProvider } from './providers/hover';
@@ -885,8 +886,85 @@ export function create_resolve_sthlp_file_handler(
         if (!deps.workspace_indexer) {
             return { file_path: null };
         }
-        return {
-            file_path: await deps.workspace_indexer.resolve_sthlp_file(params.topic)
+        const my_indexer = deps.workspace_indexer;
+        const my_topic = (params.topic ?? '').trim();
+        if (my_topic.length === 0) {
+            return { file_path: null };
+        }
+
+        // 1. Try the topic as the user typed it (and its
+        //    spaces-as-underscores variant, handled inside the
+        //    indexer).
+        const my_direct = await my_indexer.resolve_sthlp_file(my_topic);
+        if (my_direct) {
+            return { file_path: my_direct };
+        }
+
+        // 2. Try expanding the first word of the topic via Stata's
+        //    abbreviation conventions (e.g. `reg` → `regress`, `di`
+        //    → `display` or `dir`, `gen` → `generate`), preserving
+        //    any trailing words so `reg postestimation` resolves via
+        //    `regress_postestimation.sthlp`.
+        const my_first_space = my_topic.search(/\s/);
+        const my_head = my_first_space === -1
+            ? my_topic
+            : my_topic.substring(0, my_first_space);
+        const my_tail = my_first_space === -1
+            ? ''
+            : my_topic.substring(my_first_space);
+        if (my_head.length === 0) {
+            return { file_path: null };
+        }
+
+        // Gather candidate expansions in preference order. Stata's
+        // command-database cache marks more commonly-used commands
+        // with a lower `priority` value (1 = Tier 1 / most common),
+        // so we use that as the primary sort key. Ties break on
+        // command name length (shorter is usually the canonical
+        // command, e.g. `regress` over `regression`). The cache's
+        // explicit abbreviations map (`lookup`) is tried first as a
+        // published short form.
+        interface Candidate { name: string; priority: number; }
+        const the_tried = new Set<string>();
+        const the_candidates: Candidate[] = [];
+        const my_head_lower = my_head.toLowerCase();
+        const add_candidate = (name: string, priority: number | undefined): void => {
+            const my_normalized = name.toLowerCase();
+            if (my_normalized === my_head_lower) return;
+            if (the_tried.has(my_normalized)) return;
+            the_tried.add(my_normalized);
+            the_candidates.push({ name, priority: priority ?? 99 });
         };
+
+        const my_lookup = command_database.lookup(my_head);
+        if (my_lookup) {
+            add_candidate(my_lookup.name, my_lookup.priority);
+        }
+        for (const my_match of command_database.expand_abbreviation(my_head)) {
+            add_candidate(my_match.name, my_match.priority);
+        }
+        for (const my_match of command_database.search(my_head)) {
+            add_candidate(my_match.name, my_match.priority);
+        }
+
+        // Sort by priority ascending (1 = Tier 1 / most common), then
+        // by name length ascending so the short canonical command
+        // name (`regress`, `display`) wins over verbose relatives
+        // (`regression`, `dir`). This makes `di` → `display` even
+        // though the cache's `abbreviations` map says otherwise.
+        the_candidates.sort((a, b) => {
+            if (a.priority !== b.priority) return a.priority - b.priority;
+            return a.name.length - b.name.length;
+        });
+
+        for (const my_candidate of the_candidates) {
+            const my_resolved = await my_indexer.resolve_sthlp_file(
+                my_candidate.name + my_tail
+            );
+            if (my_resolved) {
+                return { file_path: my_resolved };
+            }
+        }
+        return { file_path: null };
     };
 }

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -943,7 +943,11 @@ export function create_resolve_sthlp_file_handler(
             // Subcommands (`macro dir`, `frame drop`) that aren't backed
             // by a dedicated `<head>_<sub>.sthlp` should still open the
             // parent's help page rather than surfacing "not found".
-            const my_parent_only = await my_indexer.resolve_sthlp_file(my_head);
+            // Use the expanded name so abbreviated heads like `mac dir`
+            // or `fr drop` resolve to `macro.sthlp` / `frame.sthlp`.
+            const my_parent_only = await my_indexer.resolve_sthlp_file(
+                my_head_lookup.name
+            );
             if (my_parent_only) {
                 return { file_path: my_parent_only };
             }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -437,6 +437,13 @@ export interface CommandInfo {
   category: string;
   isBuiltin: boolean;
   priority?: 1 | 2 | 3;
+  /**
+   * Basename (without `.sthlp`) of the help file that documents this
+   * command when it differs from `name`. Populated from the cache so the
+   * `sight/resolveSthlpFile` handler can redirect topics like `local` to
+   * `macro.sthlp`.
+   */
+  helpFile?: string;
 }
 
 export interface OptionInfo {

--- a/src/utils/findalias-resolver.ts
+++ b/src/utils/findalias-resolver.ts
@@ -163,6 +163,8 @@ export abstract class MaintAliasStore {
     }
 
     private any_cached_file_changed(): boolean {
+        // Check previously contributing files for removal or mtime
+        // changes.
         for (const my_file of this.merged_file_paths) {
             const my_cached = this.file_cache.get(my_file);
             if (!my_cached) return true;
@@ -176,6 +178,27 @@ export abstract class MaintAliasStore {
             }
             if (my_stat.mtimeMs !== my_cached.mtime_ms) {
                 return true;
+            }
+        }
+        // Probe canonical candidate paths for newly created .maint
+        // files that weren't present when the cache was built.
+        const the_known = new Set(this.merged_file_paths);
+        for (const my_dir of this.search_dirs) {
+            for (const my_letter of LETTER_SUBDIRS) {
+                const my_candidate = path.join(
+                    my_dir,
+                    my_letter,
+                    `${my_letter}${this.file_suffix}`
+                );
+                if (the_known.has(my_candidate)) continue;
+                try {
+                    fs.statSync(my_candidate);
+                    // File exists but wasn't in the previous merge —
+                    // a new file appeared on disk.
+                    return true;
+                } catch {
+                    // Still absent, nothing to do.
+                }
             }
         }
         return false;

--- a/src/utils/findalias-resolver.ts
+++ b/src/utils/findalias-resolver.ts
@@ -1,0 +1,268 @@
+/**
+ * Resolvers for Stata's `.maint` alias files.
+ *
+ * Two file families share the exact same on-disk format — a key
+ * column, whitespace, then a value column — and the same lookup
+ * semantics (case-sensitive, earlier-directory-wins), so they share
+ * the cache plumbing in `MaintAliasStore`:
+ *
+ *   * `*smcl_alias.maint` — undocumented `{findalias X}` SMCL
+ *     substitutions. Consumed by `FindaliasResolver` and routed into
+ *     the SMCL-to-HTML renderer.
+ *   * `*help_alias.maint` — `help topic` redirects that rewrite the
+ *     user-typed topic to a different `.sthlp` basename. Consumed by
+ *     `HelpAliasResolver` and routed into `resolve_sthlp_file`.
+ *
+ * Each line has the shape:
+ *
+ *     <key><whitespace><value>
+ *
+ * For example:
+ *
+ *     ado/base/f/fsmcl_alias.maint: frexp      {manlink U 13 Functions and expressions}
+ *     ado/base/o/ohelp_alias.maint: operators  operator
+ *
+ * Resolution rules for both resolvers:
+ *   * Keys are matched case-sensitively, exactly as typed (Stata is
+ *     case-sensitive).
+ *   * Each resolver reads only its own file suffix; the two never
+ *     cross-contaminate.
+ *   * Results are cached per-file by mtime so repeated lookups are
+ *     effectively free and changes on disk are picked up without a
+ *     server restart.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Letters we probe for per-ado-directory `.maint` files. Stata's base
+// ado tree only ever uses lowercase single-letter subdirectories
+// (`a/`, `b/`, …, `z/`, plus the rarely-used `_/`). Restricting the
+// probe to this fixed set keeps the scan O(1) per ado root instead of
+// readdir'ing arbitrary layouts.
+const LETTER_SUBDIRS: readonly string[] = [
+    '_',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+    'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+    'u', 'v', 'w', 'x', 'y', 'z',
+];
+
+interface CachedMaint {
+    mtime_ms: number;
+    aliases: Map<string, string>;
+}
+
+/**
+ * Shared base class for `.maint`-file alias resolvers. Handles search
+ * directory normalization, per-file mtime caching, and merged-map
+ * construction. Subclasses only supply the file suffix they target
+ * (e.g. `smcl_alias.maint` vs `help_alias.maint`).
+ */
+export abstract class MaintAliasStore {
+    private search_dirs: string[] = [];
+    // Per-maint-file cache keyed by absolute path.
+    private file_cache: Map<string, CachedMaint> = new Map();
+    // Merged alias map. Rebuilt lazily whenever `search_dirs` changes
+    // or any cached file's mtime no longer matches disk.
+    private merged_cache: Map<string, string> | null = null;
+    // The file paths that contributed to the current `merged_cache`,
+    // so we can detect changes cheaply in `lookup`.
+    private merged_file_paths: string[] = [];
+
+    /**
+     * Filename suffix (relative to the letter subdir) this store
+     * reads. Subclasses return a constant like `smcl_alias.maint` or
+     * `help_alias.maint`.
+     */
+    protected abstract get file_suffix(): string;
+
+    /**
+     * Update the list of directories to search for `.maint` files.
+     * Paths should be absolute. Order is preserved: when two files
+     * define the same alias, the earlier directory wins.
+     */
+    set_search_dirs(dirs: string[]): void {
+        const the_normalized: string[] = [];
+        const the_seen = new Set<string>();
+        for (const my_dir of dirs) {
+            if (!my_dir) continue;
+            const my_resolved = path.resolve(my_dir);
+            if (the_seen.has(my_resolved)) continue;
+            the_seen.add(my_resolved);
+            the_normalized.push(my_resolved);
+        }
+        // Only invalidate the merged cache if the set actually changed.
+        if (!arrays_equal(the_normalized, this.search_dirs)) {
+            this.search_dirs = the_normalized;
+            this.merged_cache = null;
+        }
+    }
+
+    /**
+     * Read-only view of the currently-configured search directories.
+     * Exposed primarily for tests.
+     */
+    get_search_dirs(): string[] {
+        return [...this.search_dirs];
+    }
+
+    /**
+     * Resolve an alias. Returns the raw value string from the `.maint`
+     * file (the interpretation is up to the caller — raw SMCL for
+     * `FindaliasResolver`, a help-topic basename for
+     * `HelpAliasResolver`) or `null` when the alias is unknown.
+     */
+    lookup(alias: string): string | null {
+        const my_key = alias.trim();
+        if (my_key.length === 0) return null;
+        const the_merged = this.get_merged_map();
+        const my_value = the_merged.get(my_key);
+        return my_value ?? null;
+    }
+
+    /**
+     * Drop all caches. Intended for tests.
+     */
+    reset_cache(): void {
+        this.file_cache.clear();
+        this.merged_cache = null;
+        this.merged_file_paths = [];
+    }
+
+    // ---------------------------------------------------------------
+    // Internals
+    // ---------------------------------------------------------------
+
+    private get_merged_map(): Map<string, string> {
+        if (this.merged_cache !== null && !this.any_cached_file_changed()) {
+            return this.merged_cache;
+        }
+        const the_merged = new Map<string, string>();
+        const the_contributing_files: string[] = [];
+        for (const my_dir of this.search_dirs) {
+            for (const my_letter of LETTER_SUBDIRS) {
+                const my_file = path.join(
+                    my_dir,
+                    my_letter,
+                    `${my_letter}${this.file_suffix}`
+                );
+                const the_aliases = this.load_file(my_file);
+                if (!the_aliases) continue;
+                the_contributing_files.push(my_file);
+                for (const [my_alias, my_value] of the_aliases) {
+                    // Earlier directory wins (ado_paths > workspace >
+                    // install), matching resolve_sthlp_file ordering.
+                    if (!the_merged.has(my_alias)) {
+                        the_merged.set(my_alias, my_value);
+                    }
+                }
+            }
+        }
+        this.merged_cache = the_merged;
+        this.merged_file_paths = the_contributing_files;
+        return the_merged;
+    }
+
+    private any_cached_file_changed(): boolean {
+        for (const my_file of this.merged_file_paths) {
+            const my_cached = this.file_cache.get(my_file);
+            if (!my_cached) return true;
+            let my_stat: fs.Stats | null = null;
+            try {
+                my_stat = fs.statSync(my_file);
+            } catch {
+                // File was removed since we last read it.
+                this.file_cache.delete(my_file);
+                return true;
+            }
+            if (my_stat.mtimeMs !== my_cached.mtime_ms) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private load_file(file_path: string): Map<string, string> | null {
+        let my_stat: fs.Stats;
+        try {
+            my_stat = fs.statSync(file_path);
+        } catch {
+            return null;
+        }
+        if (!my_stat.isFile()) return null;
+
+        const my_cached = this.file_cache.get(file_path);
+        if (my_cached && my_cached.mtime_ms === my_stat.mtimeMs) {
+            return my_cached.aliases;
+        }
+
+        let my_content: string;
+        try {
+            my_content = fs.readFileSync(file_path, 'utf-8');
+        } catch {
+            return null;
+        }
+
+        const the_aliases = parse_maint_file(my_content);
+        this.file_cache.set(file_path, {
+            mtime_ms: my_stat.mtimeMs,
+            aliases: the_aliases,
+        });
+        return the_aliases;
+    }
+}
+
+/**
+ * Resolver for `{findalias X}` SMCL substitutions, backed by
+ * `*smcl_alias.maint` files.
+ */
+export class FindaliasResolver extends MaintAliasStore {
+    protected get file_suffix(): string {
+        return 'smcl_alias.maint';
+    }
+}
+
+/**
+ * Resolver for `help <topic>` redirects, backed by `*help_alias.maint`
+ * files. Returns the redirected topic basename (e.g. `operator` for
+ * `operators`), which the caller then feeds back into the normal
+ * `.sthlp` file-path resolution flow.
+ */
+export class HelpAliasResolver extends MaintAliasStore {
+    protected get file_suffix(): string {
+        return 'help_alias.maint';
+    }
+}
+
+/**
+ * Parse the contents of a `*smcl_alias.maint` file into an alias map.
+ *
+ * Exported for tests. Blank lines and pure-comment lines are ignored.
+ * The key is the first whitespace-delimited token; the value is the
+ * remainder of the line, trimmed.
+ */
+export function parse_maint_file(content: string): Map<string, string> {
+    const the_aliases = new Map<string, string>();
+    const the_lines = content.split(/\r?\n/);
+    for (const my_line of the_lines) {
+        if (my_line.trim().length === 0) continue;
+        const my_match = my_line.match(/^\s*(\S+)\s+(.+?)\s*$/);
+        if (!my_match) continue;
+        const my_key = my_match[1];
+        const my_value = my_match[2];
+        if (my_key.length === 0 || my_value.length === 0) continue;
+        // First definition wins (matches merge precedence semantics
+        // applied at the directory level).
+        if (!the_aliases.has(my_key)) {
+            the_aliases.set(my_key, my_value);
+        }
+    }
+    return the_aliases;
+}
+
+function arrays_equal(a: string[], b: string[]): boolean {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false;
+    }
+    return true;
+}

--- a/src/utils/findalias-resolver.ts
+++ b/src/utils/findalias-resolver.ts
@@ -267,7 +267,16 @@ export function parse_maint_file(content: string): Map<string, string> {
     const the_aliases = new Map<string, string>();
     const the_lines = content.split(/\r?\n/);
     for (const my_line of the_lines) {
-        if (my_line.trim().length === 0) continue;
+        const my_trimmed = my_line.trimStart();
+        if (my_trimmed.length === 0) continue;
+        // Skip comment lines so they aren't mistakenly parsed as
+        // alias entries (the regex below would match them).
+        if (
+            my_trimmed.startsWith('*') ||
+            my_trimmed.startsWith('//') ||
+            my_trimmed.startsWith('#') ||
+            my_trimmed.startsWith(';')
+        ) continue;
         const my_match = my_line.match(/^\s*(\S+)\s+(.+?)\s*$/);
         if (!my_match) continue;
         const my_key = my_match[1];

--- a/src/utils/help-link.ts
+++ b/src/utils/help-link.ts
@@ -1,0 +1,13 @@
+/**
+ * Render a markdown command link that opens the Sight help viewer for
+ * the given topic. The link label keeps the familiar `help <topic>`
+ * shape so users coming from Stata's `help` command recognize it.
+ *
+ * VS Code requires command arguments to be a JSON array encoded with
+ * `encodeURIComponent`. The client middleware trusts this specific
+ * command URI so the link is clickable from LSP-provided markdown.
+ */
+export function format_help_link(topic: string): string {
+    const my_encoded_args = encodeURIComponent(JSON.stringify([topic]));
+    return `[help ${topic}](command:sight.openHelpTopic?${my_encoded_args})`;
+}

--- a/src/utils/stata-install-paths.ts
+++ b/src/utils/stata-install-paths.ts
@@ -1,0 +1,220 @@
+/**
+ * Stata install path auto-discovery
+ *
+ * Probes well-known Stata install and user ado directories across
+ * macOS, Linux, and Windows. Returns only paths that actually exist.
+ *
+ * Used by the help-topic resolver so users can click a hover link and
+ * open a `.sthlp` file without first having to configure
+ * `sight.adoPaths` by hand — the base ado directory that ships with
+ * every Stata install (home of `help include`, `help display`, etc.)
+ * is picked up automatically when it lives in a standard location.
+ *
+ * This module intentionally avoids doing any work that would slow
+ * startup: `fs.existsSync` is called at most a few dozen times, on
+ * paths shallow enough that the check is effectively free. The
+ * resolver consumes the returned list for lookups — it does NOT add
+ * these directories to the workspace scanner, so we never start
+ * recursively indexing thousands of built-in `.ado` files.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Major Stata release versions to probe for under install roots.
+// We scan in newest-first order so that a user with multiple versions
+// installed gets the most recent one picked first. The range covers
+// the common in-the-wild releases (13 through 18 are supported by the
+// command-database generator) plus a small lookahead.
+const STATA_MAJOR_VERSIONS = [20, 19, 18, 17, 16, 15, 14, 13];
+
+const WINDOWS_VARIANT_DIRS = ['Stata'];
+const MAC_VARIANT_DIRS = ['Stata', 'StataMP', 'StataSE', 'StataBE', 'StataIC'];
+
+/**
+ * Test-friendly options for path discovery. Each field defaults to
+ * the real-world value so production callers can invoke
+ * `discover_stata_ado_paths()` with no arguments.
+ */
+export interface DiscoverStataPathsOptions {
+    /** Override the user's home directory (for tests). */
+    home?: string;
+    /** Override the platform name (for tests). */
+    platform?: NodeJS.Platform;
+    /**
+     * Override the file-existence predicate (for tests). Must return
+     * true if the given absolute path refers to an existing directory.
+     */
+    exists?: (candidate_path: string) => boolean;
+    /**
+     * Override environment variable lookup (for tests). Defaults to
+     * `process.env`. Used on Windows to honour ProgramFiles, etc.
+     */
+    env?: Record<string, string | undefined>;
+}
+
+/**
+ * Return the list of existing Stata-related ado directories that are
+ * likely to contain `.sthlp` help files.
+ *
+ * The returned list is de-duplicated, order-stable, and composed of
+ * absolute paths. Paths that do not currently exist are omitted so the
+ * resolver can treat every entry as a safe `fs.access` target.
+ */
+export function discover_stata_ado_paths(
+    options: DiscoverStataPathsOptions = {}
+): string[] {
+    const my_home = options.home ?? os.homedir();
+    const my_platform = options.platform ?? process.platform;
+    const my_exists = options.exists ?? ((p: string) => {
+        try {
+            return fs.statSync(p).isDirectory();
+        } catch {
+            return false;
+        }
+    });
+    const my_env = options.env ?? (process.env as Record<string, string | undefined>);
+
+    // Use platform-appropriate path semantics. This makes the tests
+    // deterministic when running on a host whose native separator
+    // differs from the platform under test.
+    const my_path = path_for_platform(my_platform);
+    const the_candidates = gather_candidates(my_home, my_platform, my_env, my_path);
+
+    const the_seen = new Set<string>();
+    const the_result: string[] = [];
+    for (const my_candidate of the_candidates) {
+        if (!my_candidate) continue;
+        const my_normalized = my_path.resolve(my_candidate);
+        if (the_seen.has(my_normalized)) continue;
+        the_seen.add(my_normalized);
+        if (my_exists(my_normalized)) {
+            the_result.push(my_normalized);
+        }
+    }
+    return the_result;
+}
+
+function path_for_platform(
+    platform: NodeJS.Platform
+): typeof path.posix | typeof path.win32 {
+    return platform === 'win32' ? path.win32 : path.posix;
+}
+
+function gather_candidates(
+    home: string,
+    platform: NodeJS.Platform,
+    env: Record<string, string | undefined>,
+    my_path: typeof path.posix | typeof path.win32
+): string[] {
+    const the_paths: string[] = [];
+
+    // User-level ado directories (applicable on every platform).
+    // `resolve_sthlp_file` probes both `dir/<letter>/topic.sthlp` and
+    // `dir/topic.sthlp`, so including the ado root itself covers very
+    // old installs that drop .sthlp files directly under `~/ado/`.
+    for (const my_user_root of user_ado_roots(home, platform, my_path)) {
+        the_paths.push(my_user_root);
+        the_paths.push(my_path.join(my_user_root, 'personal'));
+        the_paths.push(my_path.join(my_user_root, 'plus'));
+    }
+
+    // System / install ado directories.
+    for (const my_install_root of stata_install_roots(platform, env, my_path)) {
+        the_paths.push(my_path.join(my_install_root, 'ado', 'base'));
+        the_paths.push(my_path.join(my_install_root, 'ado', 'site'));
+        the_paths.push(my_path.join(my_install_root, 'ado', 'updates'));
+    }
+
+    return the_paths;
+}
+
+function user_ado_roots(
+    home: string,
+    platform: NodeJS.Platform,
+    my_path: typeof path.posix | typeof path.win32
+): string[] {
+    const the_roots: string[] = [
+        // Cross-platform legacy convention that Stata's sysdir defaults to.
+        my_path.join(home, 'ado'),
+    ];
+    if (platform === 'darwin') {
+        // Modern macOS PERSONAL / PLUS location used by Stata 17+.
+        the_roots.push(
+            my_path.join(
+                home,
+                'Library',
+                'Application Support',
+                'Stata',
+                'ado'
+            )
+        );
+    }
+    return the_roots;
+}
+
+function stata_install_roots(
+    platform: NodeJS.Platform,
+    env: Record<string, string | undefined>,
+    my_path: typeof path.posix | typeof path.win32
+): string[] {
+    if (platform === 'darwin') {
+        return mac_install_roots(my_path);
+    }
+    if (platform === 'win32') {
+        return windows_install_roots(env, my_path);
+    }
+    // Linux, FreeBSD, etc. treat as POSIX with standard prefixes.
+    return posix_install_roots(my_path);
+}
+
+function mac_install_roots(
+    my_path: typeof path.posix | typeof path.win32
+): string[] {
+    const the_roots: string[] = [];
+    for (const my_variant of MAC_VARIANT_DIRS) {
+        the_roots.push(my_path.join('/Applications', my_variant));
+    }
+    return the_roots;
+}
+
+function windows_install_roots(
+    env: Record<string, string | undefined>,
+    my_path: typeof path.posix | typeof path.win32
+): string[] {
+    const the_program_files_roots = new Set<string>();
+    for (const my_var of ['ProgramFiles', 'ProgramW6432', 'ProgramFiles(x86)']) {
+        const my_value = env[my_var];
+        if (my_value && my_value.length > 0) {
+            the_program_files_roots.add(my_value);
+        }
+    }
+    if (the_program_files_roots.size === 0) {
+        // Common defaults when the env vars are unavailable.
+        the_program_files_roots.add('C:\\Program Files');
+        the_program_files_roots.add('C:\\Program Files (x86)');
+    }
+    const the_roots: string[] = [];
+    for (const my_pf of the_program_files_roots) {
+        for (const my_version of STATA_MAJOR_VERSIONS) {
+            the_roots.push(my_path.join(my_pf, `Stata${my_version}`));
+        }
+        for (const my_variant of WINDOWS_VARIANT_DIRS) {
+            the_roots.push(my_path.join(my_pf, my_variant));
+        }
+    }
+    return the_roots;
+}
+
+function posix_install_roots(
+    my_path: typeof path.posix | typeof path.win32
+): string[] {
+    const the_roots: string[] = [];
+    for (const my_prefix of ['/usr/local', '/opt']) {
+        for (const my_version of STATA_MAJOR_VERSIONS) {
+            the_roots.push(my_path.join(my_prefix, `stata${my_version}`));
+        }
+        the_roots.push(my_path.join(my_prefix, 'stata'));
+    }
+    return the_roots;
+}

--- a/tests/integration/help-topic-coverage.test.ts
+++ b/tests/integration/help-topic-coverage.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Help-topic coverage test.
+ *
+ * Runs only on developer machines where a real Stata install is
+ * detectable (we skip when `discover_stata_ado_paths()` returns an
+ * empty list, so CI boxes and non-Stata contributors are unaffected).
+ *
+ * For every command in the committed v18 cache and every entry in
+ * `STATA_EXPRESSION_FUNCTIONS` (+ aliases) the test drives the real
+ * `sight/resolveSthlpFile` handler and asserts that the returned
+ * `file_path` is non-null. When something regresses, the failure
+ * message lists every unresolved topic so it's obvious what the
+ * cache is missing.
+ */
+
+import { describe, expect, it, beforeAll } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import {
+    create_resolve_sthlp_file_handler,
+    HandlerDependencies,
+} from '../../src/server-handlers';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { DocumentStore } from '../../src/document-store';
+import { command_database } from '../../src/command-database';
+import type { CommandCache } from '../../src/command-database/types';
+import {
+    STATA_EXPRESSION_FUNCTIONS,
+    STATA_EXPRESSION_FUNCTION_ALIASES,
+} from '../../src/providers/hover';
+import { discover_stata_ado_paths } from '../../src/utils/stata-install-paths';
+
+function make_deps(workspace_indexer: WorkspaceIndexer): HandlerDependencies {
+    return {
+        debounce_manager: null,
+        document_store: new DocumentStore(),
+        diagnostics_provider: null,
+        completion_provider: null,
+        hover_provider: null,
+        definition_provider: null,
+        references_provider: null,
+        symbol_provider: null,
+        formatter_provider: null,
+        workspace_indexer,
+        scope_resolver: null,
+        forward_scope_resolver: null,
+        dependency_graph: null,
+        rename_handler: null,
+        get_document_settings: async () => ({} as any),
+        connection: {
+            sendDiagnostics: () => {},
+            console: { log: () => {} },
+        },
+    };
+}
+
+const the_stata_ado_paths = discover_stata_ado_paths();
+const stata_is_installed = the_stata_ado_paths.length > 0;
+
+// `describe.skipIf` is Bun-native; we preserve the describe block so
+// the skip shows up in the test report (with a helpful reason).
+const describe_if_stata = stata_is_installed ? describe : describe.skip;
+
+describe_if_stata('Help topic coverage (local Stata install required)', () => {
+    let throwaway_workspace: string;
+    let indexer: WorkspaceIndexer;
+    let handler: (params: { topic: string }) => Promise<{ file_path: string | null }>;
+
+    beforeAll(async () => {
+        if (!stata_is_installed) return;
+
+        throwaway_workspace = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'sight-help-coverage-')
+        );
+
+        // Load the committed cache so the resolver exercises the exact
+        // `help_file` pointers shipped to users.
+        const cache_path = join(
+            __dirname,
+            '../../src/command-database/caches/v18.json'
+        );
+        const the_cache = JSON.parse(
+            readFileSync(cache_path, 'utf-8')
+        ) as CommandCache;
+        command_database.load_cache(the_cache);
+
+        indexer = new WorkspaceIndexer();
+        await indexer.initialize([throwaway_workspace]);
+        indexer.set_help_search_paths(the_stata_ado_paths);
+
+        handler = create_resolve_sthlp_file_handler(make_deps(indexer));
+    });
+
+    it('resolves every command in the cache to a .sthlp file', async () => {
+        if (!stata_is_installed) return;
+
+        const the_topics = Object.keys(
+            (command_database as any).cache?.commands ?? {}
+        );
+        const the_unresolved: string[] = [];
+
+        for (const my_topic of the_topics) {
+            const my_result = await handler({ topic: my_topic });
+            if (!my_result.file_path) {
+                the_unresolved.push(my_topic);
+            }
+        }
+
+        if (the_unresolved.length > 0) {
+            const my_preview = the_unresolved.slice(0, 50).join(', ');
+            const my_suffix = the_unresolved.length > 50
+                ? ` ...and ${the_unresolved.length - 50} more`
+                : '';
+            throw new Error(
+                `Could not resolve .sthlp for ${the_unresolved.length} `
+                + `cached commands (out of ${the_topics.length}): `
+                + `${my_preview}${my_suffix}`
+            );
+        }
+
+        expect(the_unresolved).toEqual([]);
+    }, 60_000);
+
+    it('resolves every expression function (and alias) to a .sthlp file', async () => {
+        if (!stata_is_installed) return;
+
+        const the_topics = new Set<string>([
+            ...STATA_EXPRESSION_FUNCTIONS,
+            ...STATA_EXPRESSION_FUNCTION_ALIASES.keys(),
+            ...STATA_EXPRESSION_FUNCTION_ALIASES.values(),
+        ]);
+        const the_unresolved: string[] = [];
+
+        for (const my_topic of the_topics) {
+            const my_result = await handler({ topic: my_topic });
+            if (!my_result.file_path) {
+                the_unresolved.push(my_topic);
+            }
+        }
+
+        if (the_unresolved.length > 0) {
+            throw new Error(
+                `Could not resolve .sthlp for ${the_unresolved.length} `
+                + `expression function(s) (out of ${the_topics.size}): `
+                + the_unresolved.join(', ')
+            );
+        }
+
+        expect(the_unresolved).toEqual([]);
+    }, 30_000);
+});

--- a/tests/integration/help-topic-coverage.test.ts
+++ b/tests/integration/help-topic-coverage.test.ts
@@ -98,9 +98,7 @@ describe_if_stata('Help topic coverage (local Stata install required)', () => {
     it('resolves every command in the cache to a .sthlp file', async () => {
         if (!stata_is_installed) return;
 
-        const the_topics = Object.keys(
-            (command_database as any).cache?.commands ?? {}
-        );
+        const the_topics = command_database.get_all_command_names();
         const the_unresolved: string[] = [];
 
         for (const my_topic of the_topics) {

--- a/tests/integration/lsp-lifecycle.test.ts
+++ b/tests/integration/lsp-lifecycle.test.ts
@@ -344,7 +344,16 @@ describe('LSP Lifecycle - Handler Factories', () => {
                 && 'value' in result.contents
             ) {
                 expect(result.contents.value).toContain('**missing**');
-                expect(result.contents.value).toContain('help missing()');
+                // Expression functions now link to the Sight help
+                // viewer via a `command:sight.openHelpTopic?...`
+                // markdown URI. The label keeps the `help <topic>`
+                // shape so the existing mental model is preserved.
+                const my_expected_args =
+                    encodeURIComponent(JSON.stringify(['missing']));
+                expect(result.contents.value).toContain(
+                    `(command:sight.openHelpTopic?${my_expected_args})`
+                );
+                expect(result.contents.value).toContain('[help missing]');
             }
         });
     });

--- a/tests/unit/findalias-resolver.test.ts
+++ b/tests/unit/findalias-resolver.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for the FindaliasResolver.
+ *
+ * Points a resolver at temporary ado directories that contain small
+ * hand-rolled `*smcl_alias.maint` files and asserts:
+ *   * line parsing preserves the full SMCL payload
+ *   * lookups are case-sensitive, trimmed, and return `null` on miss
+ *   * the first search directory wins on duplicate aliases
+ *   * cached results reflect on-disk edits (mtime invalidation)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+    FindaliasResolver,
+    HelpAliasResolver,
+    parse_maint_file,
+} from '../../src/utils/findalias-resolver';
+
+describe('parse_maint_file', () => {
+    it('parses a simple alias line', () => {
+        const the_map = parse_maint_file(
+            'frexp                    {manlink U 13 Functions and expressions}\n'
+        );
+        expect(the_map.get('frexp')).toBe(
+            '{manlink U 13 Functions and expressions}'
+        );
+    });
+
+    it('skips blank lines', () => {
+        const the_map = parse_maint_file(
+            '\n\nfrexp {manlink U 13}\n\n'
+        );
+        expect(the_map.size).toBe(1);
+        expect(the_map.get('frexp')).toBe('{manlink U 13}');
+    });
+
+    it('keeps the first definition when an alias repeats', () => {
+        const the_map = parse_maint_file(
+            'frexp first\nfrexp second\n'
+        );
+        expect(the_map.get('frexp')).toBe('first');
+    });
+
+    it('treats keys as case-sensitive', () => {
+        const the_map = parse_maint_file('Frexp Value\nfrexp other\n');
+        expect(the_map.get('Frexp')).toBe('Value');
+        expect(the_map.get('frexp')).toBe('other');
+        expect(the_map.get('FREXP')).toBeUndefined();
+    });
+});
+
+describe('FindaliasResolver', () => {
+    let temp_dir: string;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'sight-findalias-')
+        );
+    });
+
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    function write_maint(
+        ado_root: string,
+        letter: string,
+        lines: string[]
+    ): string {
+        const my_dir = path.join(ado_root, letter);
+        fs.mkdirSync(my_dir, { recursive: true });
+        const my_path = path.join(my_dir, `${letter}smcl_alias.maint`);
+        fs.writeFileSync(my_path, lines.join('\n') + '\n');
+        return my_path;
+    }
+
+    it('resolves an alias from fsmcl_alias.maint', () => {
+        const my_ado = path.join(temp_dir, 'ado');
+        write_maint(my_ado, 'f', [
+            'frexp                    {manlink U 13 Functions and expressions}',
+        ]);
+
+        const resolver = new FindaliasResolver();
+        resolver.set_search_dirs([my_ado]);
+
+        expect(resolver.lookup('frexp')).toBe(
+            '{manlink U 13 Functions and expressions}'
+        );
+    });
+
+    it('returns null for an unknown alias', () => {
+        const my_ado = path.join(temp_dir, 'ado');
+        write_maint(my_ado, 'f', ['frexp payload']);
+
+        const resolver = new FindaliasResolver();
+        resolver.set_search_dirs([my_ado]);
+
+        expect(resolver.lookup('unknown')).toBeNull();
+    });
+
+    it('returns null when no `.maint` file is found', () => {
+        const resolver = new FindaliasResolver();
+        resolver.set_search_dirs([path.join(temp_dir, 'does-not-exist')]);
+        expect(resolver.lookup('frexp')).toBeNull();
+    });
+
+    it('trims whitespace from the looked-up alias', () => {
+        const my_ado = path.join(temp_dir, 'ado');
+        write_maint(my_ado, 'f', ['frexp payload']);
+
+        const resolver = new FindaliasResolver();
+        resolver.set_search_dirs([my_ado]);
+
+        expect(resolver.lookup('  frexp  ')).toBe('payload');
+    });
+
+    it('treats alias lookups as case-sensitive', () => {
+        const my_ado = path.join(temp_dir, 'ado');
+        write_maint(my_ado, 'f', ['frexp lowercase_payload']);
+
+        const resolver = new FindaliasResolver();
+        resolver.set_search_dirs([my_ado]);
+
+        expect(resolver.lookup('frexp')).toBe('lowercase_payload');
+        expect(resolver.lookup('FREXP')).toBeNull();
+        expect(resolver.lookup('Frexp')).toBeNull();
+    });
+
+    it('earlier search directory wins on duplicate aliases', () => {
+        const my_ado_a = path.join(temp_dir, 'ado-a');
+        const my_ado_b = path.join(temp_dir, 'ado-b');
+        write_maint(my_ado_a, 'f', ['frexp from_a']);
+        write_maint(my_ado_b, 'f', ['frexp from_b']);
+
+        const resolver = new FindaliasResolver();
+        resolver.set_search_dirs([my_ado_a, my_ado_b]);
+        expect(resolver.lookup('frexp')).toBe('from_a');
+
+        resolver.set_search_dirs([my_ado_b, my_ado_a]);
+        expect(resolver.lookup('frexp')).toBe('from_b');
+    });
+
+    it('picks up on-disk edits via mtime invalidation', () => {
+        const my_ado = path.join(temp_dir, 'ado');
+        const my_file = write_maint(my_ado, 'f', ['frexp initial_payload']);
+
+        const resolver = new FindaliasResolver();
+        resolver.set_search_dirs([my_ado]);
+        expect(resolver.lookup('frexp')).toBe('initial_payload');
+
+        // Rewrite the file with a different mtime so the cache refreshes.
+        const my_later_time = new Date(Date.now() + 5000);
+        fs.writeFileSync(my_file, 'frexp updated_payload\n');
+        fs.utimesSync(my_file, my_later_time, my_later_time);
+
+        expect(resolver.lookup('frexp')).toBe('updated_payload');
+    });
+
+    it('does not scan non-smcl maint files', () => {
+        const my_ado = path.join(temp_dir, 'ado');
+        // Drop a help_alias.maint (which we intentionally ignore) next
+        // to a valid smcl_alias.maint.
+        const my_dir = path.join(my_ado, 'f');
+        fs.mkdirSync(my_dir, { recursive: true });
+        fs.writeFileSync(
+            path.join(my_dir, 'fhelp_alias.maint'),
+            'frexp   {manlink U 99 Should not be resolved}\n'
+        );
+
+        const resolver = new FindaliasResolver();
+        resolver.set_search_dirs([my_ado]);
+        expect(resolver.lookup('frexp')).toBeNull();
+    });
+});
+
+describe('HelpAliasResolver', () => {
+    let temp_dir: string;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'sight-helpalias-')
+        );
+    });
+
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    function write_help_alias(
+        ado_root: string,
+        letter: string,
+        lines: string[]
+    ): string {
+        const my_dir = path.join(ado_root, letter);
+        fs.mkdirSync(my_dir, { recursive: true });
+        const my_path = path.join(my_dir, `${letter}help_alias.maint`);
+        fs.writeFileSync(my_path, lines.join('\n') + '\n');
+        return my_path;
+    }
+
+    it('resolves a help-topic redirect (operators → operator)', () => {
+        const my_ado = path.join(temp_dir, 'ado');
+        write_help_alias(my_ado, 'o', ['operators\t\toperator']);
+
+        const resolver = new HelpAliasResolver();
+        resolver.set_search_dirs([my_ado]);
+
+        expect(resolver.lookup('operators')).toBe('operator');
+    });
+
+    it('returns null for an unknown alias', () => {
+        const my_ado = path.join(temp_dir, 'ado');
+        write_help_alias(my_ado, 'o', ['operators\t\toperator']);
+
+        const resolver = new HelpAliasResolver();
+        resolver.set_search_dirs([my_ado]);
+
+        expect(resolver.lookup('nope')).toBeNull();
+    });
+
+    it('treats lookups as case-sensitive', () => {
+        const my_ado = path.join(temp_dir, 'ado');
+        write_help_alias(my_ado, 'o', ['operators operator']);
+
+        const resolver = new HelpAliasResolver();
+        resolver.set_search_dirs([my_ado]);
+
+        expect(resolver.lookup('operators')).toBe('operator');
+        expect(resolver.lookup('OPERATORS')).toBeNull();
+    });
+
+    it('does not cross-read from smcl_alias.maint', () => {
+        // A stray entry in `*smcl_alias.maint` must not leak into
+        // help-alias lookups.
+        const my_ado = path.join(temp_dir, 'ado');
+        const my_dir = path.join(my_ado, 'o');
+        fs.mkdirSync(my_dir, { recursive: true });
+        fs.writeFileSync(
+            path.join(my_dir, 'osmcl_alias.maint'),
+            'operators   {manlink U 99 Should not be resolved}\n'
+        );
+
+        const resolver = new HelpAliasResolver();
+        resolver.set_search_dirs([my_ado]);
+        expect(resolver.lookup('operators')).toBeNull();
+    });
+
+    it('earlier search directory wins on duplicate aliases', () => {
+        const my_ado_a = path.join(temp_dir, 'ado-a');
+        const my_ado_b = path.join(temp_dir, 'ado-b');
+        write_help_alias(my_ado_a, 'o', ['operators from_a']);
+        write_help_alias(my_ado_b, 'o', ['operators from_b']);
+
+        const resolver = new HelpAliasResolver();
+        resolver.set_search_dirs([my_ado_a, my_ado_b]);
+        expect(resolver.lookup('operators')).toBe('from_a');
+
+        resolver.set_search_dirs([my_ado_b, my_ado_a]);
+        expect(resolver.lookup('operators')).toBe('from_b');
+    });
+
+    it('picks up on-disk edits via mtime invalidation', () => {
+        const my_ado = path.join(temp_dir, 'ado');
+        const my_file = write_help_alias(my_ado, 'o', [
+            'operators initial',
+        ]);
+
+        const resolver = new HelpAliasResolver();
+        resolver.set_search_dirs([my_ado]);
+        expect(resolver.lookup('operators')).toBe('initial');
+
+        const my_later_time = new Date(Date.now() + 5000);
+        fs.writeFileSync(my_file, 'operators updated\n');
+        fs.utimesSync(my_file, my_later_time, my_later_time);
+
+        expect(resolver.lookup('operators')).toBe('updated');
+    });
+});

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -165,6 +165,61 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             }
         });
 
+        it('should include a sight.openHelpTopic command link for built-in commands', async () => {
+            const my_content = 'generate x = 1';
+            const my_doc = create_test_document(my_content);
+            init_tracker_from_source(context_tracker, my_content);
+
+            const my_hover = await hover_provider.get_hover(
+                my_doc,
+                { line: 0, character: 2 }
+            );
+
+            expect(my_hover).not.toBeNull();
+            if (
+                typeof my_hover?.contents === 'object'
+                && 'value' in my_hover.contents
+            ) {
+                const my_value = my_hover.contents.value;
+                const my_expected_args =
+                    encodeURIComponent(JSON.stringify(['generate']));
+                expect(my_value).toContain(
+                    `(command:sight.openHelpTopic?${my_expected_args})`
+                );
+                expect(my_value).toContain('[help generate]');
+                // Legacy plain-text form should no longer appear.
+                expect(my_value).not.toContain('`help generate`');
+            }
+        });
+
+        it('should include a frame-subcommand help link using the space-joined topic', async () => {
+            command_db = create_frame_command_db();
+            hover_provider = new HoverProvider(command_db, context_tracker);
+
+            const my_content = 'frame create myframe';
+            const my_doc = create_test_document(my_content);
+            init_tracker_from_source(context_tracker, my_content);
+
+            const my_hover = await hover_provider.get_hover(
+                my_doc,
+                { line: 0, character: 8 }
+            );
+
+            expect(my_hover).not.toBeNull();
+            if (
+                my_hover
+                && typeof my_hover.contents === 'object'
+                && 'value' in my_hover.contents
+            ) {
+                const my_expected_args =
+                    encodeURIComponent(JSON.stringify(['frame create']));
+                expect(my_hover.contents.value).toContain(
+                    `(command:sight.openHelpTopic?${my_expected_args})`
+                );
+                expect(my_hover.contents.value).toContain('[help frame create]');
+            }
+        });
+
         it('should provide macro hover in Stata context', async () => {
             const my_content = 'local x = 5\nuse `x`';
             const my_doc = create_test_document(my_content, {

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -72,6 +72,57 @@ describe('WorkspaceIndexer', () => {
         expect(resolved).toBe(my_help_path);
     });
 
+    it('resolves .sthlp files under auto-discovered help search paths', async () => {
+        // Simulate a Stata install outside the workspace: the ado base
+        // directory with the letter-subdir layout.
+        const my_base = path.join(temp_dir, 'fake-stata', 'ado', 'base');
+        const my_letter_dir = path.join(my_base, 'i');
+        const my_help_path = path.join(my_letter_dir, 'include.sthlp');
+        fs.mkdirSync(my_letter_dir, { recursive: true });
+        fs.writeFileSync(my_help_path, '{smcl}');
+
+        // Initialize with a totally unrelated workspace so the topic
+        // can only be resolved via the help search paths.
+        const my_other_workspace = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'sight-other-')
+        );
+        try {
+            await indexer.initialize([my_other_workspace]);
+            indexer.set_help_search_paths([my_base]);
+
+            const resolved = await indexer.resolve_sthlp_file('include');
+
+            expect(resolved).toBe(my_help_path);
+        } finally {
+            fs.rmSync(my_other_workspace, { recursive: true, force: true });
+        }
+    });
+
+    it('prefers user ado_paths over auto-discovered help search paths', async () => {
+        // Both user and auto paths provide the same topic; user wins.
+        const my_user_dir = path.join(temp_dir, 'user-ado', 'r');
+        const my_user_help = path.join(my_user_dir, 'regress.sthlp');
+        fs.mkdirSync(my_user_dir, { recursive: true });
+        fs.writeFileSync(my_user_help, '{smcl}user version');
+
+        const my_auto_dir = path.join(temp_dir, 'auto-ado', 'r');
+        const my_auto_help = path.join(my_auto_dir, 'regress.sthlp');
+        fs.mkdirSync(my_auto_dir, { recursive: true });
+        fs.writeFileSync(my_auto_help, '{smcl}auto version');
+
+        await indexer.initialize(
+            [temp_dir],
+            [path.join(temp_dir, 'user-ado')]
+        );
+        indexer.set_help_search_paths([
+            path.join(temp_dir, 'auto-ado'),
+        ]);
+
+        const resolved = await indexer.resolve_sthlp_file('regress');
+
+        expect(resolved).toBe(my_user_help);
+    });
+
     it('should remove symbols when file is removed', async () => {
         const file_path = path.join(temp_dir, 'test.do');
         fs.writeFileSync(file_path, 'program define todelete\nend');

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -98,6 +98,25 @@ describe('WorkspaceIndexer', () => {
         }
     });
 
+    it('maps multi-word topics to underscore-joined .sthlp filenames', async () => {
+        // Stata convention: `{help regress postestimation}` lives in
+        // `regress_postestimation.sthlp`. The resolver should try both
+        // the literal topic and the underscore-joined form.
+        const my_ado_dir = path.join(temp_dir, 'ado', 'r');
+        const my_help_path = path.join(
+            my_ado_dir, 'regress_postestimation.sthlp'
+        );
+        fs.mkdirSync(my_ado_dir, { recursive: true });
+        fs.writeFileSync(my_help_path, '{smcl}');
+
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const resolved = await indexer.resolve_sthlp_file(
+            'regress postestimation'
+        );
+        expect(resolved).toBe(my_help_path);
+    });
+
     it('prefers user ado_paths over auto-discovered help search paths', async () => {
         // Both user and auto paths provide the same topic; user wins.
         const my_user_dir = path.join(temp_dir, 'user-ado', 'r');

--- a/tests/unit/resolve-findalias.test.ts
+++ b/tests/unit/resolve-findalias.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for the `sight/resolveFindalias` handler.
+ *
+ * Points a real `WorkspaceIndexer` at a temp ado directory with a
+ * synthetic `*smcl_alias.maint` and asserts the handler surfaces the
+ * alias's SMCL substitution (or null) as expected.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+    create_resolve_findalias_handler,
+    HandlerDependencies,
+} from '../../src/server-handlers';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { DocumentStore } from '../../src/document-store';
+
+function make_deps(workspace_indexer: WorkspaceIndexer | null): HandlerDependencies {
+    return {
+        debounce_manager: null,
+        document_store: new DocumentStore(),
+        diagnostics_provider: null,
+        completion_provider: null,
+        hover_provider: null,
+        definition_provider: null,
+        references_provider: null,
+        symbol_provider: null,
+        formatter_provider: null,
+        workspace_indexer,
+        scope_resolver: null,
+        forward_scope_resolver: null,
+        dependency_graph: null,
+        rename_handler: null,
+        get_document_settings: async () => ({} as any),
+        connection: {
+            sendDiagnostics: () => {},
+            console: { log: () => {} },
+        },
+    };
+}
+
+describe('resolveFindalias', () => {
+    let temp_dir: string;
+    let indexer: WorkspaceIndexer;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'sight-resolve-findalias-')
+        );
+        indexer = new WorkspaceIndexer();
+    });
+
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    function write_maint(letter: string, lines: string[]): string {
+        const my_dir = path.join(temp_dir, 'ado', letter);
+        fs.mkdirSync(my_dir, { recursive: true });
+        const my_path = path.join(my_dir, `${letter}smcl_alias.maint`);
+        fs.writeFileSync(my_path, lines.join('\n') + '\n');
+        return my_path;
+    }
+
+    it('returns the SMCL substitution for a known alias', async () => {
+        write_maint('f', [
+            'frexp                    {manlink U 13 Functions and expressions}',
+        ]);
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const handler = create_resolve_findalias_handler(make_deps(indexer));
+        const result = await handler({ alias: 'frexp' });
+
+        expect(result.smcl).toBe(
+            '{manlink U 13 Functions and expressions}'
+        );
+    });
+
+    it('returns null for an unknown alias', async () => {
+        write_maint('f', ['frexp payload']);
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const handler = create_resolve_findalias_handler(make_deps(indexer));
+        const result = await handler({ alias: 'not_a_real_alias' });
+
+        expect(result.smcl).toBeNull();
+    });
+
+    it('returns null when workspace_indexer is absent', async () => {
+        const handler = create_resolve_findalias_handler(make_deps(null));
+        const result = await handler({ alias: 'frexp' });
+        expect(result.smcl).toBeNull();
+    });
+
+    it('returns null for an empty alias', async () => {
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+        const handler = create_resolve_findalias_handler(make_deps(indexer));
+        const result = await handler({ alias: '' });
+        expect(result.smcl).toBeNull();
+    });
+});

--- a/tests/unit/resolve-sthlp-file.test.ts
+++ b/tests/unit/resolve-sthlp-file.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for the `sight/resolveSthlpFile` handler's ability to
+ * redirect a topic whose `.sthlp` file is named for a different
+ * command (e.g. `local` \u2192 `macro.sthlp`).
+ *
+ * The handler consults `command_database.lookup(topic).helpFile` after
+ * direct lookup fails, so these tests stub the singleton with a minimal
+ * cache and point a real `WorkspaceIndexer` at a temp ado directory
+ * that contains only the redirected file.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+    create_resolve_sthlp_file_handler,
+    HandlerDependencies,
+} from '../../src/server-handlers';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { DocumentStore } from '../../src/document-store';
+import { command_database } from '../../src/command-database';
+import type { CommandCache } from '../../src/command-database/types';
+
+function make_deps(workspace_indexer: WorkspaceIndexer): HandlerDependencies {
+    return {
+        debounce_manager: null,
+        document_store: new DocumentStore(),
+        diagnostics_provider: null,
+        completion_provider: null,
+        hover_provider: null,
+        definition_provider: null,
+        references_provider: null,
+        symbol_provider: null,
+        formatter_provider: null,
+        workspace_indexer,
+        scope_resolver: null,
+        forward_scope_resolver: null,
+        dependency_graph: null,
+        rename_handler: null,
+        get_document_settings: async () => ({} as any),
+        connection: {
+            sendDiagnostics: () => {},
+            console: { log: () => {} },
+        },
+    };
+}
+
+describe('resolveSthlpFile - help_file redirects', () => {
+    let temp_dir: string;
+    let indexer: WorkspaceIndexer;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sight-resolve-sthlp-'));
+        indexer = new WorkspaceIndexer();
+
+        // Load a minimal cache that mirrors the generator output:
+        // `local` and `global` are documented in `macro.sthlp`, so they
+        // carry a `help_file` pointer. `macro` itself is a regular
+        // entry whose name matches its file.
+        const the_cache: CommandCache = {
+            version: 18,
+            commands: {
+                local: {
+                    name: 'local',
+                    min_abbreviation: 3,
+                    options: [],
+                    priority: 1,
+                    help_file: 'macro',
+                },
+                global: {
+                    name: 'global',
+                    min_abbreviation: 2,
+                    options: [],
+                    priority: 1,
+                    help_file: 'macro',
+                },
+                macro: {
+                    name: 'macro',
+                    min_abbreviation: 2,
+                    options: [],
+                    priority: 2,
+                },
+                regress: {
+                    name: 'regress',
+                    min_abbreviation: 3,
+                    options: [],
+                    priority: 1,
+                },
+            },
+            abbreviations: {
+                loc: 'local',
+                loca: 'local',
+                gl: 'global',
+                glo: 'global',
+                glob: 'global',
+                globa: 'global',
+                reg: 'regress',
+            },
+        };
+        command_database.load_cache(the_cache);
+    });
+
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+        command_database.clear();
+    });
+
+    it('redirects `local` to macro.sthlp via helpFile', async () => {
+        // Temp ado dir contains only m/macro.sthlp (no l/local.sthlp),
+        // simulating the actual Stata layout.
+        const my_macro_dir = path.join(temp_dir, 'ado', 'm');
+        const my_macro_path = path.join(my_macro_dir, 'macro.sthlp');
+        fs.mkdirSync(my_macro_dir, { recursive: true });
+        fs.writeFileSync(my_macro_path, '{smcl}');
+
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const handler = create_resolve_sthlp_file_handler(make_deps(indexer));
+        const result = await handler({ topic: 'local' });
+
+        expect(result.file_path).toBe(my_macro_path);
+    });
+
+    it('redirects `global` to macro.sthlp via helpFile', async () => {
+        const my_macro_dir = path.join(temp_dir, 'ado', 'm');
+        const my_macro_path = path.join(my_macro_dir, 'macro.sthlp');
+        fs.mkdirSync(my_macro_dir, { recursive: true });
+        fs.writeFileSync(my_macro_path, '{smcl}');
+
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const handler = create_resolve_sthlp_file_handler(make_deps(indexer));
+        const result = await handler({ topic: 'global' });
+
+        expect(result.file_path).toBe(my_macro_path);
+    });
+
+    it('resolves `macro` itself directly without redirect', async () => {
+        const my_macro_dir = path.join(temp_dir, 'ado', 'm');
+        const my_macro_path = path.join(my_macro_dir, 'macro.sthlp');
+        fs.mkdirSync(my_macro_dir, { recursive: true });
+        fs.writeFileSync(my_macro_path, '{smcl}');
+
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const handler = create_resolve_sthlp_file_handler(make_deps(indexer));
+        const result = await handler({ topic: 'macro' });
+
+        expect(result.file_path).toBe(my_macro_path);
+    });
+
+    it('still resolves commands whose .sthlp file matches the name', async () => {
+        // Direct lookup path: `regress` \u2192 `regress.sthlp`.
+        const my_regress_dir = path.join(temp_dir, 'ado', 'r');
+        const my_regress_path = path.join(my_regress_dir, 'regress.sthlp');
+        fs.mkdirSync(my_regress_dir, { recursive: true });
+        fs.writeFileSync(my_regress_path, '{smcl}');
+
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const handler = create_resolve_sthlp_file_handler(make_deps(indexer));
+        const result = await handler({ topic: 'regress' });
+
+        expect(result.file_path).toBe(my_regress_path);
+    });
+
+    it('returns null when neither direct nor redirected topic resolves', async () => {
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const handler = create_resolve_sthlp_file_handler(make_deps(indexer));
+        const result = await handler({ topic: 'local' });
+
+        expect(result.file_path).toBeNull();
+    });
+
+    it('falls back to the parent help page for subcommand topics without their own file', async () => {
+        // `macro dir` has no dedicated `macro_dir.sthlp`; the handler
+        // should open `macro.sthlp` as the parent fallback.
+        const my_macro_dir = path.join(temp_dir, 'ado', 'm');
+        const my_macro_path = path.join(my_macro_dir, 'macro.sthlp');
+        fs.mkdirSync(my_macro_dir, { recursive: true });
+        fs.writeFileSync(my_macro_path, '{smcl}');
+
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const handler = create_resolve_sthlp_file_handler(make_deps(indexer));
+        const result = await handler({ topic: 'macro dir' });
+
+        expect(result.file_path).toBe(my_macro_path);
+    });
+});

--- a/tests/unit/resolve-sthlp-file.test.ts
+++ b/tests/unit/resolve-sthlp-file.test.ts
@@ -189,4 +189,44 @@ describe('resolveSthlpFile - help_file redirects', () => {
 
         expect(result.file_path).toBe(my_macro_path);
     });
+
+    it('follows a help_alias.maint redirect (operators → operator)', async () => {
+        // operators.sthlp does not exist; Stata ships a redirect in
+        // ohelp_alias.maint that the resolver must follow.
+        const my_op_dir = path.join(temp_dir, 'ado', 'o');
+        const my_op_path = path.join(my_op_dir, 'operator.sthlp');
+        fs.mkdirSync(my_op_dir, { recursive: true });
+        fs.writeFileSync(my_op_path, '{smcl}');
+        fs.writeFileSync(
+            path.join(my_op_dir, 'ohelp_alias.maint'),
+            'operators\t\toperator\n'
+        );
+
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const handler = create_resolve_sthlp_file_handler(make_deps(indexer));
+        const result = await handler({ topic: 'operators' });
+
+        expect(result.file_path).toBe(my_op_path);
+    });
+
+    it('returns null when a help-alias chain cycles back on itself', async () => {
+        // Malformed `.maint` files that alias a → b and b → a must not
+        // hang the resolver. The first filesystem lookup misses, the
+        // alias lookup points to `b`, that also has no file and aliases
+        // back to `a`, and the visited set breaks the loop.
+        const my_dir = path.join(temp_dir, 'ado', 'o');
+        fs.mkdirSync(my_dir, { recursive: true });
+        fs.writeFileSync(
+            path.join(my_dir, 'ohelp_alias.maint'),
+            'operators\toperators2\noperators2\toperators\n'
+        );
+
+        indexer.set_help_search_paths([path.join(temp_dir, 'ado')]);
+
+        const handler = create_resolve_sthlp_file_handler(make_deps(indexer));
+        const result = await handler({ topic: 'operators' });
+
+        expect(result.file_path).toBeNull();
+    });
 });

--- a/tests/unit/smcl-extractor.test.ts
+++ b/tests/unit/smcl-extractor.test.ts
@@ -757,6 +757,78 @@ describe('SMCL Command Extractor - Source File Tracking', () => {
     });
 });
 
+// ============================================================================
+// Tests for Provenance Flags Used by the Cache Generator
+// ============================================================================
+
+describe('SMCL Command Extractor - Provenance Flags', () => {
+    test('macro.sthlp marks local and global with has_viewerdialog=true', () => {
+        const result = extract_commands_from_content(
+            MACRO_STHLP_MOCK,
+            'macro.sthlp'
+        );
+
+        const my_local = result.commands.find(c => c.name === 'local');
+        const my_global = result.commands.find(c => c.name === 'global');
+        const my_tempvar = result.commands.find(c => c.name === 'tempvar');
+        expect(my_local?.has_viewerdialog).toBe(true);
+        expect(my_global?.has_viewerdialog).toBe(true);
+        expect(my_tempvar?.has_viewerdialog).toBe(true);
+    });
+
+    test('generate.sthlp marks replace with has_viewerdialog=true', () => {
+        const result = extract_commands_from_content(
+            GENERATE_STHLP_MOCK,
+            'generate.sthlp'
+        );
+
+        const my_replace = result.commands.find(c => c.name === 'replace');
+        expect(my_replace?.has_viewerdialog).toBe(true);
+    });
+
+    test('macro.sthlp marks cmdab commands as paragraph leads', () => {
+        const result = extract_commands_from_content(
+            MACRO_STHLP_MOCK,
+            'macro.sthlp'
+        );
+
+        const my_local = result.commands.find(c => c.name === 'local');
+        const my_global = result.commands.find(c => c.name === 'global');
+        const my_tempvar = result.commands.find(c => c.name === 'tempvar');
+        expect(my_local?.is_paragraph_lead).toBe(true);
+        expect(my_global?.is_paragraph_lead).toBe(true);
+        expect(my_tempvar?.is_paragraph_lead).toBe(true);
+    });
+
+    test('char-style inline {cmdab} is NOT marked as paragraph lead', () => {
+        // `{c -(}{cmdab:loc:al} | {cmdab:gl:obal}{c )-}` — the command
+        // appears inside an alternation, not at the paragraph start.
+        const CHAR_STYLE_INLINE_MOCK = [
+            '{smcl}',
+            '{p2col:{bf:[P] char} {hline 2}}Characteristics{p_end}',
+            '',
+            '{marker syntax}{...}',
+            '{title:Syntax}',
+            '',
+            '{p 8 25 2}{c -(}{cmdab:loc:al} | {cmdab:gl:obal}{c )-} {it:mname}'
+        ].join('\n');
+
+        const result = extract_commands_from_content(
+            CHAR_STYLE_INLINE_MOCK,
+            'char.sthlp'
+        );
+
+        const my_local = result.commands.find(c => c.name === 'local');
+        const my_global = result.commands.find(c => c.name === 'global');
+        // The extractor still picks them up (they're real cmdab tags),
+        // but they shouldn't be flagged as paragraph leads — that's the
+        // signal the cache generator uses to avoid writing
+        // `help_file: 'char'` for the `local` command.
+        expect(my_local?.is_paragraph_lead).toBe(false);
+        expect(my_global?.is_paragraph_lead).toBe(false);
+    });
+});
+
 
 // ============================================================================
 // Mock SMCL Content for Integration Tests

--- a/tests/unit/smcl-to-html.test.ts
+++ b/tests/unit/smcl-to-html.test.ts
@@ -595,14 +595,88 @@ describe('smcl_to_html', () => {
             );
         });
 
-        it('falls back to plain mansection text when the target does not match the single-entry pattern', () => {
+        it('resolves U-style section references to chapter PDFs with anchors', () => {
+            // Destinations verified against /manuals/u12.pdf.
             const result = smcl_to_html(
-                'see {mansection U 12.5 Formats:Formats}'
+                '{mansection U 12.5FormatsControllinghowdataaredisplayed:'
+                + '[U] 12.5 Formats: Controlling how data are displayed}'
             );
-            expect(result.html).not.toContain(
-                'href="https://www.stata.com/manuals/'
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/u12.pdf'
+                + '#u12.5FormatsControllinghowdataaredisplayed"'
             );
-            expect(result.html).toContain('Formats');
+        });
+    });
+
+    describe('{manlink} references', () => {
+        it('renders {manlink R display} as a help-topic link (sthlp route)', () => {
+            const result = smcl_to_html('see {manlink R display} for details');
+            expect(result.html).toContain('data-smcl-topic="display"');
+            // Displayed text keeps the `[R] display` shape.
+            expect(result.html).toContain('>[R] display</a>');
+            // Topic links should NOT become browser-opening PDF links.
+            expect(result.html).not.toContain('www.stata.com/manuals');
+        });
+
+        it('renders {manlink U 12.5Foo} as a PDF link (browse route)', () => {
+            const result = smcl_to_html(
+                '{manlink U 12.5FormatsControllinghowdataaredisplayed}'
+            );
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/u12.pdf'
+                + '#u12.5FormatsControllinghowdataaredisplayed"'
+            );
+            expect(result.html).toContain('smcl-browse');
+            expect(result.html).not.toContain('target="_blank"');
+        });
+
+        it('wraps {manlinki X Y} in <em> while still emitting a link', () => {
+            const result = smcl_to_html('{manlinki R display}');
+            expect(result.html).toContain('<em>');
+            expect(result.html).toContain('data-smcl-topic="display"');
+        });
+    });
+
+    describe('{bf:[X] name} inline manual references', () => {
+        it('makes `{bf:[R] regress}` a topic link (case preserved label)', () => {
+            const result = smcl_to_html(
+                'Use {bf:[R] regress} for ordinary least squares.'
+            );
+            expect(result.html).toContain(
+                '<strong><a class="smcl-help-link smcl-manlink-topic"'
+            );
+            expect(result.html).toContain('data-smcl-topic="regress"');
+            expect(result.html).toContain('>[R] regress</a>');
+        });
+
+        it('makes `{bf:[U] 12.5 Formats}` a PDF link', () => {
+            const result = smcl_to_html('see {bf:[U] 12.5 Formats}');
+            expect(result.html).toContain(
+                '<strong><a class="smcl-browse smcl-mansection smcl-manlink-pdf"'
+            );
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/u12.pdf#u12.5Formats"'
+            );
+            expect(result.html).toContain('>[U] 12.5 Formats</a>');
+        });
+
+        it('leaves unrelated `{bf:}` content as plain <strong>', () => {
+            const result = smcl_to_html('{bf:some bold words}');
+            // Content is wrapped in a data-line <span> for scroll
+            // sync; what matters is that no manlink anchor is added.
+            expect(result.html).toContain('<strong>');
+            expect(result.html).toContain('some bold words');
+            expect(result.html).not.toContain('smcl-manlink-topic');
+            expect(result.html).not.toContain('smcl-manlink-pdf');
+            expect(result.html).not.toContain('data-smcl-topic');
+        });
+
+        it('does not transform `{bf:}` content that contains nested markup', () => {
+            // Nested directive inside bf: render as plain bold (no topic).
+            const result = smcl_to_html('{bf:{it:[R] regress}}');
+            expect(result.html).not.toContain('smcl-manlink-topic');
+            expect(result.html).not.toContain('smcl-manlink-pdf');
+            expect(result.html).toContain('<strong>');
         });
     });
 

--- a/tests/unit/smcl-to-html.test.ts
+++ b/tests/unit/smcl-to-html.test.ts
@@ -966,7 +966,7 @@ describe('smcl_to_html', () => {
     });
 
     describe('findalias-driven help title', () => {
-        const the_map = new Map([
+        const my_findalias_map = new Map([
             ['froperators', '{manlink U 13.2 Operators}'],
             ['frexp', '{manlink U 13 Functions and expressions}'],
         ]);
@@ -974,7 +974,7 @@ describe('smcl_to_html', () => {
         it('renders {pstd}{findalias X} as a full help-title header', () => {
             const result = smcl_to_html(
                 '{title:Title}\n\n{pstd}\n{findalias froperators}\n\n{marker syntax}',
-                { findalias_map: the_map }
+                { findalias_map: my_findalias_map }
             );
             expect(result.html).toContain('smcl-help-title');
             expect(result.html).toContain('smcl-help-title-heading');
@@ -998,7 +998,7 @@ describe('smcl_to_html', () => {
         it('strips section numbers from multi-word entries', () => {
             const result = smcl_to_html(
                 '{pstd}\n{findalias frexp}\n\n{marker remarks}',
-                { findalias_map: the_map }
+                { findalias_map: my_findalias_map }
             );
             expect(result.html).toContain('>Functions and expressions<');
             expect(result.html).toContain(
@@ -1031,7 +1031,7 @@ describe('smcl_to_html', () => {
             // convention and we must not swallow the pstd paragraph.
             const result = smcl_to_html(
                 '{title:Description}\n\n{pstd}\n{findalias froperators}\n',
-                { findalias_map: the_map }
+                { findalias_map: my_findalias_map }
             );
             expect(result.html).not.toContain('smcl-help-title-heading');
             expect(result.html).toContain('Description');

--- a/tests/unit/smcl-to-html.test.ts
+++ b/tests/unit/smcl-to-html.test.ts
@@ -858,6 +858,46 @@ describe('smcl_to_html', () => {
         });
     });
 
+    describe('placeholder {title:Title}', () => {
+        it('strips a leading {title:Title} placeholder', () => {
+            const result = smcl_to_html('{title:Title}');
+            expect(result.html).not.toContain('smcl-title');
+            expect(result.html).not.toContain('Title');
+        });
+
+        it('keeps meaningful title headings intact', () => {
+            const result = smcl_to_html(
+                '{title:Syntax}\n{title:Title}'
+            );
+            // First title is "Syntax" (meaningful), so the scan stops
+            // there and the literal {title:Title} later in the doc is
+            // left alone.
+            expect(result.html).toContain('smcl-title');
+            expect(result.html).toContain('Syntax');
+            expect(result.html).toContain('Title');
+        });
+
+        it('strips {title:Title} even when preceded by trivia', () => {
+            const result = smcl_to_html(
+                '{smcl}\n{vieweralsosee "" "--"}\n{title:Title}\n{title:Remarks}'
+            );
+            // Only the placeholder is dropped; Remarks survives.
+            expect(result.html).toContain('Remarks');
+            // No literal "Title" heading remains.
+            expect(result.html).not.toMatch(/<h2[^>]*>Title<\/h2>/);
+        });
+
+        it('keeps {title:Title} that appears after other titles', () => {
+            const result = smcl_to_html(
+                '{title:Description}\n{title:Title}'
+            );
+            // The first title was not the placeholder, so we leave
+            // subsequent occurrences alone.
+            expect(result.html).toContain('Description');
+            expect(result.html).toContain('>Title<');
+        });
+    });
+
     describe('findalias substitution', () => {
         it('renders nothing when no findalias_map is provided', () => {
             const result = smcl_to_html('{findalias frexp}');
@@ -872,11 +912,17 @@ describe('smcl_to_html', () => {
         });
 
         it('substitutes and renders the alias target as SMCL', () => {
-            const result = smcl_to_html('{findalias frexp}', {
-                findalias_map: new Map([
-                    ['frexp', '{manlink U 13 Functions and expressions}'],
-                ]),
-            });
+            // A preceding `{marker}` prevents the findalias-driven
+            // help-title transform from kicking in, so this case
+            // exercises the raw inline substitution path.
+            const result = smcl_to_html(
+                '{marker body}\n{findalias frexp}',
+                {
+                    findalias_map: new Map([
+                        ['frexp', '{manlink U 13 Functions and expressions}'],
+                    ]),
+                }
+            );
             // `{manlink U 13 Functions and expressions}` renders as
             // a bolded PDF link (see render_manlink).
             expect(result.html).toContain('[U] 13 Functions and expressions');
@@ -887,8 +933,10 @@ describe('smcl_to_html', () => {
         });
 
         it('renders the substitution inline within surrounding SMCL', () => {
+            // As above: the `{marker}` keeps the findalias from being
+            // collapsed into a help-title header.
             const result = smcl_to_html(
-                '{pstd}\n{findalias frexp}\n{p_end}',
+                '{marker body}\n{pstd}\n{findalias frexp}\n{p_end}',
                 {
                     findalias_map: new Map([
                         ['frexp', '{manlink U 13 Functions and expressions}'],
@@ -910,6 +958,79 @@ describe('smcl_to_html', () => {
                 ]),
             });
             expect(result.html).toBe('');
+        });
+    });
+
+    describe('findalias-driven help title', () => {
+        const the_map = new Map([
+            ['froperators', '{manlink U 13.2 Operators}'],
+            ['frexp', '{manlink U 13 Functions and expressions}'],
+        ]);
+
+        it('renders {pstd}{findalias X} as a full help-title header', () => {
+            const result = smcl_to_html(
+                '{title:Title}\n\n{pstd}\n{findalias froperators}\n\n{marker syntax}',
+                { findalias_map: the_map }
+            );
+            expect(result.html).toContain('smcl-help-title');
+            expect(result.html).toContain('smcl-help-title-heading');
+            // Heading strips the leading section number ("13.2 ").
+            expect(result.html).toContain('>Operators<');
+            // Full manual reference appears as subtitle.
+            expect(result.html).toContain('[U] 13.2 Operators');
+            // PDF link with the standard label.
+            expect(result.html).toContain(
+                'View the complete manual entry (PDF, opens in browser)'
+            );
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/u13.pdf'
+            );
+            // The pstd paragraph itself should not survive, so we
+            // don't leak the original {findalias} rendering next to
+            // the header.
+            expect(result.html).not.toContain('smcl-pstd');
+        });
+
+        it('strips section numbers from multi-word entries', () => {
+            const result = smcl_to_html(
+                '{pstd}\n{findalias frexp}\n\n{marker remarks}',
+                { findalias_map: the_map }
+            );
+            expect(result.html).toContain('>Functions and expressions<');
+            expect(result.html).toContain(
+                '[U] 13 Functions and expressions'
+            );
+        });
+
+        it('leaves the tree alone when the findalias_map is absent', () => {
+            const result = smcl_to_html(
+                '{pstd}\n{findalias froperators}\n\n{marker syntax}'
+            );
+            expect(result.html).not.toContain('smcl-help-title');
+        });
+
+        it('leaves the tree alone when the substitution is not a manlink', () => {
+            const result = smcl_to_html(
+                '{pstd}\n{findalias asfroperators}\n\n{marker syntax}',
+                {
+                    findalias_map: new Map([
+                        ['asfroperators', '{vieweralsosee "[U] 13.2 Operators" "mansection U 13.2Operators"}'],
+                    ]),
+                }
+            );
+            expect(result.html).not.toContain('smcl-help-title');
+        });
+
+        it('leaves the tree alone when a real title precedes the findalias', () => {
+            // If some other meaningful title (e.g. `Description`)
+            // appears first, the file isn't using the placeholder
+            // convention and we must not swallow the pstd paragraph.
+            const result = smcl_to_html(
+                '{title:Description}\n\n{pstd}\n{findalias froperators}\n',
+                { findalias_map: the_map }
+            );
+            expect(result.html).not.toContain('smcl-help-title-heading');
+            expect(result.html).toContain('Description');
         });
     });
 

--- a/tests/unit/smcl-to-html.test.ts
+++ b/tests/unit/smcl-to-html.test.ts
@@ -256,12 +256,16 @@ describe('smcl_to_html', () => {
             expect(result.cross_references).toHaveLength(1);
         });
 
-        it('renders {browse URL} as external link', () => {
+        it('renders {browse URL} as external link without target="_blank"', () => {
+            // The webview click handler routes browse clicks to
+            // `vscode.env.openExternal`. Keeping `target="_blank"` on
+            // the anchor would make VS Code also open the URL via its
+            // native link interception, producing a duplicate prompt.
             const result = smcl_to_html(
                 '{browse https://stata.com}'
             );
             expect(result.html).toContain('href="https://stata.com"');
-            expect(result.html).toContain('target="_blank"');
+            expect(result.html).not.toContain('target="_blank"');
         });
 
         it('renders {browse URL:text} with display text', () => {
@@ -305,12 +309,63 @@ describe('smcl_to_html', () => {
             expect(result.html).toContain('id="syntax"');
         });
 
-        it('renders {viewerjumpto} as in-page link', () => {
-            const result = smcl_to_html(
-                '{viewerjumpto "Syntax" "regress##syntax"}'
+        it('suppresses preamble {viewerjumpto}, {vieweralsosee}, and {viewerdialog} metadata', () => {
+            // These directives feed Stata's native viewer toolbar / See
+            // Also sidebar. Rendering them inline produces a wall of
+            // raw quoted args above the real title, so we drop them
+            // until a proper chrome lands (tracked upstream).
+            const my_preamble =
+                '{viewerjumpto "Syntax" "regress##syntax"}{...}\n' +
+                '{viewerjumpto "Description" "regress##description"}{...}\n' +
+                '{vieweralsosee "[D] dir" "mansection D dir"}{...}\n' +
+                '{vieweralsosee "" "--"}{...}\n' +
+                '{vieweralsosee "[D] cd" "help cd"}{...}\n' +
+                '{viewerdialog regress "dialog regress"}{...}';
+            const result = smcl_to_html(my_preamble);
+            // All visible text should be whitespace; the only surviving
+            // markup is the data-line wrappers around the newlines
+            // between directives.
+            const my_visible = result.html
+                .replace(/<[^>]+>/g, '')
+                .trim();
+            expect(my_visible).toBe('');
+            expect(result.html).not.toContain('href="#');
+            expect(result.html).not.toContain('mansection');
+            expect(result.html).not.toContain('help cd');
+        });
+
+        it('hides the preamble while preserving the title row for a real .sthlp header', () => {
+            // Verbatim top of /Applications/Stata/ado/base/d/dir.sthlp
+            // plus the title row; we expect the garbage above the title
+            // to be gone while the title text is rendered.
+            const my_header =
+                '{smcl}\n' +
+                '{* *! version 1.1.8  03sep2020}{...}\n' +
+                '{vieweralsosee "[D] dir" "mansection D dir"}{...}\n' +
+                '{vieweralsosee "" "--"}{...}\n' +
+                '{vieweralsosee "[D] cd" "help cd"}{...}\n' +
+                '{viewerjumpto "Syntax" "dir##syntax"}{...}\n' +
+                '{viewerjumpto "Description" "dir##description"}{...}\n' +
+                '{p2colset 1 12 14 2}{...}\n' +
+                '{p2col:{bf:[D] dir} {hline 2}}Display filenames{p_end}\n' +
+                '{p2colreset}{...}';
+            const result = smcl_to_html(my_header);
+            // Title row is now rendered as a heading with just the
+            // entry name; the [D] manual reference is suppressed.
+            expect(result.html).toContain(
+                '<h1 class="smcl-help-title-heading">dir</h1>'
             );
-            expect(result.html).toContain('href="#syntax"');
-            expect(result.html).toContain('Syntax</a>');
+            expect(result.html).not.toContain('[D]');
+            expect(result.html).toContain('Display filenames');
+            // None of the preamble directive args should leak into the
+            // rendered output.
+            expect(result.html).not.toContain('mansection D dir');
+            expect(result.html).not.toContain('help cd');
+            expect(result.html).not.toContain('dir##syntax');
+            expect(result.html).not.toContain('Links to PDF documentation');
+            // Literal quoted pair (from vieweralsosee "" "--") must not
+            // render either.
+            expect(result.html).not.toContain('"--"');
         });
     });
 
@@ -383,6 +438,171 @@ describe('smcl_to_html', () => {
             const my_table_end = result.html.lastIndexOf('</table>');
             const my_after = result.html.indexOf('After table');
             expect(my_after).toBeGreaterThan(my_table_end);
+        });
+
+        it('drops whitespace-only text between synopt rows', () => {
+            // Blank lines between {synopt:...}{p_end} rows would
+            // otherwise be emitted as text children of <table>, which
+            // the HTML parser foster-parents out of the table and
+            // stacks visually above it as blank lines.
+            const result = smcl_to_html(
+                '{synoptset 32}\n' +
+                '{synopt:{opt a}}first{p_end}\n' +
+                '\n' +
+                '{synopt:{opt b}}second{p_end}\n' +
+                '\n' +
+                '{synopt:{opt c}}third{p_end}\n' +
+                '{p2colreset}'
+            );
+            // No whitespace-only <span> should appear directly
+            // between </tr> and the next <tr>.
+            expect(result.html).not.toMatch(/<\/tr><span[^>]*>\s*<\/span><tr/);
+            // Rows should be contiguous (no other node in between).
+            const my_between_rows = result.html.match(
+                /<\/tr>([\s\S]*?)<tr/g
+            );
+            expect(my_between_rows).not.toBeNull();
+            for (const my_match of my_between_rows!) {
+                expect(my_match).toBe('</tr><tr');
+            }
+        });
+
+        it('drops whitespace-only text between p2col rows', () => {
+            const result = smcl_to_html(
+                '{p2colset 5 19 21 2}\n' +
+                '{p2col:{cmd:a}}desc a{p_end}\n' +
+                '\n' +
+                '{p2col:{cmd:b}}desc b{p_end}\n' +
+                '{p2colreset}'
+            );
+            expect(result.html).not.toMatch(/<\/tr><span[^>]*>\s*<\/span><tr/);
+        });
+    });
+
+    describe('help-file title block', () => {
+        it('collapses the standard title p2colset into a heading with a PDF manual link', () => {
+            const my_header =
+                '{smcl}\n' +
+                '{p2colset 1 12 14 2}{...}\n' +
+                '{p2col:{bf:[P] display} {hline 2}}Display strings and values of scalar expressions{p_end}\n' +
+                '{p2col:}({mansection P display:View complete PDF manual entry}){p_end}\n' +
+                '{p2colreset}{...}';
+            const result = smcl_to_html(my_header);
+
+            expect(result.html).toContain('<header class="smcl-help-title"');
+            // The heading shows just the entry name; the `[P]` manual
+            // reference is noise to most users and is intentionally
+            // stripped.
+            expect(result.html).toContain(
+                '<h1 class="smcl-help-title-heading">display</h1>'
+            );
+            expect(result.html).not.toContain('[P]');
+            expect(result.html).not.toContain('smcl-manual-ref');
+            expect(result.html).toContain(
+                '<p class="smcl-help-subtitle">Display strings and values of scalar expressions</p>'
+            );
+            // PDF manual link resolves to Stata's online manual and
+            // routes through the webview's openExternal handler.
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/pdisplay.pdf"'
+            );
+            expect(result.html).not.toContain('target="_blank"');
+            // The visible label is overridden to make it clear that
+            // clicking leaves VS Code and opens a PDF in the user's
+            // browser.
+            expect(result.html).toContain(
+                'View the complete manual entry (PDF, opens in browser)</a>'
+            );
+            expect(result.html).not.toContain(
+                'View complete PDF manual entry</a>'
+            );
+            expect(result.html).not.toContain('smcl-p2col-table');
+        });
+
+        it('handles multi-word entries such as frame create', () => {
+            const my_header =
+                '{p2colset 1 16 18 2}{...}\n' +
+                '{p2col:{bf:[D] frame create} {hline 2}}Create a new frame{p_end}\n' +
+                '{p2col:}({mansection D framecreate:View complete PDF manual entry}){p_end}\n' +
+                '{p2colreset}{...}';
+            const result = smcl_to_html(my_header);
+            expect(result.html).toContain(
+                '<h1 class="smcl-help-title-heading">frame create</h1>'
+            );
+            expect(result.html).not.toContain('[D]');
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/dframecreate.pdf"'
+            );
+        });
+
+        it('falls back to a normal p2col table when the first row is not a title', () => {
+            // No `{bf:[X] name}` in the first column → render as table.
+            const my_body =
+                '{p2colset 5 19 21 2}\n' +
+                '{p2col:{cmd:regress}}Linear regression{p_end}\n' +
+                '{p2col:{cmd:logit}}Logistic regression{p_end}\n' +
+                '{p2colreset}';
+            const result = smcl_to_html(my_body);
+            expect(result.html).toContain('smcl-p2col-table');
+            expect(result.html).not.toContain('smcl-help-title');
+        });
+
+        it('renders an inline {mansection} as a link outside of the title block', () => {
+            const result = smcl_to_html(
+                'see {mansection P display:the Programming manual}'
+            );
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/pdisplay.pdf"'
+            );
+            // target="_blank" would cause VS Code to race the native
+            // link handler with our postMessage route — the link
+            // should rely solely on the webview click handler.
+            expect(result.html).not.toContain('target="_blank"');
+            expect(result.html).toContain('the Programming manual</a>');
+        });
+
+        it('deep-links mansection subsection targets to the case-preserved PDF destination', () => {
+            // `{mansection P displayRemarksandexamples:Remarks and examples}`
+            // must resolve to `pdisplay.pdf#pdisplayRemarksandexamples`
+            // (case preserved). The destination name was confirmed by
+            // parsing stata.com's published PDF.
+            const result = smcl_to_html(
+                '{mansection P displayRemarksandexamples:Remarks and examples}'
+            );
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/pdisplay.pdf#pdisplayRemarksandexamples"'
+            );
+            // Case-preservation is the whole point — the previous
+            // lowercased form doesn't match the PDF's named
+            // destination and landed on page 1.
+            expect(result.html).not.toContain(
+                'pdisplay.pdf#pdisplayremarksandexamples'
+            );
+            // And the broken `pdisplayremarksandexamples.pdf` guess
+            // must not resurface.
+            expect(result.html).not.toContain(
+                'pdisplayremarksandexamples.pdf'
+            );
+            expect(result.html).toContain('Remarks and examples</a>');
+        });
+
+        it('preserves case for mansection anchors across manuals (rregress)', () => {
+            const result = smcl_to_html(
+                '{mansection R regressMethodsandformulas:Methods and formulas}'
+            );
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/rregress.pdf#rregressMethodsandformulas"'
+            );
+        });
+
+        it('falls back to plain mansection text when the target does not match the single-entry pattern', () => {
+            const result = smcl_to_html(
+                'see {mansection U 12.5 Formats:Formats}'
+            );
+            expect(result.html).not.toContain(
+                'href="https://www.stata.com/manuals/'
+            );
+            expect(result.html).toContain('Formats');
         });
     });
 
@@ -565,10 +785,13 @@ describe('smcl_to_html', () => {
             ].join('\n');
 
             const result = smcl_to_html(smcl);
-            expect(result.html).toContain('href="#syntax"');
-            expect(result.html).toContain('href="#options"');
+            // {viewerjumpto} metadata is suppressed until a dedicated
+            // TOC is implemented; the title row is now rendered as a
+            // heading block rather than a <strong> cell.
+            expect(result.html).not.toContain('href="#syntax"');
+            expect(result.html).not.toContain('href="#options"');
             expect(result.html).toContain('<hr');
-            expect(result.html).toContain('<strong>');
+            expect(result.html).toContain('smcl-help-title-heading');
             expect(result.html).toContain('Linear regression');
         });
     });

--- a/tests/unit/smcl-to-html.test.ts
+++ b/tests/unit/smcl-to-html.test.ts
@@ -858,6 +858,61 @@ describe('smcl_to_html', () => {
         });
     });
 
+    describe('findalias substitution', () => {
+        it('renders nothing when no findalias_map is provided', () => {
+            const result = smcl_to_html('{findalias frexp}');
+            expect(result.html).toBe('');
+        });
+
+        it('renders nothing when the alias is not in the map', () => {
+            const result = smcl_to_html('{findalias unknown}', {
+                findalias_map: new Map([['frexp', '{manlink U 13 Functions and expressions}']]),
+            });
+            expect(result.html).toBe('');
+        });
+
+        it('substitutes and renders the alias target as SMCL', () => {
+            const result = smcl_to_html('{findalias frexp}', {
+                findalias_map: new Map([
+                    ['frexp', '{manlink U 13 Functions and expressions}'],
+                ]),
+            });
+            // `{manlink U 13 Functions and expressions}` renders as
+            // a bolded PDF link (see render_manlink).
+            expect(result.html).toContain('[U] 13 Functions and expressions');
+            expect(result.html).toContain('<strong>');
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/u13.pdf'
+            );
+        });
+
+        it('renders the substitution inline within surrounding SMCL', () => {
+            const result = smcl_to_html(
+                '{pstd}\n{findalias frexp}\n{p_end}',
+                {
+                    findalias_map: new Map([
+                        ['frexp', '{manlink U 13 Functions and expressions}'],
+                    ]),
+                }
+            );
+            expect(result.html).toContain('smcl-pstd');
+            expect(result.html).toContain('[U] 13 Functions and expressions');
+        });
+
+        it('guards against recursive substitution', () => {
+            // `a` expands to `{findalias b}`, `b` expands back to
+            // `{findalias a}`. The renderer must short-circuit the
+            // second recurrence instead of looping forever.
+            const result = smcl_to_html('{findalias a}', {
+                findalias_map: new Map([
+                    ['a', '{findalias b}'],
+                    ['b', '{findalias a}'],
+                ]),
+            });
+            expect(result.html).toBe('');
+        });
+    });
+
     describe('mixed real-world content', () => {
         it('handles a typical help file header', () => {
             const smcl = [

--- a/tests/unit/smcl-to-html.test.ts
+++ b/tests/unit/smcl-to-html.test.ts
@@ -609,13 +609,21 @@ describe('smcl_to_html', () => {
     });
 
     describe('{manlink} references', () => {
-        it('renders {manlink R display} as a help-topic link (sthlp route)', () => {
+        it('renders {manlink R display} as a Reference Manual PDF link', () => {
+            // Matches Stata's native viewer behavior: `{manlink R display}`
+            // opens the R Reference Manual PDF entry, not the display
+            // sthlp help file (which would just re-reveal the page the
+            // user is already viewing).
             const result = smcl_to_html('see {manlink R display} for details');
-            expect(result.html).toContain('data-smcl-topic="display"');
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/rdisplay.pdf"'
+            );
+            expect(result.html).toContain('smcl-manlink-pdf');
             // Displayed text keeps the `[R] display` shape.
             expect(result.html).toContain('>[R] display</a>');
-            // Topic links should NOT become browser-opening PDF links.
-            expect(result.html).not.toContain('www.stata.com/manuals');
+            // PDF-routed manlinks should not emit an internal navigate.
+            expect(result.html).not.toContain('data-smcl-topic');
+            expect(result.html).not.toContain('target="_blank"');
         });
 
         it('renders {manlink U 12.5Foo} as a PDF link (browse route)', () => {
@@ -630,23 +638,29 @@ describe('smcl_to_html', () => {
             expect(result.html).not.toContain('target="_blank"');
         });
 
-        it('wraps {manlinki X Y} in <em> while still emitting a link', () => {
+        it('wraps {manlinki X Y} in <em> while still emitting a PDF link', () => {
             const result = smcl_to_html('{manlinki R display}');
             expect(result.html).toContain('<em>');
-            expect(result.html).toContain('data-smcl-topic="display"');
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/rdisplay.pdf"'
+            );
+            expect(result.html).not.toContain('data-smcl-topic');
         });
     });
 
     describe('{bf:[X] name} inline manual references', () => {
-        it('makes `{bf:[R] regress}` a topic link (case preserved label)', () => {
+        it('makes `{bf:[R] regress}` a Reference Manual PDF link', () => {
             const result = smcl_to_html(
                 'Use {bf:[R] regress} for ordinary least squares.'
             );
             expect(result.html).toContain(
-                '<strong><a class="smcl-help-link smcl-manlink-topic"'
+                '<strong><a class="smcl-browse smcl-mansection smcl-manlink-pdf"'
             );
-            expect(result.html).toContain('data-smcl-topic="regress"');
+            expect(result.html).toContain(
+                'href="https://www.stata.com/manuals/rregress.pdf"'
+            );
             expect(result.html).toContain('>[R] regress</a>');
+            expect(result.html).not.toContain('data-smcl-topic');
         });
 
         it('makes `{bf:[U] 12.5 Formats}` a PDF link', () => {

--- a/tests/unit/smcl-to-html.test.ts
+++ b/tests/unit/smcl-to-html.test.ts
@@ -325,9 +325,13 @@ describe('smcl_to_html', () => {
             // All visible text should be whitespace; the only surviving
             // markup is the data-line wrappers around the newlines
             // between directives.
-            const my_visible = result.html
-                .replace(/<[^>]+>/g, '')
-                .trim();
+            let my_visible = result.html;
+            let my_prev: string;
+            do {
+                my_prev = my_visible;
+                my_visible = my_visible.replace(/<[^>]+>/g, '');
+            } while (my_visible !== my_prev);
+            my_visible = my_visible.trim();
             expect(my_visible).toBe('');
             expect(result.html).not.toContain('href="#');
             expect(result.html).not.toContain('mansection');

--- a/tests/unit/stata-install-paths.test.ts
+++ b/tests/unit/stata-install-paths.test.ts
@@ -190,31 +190,22 @@ describe('discover_stata_ado_paths', () => {
     });
 
     it('deduplicates candidate paths that resolve to the same absolute path', () => {
-        let the_query_count = 0;
+        const the_unique_queries = new Set<string>();
+        let the_total_queries = 0;
         const the_paths = discover_stata_ado_paths({
             home: '/Users/me',
             platform: 'darwin',
             env: {},
             exists: candidate => {
-                the_query_count++;
+                the_total_queries++;
+                the_unique_queries.add(candidate);
                 return candidate === '/Applications/Stata/ado/base';
             },
         });
         // Only existing path makes it into the result.
         expect(the_paths).toEqual(['/Applications/Stata/ado/base']);
-        // Dedup means each normalized candidate is queried at most once.
-        const the_unique_queries = new Set<string>();
-        // Re-run to count unique queries deterministically.
-        discover_stata_ado_paths({
-            home: '/Users/me',
-            platform: 'darwin',
-            env: {},
-            exists: candidate => {
-                the_unique_queries.add(candidate);
-                return false;
-            },
-        });
+        // Each normalized candidate should be probed at most once.
         expect(the_unique_queries.size).toBeGreaterThan(0);
-        expect(the_query_count).toBeGreaterThan(0);
+        expect(the_total_queries).toBe(the_unique_queries.size);
     });
 });

--- a/tests/unit/stata-install-paths.test.ts
+++ b/tests/unit/stata-install-paths.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for `discover_stata_ado_paths`.
+ *
+ * Uses injected `home`, `platform`, `env`, and `exists` so the tests
+ * are deterministic regardless of the machine they run on.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import * as path from 'path';
+import { discover_stata_ado_paths } from '../../src/utils/stata-install-paths';
+
+function make_exists(
+    the_present_paths: string[],
+    my_path: typeof path.posix | typeof path.win32 = path.posix
+): (p: string) => boolean {
+    const my_normalized = new Set(
+        the_present_paths.map(p => my_path.resolve(p))
+    );
+    return (candidate: string) => my_normalized.has(my_path.resolve(candidate));
+}
+
+describe('discover_stata_ado_paths', () => {
+    it('returns an empty list when no candidate directories exist', () => {
+        const the_paths = discover_stata_ado_paths({
+            home: '/home/user',
+            platform: 'linux',
+            exists: () => false,
+            env: {},
+        });
+        expect(the_paths).toEqual([]);
+    });
+
+    describe('macOS', () => {
+        it('picks up the canonical /Applications/Stata install dir', () => {
+            const the_present = [
+                '/Applications/Stata/ado/base',
+                '/Applications/Stata/ado/site',
+                '/Applications/Stata/ado/updates',
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: '/Users/me',
+                platform: 'darwin',
+                exists: make_exists(the_present),
+                env: {},
+            });
+            expect(the_paths).toEqual(the_present);
+        });
+
+        it('includes the modern Library Application Support PERSONAL dir', () => {
+            const the_present = [
+                '/Users/me/Library/Application Support/Stata/ado/personal',
+                '/Users/me/Library/Application Support/Stata/ado/plus',
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: '/Users/me',
+                platform: 'darwin',
+                exists: make_exists(the_present),
+                env: {},
+            });
+            expect(the_paths).toEqual(the_present);
+        });
+
+        it('covers legacy ~/ado/personal alongside the modern Library dir', () => {
+            const the_present = [
+                '/Users/me/ado/personal',
+                '/Users/me/Library/Application Support/Stata/ado/plus',
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: '/Users/me',
+                platform: 'darwin',
+                exists: make_exists(the_present),
+                env: {},
+            });
+            expect(the_paths).toEqual(the_present);
+        });
+
+        it('considers Stata variants like StataMP and StataSE', () => {
+            const the_present = [
+                '/Applications/StataMP/ado/base',
+                '/Applications/StataSE/ado/base',
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: '/Users/me',
+                platform: 'darwin',
+                exists: make_exists(the_present),
+                env: {},
+            });
+            expect(the_paths).toContain('/Applications/StataMP/ado/base');
+            expect(the_paths).toContain('/Applications/StataSE/ado/base');
+        });
+    });
+
+    describe('Linux', () => {
+        it('picks up /usr/local/stata<version>/ado/base', () => {
+            const the_present = [
+                '/usr/local/stata18/ado/base',
+                '/usr/local/stata18/ado/site',
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: '/home/user',
+                platform: 'linux',
+                exists: make_exists(the_present),
+                env: {},
+            });
+            expect(the_paths).toEqual(the_present);
+        });
+
+        it('falls back to /opt prefix and unversioned directories', () => {
+            const the_present = [
+                '/opt/stata/ado/base',
+                '/opt/stata17/ado/base',
+                '/home/user/ado/personal',
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: '/home/user',
+                platform: 'linux',
+                exists: make_exists(the_present),
+                env: {},
+            });
+            // Order: user paths first, then system, newest version first.
+            expect(the_paths[0]).toBe('/home/user/ado/personal');
+            expect(the_paths).toContain('/opt/stata17/ado/base');
+            expect(the_paths).toContain('/opt/stata/ado/base');
+            const my_stata17_idx = the_paths.indexOf('/opt/stata17/ado/base');
+            const my_stata_unversioned_idx = the_paths.indexOf('/opt/stata/ado/base');
+            expect(my_stata17_idx).toBeLessThan(my_stata_unversioned_idx);
+        });
+
+        it('does not include macOS-only Library paths on Linux', () => {
+            const the_present = [
+                '/home/user/Library/Application Support/Stata/ado/personal',
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: '/home/user',
+                platform: 'linux',
+                exists: make_exists(the_present),
+                env: {},
+            });
+            expect(the_paths).toEqual([]);
+        });
+    });
+
+    describe('Windows', () => {
+        it('honours ProgramFiles / ProgramW6432 / ProgramFiles(x86) env vars', () => {
+            const my_env = {
+                ProgramFiles: 'D:\\Programs',
+                ProgramW6432: 'D:\\Programs',
+                'ProgramFiles(x86)': 'D:\\Programs (x86)',
+            };
+            const the_present = [
+                path.win32.resolve('D:\\Programs\\Stata18\\ado\\base'),
+                path.win32.resolve('D:\\Programs (x86)\\Stata17\\ado\\base'),
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: 'C:\\Users\\me',
+                platform: 'win32',
+                exists: make_exists(the_present, path.win32),
+                env: my_env,
+            });
+            expect(the_paths).toEqual(the_present);
+        });
+
+        it('uses sensible defaults when Program Files env vars are missing', () => {
+            const the_present = [
+                path.win32.resolve('C:\\Program Files\\Stata18\\ado\\base'),
+                path.win32.resolve('C:\\Program Files (x86)\\Stata17\\ado\\base'),
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: 'C:\\Users\\me',
+                platform: 'win32',
+                exists: make_exists(the_present, path.win32),
+                env: {},
+            });
+            expect(the_paths).toEqual(the_present);
+        });
+
+        it('includes the home-directory ~/ado conventions on Windows too', () => {
+            const the_present = [
+                path.win32.resolve('C:\\Users\\me\\ado\\personal'),
+                path.win32.resolve('C:\\Users\\me\\ado\\plus'),
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: 'C:\\Users\\me',
+                platform: 'win32',
+                exists: make_exists(the_present, path.win32),
+                env: {},
+            });
+            expect(the_paths).toEqual(the_present);
+        });
+    });
+
+    it('deduplicates candidate paths that resolve to the same absolute path', () => {
+        let the_query_count = 0;
+        const the_paths = discover_stata_ado_paths({
+            home: '/Users/me',
+            platform: 'darwin',
+            env: {},
+            exists: candidate => {
+                the_query_count++;
+                return candidate === '/Applications/Stata/ado/base';
+            },
+        });
+        // Only existing path makes it into the result.
+        expect(the_paths).toEqual(['/Applications/Stata/ado/base']);
+        // Dedup means each normalized candidate is queried at most once.
+        const the_unique_queries = new Set<string>();
+        // Re-run to count unique queries deterministically.
+        discover_stata_ado_paths({
+            home: '/Users/me',
+            platform: 'darwin',
+            env: {},
+            exists: candidate => {
+                the_unique_queries.add(candidate);
+                return false;
+            },
+        });
+        expect(the_unique_queries.size).toBeGreaterThan(0);
+        expect(the_query_count).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Summary

Adds an in-editor help viewer so users can read Stata `.sthlp` pages without leaving VS Code. Hovers, completions, and a new palette command emit clickable `[help <topic>]` links that resolve a topic to its help file and open it in the SMCL preview panel.

## Highlights

**Help-link plumbing**
- Hover/completion markdown emits `command:sight.openHelpTopic?<args>` URIs, with narrow client middleware that trusts only that one command.
- New `Sight: Open Help Topic` palette command (prompts for a topic via `showInputBox` when invoked without an argument).
- Inline manual references (`{manlink ...}`, `{bf:[X] name}`) route to stata.com manual PDFs; lowercase help topics open the `.sthlp` in the preview panel.

**Topic resolution**
- Cross-platform auto-discovery of common Stata install paths (`/Applications/Stata/ado/{base,site,updates}`, `/usr/local/stata<N>`, `C:\Program Files\Stata<N>`, `~/ado/{personal,plus}`, `~/Library/Application Support/Stata/ado/`). User-configured `sight.adoPaths` still wins.
- `sight/resolveSthlpFile` understands abbreviations, multi-word topics (spaces -> underscores), and falls back to abbreviation expansion ranked by Stata priority tier (so `reg` -> `regress`, `di` -> `display`, `gen` -> `generate`).
- Persists "which `.sthlp` actually documents this command" in the command-database cache via a new `helpFile` pointer, so `help local`, `help global`, `help replace`, `help noisily`, etc. resolve to their real home (`macro.sthlp`, `generate.sthlp`, `quietly.sthlp`).
- Resolves Stata's `.maint` alias files via a new `MaintAliasStore`: `FindaliasResolver` (`smcl_alias.maint`) backs `sight/resolveFindalias`, and `HelpAliasResolver` (`help_alias.maint`) is consulted by the workspace indexer after the filesystem lookup misses.
- Abbreviated subcommand heads resolve through the expanded parent name (`mac dir` -> `macro.sthlp`, `fr drop` -> `frame.sthlp`).

**SMCL renderer improvements**
- Help-title preprocessor turns the top-of-file `{p2colset}...{p2colreset}` block into a clean `<header><h1>` with a subtitle and a "View the complete manual entry (PDF, opens in browser)" link.
- `findalias`-style title pages (e.g. `exp.sthlp`, `operator.sthlp`) collapse their `{title:Title}` + `{pstd}{findalias X}` preamble into the same synthesized title block.
- `{mansection}` -> stata.com PDF link with a case-preserved named-destination anchor (URL convention reverse-engineered from `/Applications/Stata/docs/*.pdf`).
- `findalias` substitutions resolve transitively (up to 5 rounds) with cycle guards and a seen-set.
- Suppresses noisy preamble directives, drops whitespace-only nodes between synopt/p2col rows, and stops table cells from inheriting `white-space: pre-wrap`.
- Async refresh guarded by a monotonic sequence token to prevent stale previews when a slower older render lands after a newer one.

**Diagnostics**
- The not-found notification names the paths Sight searched and offers an "Open Settings" button that jumps to `sight.adoPaths`.

## Tests
- 30+ new tests covering the help-title block, `mansection` URL construction, install-path auto-discovery, indexer help-path wiring, `findalias` resolution end-to-end, and a no-foster-parented-whitespace regression.
- New `tests/integration/help-topic-coverage.test.ts` walks every cached command and `STATA_EXPRESSION_FUNCTIONS` entry through the real resolver when a Stata install is detected.
- Cache regenerated: 1648 -> 1672 commands, with `helpFile` pointers populated.

## Test plan
- [ ] Hover a command and click `[help <topic>]` -> opens preview to the right
- [ ] `Sight: Open Help Topic` palette command prompts when invoked without args
- [ ] `help local`, `help global`, `help replace`, `help noisily` resolve
- [ ] `help operators`, `help exp` render with proper title headers (via `.maint` aliases / findalias)
- [ ] `{manlink R display}` and `{bf:[U] 12.5 Formats}` open stata.com PDFs
- [ ] Not-found notification lists searched paths and offers "Open Settings"