### PR TITLE
docs: add diagnostics reference, refresh completion + READMEs

### DIFF
--- a/.kiro/specs/archive/abandoned/README.md
+++ b/.kiro/specs/archive/abandoned/README.md
@@ -30,6 +30,12 @@ These archived specifications provide:
 - **Requirements archaeology** showing how needs evolved over time
 - **Decision rationale** for why certain paths were not taken
 
+## Related User Documentation
+
+For current user-facing viewer documentation, see:
+- [Log Viewer](../../../../docs/log-viewer.md)
+- [Help Viewer](../../../../docs/help-viewer.md)
+
 ## Common Reasons for Abandonment
 
 ### Marketplace Publishing Deferral

--- a/README.md
+++ b/README.md
@@ -64,22 +64,22 @@ The editor extension enables language server features and further provides:
 #### Undefined local macro
 
 Stata would evaluate `` `froot' `` to `""` because of the misspelling. In this example, it affects the displayed text. When combined with if-then-else statements, this leads to unexpected control flow.
-<img width="683" height="390" src="examples/undefined_local.png"/>
+<img width="683" height="390" alt="Undefined local macro diagnostic" src="examples/undefined_local.png"/>
 
 #### Command completion
-<img width="615" height="420" src="examples/command_completion.png"/>
+<img width="615" height="420" alt="Command completion popup" src="examples/command_completion.png"/>
 
 #### Syntax highlighting
 
 Sight colorizes nesting depth of compound strings and local macros.
 
-<img width="581" height="386" src="examples/nested_locals_within_compound_strings_dark.png"/>
-<img width="581" height="386" src="examples/nested_locals_within_compound_strings_light.png"/>
+<img width="581" height="386" alt="Syntax highlighting with nesting depth colors (dark theme)" src="examples/nested_locals_within_compound_strings_dark.png"/>
+<img width="581" height="386" alt="Syntax highlighting with nesting depth colors (light theme)" src="examples/nested_locals_within_compound_strings_light.png"/>
 
 #### Send to Stata
 
 Execute code in Stata directly from the editor.
-<img width="641" height="565" src="examples/send_to_stata_menu.png"/>
+<img width="641" height="565" alt="Send to Stata menu" src="examples/send_to_stata_menu.png"/>
 
 > See the [Examples Gallery](docs/examples.md) for more screenshots.
 

--- a/README.md
+++ b/README.md
@@ -16,25 +16,26 @@ Sight's sister project [Raven](https://github.com/jbearak/raven) implements a la
 
 ### Language Server:
 
-- **Diagnostics**: Real-time syntax error detection and undefined macro warnings
-- **Code Completion**: Context-aware completions for commands, options, macros, and variables
+- **[Diagnostics](docs/diagnostics.md)**: Real-time syntax error detection and undefined macro warnings
+- **[Code Completion](docs/completion.md)**: Context-aware completions for commands, options, macros, and variables
 - **Go-to-Definition**: Jump to definitions of local/global macros and programs across the workspace
-- **Find References**: Locate every use of a macro, program, or variable across related files
-- **Cross-file awareness**: Symbol resolution across `do`/`include` chains with position-aware scope
-- **Declaration directives**: Suppress diagnostics for dynamically-created symbols (`@lsp-local`, `@lsp-global`)
-- **Document Outline**: Hierarchical code navigation with programs, macros, variables, and code sections
+- **[Find References](docs/find-references.md)**: Locate every use of a macro, program, or variable across related files
+- **[Cross-file awareness](docs/cross-file.md)**: Symbol resolution across `do`/`include` chains with position-aware scope
+- **[Declaration directives](docs/declaration-directives.md)**: Suppress diagnostics for dynamically-created symbols (`@lsp-local`, `@lsp-global`)
+- **[Document Outline](docs/document-outline.md)**: Hierarchical code navigation with programs, macros, variables, and code sections
 - **Workspace Symbols**: Search for symbols across the entire workspace
 
 ### Editor Extension:
 
 The editor extension enables language server features and further provides:
 
-- **Run Code**: Execute code in the Stata application or terminal with intelligent statement detection and working directory management
-- **Syntax Highlighting**: Rich syntax highlighting with unique features like macro/string nesting depth coloring
-- **Auto-Closing Pairs**: Intelligently handles Stata's unique conventions for nested macros and compound strings
-- **Data Browser**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels
-- **Log Viewer**: Render Stata log files (`.smcl`) with formatted output directly in VS Code
-- **Help Viewer**: Read Stata help files (`.sthlp`) directly in VS Code with clickable help-topic links
+- **[Run Code](docs/send-to-stata.md)**: Execute code in the Stata application or terminal with intelligent statement detection and working directory management
+- **[Syntax Highlighting](docs/syntax-highlighting.md)**: Rich syntax highlighting with unique features like macro/string nesting depth coloring
+- **[Auto-Closing Pairs](docs/quote-auto-close.md)**: Intelligently handles Stata's unique conventions for nested macros and compound strings
+- **[Data Browser](docs/data-browser.md)**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels
+- **[Log Viewer](docs/log-viewer.md)**: Render Stata log files (`.smcl`) with formatted output directly in VS Code
+- **[Help Viewer](docs/help-viewer.md)**: Read Stata help files (`.sthlp`) directly in VS Code with clickable help-topic links
+- **[Code Formatting](docs/formatting.md)** (experimental): Format `.do` files and normalize comment styles
 
 ## Documentation
 
@@ -45,19 +46,8 @@ The editor extension enables language server features and further provides:
 - [Editor Integrations](docs/editor-integrations.md) - Generic LSP clients, AI agents
 - [Neovim Setup](docs/neovim-setup.md) - Configure Sight for Neovim
 
-### Features
-
-- [Diagnostics](docs/diagnostics.md) - Real-time error detection, scoping rules, suppression directives
-- [Data Browser](docs/data-browser.md) - Browse datasets in VS Code with the `vview` command
-- [Log Viewer](docs/log-viewer.md) - Render Stata `.smcl` log files in VS Code
-- [Help Viewer](docs/help-viewer.md) - Read Stata `.sthlp` help files in VS Code
-- [Document Outline](docs/document-outline.md) - Hierarchical code navigation with sections, programs, and macros
-- [Cross-File Awareness](docs/cross-file.md) - Workspace indexing, directives, scope resolution
-- [Declaration Directives](docs/declaration-directives.md) - `@lsp-local`, `@lsp-global` for dynamically-created symbols
-- [Send to Stata](docs/send-to-stata.md) - Execute code in Stata from VS Code or terminal
-- [Quote Auto-Close](docs/quote-auto-close.md) - Intelligent auto-closing for Stata quoting conventions
-- [Formatting](docs/formatting.md) - Code formatting and comment normalization (experimental)
-- [Syntax Highlighting](docs/syntax-highlighting.md) - TextMate scopes, nesting depth colors
+Per-feature reference pages live in [`docs/`](docs) and are linked from
+each entry in [Features](#features) above.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The editor extension enables language server features and further provides:
 
 ### Features
 
+- [Diagnostics](docs/diagnostics.md) - Real-time error detection, scoping rules, suppression directives
 - [Data Browser](docs/data-browser.md) - Browse datasets in VS Code with the `vview` command
 - [Log Viewer](docs/log-viewer.md) - Render Stata `.smcl` log files in VS Code
 - [Help Viewer](docs/help-viewer.md) - Read Stata `.sthlp` help files in VS Code

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Execute code in Stata directly from the editor.
   - Extensions → `...` menu → "Install from VSIX..."
   - Or via CLI: `code --install-extension sight-client-<version>.vsix`
 
-> **Note:** If you have other extensions installed that provide Stata syntax highlighting (e.g., `stata-enhanced` or `stata-language`), disable them to use Sight's syntax highlighting. Extensions like `stataRun` (which launches Stata from VS Code) can remain enabled.
+> **Note:** If you have other extensions installed that provide Stata syntax highlighting (e.g., `stata-enhanced` or `stata-language`), disable them to use Sight's syntax highlighting.
 
 ### Other Methods
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The editor extension enables language server features and further provides:
 - [Neovim Setup](docs/neovim-setup.md) - Configure Sight for Neovim
 
 Per-feature reference pages live in [`docs/`](docs) and are linked from
-each entry in [Features](#features) above.
+most entries in [Features](#features) above.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -15,35 +15,38 @@ Sight's sister project [Raven](https://github.com/jbearak/raven) implements a la
 ## Features
 
 ### Language Server:
-- **Code Completion**: Context-aware completions for commands, options, macros, and variables
+
 - **Diagnostics**: Real-time syntax error detection and undefined macro warnings
+- **Code Completion**: Context-aware completions for commands, options, macros, and variables
 - **Go-to-Definition**: Jump to definitions of local/global macros and programs across the workspace
 - **Find References**: Locate every use of a macro, program, or variable across related files
-- **Document Outline**: Hierarchical code navigation with programs, macros, variables, and code sections
-- **Workspace Symbols**: Search for symbols across the entire workspace
 - **Cross-file awareness**: Symbol resolution across `do`/`include` chains with position-aware scope
 - **Declaration directives**: Suppress diagnostics for dynamically-created symbols (`@lsp-local`, `@lsp-global`)
+- **Document Outline**: Hierarchical code navigation with programs, macros, variables, and code sections
+- **Workspace Symbols**: Search for symbols across the entire workspace
 
 ### Editor Extension:
 
 The editor extension enables language server features and further provides:
 
+- **Run Code**: Execute code in the Stata application or terminal with intelligent statement detection and working directory management
+- **Syntax Highlighting**: Rich syntax highlighting with unique features like macro/string nesting depth coloring
+- **Auto-Closing Pairs**: Intelligently handles Stata's unique conventions for nested macros and compound strings
 - **Data Browser**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels
 - **Log Viewer**: Render Stata log files (`.smcl`) with formatted output directly in VS Code
 - **Help Viewer**: Read Stata help files (`.sthlp`) directly in VS Code with clickable help-topic links
-- **Run Code**: Execute code in the Stata application or terminal with intelligent statement detection and working directory management
-- **Syntax Highlighting**: Rich syntax highlighting with unique features like macro/string nesting depth coloring
-- **Quote Auto-Close**: Intelligently handles Stata's unique conventions for nested macros and compound strings
 
 ## Documentation
 
 ### Guides
+
 - [Configuration](docs/configuration.md) - All settings and options
 - [Standalone Installation](docs/standalone-installation.md) - CLI usage, npm/npx, build from source
 - [Editor Integrations](docs/editor-integrations.md) - Generic LSP clients, AI agents
 - [Neovim Setup](docs/neovim-setup.md) - Configure Sight for Neovim
 
 ### Features
+
 - [Data Browser](docs/data-browser.md) - Browse datasets in VS Code with the `vview` command
 - [Log Viewer](docs/log-viewer.md) - Render Stata `.smcl` log files in VS Code
 - [Help Viewer](docs/help-viewer.md) - Read Stata `.sthlp` help files in VS Code
@@ -58,6 +61,7 @@ The editor extension enables language server features and further provides:
 ### Examples
 
 #### Undefined local macro
+
 Stata would evaluate `` `froot' `` to `""` because of the misspelling. In this example, it affects the displayed text. When combined with if-then-else statements, this leads to unexpected control flow.
 <img width="683" height="390" src="examples/undefined_local.png"/>
 
@@ -65,12 +69,14 @@ Stata would evaluate `` `froot' `` to `""` because of the misspelling. In this e
 <img width="615" height="420" src="examples/command_completion.png"/>
 
 #### Syntax highlighting
+
 Sight colorizes nesting depth of compound strings and local macros.
 
 <img width="581" height="386" src="examples/nested_locals_within_compound_strings_dark.png"/>
 <img width="581" height="386" src="examples/nested_locals_within_compound_strings_light.png"/>
 
 #### Send to Stata
+
 Execute code in Stata directly from the editor.
 <img width="641" height="565" src="examples/send_to_stata_menu.png"/>
 
@@ -87,8 +93,8 @@ Execute code in Stata directly from the editor.
 
 1. Download the latest `.vsix` from the [releases page](https://github.com/jbearak/sight/releases)
 2. In VS Code:
-   - Extensions → `...` menu → "Install from VSIX..."
-   - Or via CLI: `code --install-extension sight-client-<version>.vsix`
+  - Extensions → `...` menu → "Install from VSIX..."
+  - Or via CLI: `code --install-extension sight-client-<version>.vsix`
 
 > **Note:** If you have other extensions installed that provide Stata syntax highlighting (e.g., `stata-enhanced` or `stata-language`), disable them to use Sight's syntax highlighting. Extensions like `stataRun` (which launches Stata from VS Code) can remain enabled.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Sight's sister project [Raven](https://github.com/jbearak/raven) implements a la
 The editor extension enables language server features and further provides:
 
 - **Data Browser**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels
-- **SMCL Log Viewer**: Render Stata log files (`.smcl`) with formatted output directly in VS Code
+- **Log Viewer**: Render Stata log files (`.smcl`) with formatted output directly in VS Code
+- **Help Viewer**: Read Stata help files (`.sthlp`) directly in VS Code with clickable help-topic links
 - **Run Code**: Execute code in the Stata application or terminal with intelligent statement detection and working directory management
 - **Syntax Highlighting**: Rich syntax highlighting with unique features like macro/string nesting depth coloring
 - **Quote Auto-Close**: Intelligently handles Stata's unique conventions for nested macros and compound strings
@@ -44,7 +45,8 @@ The editor extension enables language server features and further provides:
 
 ### Features
 - [Data Browser](docs/data-browser.md) - Browse datasets in VS Code with the `vview` command
-- [SMCL Log Viewer](docs/smcl-viewer.md) - Render Stata `.smcl` log files in VS Code
+- [Log Viewer](docs/log-viewer.md) - Render Stata `.smcl` log files in VS Code
+- [Help Viewer](docs/help-viewer.md) - Read Stata `.sthlp` help files in VS Code
 - [Document Outline](docs/document-outline.md) - Hierarchical code navigation with sections, programs, and macros
 - [Cross-File Awareness](docs/cross-file.md) - Workspace indexing, directives, scope resolution
 - [Declaration Directives](docs/declaration-directives.md) - `@lsp-local`, `@lsp-global` for dynamically-created symbols

--- a/client/README.md
+++ b/client/README.md
@@ -1,42 +1,51 @@
 # Sight - Comprehensive Stata Language Support
 
-Comprehensive language support for Stata: real-time diagnostics, completions, go-to-definition, find references, code formatting, syntax highlighting with nesting depth colors, cross-file symbol resolution, and integrated code execution.
+Comprehensive language support for Stata: real-time diagnostics, completions, go-to-definition, find references, run code in Stata, syntax highlighting with nesting depth colors, code formatting, cross-file symbol resolution, and built-in viewers for datasets, logs, and help files.
 
 ## Features
 
-### Language Server
-
-- **Real-time Diagnostics**: Catch undefined macros and other issues as you type
-
-  <img width="683" height="390" src="https://github.com/jbearak/sight/blob/main/examples/undefined_local.png?raw=true"/>
-
-- **Intelligent Completions**: Context-aware completions for commands, options, macros, and variables
-
-  <img width="615" height="420" src="https://github.com/jbearak/sight/blob/main/examples/command_completion.png?raw=true"/>
-
-  <img width="651" height="449" src="https://github.com/jbearak/sight/blob/main/examples/macro_completion.png?raw=true"/>
-
+- **[Real-time Diagnostics](https://github.com/jbearak/sight/blob/main/docs/diagnostics.md)**: Catch undefined macros and other issues as you type
+- **[Intelligent Completions](https://github.com/jbearak/sight/blob/main/docs/completion.md)**: Context-aware completions for commands, options, macros, and variables
 - **Go-to-Definition**: Jump to definitions of local/global macros and programs across the workspace
-- **Find References**: Locate every use of a macro, program, or variable across related files
-- **Cross-File Awareness**: Symbol resolution across `do`/`run`/`include` chains with position-aware scope. Works automatically for most projects; some edge cases (e.g., dynamic macro paths or files outside the workspace) require manual configuration — see [Cross-File Awareness](https://github.com/jbearak/sight/blob/main/docs/cross-file.md).
-- **Declaration Directives**: Suppress diagnostics for dynamically-created symbols (`@lsp-local`, `@lsp-global`)
-- **Document Outline**: Hierarchical code navigation with programs, macros, variables, and code sections
+- **[Find References](https://github.com/jbearak/sight/blob/main/docs/find-references.md)**: Locate every use of a macro, program, or variable across related files
+- **[Run Code in Stata](https://github.com/jbearak/sight/blob/main/docs/send-to-stata.md)**: Execute code in the Stata application or terminal with intelligent statement detection and working directory management
+- **[Syntax Highlighting](https://github.com/jbearak/sight/blob/main/docs/syntax-highlighting.md)**: Rich highlighting with nesting depth colors for compound strings and nested macros
+- **[Auto-Closing Pairs](https://github.com/jbearak/sight/blob/main/docs/quote-auto-close.md)**: Intelligently handles Stata's unique conventions for nested macros and compound strings
+- **[Cross-File Awareness](https://github.com/jbearak/sight/blob/main/docs/cross-file.md)**: Symbol resolution across `do`/`run`/`include` chains with position-aware scope. Works automatically for most projects; some edge cases (e.g., dynamic macro paths or files outside the workspace) require manual configuration.
+- **[Declaration Directives](https://github.com/jbearak/sight/blob/main/docs/declaration-directives.md)**: Suppress diagnostics for dynamically-created symbols (`@lsp-local`, `@lsp-global`)
+- **[Document Outline](https://github.com/jbearak/sight/blob/main/docs/document-outline.md)**: Hierarchical code navigation with programs, macros, variables, and code sections
 - **Workspace Symbols**: Search for symbols across the entire workspace
+- **[Data Browser](https://github.com/jbearak/sight/blob/main/docs/data-browser.md)**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels
+- **[Log Viewer](https://github.com/jbearak/sight/blob/main/docs/log-viewer.md)**: Render Stata `.smcl` log files with formatted output directly in VS Code
+- **[Help Viewer](https://github.com/jbearak/sight/blob/main/docs/help-viewer.md)**: Read Stata `.sthlp` help files directly in VS Code with clickable help-topic links
 
-### Editor Extension
+## Screenshots
 
-- **Run Code in Stata**: Execute code in the Stata application or terminal with intelligent statement detection and working directory management
+<details>
+<summary>Real-time diagnostics</summary>
 
-  <img width="641" height="565" src="https://github.com/jbearak/sight/blob/main/examples/send_to_stata_menu.png?raw=true"/>
+<img width="683" height="390" src="https://github.com/jbearak/sight/blob/main/examples/undefined_local.png?raw=true"/>
+</details>
 
-- **Syntax Highlighting**: Rich highlighting with nesting depth colors for compound strings and nested macros
+<details>
+<summary>Intelligent completions</summary>
 
-  <img width="581" height="386" src="https://github.com/jbearak/sight/blob/main/examples/nested_locals_within_compound_strings_dark.png?raw=true"/>
+<img width="615" height="420" src="https://github.com/jbearak/sight/blob/main/examples/command_completion.png?raw=true"/>
 
-- **Auto-Closing Pairs**: Intelligently handles Stata's unique conventions for nested macros and compound strings
-- **Data Browser**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels
-- **Log Viewer**: Render Stata `.smcl` log files with formatted output directly in VS Code
-- **Help Viewer**: Read Stata `.sthlp` help files directly in VS Code with clickable help-topic links
+<img width="651" height="449" src="https://github.com/jbearak/sight/blob/main/examples/macro_completion.png?raw=true"/>
+</details>
+
+<details>
+<summary>Run code in Stata</summary>
+
+<img width="641" height="565" src="https://github.com/jbearak/sight/blob/main/examples/send_to_stata_menu.png?raw=true"/>
+</details>
+
+<details>
+<summary>Syntax highlighting with nesting depth colors</summary>
+
+<img width="581" height="386" src="https://github.com/jbearak/sight/blob/main/examples/nested_locals_within_compound_strings_dark.png?raw=true"/>
+</details>
 
 ## Installation
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,44 +1,42 @@
 # Sight - Comprehensive Stata Language Support
 
-Comprehensive language support for Stata: real-time diagnostics, completions, go-to-definition, code formatting, syntax highlighting with nesting depth colors, cross-file symbol resolution, and integrated code execution.
+Comprehensive language support for Stata: real-time diagnostics, completions, go-to-definition, find references, code formatting, syntax highlighting with nesting depth colors, cross-file symbol resolution, and integrated code execution.
 
 ## Features
 
-### Intelligent Completions
+### Language Server
 
-Context-aware completions for commands, options, macros, and variables.
+- **Real-time Diagnostics**: Catch undefined macros and other issues as you type
 
-<img width="615" height="420" src="https://github.com/jbearak/sight/blob/main/examples/command_completion.png?raw=true"/>
+  <img width="683" height="390" src="https://github.com/jbearak/sight/blob/main/examples/undefined_local.png?raw=true"/>
 
-<img width="651" height="449" src="https://github.com/jbearak/sight/blob/main/examples/macro_completion.png?raw=true"/>
+- **Intelligent Completions**: Context-aware completions for commands, options, macros, and variables
 
-### Real-time Diagnostics
+  <img width="615" height="420" src="https://github.com/jbearak/sight/blob/main/examples/command_completion.png?raw=true"/>
 
-Catch undefined macros and other issues as you type.
+  <img width="651" height="449" src="https://github.com/jbearak/sight/blob/main/examples/macro_completion.png?raw=true"/>
 
-<img width="683" height="390" src="https://github.com/jbearak/sight/blob/main/examples/undefined_local.png?raw=true"/>
+- **Go-to-Definition**: Jump to definitions of local/global macros and programs across the workspace
+- **Find References**: Locate every use of a macro, program, or variable across related files
+- **Cross-File Awareness**: Symbol resolution across `do`/`run`/`include` chains with position-aware scope. Works automatically for most projects; some edge cases (e.g., dynamic macro paths or files outside the workspace) require manual configuration — see [Cross-File Awareness](https://github.com/jbearak/sight/blob/main/docs/cross-file.md).
+- **Declaration Directives**: Suppress diagnostics for dynamically-created symbols (`@lsp-local`, `@lsp-global`)
+- **Document Outline**: Hierarchical code navigation with programs, macros, variables, and code sections
+- **Workspace Symbols**: Search for symbols across the entire workspace
 
-### Go-to-Definition
+### Editor Extension
 
-Cmd/Ctrl+click to jump to macro and program definitions.
+- **Run Code in Stata**: Execute code in the Stata application or terminal with intelligent statement detection and working directory management
 
-<img width="671" height="386" src="https://github.com/jbearak/sight/blob/main/examples/command_click.png?raw=true"/>
+  <img width="641" height="565" src="https://github.com/jbearak/sight/blob/main/examples/send_to_stata_menu.png?raw=true"/>
 
-### Syntax Highlighting
+- **Syntax Highlighting**: Rich highlighting with nesting depth colors for compound strings and nested macros
 
-Rich highlighting with nesting depth colors for compound strings and nested macros.
+  <img width="581" height="386" src="https://github.com/jbearak/sight/blob/main/examples/nested_locals_within_compound_strings_dark.png?raw=true"/>
 
-<img width="581" height="386" src="https://github.com/jbearak/sight/blob/main/examples/nested_locals_within_compound_strings_dark.png?raw=true"/>
-
-### Cross-File Awareness
-
-Automatically resolves symbols across files — globals, programs, scalars, and variables defined in parent files are inherited by child files via `do`, `run`, and `include` commands. Works automatically for most projects; some edge cases (e.g., dynamic macro paths or files outside the workspace) require manual configuration — see [Cross-File Awareness](https://github.com/jbearak/sight/blob/main/docs/cross-file.md) for details.
-
-### Run Code in Stata
-
-Execute code in Stata directly from the editor.
-
-<img width="641" height="565" src="https://github.com/jbearak/sight/blob/main/examples/send_to_stata_menu.png?raw=true"/>
+- **Auto-Closing Pairs**: Intelligently handles Stata's unique conventions for nested macros and compound strings
+- **Data Browser**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels
+- **Log Viewer**: Render Stata `.smcl` log files with formatted output directly in VS Code
+- **Help Viewer**: Read Stata `.sthlp` help files directly in VS Code with clickable help-topic links
 
 ## Installation
 

--- a/client/README.md
+++ b/client/README.md
@@ -24,27 +24,27 @@ Comprehensive language support for Stata: real-time diagnostics, completions, go
 <details>
 <summary>Real-time diagnostics</summary>
 
-<img width="683" height="390" src="https://github.com/jbearak/sight/blob/main/examples/undefined_local.png?raw=true"/>
+<img width="683" height="390" alt="Undefined local macro diagnostic" src="https://github.com/jbearak/sight/blob/main/examples/undefined_local.png?raw=true"/>
 </details>
 
 <details>
 <summary>Intelligent completions</summary>
 
-<img width="615" height="420" src="https://github.com/jbearak/sight/blob/main/examples/command_completion.png?raw=true"/>
+<img width="615" height="420" alt="Command completion popup" src="https://github.com/jbearak/sight/blob/main/examples/command_completion.png?raw=true"/>
 
-<img width="651" height="449" src="https://github.com/jbearak/sight/blob/main/examples/macro_completion.png?raw=true"/>
+<img width="651" height="449" alt="Macro completion popup" src="https://github.com/jbearak/sight/blob/main/examples/macro_completion.png?raw=true"/>
 </details>
 
 <details>
 <summary>Run code in Stata</summary>
 
-<img width="641" height="565" src="https://github.com/jbearak/sight/blob/main/examples/send_to_stata_menu.png?raw=true"/>
+<img width="641" height="565" alt="Send to Stata menu" src="https://github.com/jbearak/sight/blob/main/examples/send_to_stata_menu.png?raw=true"/>
 </details>
 
 <details>
 <summary>Syntax highlighting with nesting depth colors</summary>
 
-<img width="581" height="386" src="https://github.com/jbearak/sight/blob/main/examples/nested_locals_within_compound_strings_dark.png?raw=true"/>
+<img width="581" height="386" alt="Syntax highlighting with nesting depth colors" src="https://github.com/jbearak/sight/blob/main/examples/nested_locals_within_compound_strings_dark.png?raw=true"/>
 </details>
 
 ## Installation

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -1,168 +1,141 @@
-# Completion — Design Notes
+# Completion
 
-This page documents deliberate design decisions in Sight's completion
-provider. It is not a usage guide.
+Sight offers completion for Stata commands, options, macros, programs,
+scalars, matrices, and variables. This page describes what shows up at
+the cursor, why some entries are marked **out of scope**, and how
+ranking decides the order.
 
-## Scoping Model
+The guiding principle: **accepting a suggestion should not silently
+trigger an undefined-symbol diagnostic.** Where that conflicts with
+discoverability, the entry is shown but marked out of scope rather
+than hidden.
 
-Completion applies different visibility rules per symbol category. The
-driving principle: **a completion offered at the cursor should not
-silently trigger an undefined-symbol diagnostic if the user accepts
-it.** Where that rule conflicts with discoverability, the conflict is
-resolved by marking the entry out-of-scope rather than hiding it.
+## What's offered, by symbol type
 
-| Symbol type | Scope at cursor | Out-of-scope treatment |
+| Symbol type | Visible at the cursor | Out-of-scope treatment |
 |---|---|---|
-| **Local macros** | Current file only, further narrowed to `definition_line <= cursor.line` (same-file locals defined on or before the cursor are visible; only definitions on later lines are excluded) | Hidden — workspace locals and same-file locals defined below the cursor are never shown |
-| **Global macros, programs, scalars, matrices** | Current file + scope-chain entries (call-site-filtered) | Shown, ranked last, with `detail = "<kind> (out of scope — from <relative path>)"` |
-| **Variables** | Entire workspace | No out-of-scope treatment — variables keep their normal detail |
+| **Local macros** | Current file only, and only if defined on or before the cursor line | Hidden — workspace locals and same-file locals defined below the cursor are never shown |
+| **Global macros, programs, scalars, matrices** | Current file plus scope-chain entries (call-site-filtered) | Shown, ranked last, with `detail = "<kind> (out of scope — from <relative path>)"` |
+| **Variables** | Entire workspace | None — variables keep their normal detail |
 
-"In scope" itself depends on mode (see [Mode dependency](#mode-dependency)
-below).
+What counts as "in scope" depends on whether the file has resolved
+parents (see [Modes](#modes) below).
 
 ## Rules
 
-### Rule 1 — No completion silently triggers a diagnostic
+### 1. No suggestion silently triggers a diagnostic
 
-If accepting a suggestion would emit an undefined-symbol diagnostic, the
-suggestion is either hidden (locals) or clearly marked (globals,
+If accepting an entry would emit an undefined-symbol diagnostic, it is
+either hidden (locals) or clearly marked out of scope (globals,
 programs, scalars, matrices). Variables are the deliberate exception:
-Stata dataset columns are legitimately shared across unrelated analyses,
-and the undefined-variable diagnostic is advisory rather than
-load-bearing.
+Stata dataset columns are legitimately shared across unrelated
+analyses, and the undefined-variable diagnostic is advisory.
 
-### Rule 2 — Locals are file-and-position scoped
+### 2. Locals are file- and position-scoped
 
-Workspace locals from other files are never offered in completion —
-Stata locals do not propagate through `do` or `run`, and `include`
-inheritance is already resolved upstream by `ScopeResolver`. Within the
-current file, the position filter keeps any local whose
-`definition_line <= cursor.line`; only locals defined on lines strictly
-after the cursor are excluded, because a Stata local is not yet bound on
-lines at or before its definition but becomes visible once execution
-passes the definition line. Locals inherited from a parent file via an
-`include` chain are in scope when the scope resolver places them there;
-no additional position filter runs in the provider, because the parent's
-call-site filter has already happened upstream.
+Stata locals do not propagate through `do` or `run`, so workspace
+locals from other files are never offered. Within the current file, a
+local is offered once the cursor sits at or below its definition line —
+before that point the macro does not yet exist at the execution
+point. Locals inherited via an `include` chain are placed in scope by
+the resolver upstream and require no further filtering.
 
-### Rule 3 — Workspace non-variable symbols surface as out-of-scope
+### 3. Workspace non-variable symbols surface as out of scope
 
-Global macros, programs, scalars, and matrices defined in unrelated
-workspace files are not hidden. They appear at the bottom of the
-completion list with a distinct `(out of scope — from <path>)` detail,
-and their `sortText` places them below every in-scope entry of the same
-category. Accepting one produces an undefined-symbol diagnostic; that
-diagnostic is the user's cue to add a `do`/`run`/`include` statement or
-a cross-file directive (`@lsp-do`, `@lsp-done-by`, `@lsp-included-by`,
-etc.) to bring the symbol into scope.
+Globals, programs, scalars, and matrices defined in unrelated workspace
+files are not hidden. They appear at the bottom of the list with a
+`(out of scope — from <path>)` detail. Accepting one produces an
+undefined-symbol diagnostic — the cue to add a `do` / `run` / `include`
+statement or a cross-file directive (`@lsp-do`, `@lsp-done-by`,
+`@lsp-included-by`, …) to bring the symbol into scope.
 
-### Rule 4 — Built-ins win over out-of-scope programs
+### 4. Built-ins win over out-of-scope programs
 
-A workspace program named `display` — or any other name that collides
-with a built-in command — must not suppress the built-in from
-completion. Out-of-scope programs are filtered against the command
-database before emission (skipped if a built-in with the same name
-exists) and never claim a `seen_labels` slot. Precedence:
+A workspace program named `display` (or any other name colliding with a
+built-in command) must not crowd the built-in out of completion. An
+out-of-scope program is dropped if a built-in with the same name
+exists. Precedence:
 
 ```text
 in-scope user program > built-in command > out-of-scope user program
 ```
 
-### Rule 5 — Variables stay workspace-wide
+### 5. Variables stay workspace-wide
 
-Variables are exempt from the out-of-scope treatment at every layer:
-they are not stripped from the Global-Mode in-scope bag by
-`build_merged_map`, they are forced empty in
-`partition_symbols_for_completion`'s output, and
-`get_variable_completions` has no out-of-scope variable loop. The
-workspace-wide model matches find-references' variable handling.
+Variables are exempt from out-of-scope treatment at every layer. The
+workspace-wide model matches how [find-references](find-references.md)
+handles variables, and reflects that dataset columns like `id`,
+`year`, or `analysis_sample` legitimately recur across unrelated
+analyses.
+
+## Modes
+
+### Resolved-scope mode
+
+Active when the file has `@lsp-*` directives or auto-discovered
+parents via the dependency graph. The in-scope set is the current
+file plus the call-site-filtered scope chain. Entries the resolver
+ruled out (after the call site, or excluded by `do` / `run`
+inheritance) are kept hidden, not surfaced as out-of-scope.
+
+### Global mode
+
+Active when no directives or auto-parents are found. The in-scope set
+is the current file alone. Workspace locals are dropped; workspace
+globals, programs, scalars, and matrices are routed to the
+out-of-scope bag. Variables pass through unchanged.
+
+See [Cross-File Awareness](cross-file.md) for how parents are
+auto-discovered or declared.
 
 ## Ranking
 
-`compute_ranking_key` composes a lexicographic `sortText` from
-`(scope_depth, directive_type, symbol_type, parent_uri, name)`, in that
-order — `scope_depth` is the primary key, `directive_type` the
-secondary, `symbol_type` the tertiary, with `parent_uri` and `name`
-breaking remaining ties. The `directive_type` bucket maps `'current'` →
-0, `'included-by'` → 1, `'done-by'` → 2, `'out-of-scope'` → 3 — so
-out-of-scope entries rank last within a given `scope_depth` because of
-the `directive_type` bucket, not because of symbol-type tiering. This is
-why an in-scope local-macro (directive_type = 0) still sorts above an
-out-of-scope program (directive_type = 3) even though the program's
-`symbol_type` bucket (user-program, priority 0) would otherwise precede
-the local's (local-macro, priority 10) within the same `directive_type`.
+Completion order is deterministic. Each entry's `sortText` is built
+from, in order:
 
-## Mode dependency
+1. **Scope depth** — current file first, then immediate parents, then
+   grandparents, and so on.
+2. **Directive type** — `current` (0), `included-by` (1), `done-by`
+   (2), `out-of-scope` (3).
+3. **Symbol type** — built-in commands and other priority tiers.
+4. **Parent URI**, then **name**, as final tiebreakers.
 
-"In scope" resolves differently depending on whether the file has
-directives or auto-discovered parents.
+Because directive type outranks symbol type, an in-scope local macro
+sorts above an out-of-scope program even though the program's symbol
+tier would otherwise come first.
 
-**Resolved-Scope Mode** (file has `@lsp-*` directives or
-auto-discovered parents via the dep graph): the in-scope bag is
-`get_visible_symbols_at(resolved_scope, cursor_line)` — current file
-plus scope-chain entries, call-site-filtered. Entries the scope
-resolver deemed out-of-scope for `after_call_site` or
-`inheritance_excludes_locals` reasons are excluded from the new
-workspace out-of-scope partition as well; they stay hidden.
+## Why these rules
 
-**Global Mode** (no directives, no auto-parents): the in-scope bag is
-current-file-only. `build_merged_map` strips workspace locals, globals,
-programs, scalars, and matrices from the merged in-scope view, and
-`partition_symbols_for_completion` routes them to the out-of-scope bag
-instead. Variables pass through untouched, preserving their
-workspace-wide behavior.
+**Locals are the narrowest** because Stata propagates them only
+through `include`, never through `do` or `run`, and a local defined
+below the cursor literally does not yet exist at the cursor's
+execution point.
 
-## Rationale
+**Non-variable workspace symbols are surfaced anyway** because pure
+hiding hurts discoverability. The two-step workflow — see the
+suggestion, accept it, then resolve the resulting diagnostic by
+linking the file — depends on the symbol being visible in the first
+place. The out-of-scope label makes the workflow legible.
 
-**Why locals are narrowest:** Stata propagates locals only through
-`include`, never through `do` or `run`. A local in a `do`-called child
-is a separate macro from a same-named local in its caller. Position
-within the current file matters too: a local defined below the cursor
-literally does not exist yet at the cursor's execution point.
-
-**Why non-variable workspace symbols are surfaced at all:** Pure
-hiding would hurt discoverability. Engineers often want completion to
-suggest a helper program or a configuration global defined elsewhere
-in the project, then add a `do` statement or directive to pull it into
-scope. The out-of-scope label makes this two-step workflow visible:
-the suggestion appears, and the resulting diagnostic guides the user
-to the linking step.
-
-**Why variables are workspace-wide:** Stata dataset columns like `id`,
-`year`, or `analysis_sample` frequently refer to the same underlying
-column across many unrelated `.do` files. The "column identity is
-name-only" convention means treating every workspace-known column as
-in-scope is more useful than gating on reachability. This matches how
-find-references scopes variables (see `docs/find-references.md`).
-
-## Implementation
-
-- `src/providers/completion.ts::partition_symbols_for_completion` —
-  builds the out-of-scope SymbolTable view; always returns empty
-  `localMacros` and `variables`.
-- `src/providers/completion.ts::build_merged_map` — produces the
-  Global-Mode in-scope bag; strips workspace locals, globals, programs,
-  scalars, and matrices, leaves variables in place.
-- `src/providers/completion.ts::compute_ranking_key` — sortText
-  composition including the `'out-of-scope'` tier.
-- `src/providers/completion.ts::get_macro_completions` — position
-  filter for same-file locals; out-of-scope pass for global macros
-  (skipped when `scope === 'local'`).
-- `src/providers/completion.ts::get_command_completions` and
-  `get_program_completions` — in-scope and out-of-scope program
-  emission with the built-in-precedence guard described in Rule 4.
-- `src/providers/completion.ts::get_variable_completions` — in-scope
-  variable/scalar/matrix loops plus out-of-scope passes for scalars
-  and matrices only (no variable out-of-scope pass).
+**Variables are workspace-wide** because Stata dataset columns are
+identified by name across `.do` files, so reachability is the wrong
+gate.
 
 ## Relationship to find-references
 
-Completion's visibility model is **not** the same as find-references'.
-Find-references pools same-identity declarations across the reachable
+Completion is narrower than [find-references](find-references.md).
+Find-references pools same-name declarations across the reachable
 dep-graph chain so a user searching by name sees every declaration
-that could bind to that name (see `docs/find-references.md`).
-Completion is narrower: it only shows what the cursor can reference
-right now. A symbol can legitimately surface in find-references
-(because the user knows the name and is searching) while being hidden
-or marked out-of-scope in completion (because the user has not yet
-linked the file).
+that could bind to that name. Completion only shows what the cursor
+can reference right now. A symbol can legitimately appear in
+find-references while being hidden or marked out of scope in
+completion — the user has not yet linked the file.
+
+## Relationship to diagnostics
+
+Completion and [diagnostics](diagnostics.md) share the same scope
+resolver but apply different rules. Completion may surface workspace
+symbols as out-of-scope suggestions; diagnostics never treat
+workspace-only visibility as resolved scope. Accepting an out-of-scope
+completion produces a diagnostic by design — that is the signal to
+link the file via `do` / `run` / `include` or a cross-file directive.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -111,8 +111,7 @@ turned off independently.
 
 ## Configuration
 
-All keys live under `sight.*` in VS Code settings or in `.sight.json`
-at the workspace root.
+Diagnostics keys live under `sight.*` in VS Code's `settings.json`:
 
 ```jsonc
 {
@@ -127,6 +126,23 @@ at the workspace root.
   "sight.diagnostics.severity.mixedLogicalOperators":       "warning"
 }
 ```
+
+The workspace-root `.sight.json` file uses a separate, unprefixed
+schema and currently exposes only the indentation toggle for
+diagnostics:
+
+```json
+{
+  "diagnostics": {
+    "indentation": false
+  }
+}
+```
+
+Severity keys are not yet recognized in `.sight.json` — set them in
+VS Code settings. See the
+[Project Configuration File](configuration.md#project-configuration-file)
+section for the full `.sight.json` schema.
 
 Each severity key accepts `"error"`, `"warning"`, `"information"`,
 `"hint"`, or `"off"`. Notes:

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -13,8 +13,12 @@ tables below) and `source: "sight"`.
 ## Quick reference
 
 - **Silence one site** — add `// @lsp-ignore` on the offending line, or
-  `// @lsp-ignore-next` on the line above. Suppresses every Sight
-  diagnostic on the targeted line.
+  `// @lsp-ignore-next` on the line above. Suppresses undefined-symbol
+  (`UNDEFINED_MACRO`, `UNDEFINED_VARIABLE`, `OUT_OF_SCOPE_SYMBOL`) and
+  operator-style diagnostics on the targeted line. Lexer, parser /
+  brace-style, and indentation diagnostics are not silenced this way —
+  fix lexer/parser issues at the source, or turn indentation off via
+  `sight.diagnostics.indentation` (it ships off by default).
 - **Declare a symbol the analyzer can't see** — use
   [`@lsp-local`, `@lsp-global`, `@lsp-variables`, `@lsp-scalar`,
   `@lsp-matrix`, `@lsp-program`](declaration-directives.md). Forward-only:
@@ -86,17 +90,6 @@ first definition (see [Forward references](#forward-references)).
 Positional macro arguments (`` `0' ``, `` `1' ``, …) bypass position
 and scope checks: they are bound by the caller, not by lexical position.
 
-## Indentation diagnostics
-
-Off by default. Enable with `sight.diagnostics.indentation: true`.
-This is an on/off toggle — there is no severity key; both codes are
-emitted at `information` severity.
-
-| Code | Name | Trigger |
-|---|---|---|
-| 5001 | `UNNECESSARY_INDENTATION` | A line is indented past the AST-computed depth. |
-| 5002 | `MISSING_INDENTATION` | A line is at a shallower indent than its block depth. |
-
 ## Operator style diagnostics
 
 Each operator diagnostic has its own severity key, and each can be
@@ -108,6 +101,17 @@ turned off independently.
 | 6002 | `INVALID_OPERATOR_SEQUENCE` | error | `invalidOperatorSequence` | Token sequences Stata cannot parse (e.g., `< \|`, `= ==`). |
 | 6003 | `CSTYLE_LOGICAL_IN_CONTROL_FLOW` | information | `cStyleLogicalInControlFlow` | `&&` / `\|\|` used in `if` / `else if`. Legal in Stata, but the canonical style uses `&` / `\|`. |
 | 6004 | `MIXED_LOGICAL_OPERATORS` | warning | `mixedLogicalOperators` | `&` and `\|` mixed in one expression without parentheses; precedence is easy to misread. |
+
+## Indentation diagnostics
+
+Off by default. Enable with `sight.diagnostics.indentation: true`.
+This is an on/off toggle — there is no severity key; both codes are
+emitted at `information` severity.
+
+| Code | Name | Trigger |
+|---|---|---|
+| 5001 | `UNNECESSARY_INDENTATION` | A line is indented past the AST-computed depth. |
+| 5002 | `MISSING_INDENTATION` | A line is at a shallower indent than its block depth. |
 
 ## Configuration
 
@@ -152,17 +156,19 @@ Each severity key accepts `"error"`, `"warning"`, `"information"`,
 - `undefinedVariable` is experimental and ships off — see
   [Why undefined-variable is off by default](#why-undefined-variable-is-off-by-default).
 - `styleWarnings` currently gates `CONTINUATION_NO_SPACE` (1004).
-- Parse, brace-style, and indentation diagnostics do not have
-  per-category severity keys; use `@lsp-ignore` to silence individual
-  sites, or disable indentation as a whole via
-  `sight.diagnostics.indentation`.
+- Parse and brace-style diagnostics have no per-category control and
+  `@lsp-ignore` does not silence them — fix the underlying issue.
+- Indentation diagnostics ship off; turn them on with the boolean
+  `sight.diagnostics.indentation`. Both indentation codes emit at
+  `information` severity (there is no severity key), and `@lsp-ignore`
+  does not silence individual sites.
 
 ## Suppressing diagnostics in source
 
 | Directive | Effect |
 |---|---|
-| `// @lsp-ignore` | Suppresses Sight diagnostics on the same line. |
-| `// @lsp-ignore-next` | Suppresses Sight diagnostics on the next non-trivia statement. |
+| `// @lsp-ignore` | Suppresses undefined-symbol and operator-style diagnostics on the same line. Does not silence lexer, parser / brace-style, or indentation diagnostics. |
+| `// @lsp-ignore-next` | Same effect as `@lsp-ignore`, but applied to the next non-trivia statement. |
 | `// @lsp-local name [name …]` | Declares one or more local macros from the directive line forward. |
 | `// @lsp-global name [name …]` | Same, for globals. |
 | `// @lsp-variables var [var …]` | Declares variables (e.g., loaded from a `.dta` file). |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -100,7 +100,7 @@ turned off independently.
 | Code | Name | Default | Severity key | Trigger |
 |---|---|---|---|---|
 | 6001 | `MALFORMED_OPERATOR` | warning | `malformedOperator` | Compound operators split by whitespace (`< =`, `> =`, `! =`). Stata accepts these but they are usually typos. |
-| 6002 | `INVALID_OPERATOR_SEQUENCE` | error | `invalidOperatorSequence` | Token sequences Stata cannot parse (e.g., `< |`, `= ==`). |
+| 6002 | `INVALID_OPERATOR_SEQUENCE` | error | `invalidOperatorSequence` | Token sequences Stata cannot parse (e.g., `< \|`, `= ==`). |
 | 6003 | `CSTYLE_LOGICAL_IN_CONTROL_FLOW` | information | `cStyleLogicalInControlFlow` | `&&` / `\|\|` used in `if` / `else if`. Legal in Stata, but the canonical style uses `&` / `\|`. |
 | 6004 | `MIXED_LOGICAL_OPERATORS` | warning | `mixedLogicalOperators` | `&` and `\|` mixed in one expression without parentheses; precedence is easy to misread. |
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,242 @@
+# Diagnostics
+
+Sight reports problems in your Stata code as you type — syntax errors,
+unresolved macros, suspicious operators, and style issues. This page
+lists every diagnostic, shows how to silence individual reports, and
+documents the configuration keys that control severity.
+
+Diagnostics are deferred until the workspace scan completes, so
+cross-file warnings reflect the full project rather than just the open
+buffer. Each diagnostic carries a numeric `code` (the values in the
+tables below) and `source: "sight"`.
+
+## Quick reference
+
+- **Silence one site** — add `// @lsp-ignore` on the offending line, or
+  `// @lsp-ignore-next` on the line above. Suppresses every Sight
+  diagnostic on the targeted line.
+- **Declare a symbol the analyzer can't see** — use
+  [`@lsp-local`, `@lsp-global`, `@lsp-variables`, `@lsp-scalar`,
+  `@lsp-matrix`, `@lsp-program`](declaration-directives.md). Forward-only:
+  effective at and after the directive line.
+- **Bring a sibling file's symbols into scope** — usually nothing to do:
+  Sight auto-discovers `do` / `run` / `include` relationships and
+  inherits the parent's symbols. Add a header directive
+  (`@lsp-done-by`, `@lsp-included-by`) only when auto-discovery can't
+  see the link — for example, when the path is built from macros. See
+  [Cross-File Awareness](cross-file.md).
+- **Turn a category off globally** — set the matching severity to
+  `"off"` (see [Configuration](#configuration)).
+- **Disable everything** — set `sight.diagnostics.enabled` to `false`.
+
+## Lexical errors
+
+Reported by the lexer. Most are hard errors; `CONTINUATION_NO_SPACE` is
+gated by the `styleWarnings` severity.
+
+| Code | Name | Default | Trigger |
+|---|---|---|---|
+| 1001 | `UNBALANCED_QUOTES` | error | A string literal is opened but never closed on the same statement. |
+| 1002 | `UNBALANCED_BLOCK_COMMENT` | error | `/*` is not matched by `*/`. |
+| 1003 | `UNTERMINATED_STATEMENT` | error | A statement runs off the end of the file in `#delimit ;` mode without a terminating `;`. |
+| 1004 | `CONTINUATION_NO_SPACE` | hint (`styleWarnings`) | `///` continuation marker not preceded by whitespace (`foo///` instead of `foo ///`). |
+| 1005 | `BLOCK_COMMENT_IN_STAR_COMMENT` | warning | A `/* … */` block appears inside a `*` line comment, which Stata parses unexpectedly. |
+
+## Parse and structural errors
+
+Reported by the parser and context tracker. Severity is fixed (no
+configuration key); two entries are warnings rather than errors because
+Stata still runs the code.
+
+| Code | Name | Default | Trigger |
+|---|---|---|---|
+| 3000 | `SYNTAX_ERROR` | error | Generic parser failure not covered by a more specific code. |
+| 3001 | `BRACE_ELSE_SAME_LINE` | error | `} else {` style — Stata requires the closing brace and `else` on separate lines. |
+| 3002 | `BRACE_NOT_ALONE` | error | A closing `}` shares a line with other code. |
+| 3003 | `MISSING_PROGRAM_END` | error | A `program` / `mata` / `python` block is not closed by `end`. |
+| 3004 | `OPEN_BRACE_ALONE` | error | An opening `{` appears alone on a line where Stata expects it on the control statement. |
+| 3005 | `UNCLOSED_BLOCK` | error | An `if` / `foreach` / `forvalues` / `while` / frame / mata / python block is not closed. |
+| 3006 | `CODE_AFTER_OPEN_BRACE` | warning | Tokens follow `{` on the same line as the opening brace. Stata runs the block but ignores trailing code on that line. |
+| 3008 | `FORVALUES_SYNTAX` | error | Malformed `forvalues` range (e.g., missing `=` or bad `to`/`/` separators). |
+| 3009 | `REDUNDANT_MACRO_SUFFIX` | warning | A macro reference includes redundant trailing characters that Stata ignores. |
+| 3010 | `INVALID_MACRO_CHAR` | error | A macro name contains a character Stata does not allow in identifiers. |
+
+## Semantic / scope diagnostics
+
+The analyzer flags references it cannot resolve to a definition in the
+current scope. All four codes are gated by the `undefinedMacro` or
+`undefinedVariable` severity (see [How scope is decided](#how-scope-is-decided)).
+
+| Code | Name | Default | Severity key | Trigger |
+|---|---|---|---|---|
+| 2001 | `UNDEFINED_MACRO` | warning | `undefinedMacro` | `` `name' ``, `$name`, or `${name}` references a macro that is not in scope at the reference line. Also covers undefined scalars, matrices, and programs. |
+| 2002 | `UNDEFINED_VARIABLE` | off | `undefinedVariable` | A varlist position references a name Sight has not seen defined. See [What counts as a variable definition](#what-counts-as-a-variable-definition). |
+| 2003 | `OUT_OF_SCOPE_SYMBOL` | inherits | matches the underlying symbol's key | A reference resolves to a symbol that exists in the workspace but is not reachable from this file's scope chain. The diagnostic message names the file the symbol was found in. |
+| 2004 | `MISSING_VARIABLE_NAME` | error | n/a | A command position requires a variable name and the parser found no token (e.g., `gen = 1`). |
+
+A second class — *forward references* — also surfaces under
+`UNDEFINED_MACRO` when a macro is used earlier in the same file than its
+first definition (see [Forward references](#forward-references)).
+
+Positional macro arguments (`` `0' ``, `` `1' ``, …) bypass position
+and scope checks: they are bound by the caller, not by lexical position.
+
+## Indentation diagnostics
+
+Off by default. Enable with `sight.diagnostics.indentation: true`.
+This is an on/off toggle — there is no severity key; both codes are
+emitted at `information` severity.
+
+| Code | Name | Trigger |
+|---|---|---|
+| 5001 | `UNNECESSARY_INDENTATION` | A line is indented past the AST-computed depth. |
+| 5002 | `MISSING_INDENTATION` | A line is at a shallower indent than its block depth. |
+
+## Operator style diagnostics
+
+Each operator diagnostic has its own severity key, and each can be
+turned off independently.
+
+| Code | Name | Default | Severity key | Trigger |
+|---|---|---|---|---|
+| 6001 | `MALFORMED_OPERATOR` | warning | `malformedOperator` | Compound operators split by whitespace (`< =`, `> =`, `! =`). Stata accepts these but they are usually typos. |
+| 6002 | `INVALID_OPERATOR_SEQUENCE` | error | `invalidOperatorSequence` | Token sequences Stata cannot parse (e.g., `< |`, `= ==`). |
+| 6003 | `CSTYLE_LOGICAL_IN_CONTROL_FLOW` | information | `cStyleLogicalInControlFlow` | `&&` / `\|\|` used in `if` / `else if`. Legal in Stata, but the canonical style uses `&` / `\|`. |
+| 6004 | `MIXED_LOGICAL_OPERATORS` | warning | `mixedLogicalOperators` | `&` and `\|` mixed in one expression without parentheses; precedence is easy to misread. |
+
+## Configuration
+
+All keys live under `sight.*` in VS Code settings or in `.sight.json`
+at the workspace root.
+
+```jsonc
+{
+  "sight.diagnostics.enabled": true,           // master switch
+  "sight.diagnostics.indentation": false,      // enable 5001/5002
+  "sight.diagnostics.severity.undefinedMacro":              "warning",
+  "sight.diagnostics.severity.undefinedVariable":           "off",
+  "sight.diagnostics.severity.styleWarnings":               "hint",
+  "sight.diagnostics.severity.malformedOperator":           "warning",
+  "sight.diagnostics.severity.invalidOperatorSequence":     "error",
+  "sight.diagnostics.severity.cStyleLogicalInControlFlow":  "information",
+  "sight.diagnostics.severity.mixedLogicalOperators":       "warning"
+}
+```
+
+Each severity key accepts `"error"`, `"warning"`, `"information"`,
+`"hint"`, or `"off"`. Notes:
+
+- `undefinedMacro` also governs undefined scalars, matrices, programs,
+  and the `OUT_OF_SCOPE_SYMBOL` variants of those categories.
+- `undefinedVariable` is experimental and ships off — see
+  [Why undefined-variable is off by default](#why-undefined-variable-is-off-by-default).
+- `styleWarnings` currently gates `CONTINUATION_NO_SPACE` (1004).
+- Parse, brace-style, and indentation diagnostics do not have
+  per-category severity keys; use `@lsp-ignore` to silence individual
+  sites, or disable indentation as a whole via
+  `sight.diagnostics.indentation`.
+
+## Suppressing diagnostics in source
+
+| Directive | Effect |
+|---|---|
+| `// @lsp-ignore` | Suppresses Sight diagnostics on the same line. |
+| `// @lsp-ignore-next` | Suppresses Sight diagnostics on the next non-trivia statement. |
+| `// @lsp-local name [name …]` | Declares one or more local macros from the directive line forward. |
+| `// @lsp-global name [name …]` | Same, for globals. |
+| `// @lsp-variables var [var …]` | Declares variables (e.g., loaded from a `.dta` file). |
+| `// @lsp-scalar name`, `// @lsp-matrix name`, `// @lsp-program name` | Declares scalars, matrices, and programs respectively. |
+
+Declaration directives are forward-only: they suppress warnings at and
+after the directive line, not earlier ones. See
+[Declaration Directives](declaration-directives.md) for the full
+syntax.
+
+For cross-file linkage (the usual reason a global appears "undefined"
+when it is defined in a sibling file), prefer the dependency-graph
+mechanism — Sight auto-discovers `do` / `run` / `include` chains and
+inherits the parent's symbols. Header directives (`@lsp-done-by`,
+`@lsp-included-by`) handle cases auto-discovery cannot, such as paths
+built from macros. See [Cross-File Awareness](cross-file.md).
+
+## How scope is decided
+
+A symbol is considered in scope at a reference line when one of these
+holds:
+
+1. **Same file, on or before the reference line.** Subject to the
+   forward-reference check below.
+2. **Inherited from a parent file** via the resolved scope chain:
+   - `done-by` / `run-by` / `do` / `run` inherit non-local symbols
+     (programs, globals, scalars, matrices, variables).
+   - `included-by` / `include` inherit all symbols, including local
+     macros.
+3. **Declared by directive** (`@lsp-local`, `@lsp-global`, … ) on or
+   before the reference line.
+
+Workspace indexing alone does **not** suppress diagnostics. A global
+defined in an unrelated file is still offered in completion (marked
+out of scope) but a reference to it produces an undefined-symbol
+warning. The warning is the cue to add a `do` / `run` / `include`
+statement or a cross-file directive.
+
+## Forward references
+
+Within a single file, the analyzer compares each reference's preorder
+position against the symbol's first definition:
+
+- Reference appears before the first definition in the same file →
+  warning (under `UNDEFINED_MACRO`).
+- Reference appears at or after the first definition → no warning.
+- When a name is defined more than once, the first definition wins.
+
+Forward-reference checking is intra-file only. Symbols inherited from
+parent files are subject to *call-site* filtering instead: only
+definitions on or before the call site of the current file in the
+parent are considered in scope.
+
+## Startup behavior
+
+Sight defers diagnostics until the workspace scan finishes parsing
+every `.do`, `.ado`, `.doh`, and `.mata` file and the dependency graph
+is populated. Files opened before the scan completes are re-checked
+once the graph is ready, so cross-file warnings reflect the full
+project rather than just the open buffer.
+
+## What counts as a variable definition
+
+Sight recognizes a variable as defined when it sees one of:
+
+- `generate` / `gen`, `egen`, `input` — explicit creation.
+- `rename` / `ren` — the new name is registered.
+- `confirm variable` / `confirm var` — treated as an assertion that
+  the variable exists; useful for declaring columns loaded from a
+  dataset without disabling the diagnostic.
+- `@lsp-variables name [name …]` — manual declaration, forward-only.
+
+Variables loaded from `use`, `import`, or `merge` are **not**
+introspected — Sight does not read `.dta` files. If the diagnostic is
+on and you load data, declare the columns with `@lsp-variables` (or a
+`confirm variable` line if you want a runtime assertion as well).
+
+## Why undefined-variable is off by default
+
+Stata variable existence depends on the dataset in memory at runtime,
+which the LSP cannot observe statically. Even with the definitions
+listed above, a name may legitimately come from a `use`, `import`, or
+`merge` the analyzer cannot read — particularly when the dataset path
+is built from macros. Defaulting the diagnostic to `off` avoids
+drowning users in false positives. To opt in, set
+`sight.diagnostics.severity.undefinedVariable` to any non-`off` value
+and declare dynamically-loaded columns with `@lsp-variables` or
+`confirm variable`.
+
+## Relationship to completion
+
+Completion and diagnostics share the same scope resolver but apply
+different rules. Completion may surface workspace symbols as
+out-of-scope suggestions (see [Completion](completion.md));
+diagnostics never treat workspace-only visibility as resolved scope.
+Accepting an out-of-scope completion produces a diagnostic by design —
+that is the signal to link the file via `do` / `run` / `include` or a
+cross-file directive.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -59,7 +59,12 @@ Stata still runs the code.
 | 3006 | `CODE_AFTER_OPEN_BRACE` | warning | Tokens follow `{` on the same line as the opening brace. Stata runs the block but ignores trailing code on that line. |
 | 3008 | `FORVALUES_SYNTAX` | error | Malformed `forvalues` range (e.g., missing `=` or bad `to`/`/` separators). |
 | 3009 | `REDUNDANT_MACRO_SUFFIX` | warning | A macro reference includes redundant trailing characters that Stata ignores. |
-| 3010 | `INVALID_MACRO_CHAR` | error | A macro name contains a character Stata does not allow in identifiers. |
+| 3010 | `INVALID_MACRO_CHAR` | error | A macro name contains a character Stata does not allow in identifiers. (Analyzer-emitted; shares numeric code 3010 with the parser-emitted `MISSING_EXPRESSION_AFTER_EQUALS` below.) |
+| 3010 | `MISSING_EXPRESSION_AFTER_EQUALS` | error | An `=` is followed by no expression — e.g., `gen x =`, an empty `if` / `while` condition, or an empty qualifier. |
+| 3011 | `UNBALANCED_PARENTHESES` | error | Mismatched `(` / `)` in an expression, `if` / `while` condition, or `by` / `bysort` qualifier. |
+| 3012 | `ORPHAN_CLOSE_BRACE` | error | A `}` appears with no matching opening block. |
+| 3013 | `STRAY_TOKEN_IN_CONDITION` | error | Unexpected token inside an `if` / `while` / qualifier condition. |
+| 3014 | `SPLIT_LITERAL_IN_CONDITION` | error | A string or compound literal is split across the condition boundary, leaving an unterminated literal in an `if` / `while` condition. |
 
 ## Semantic / scope diagnostics
 

--- a/docs/help-viewer.md
+++ b/docs/help-viewer.md
@@ -1,0 +1,46 @@
+# Help Viewer
+
+Sight includes an in-editor help viewer that renders Stata documentation.  
+Access it through `sight.openHelpTopic` in the Command Palette or  
+by clicking a `help <topic>` link shown when hovering a command or function  
+name.
+
+## Help Links in Hovers and Completions
+
+Hovering over a built-in command (for example `generate`), an expression
+function (for example `mi()`), or a prefix-command subcommand (for example
+`frame create`) shows a clickable `help <topic>` link. Clicking that link opens
+the matching `.sthlp` file in the preview to the right of the editor.
+
+The same link appears in the completion popup for built-in commands and their
+abbreviations.
+
+## Opening a Help File Manually
+
+You can also open a `.sthlp` file directly in VS Code and open the preview:
+
+- Click the **Open Preview** icon in the editor title bar
+- Right-click the file and select **Open SMCL Preview** or
+**Open SMCL Preview (Full Width)**
+- Use the Command Palette: **Sight: Open SMCL Preview**
+
+The preview renders Stata help markup as formatted HTML in a VS Code webview
+panel.
+
+## How Sight Resolves Help Topics
+
+Sight resolves a help topic to a file by searching, in order:
+
+1. Every directory listed in `sight.adoPaths`.
+2. Your workspace folders.
+3. Auto-detected Stata install locations (for example
+  `/Applications/Stata/ado/base` on macOS,
+   `/usr/local/stata<version>/ado/base` on Linux,
+   `C:\\Program Files\\Stata<version>\\ado\\base` on Windows), plus the usual
+   `~/ado/personal` and `~/ado/plus` conventions.
+
+Because of this search order, built-in topics like `help regress` and
+`help include` usually work without extra configuration.
+
+If a `.sthlp` file is not found, Sight shows a notification with an
+**Open Settings** button that jumps directly to `sight.adoPaths`.

--- a/docs/help-viewer.md
+++ b/docs/help-viewer.md
@@ -1,7 +1,7 @@
 # Help Viewer
 
 Sight includes an in-editor help viewer that renders Stata documentation.  
-Access it through `sight.openHelpTopic` in the Command Palette or  
+Access it through **Sight: Open Help Topic** (`sight.openHelpTopic`) in the Command Palette or  
 by clicking a `help <topic>` link shown when hovering a command or function  
 name.
 

--- a/docs/help-viewer.md
+++ b/docs/help-viewer.md
@@ -22,7 +22,7 @@ You can also open a `.sthlp` file directly in VS Code and open the preview:
 - Click the **Open Preview** icon in the editor title bar
 - Right-click the file and select **Open SMCL Preview** or
 **Open SMCL Preview (Full Width)**
-- Use the Command Palette: **Sight: Open SMCL Preview**
+- Use the Command Palette: **Open SMCL Preview** (`sight.openSmclPreview`)
 
 The preview renders Stata help markup as formatted HTML in a VS Code webview
 panel.

--- a/docs/log-viewer.md
+++ b/docs/log-viewer.md
@@ -1,0 +1,24 @@
+# Log Viewer
+
+Sight includes an in-editor log viewer that renders Stata log output (`.smcl`)
+in VS Code.
+
+## Common Ways to Open Logs
+
+Open any `.smcl` file in VS Code and use any of the following:
+
+- Click the **Open Preview** icon in the editor title bar
+- Right-click the file and select **Open SMCL Preview** or **Open SMCL Preview (Full Width)**
+- Use the Command Palette: **Sight: Open SMCL Preview**
+
+The preview renders Stata SMCL markup as formatted HTML in a VS Code webview
+panel, showing output similarly to Stata's Viewer window.
+
+## What You Can View
+
+The Log Viewer is intended for Stata session output, including:
+
+- formatted results
+- tables
+- error messages
+

--- a/docs/log-viewer.md
+++ b/docs/log-viewer.md
@@ -9,7 +9,7 @@ Open any `.smcl` file in VS Code and use any of the following:
 
 - Click the **Open Preview** icon in the editor title bar
 - Right-click the file and select **Open SMCL Preview** or **Open SMCL Preview (Full Width)**
-- Use the Command Palette: **Sight: Open SMCL Preview**
+- Use the Command Palette: **Open SMCL Preview** (`sight.openSmclPreview`)
 
 The preview renders Stata SMCL markup as formatted HTML in a VS Code webview
 panel, showing output similarly to Stata's Viewer window.

--- a/docs/quote-auto-close.md
+++ b/docs/quote-auto-close.md
@@ -1,4 +1,4 @@
-# Quote Auto-Close
+# Auto-Closing Pairs
 
 The extension provides intelligent auto-closing for Stata's unique quoting conventions. Unlike VS Code's built-in auto-closing pairs, this feature handles Stata's overlapping delimiters correctly.
 

--- a/docs/smcl-viewer.md
+++ b/docs/smcl-viewer.md
@@ -1,36 +1,10 @@
-# SMCL Log Viewer
+# SMCL Viewer (Split Documentation)
 
-Sight includes a viewer for Stata's SMCL (Stata Markup and Control Language) files. SMCL is Stata's native output format, used for log files (`.smcl`) and help files (`.sthlp`).
+This page has been split into two user-focused feature docs:
 
-## Usage
+- [Log Viewer](./log-viewer.md) for viewing Stata log files (`.smcl`)
+- [Help Viewer](./help-viewer.md) for viewing Stata help files (`.sthlp`) and
+using help links from hovers and completions
 
-Open any `.smcl` or `.sthlp` file in VS Code and use any of the following to open the preview:
-
-- Click the **Open Preview** icon in the editor title bar
-- Right-click the file and select **Open SMCL Preview** or **Open SMCL Preview (Full Width)**
-- Use the Command Palette: **Sight: Open SMCL Preview**
-
-The preview renders SMCL markup as formatted HTML in a VS Code webview panel, showing the output as it would appear in Stata's Viewer window.
-
-## Supported Formats
-
-The viewer renders both:
-- **Log files** (`.smcl`): Stata session output with formatted results, tables, and error messages
-- **Help files** (`.sthlp`): Stata help documentation with cross-references and formatted syntax
-
-## Help links in hovers and completions
-
-Hovering over a built-in command (e.g. `generate`), an expression
-function (e.g. `mi()`), or a prefix-command subcommand (e.g. `frame
-create`) shows a clickable `help <topic>` link. Clicking the link opens
-the matching `.sthlp` file in the SMCL preview to the right of the
-editor. The same link appears in the completion popup for built-in
-commands and their abbreviations.
-
-Sight resolves the topic to a file by searching, in order:
-
-1. Every directory listed in the `sight.adoPaths` setting.
-2. Your workspace folders.
-3. Auto-detected Stata install locations (e.g. `/Applications/Stata/ado/base` on macOS, `/usr/local/stata<version>/ado/base` on Linux, `C:\Program Files\Stata<version>\ado\base` on Windows), plus the usual `~/ado/personal` and `~/ado/plus` conventions.
-
-This means `help regress`, `help include`, and other built-in topics generally work out of the box without any configuration. If a `.sthlp` still isn't found, Sight shows a notification with an **Open Settings** button that jumps straight to `sight.adoPaths` so you can point it at the directory containing the help file.
+Sight still uses shared SMCL rendering infrastructure under the hood, but the
+feature docs are now organized by user task.

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -1009,7 +1009,7 @@ export function create_resolve_sthlp_file_handler(
             const my_content = await fs.promises.readFile(
                 file_path, 'utf-8'
             );
-            return expand_includes(my_content, my_ihlp_resolver);
+            return await expand_includes(my_content, my_ihlp_resolver);
         } catch {
             return null;
         }


### PR DESCRIPTION
## Summary

This PR refreshes Sight's user-facing documentation and consolidates
the README feature list.

### New / refreshed docs
- New `docs/diagnostics.md`: complete reference for every diagnostic
  Sight emits — lexical, parse, semantic, operator-style, and
  indentation — with codes, default severities, severity-config keys,
  and accurate scope for the `@lsp-ignore` / `@lsp-ignore-next`
  directives (they silence undefined-symbol and operator-style codes
  only; lexer / parse / brace-style / indentation are not affected).
  Default-on operator diagnostics are listed before the opt-in
  indentation section.
- Refresh `docs/completion.md` as a user-facing reference (tightened
  ranking and modes sections; internal implementation pointers
  dropped).
- Split the SMCL viewer doc into `docs/help-viewer.md` and
  `docs/log-viewer.md` by user workflow.
- Rename the Quote Auto-Close page heading to "Auto-Closing Pairs" so
  user-facing terminology matches the README and `client/README.md`
  (filename slug kept stable).

### README / client README
- Link each Features bullet directly to its `docs/` page (mirroring
  `client/README.md`'s style).
- Add a **Code Formatting** entry (experimental).
- Drop the redundant `Documentation > Features` subsection — every
  feature is now linked from the Features list above; replaced with a
  one-line pointer back to that section.
- Add alt text to the screenshots, reorder so diagnostics surfaces
  first, and fix small wording issues caught in earlier review.

### Misc
- `docs/help-viewer.md` and `docs/log-viewer.md`: corrected the
  Command Palette name — the registered title is **Open SMCL
  Preview** (no `Sight:` prefix); also surface the command id
  (`sight.openSmclPreview`).
- `src/server-handlers.ts`: add a missing `await` to
  `expand_includes(...)` discovered while documenting the SMCL flow.

## Test plan
- [x] Render `README.md` and `client/README.md` on GitHub and verify
      Features bullets all link correctly
- [x] Render `docs/diagnostics.md` and check internal anchors plus
      `@lsp-ignore` scope wording (Quick reference + Configuration
      note + Suppression table all consistent)
- [x] Render `docs/help-viewer.md` and `docs/log-viewer.md`; verify
      Command Palette name matches `client/package.json`
- [ ] Confirm the `await expand_includes(...)` fix doesn't change
      behaviour for help-topic resolution that previously already
      worked
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/sight/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized and consolidated feature docs and cross-references; updated README content and screenshots
  * Added comprehensive diagnostics reference with configuration and quick-reference guidance
  * Introduced dedicated Help Viewer and Log Viewer documentation and split old viewer landing content
  * Rewrote completions guidance for clearer scope, ranking, and mode behavior
  * Renamed “Quote Auto-Close” to “Auto-Closing Pairs” and added documented experimental “Code Formatting” capability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
