### PR TITLE
Fix SMCL multi-line {help...} directive parser

### DIFF
--- a/client/src/smcl-preview/smcl-to-html.ts
+++ b/client/src/smcl-preview/smcl-to-html.ts
@@ -247,7 +247,7 @@ function parse_smcl(source: string): SmclNode[] {
         // For args-only directives, collect everything to } as args
         if (is_args_only) {
             // Skip optional space after name
-            if (pos < source.length && is_dir_ws(source[pos])) pos++;
+            while (pos < source.length && is_dir_ws(source[pos])) pos++;
             // Also skip colon if present (some args-only directives
             // have the form {c -(} with no colon, but {cmdab:x:y} has)
             if (pos < source.length && source[pos] === ':') pos++;

--- a/client/src/smcl-preview/smcl-to-html.ts
+++ b/client/src/smcl-preview/smcl-to-html.ts
@@ -196,8 +196,10 @@ function parse_smcl(source: string): SmclNode[] {
         const my_directive_line = current_line();
         pos++; // consume '{'
 
+        const is_dir_ws = (ch: string) => ch === ' ' || ch === '\n';
+
         // Skip leading whitespace
-        while (pos < source.length && source[pos] === ' ') pos++;
+        while (pos < source.length && is_dir_ws(source[pos])) pos++;
 
         // Read directive name
         const name_start = pos;
@@ -243,7 +245,7 @@ function parse_smcl(source: string): SmclNode[] {
         // For args-only directives, collect everything to } as args
         if (is_args_only) {
             // Skip optional space after name
-            if (pos < source.length && source[pos] === ' ') pos++;
+            if (pos < source.length && is_dir_ws(source[pos])) pos++;
             // Also skip colon if present (some args-only directives
             // have the form {c -(} with no colon, but {cmdab:x:y} has)
             if (pos < source.length && source[pos] === ':') pos++;
@@ -266,9 +268,9 @@ function parse_smcl(source: string): SmclNode[] {
 
         // Read args (between name and colon, or name and closing brace)
         let my_args = '';
-        if (pos < source.length && source[pos] === ' ') {
+        if (pos < source.length && is_dir_ws(source[pos])) {
             // There are arguments before a potential colon
-            pos++; // skip space
+            pos++; // skip separator (space or newline)
             const args_start = pos;
             // Read until colon or closing brace, but be careful with
             // nested braces in arguments

--- a/client/src/smcl-preview/smcl-to-html.ts
+++ b/client/src/smcl-preview/smcl-to-html.ts
@@ -196,7 +196,8 @@ function parse_smcl(source: string): SmclNode[] {
         const my_directive_line = current_line();
         pos++; // consume '{'
 
-        const is_dir_ws = (ch: string) => ch === ' ' || ch === '\n';
+        const is_dir_ws = (ch: string) =>
+            ch === ' ' || ch === '\n' || ch === '\r';
 
         // Skip leading whitespace
         while (pos < source.length && is_dir_ws(source[pos])) pos++;
@@ -208,7 +209,8 @@ function parse_smcl(source: string): SmclNode[] {
             source[pos] !== '}' &&
             source[pos] !== ':' &&
             source[pos] !== ' ' &&
-            source[pos] !== '\n'
+            source[pos] !== '\n' &&
+            source[pos] !== '\r'
         ) {
             pos++;
         }

--- a/tests/unit/smcl-to-html.test.ts
+++ b/tests/unit/smcl-to-html.test.ts
@@ -275,6 +275,36 @@ describe('smcl_to_html', () => {
             expect(result.html).not.toContain('{opt');
         });
 
+        it('parses args-only {cmdab} split across CRLF before colon', () => {
+            const result = smcl_to_html('{cmdab\r\n:gl:obal}');
+            expect(result.html).toContain('<u>gl</u>obal');
+            expect(result.html).not.toContain('<u></u>');
+        });
+
+        it('parses args-only {cmdab} split across CR-only before colon', () => {
+            const result = smcl_to_html('{cmdab\r:gl:obal}');
+            expect(result.html).toContain('<u>gl</u>obal');
+            expect(result.html).not.toContain('<u></u>');
+        });
+
+        it('parses {help} directive split across CR-only newline', () => {
+            const result = smcl_to_html(
+                '{help\rgrmap##sd_master:{it:master}}'
+            );
+            expect(result.html).toContain('data-smcl-topic="grmap"');
+            expect(result.html).toContain('data-smcl-anchor="sd_master"');
+            expect(result.html).not.toContain('data-smcl-topic=""');
+        });
+
+        it('parses {help} directive with mixed whitespace before colon', () => {
+            const result = smcl_to_html(
+                '{help \r\n grmap##sd_master:{it:master}}'
+            );
+            expect(result.html).toContain('data-smcl-topic="grmap"');
+            expect(result.html).toContain('data-smcl-anchor="sd_master"');
+            expect(result.html).not.toContain('data-smcl-topic=""');
+        });
+
         it('renders {help topic:display} with custom text', () => {
             const result = smcl_to_html('{help regress:regression}');
             expect(result.html).toContain('data-smcl-topic="regress"');

--- a/tests/unit/smcl-to-html.test.ts
+++ b/tests/unit/smcl-to-html.test.ts
@@ -260,6 +260,15 @@ describe('smcl_to_html', () => {
             expect(result.html).not.toContain('data-smcl-topic=""');
         });
 
+        it('parses {help} directive split across a CRLF newline', () => {
+            const result = smcl_to_html(
+                '{help\r\ngrmap##sd_master:{it:master}}'
+            );
+            expect(result.html).toContain('data-smcl-topic="grmap"');
+            expect(result.html).toContain('data-smcl-anchor="sd_master"');
+            expect(result.html).not.toContain('data-smcl-topic=""');
+        });
+
         it('parses args-only directive split across a newline', () => {
             const result = smcl_to_html('{opt\nvce(robust)}');
             expect(result.html).toContain('vce(robust)');

--- a/tests/unit/smcl-to-html.test.ts
+++ b/tests/unit/smcl-to-html.test.ts
@@ -237,6 +237,35 @@ describe('smcl_to_html', () => {
             expect(result.cross_references[0].topic).toBe('regress');
         });
 
+        it('parses {help} directive split across a newline after the name', () => {
+            const single = smcl_to_html(
+                '{help grmap##sd_master:{it:master}}'
+            );
+            const multi = smcl_to_html(
+                '{help\ngrmap##sd_master:{it:master}}'
+            );
+            expect(multi.html).toContain('data-smcl-topic="grmap"');
+            expect(multi.html).toContain('data-smcl-anchor="sd_master"');
+            expect(multi.html).not.toContain('data-smcl-topic=""');
+            expect(multi.cross_references).toHaveLength(
+                single.cross_references.length
+            );
+            expect(multi.cross_references[0].topic).toBe('grmap');
+        });
+
+        it('parses multi-line {help} directive without colon content', () => {
+            const result = smcl_to_html('{help\ngrmap##sd_master}');
+            expect(result.html).toContain('data-smcl-topic="grmap"');
+            expect(result.html).toContain('data-smcl-anchor="sd_master"');
+            expect(result.html).not.toContain('data-smcl-topic=""');
+        });
+
+        it('parses args-only directive split across a newline', () => {
+            const result = smcl_to_html('{opt\nvce(robust)}');
+            expect(result.html).toContain('vce(robust)');
+            expect(result.html).not.toContain('{opt');
+        });
+
         it('renders {help topic:display} with custom text', () => {
             const result = smcl_to_html('{help regress:regression}');
             expect(result.html).toContain('data-smcl-topic="regress"');


### PR DESCRIPTION
## Summary
- Fixes #163: `{help X##Y:Z}` directives split across a newline produced a malformed empty `<a data-smcl-topic="">` followed by leaked text.
- `parse_smcl` now treats `\n` and `\r` as directive whitespace at the three separator checks and as name terminators, so multi-line directives parse identically to the single-line form (LF and CRLF).
- Clears the last 2 broken-link reports from `bun scripts/check-help-links.ts` (`grmap`, `bmapredict`).

## Test plan
- [x] `bun test tests/unit/smcl-to-html.test.ts` — added LF (with/without colon content), CRLF, and args-only multi-line cases (RED → GREEN).
- [x] `bun test tests/unit/` — 2450/2450 pass.
- [x] `bun run typecheck`.
- [x] `bun scripts/check-help-links.ts` — 864/864 commands resolved, 0 broken links across 20716.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes #163 