### PR TITLE
Fix macro-creating option case matching

### DIFF
--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -2090,21 +2090,21 @@ export class SemanticAnalyzer {
             for (const option of node.options) {
                 for (const opt of builtin_cmd.local_options) {
                     if (matches_option(option.name, opt)) {
-                        local_option_names.add(option.name);
+                        local_option_names.add(option.name.toLowerCase());
                     }
                 }
                 for (const opt of builtin_cmd.global_options) {
                     if (matches_option(option.name, opt)) {
-                        global_option_names.add(option.name);
+                        global_option_names.add(option.name.toLowerCase());
                     }
                 }
             }
         } else if (program_options) {
             for (const option_name of program_options.local_options) {
-                local_option_names.add(option_name);
+                local_option_names.add(option_name.toLowerCase());
             }
             for (const option_name of program_options.global_options) {
-                global_option_names.add(option_name);
+                global_option_names.add(option_name.toLowerCase());
             }
         }
         

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -733,20 +733,17 @@ export class SemanticAnalyzer {
 
     /**
      * Extract option names from syntax commands in program body.
-     * Returns a Set of option names declared in the program's syntax signature.
+     * Returns a Set of lowercased option names declared in the program's
+     * syntax signature. Stata's `syntax` command creates lowercased implicit
+     * locals for options, even when the signature uses uppercase letters to
+     * declare minimum abbreviations.
      */
     private extract_syntax_option_names(nodes: StataNode[]): Set<string> {
-        // Returns the names verbatim. The c_local-pattern matcher in
-        // extract_macro_creating_option_patterns compares against the literal
-        // text inside `\`name'`, so casing must match here too. End-to-end
-        // correctness for capitalised option names also requires lowercasing
-        // call-site option matching — a broader change tracked separately
-        // from the implicit-local fix.
         const option_names = new Set<string>();
         for (const node of nodes) {
             if (node.type === 'syntax') {
                 for (const opt of node.signature.options) {
-                    option_names.add(opt.name);
+                    option_names.add(opt.name.toLowerCase());
                 }
             } else if (this.is_control_flow(node)) {
                 // Recurse into control flow bodies
@@ -776,9 +773,10 @@ export class SemanticAnalyzer {
                     // Check if it's a macro reference pattern (starts with backtick)
                     if (macro_name.startsWith('`') && macro_name.endsWith("'")) {
                         const inner_name = macro_name.slice(1, -1);
+                        const local_name = inner_name.toLowerCase();
                         // Only add if it's a valid identifier AND matches a syntax option parameter
-                        if (inner_name && is_valid_identifier(inner_name) && syntax_option_names.has(inner_name)) {
-                            local_set.add(inner_name);
+                        if (inner_name && is_valid_identifier(inner_name) && syntax_option_names.has(local_name)) {
+                            local_set.add(local_name);
                         }
                     }
                 }
@@ -788,9 +786,10 @@ export class SemanticAnalyzer {
                     // Check if it's a macro reference pattern (starts with backtick)
                     if (macro_name.startsWith('`') && macro_name.endsWith("'")) {
                         const inner_name = macro_name.slice(1, -1);
+                        const global_name = inner_name.toLowerCase();
                         // Only add if it's a valid identifier AND matches a syntax option parameter
-                        if (inner_name && is_valid_identifier(inner_name) && syntax_option_names.has(inner_name)) {
-                            global_set.add(inner_name);
+                        if (inner_name && is_valid_identifier(inner_name) && syntax_option_names.has(global_name)) {
+                            global_set.add(global_name);
                         }
                     }
                 }
@@ -2117,12 +2116,13 @@ export class SemanticAnalyzer {
             }
             
             const macro_name = parse_result.identifier;
+            const option_name = option.name.toLowerCase();
             
             // Check if this is a local() option
-            const is_local_option = local_option_names.has(option.name);
+            const is_local_option = local_option_names.has(option_name);
             
             // Check if this is a global() option
-            const is_global_option = global_option_names.has(option.name);
+            const is_global_option = global_option_names.has(option_name);
             
             if (is_local_option) {
                 // Check if macro already exists (first definition wins)

--- a/tests/property/program-macro-creation-correctness.prop.test.ts
+++ b/tests/property/program-macro-creation-correctness.prop.test.ts
@@ -76,7 +76,7 @@ describe('Program Macro Creation Correctness Property Tests', () => {
                     const { program: valid_program } = parse_and_analyze(valid_code);
                     
                     expect(valid_program).toBeDefined();
-                    expect(valid_program!.macro_creating_local_options).toContain(option_name);
+                    expect(valid_program!.macro_creating_local_options).toContain(option_name.toLowerCase());
                     
                     // Test invalid patterns (no syntax declaration, so no macro-creating options detected)
                     const invalid_patterns = [
@@ -218,7 +218,7 @@ describe('Program Macro Creation Correctness Property Tests', () => {
                     
                     expect(program).toBeDefined();
                     expect(program!.macro_creating_local_options).toBeDefined();
-                    expect(program!.macro_creating_local_options).toContain(option_name);
+                    expect(program!.macro_creating_local_options).toContain(option_name.toLowerCase());
                 }
             ),
             { numRuns: 20 }
@@ -249,7 +249,9 @@ describe('Program Macro Creation Correctness Property Tests', () => {
                     expect(program!.macro_creating_local_options).toBeDefined();
                     
                     // Should only appear once (deduplication)
-                    const option_count = program!.macro_creating_local_options!.filter(opt => opt === option_name).length;
+                    const option_count = program!.macro_creating_local_options!.filter(
+                        opt => opt === option_name.toLowerCase()
+                    ).length;
                     expect(option_count).toBe(1);
                 }
             ),
@@ -289,17 +291,20 @@ describe('Program Macro Creation Correctness Property Tests', () => {
                     ];
                     
                     // Include both options in syntax_option_names
-                    const syntax_option_names = new Set([local_opt, global_opt]);
+                    const syntax_option_names = new Set([
+                        local_opt.toLowerCase(),
+                        global_opt.toLowerCase()
+                    ]);
                     const result = (analyzer as any).extract_macro_creating_option_patterns(mock_nodes, syntax_option_names);
                     
-                    expect(result.local_options).toContain(local_opt);
-                    expect(result.global_options).toContain(global_opt);
+                    expect(result.local_options).toContain(local_opt.toLowerCase());
+                    expect(result.global_options).toContain(global_opt.toLowerCase());
                     
                     // Local option should not appear in global options and vice versa
                     // (unless they happen to be the same identifier, which is valid)
-                    if (local_opt !== global_opt) {
-                        expect(result.global_options.includes(local_opt)).toBe(false);
-                        expect(result.local_options.includes(global_opt)).toBe(false);
+                    if (local_opt.toLowerCase() !== global_opt.toLowerCase()) {
+                        expect(result.global_options.includes(local_opt.toLowerCase())).toBe(false);
+                        expect(result.local_options.includes(global_opt.toLowerCase())).toBe(false);
                     }
                 }
             ),
@@ -329,7 +334,7 @@ describe('Program Macro Creation Correctness Property Tests', () => {
                     const { program } = parse_and_analyze(code);
                     
                     expect(program).toBeDefined();
-                    expect(program!.macro_creating_local_options).toContain(option_name);
+                    expect(program!.macro_creating_local_options).toContain(option_name.toLowerCase());
                 }
             ),
             { numRuns: 20 }
@@ -351,7 +356,7 @@ describe('Program Macro Creation Correctness Property Tests', () => {
                     const lower_code = `program define ${prog_name}\n    syntax, ${option_name}(name)\n    c_local \`${option_name}' "value"\nend`;
                     const { program: lower_program } = parse_and_analyze(lower_code);
                     expect(lower_program).toBeDefined();
-                    expect(lower_program!.macro_creating_local_options).toContain(option_name);
+                    expect(lower_program!.macro_creating_local_options).toContain(option_name.toLowerCase());
                     
                     // Uppercase C_LOCAL should NOT work (Stata is case-sensitive)
                     const upper_code = `program define ${prog_name}_upper\n    syntax, ${option_name}(name)\n    C_LOCAL \`${option_name}' "value"\nend`;
@@ -392,11 +397,9 @@ end`;
                     expect(program).toBeDefined();
                     expect(program!.macro_creating_local_options).toBeDefined();
                     
-                    // All three should be detected as separate options
-                    expect(program!.macro_creating_local_options).toContain(mixed_case_name);
+                    // All three syntax spellings share Stata's lowercased runtime option name.
                     expect(program!.macro_creating_local_options).toContain(lower_case);
-                    expect(program!.macro_creating_local_options).toContain(upper_case);
-                    expect(program!.macro_creating_local_options!.length).toBe(3);
+                    expect(program!.macro_creating_local_options!.length).toBe(1);
                 }
             ),
             { numRuns: 15 }
@@ -461,8 +464,8 @@ end`;
                     expect(program!.macro_creating_local_options).toBeDefined();
                     
                     // Valid patterns should still be detected
-                    expect(program!.macro_creating_local_options).toContain(valid_option);
-                    expect(program!.macro_creating_local_options).toContain(second_option);
+                    expect(program!.macro_creating_local_options).toContain(valid_option.toLowerCase());
+                    expect(program!.macro_creating_local_options).toContain(second_option.toLowerCase());
                     
                     // Malformed pattern should not be detected
                     expect(program!.macro_creating_local_options?.includes('malformed') || false).toBe(false);

--- a/tests/property/program-macro-creation-correctness.prop.test.ts
+++ b/tests/property/program-macro-creation-correctness.prop.test.ts
@@ -91,7 +91,7 @@ describe('Program Macro Creation Correctness Property Tests', () => {
                         const { program: invalid_program } = parse_and_analyze(invalid_code);
                         
                         expect(invalid_program).toBeDefined();
-                        expect(invalid_program!.macro_creating_local_options?.includes(option_name) || false).toBe(false);
+                        expect(invalid_program!.macro_creating_local_options?.includes(option_name.toLowerCase()) || false).toBe(false);
                     }
                 }
             ),
@@ -114,7 +114,7 @@ describe('Program Macro Creation Correctness Property Tests', () => {
                     
                     expect(program).toBeDefined();
                     // Invalid identifiers should not be detected as macro-creating options
-                    expect(program!.macro_creating_local_options?.includes(invalid_name) || false).toBe(false);
+                    expect(program!.macro_creating_local_options?.includes(invalid_name.toLowerCase()) || false).toBe(false);
                 }
             ),
             { numRuns: 25 }
@@ -145,8 +145,8 @@ describe('Program Macro Creation Correctness Property Tests', () => {
                     
                     expect(program).toBeDefined();
                     // Non-c_local/global commands should not create macro-creating options
-                    expect(program!.macro_creating_local_options?.includes(option_name) || false).toBe(false);
-                    expect(program!.macro_creating_global_options?.includes(option_name) || false).toBe(false);
+                    expect(program!.macro_creating_local_options?.includes(option_name.toLowerCase()) || false).toBe(false);
+                    expect(program!.macro_creating_global_options?.includes(option_name.toLowerCase()) || false).toBe(false);
                 }
             ),
             { numRuns: 25 }
@@ -362,7 +362,7 @@ describe('Program Macro Creation Correctness Property Tests', () => {
                     const upper_code = `program define ${prog_name}_upper\n    syntax, ${option_name}(name)\n    C_LOCAL \`${option_name}' "value"\nend`;
                     const { program: upper_program } = parse_and_analyze(upper_code);
                     expect(upper_program).toBeDefined();
-                    expect(upper_program!.macro_creating_local_options?.includes(option_name) || false).toBe(false);
+                    expect(upper_program!.macro_creating_local_options?.includes(option_name.toLowerCase()) || false).toBe(false);
                 }
             ),
             { numRuns: 20 }
@@ -429,7 +429,7 @@ end`;
                         const { program } = parse_and_analyze(code);
                         
                         expect(program).toBeDefined();
-                        expect(program!.macro_creating_local_options?.includes(option_name) || false).toBe(false);
+                        expect(program!.macro_creating_local_options?.includes(option_name.toLowerCase()) || false).toBe(false);
                     }
                 }
             ),

--- a/tests/property/program-pattern-detection-macro-creation.prop.test.ts
+++ b/tests/property/program-pattern-detection-macro-creation.prop.test.ts
@@ -53,7 +53,9 @@ describe('Program Pattern Detection and Macro Creation Property Tests', () => {
         
         // Create syntax_option_names set containing all the option names
         // (simulating that these options are declared in a syntax command)
-        const syntax_option_names = new Set([...local_options, ...global_options]);
+        const syntax_option_names = new Set(
+            [...local_options, ...global_options].map(opt => opt.toLowerCase())
+        );
         
         // Test the extraction method directly
         return (analyzer as any).extract_macro_creating_option_patterns(mock_nodes, syntax_option_names);
@@ -160,7 +162,7 @@ describe('Program Pattern Detection and Macro Creation Property Tests', () => {
                     const result = test_macro_creating_patterns('test_prog', option_names, []);
 
                     // Deduplication means unique options only
-                    const unique_options = [...new Set(option_names)];
+                    const unique_options = [...new Set(option_names.map(opt => opt.toLowerCase()))];
                     expect(result.local_options.length).toBe(unique_options.length);
 
                     for (const option_name of unique_options) {
@@ -185,7 +187,7 @@ describe('Program Pattern Detection and Macro Creation Property Tests', () => {
                     const result = test_macro_creating_patterns('test_prog', [], option_names);
                     
                     // Deduplication means unique options only
-                    const unique_options = [...new Set(option_names)];
+                    const unique_options = [...new Set(option_names.map(opt => opt.toLowerCase()))];
                     expect(result.global_options.length).toBe(unique_options.length);
                     
                     for (const option_name of unique_options) {
@@ -209,8 +211,8 @@ describe('Program Pattern Detection and Macro Creation Property Tests', () => {
                 (local_options, global_options) => {
                     const result = test_macro_creating_patterns('test_prog', local_options, global_options);
 
-                    const unique_local_options = [...new Set(local_options)];
-                    const unique_global_options = [...new Set(global_options)];
+                    const unique_local_options = [...new Set(local_options.map(opt => opt.toLowerCase()))];
+                    const unique_global_options = [...new Set(global_options.map(opt => opt.toLowerCase()))];
 
                     expect(result.local_options.length).toBe(unique_local_options.length);
                     expect(result.global_options.length).toBe(unique_global_options.length);
@@ -257,10 +259,10 @@ describe('Program Pattern Detection and Macro Creation Property Tests', () => {
                     };
                     
                     // Include option_name in syntax_option_names to simulate it being declared in syntax
-                    const syntax_option_names = new Set([option_name]);
+                    const syntax_option_names = new Set([option_name.toLowerCase()]);
                     const result = (analyzer as any).extract_macro_creating_option_patterns([mock_if_node], syntax_option_names);
                     
-                    expect(result.local_options).toContain(option_name);
+                    expect(result.local_options).toContain(option_name.toLowerCase());
                 }
             ),
             { numRuns: 30 }
@@ -288,7 +290,7 @@ describe('Program Pattern Detection and Macro Creation Property Tests', () => {
                     ];
                     
                     // Include option_name in syntax_option_names (but patterns are still invalid)
-                    const syntax_option_names = new Set([option_name]);
+                    const syntax_option_names = new Set([option_name.toLowerCase()]);
                     
                     for (const invalid_pattern of invalid_patterns) {
                         const mock_node = {
@@ -334,12 +336,12 @@ describe('Program Pattern Detection and Macro Creation Property Tests', () => {
                     }));
                     
                     // Include option_name in syntax_option_names
-                    const syntax_option_names = new Set([option_name]);
+                    const syntax_option_names = new Set([option_name.toLowerCase()]);
                     const result = (analyzer as any).extract_macro_creating_option_patterns(duplicate_nodes, syntax_option_names);
                     
                     // Implementation deduplicates, so should have exactly 1 entry
                     expect(result.local_options.length).toBe(1);
-                    expect(result.local_options[0]).toBe(option_name);
+                    expect(result.local_options[0]).toBe(option_name.toLowerCase());
                 }
             ),
             { numRuns: 20 }
@@ -348,7 +350,7 @@ describe('Program Pattern Detection and Macro Creation Property Tests', () => {
 
     /**
      * Property 8: Case Sensitivity
-     * Pattern detection should be case-sensitive for macro names but case-insensitive for commands.
+     * Pattern detection should normalize syntax-option macro names to lower case.
      */
     it('should handle case sensitivity correctly', () => {
         fc.assert(
@@ -368,10 +370,10 @@ describe('Program Pattern Detection and Macro Creation Property Tests', () => {
                     };
                     
                     // Include option_name in syntax_option_names
-                    const syntax_option_names = new Set([option_name]);
+                    const syntax_option_names = new Set([option_name.toLowerCase()]);
                     const result = (analyzer as any).extract_macro_creating_option_patterns([mock_node], syntax_option_names);
                     
-                    expect(result.local_options).toContain(option_name);
+                    expect(result.local_options).toContain(option_name.toLowerCase());
                 }
             ),
             { numRuns: 20 }
@@ -475,8 +477,8 @@ describe('Program Pattern Detection and Macro Creation Property Tests', () => {
                     const result = test_macro_creating_patterns('test_prog', local_opts, global_opts);
                     
                     // Deduplication means unique options only
-                    const unique_local = [...new Set(local_opts)];
-                    const unique_global = [...new Set(global_opts)];
+                    const unique_local = [...new Set(local_opts.map(opt => opt.toLowerCase()))];
+                    const unique_global = [...new Set(global_opts.map(opt => opt.toLowerCase()))];
                     
                     // Check all local options are detected
                     expect(result.local_options.length).toBe(unique_local.length);

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -139,6 +139,27 @@ end`;
             expect(program?.macro_creating_global_options).toContain('global');
         });
 
+        it('should lower-case macro-creating syntax options at call sites', () => {
+            const source = `program define myprog
+    syntax, Cache(string)
+    c_local \`cache' "value"
+end
+
+myprog, Cache(result)
+display \`result'
+`;
+
+            const result = analyze(source);
+
+            const program = result.symbols.programs.get('myprog');
+            expect(program?.macro_creating_local_options).toEqual(['cache']);
+            expect(result.symbols.localMacros.has('result')).toBe(true);
+            expect(result.diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('result')
+            )).toBeUndefined();
+        });
+
         it('should fall back to command range when option argument_range is undefined', () => {
             // Per spec requirements 3.3 and 4.3: definition location should use
             // option argument span, and if unavailable fall back to command span


### PR DESCRIPTION
## Summary
- Normalize syntax option names and macro-creating option pattern matches to lowercase.
- Match call-site user-program macro-creating options using lowercased option names.
- Update unit/property tests for Stata's lowercased runtime option locals.

## Validation
- bun test tests/unit/analyzer.test.ts
- bun test tests/property/program-pattern-detection-macro-creation.prop.test.ts tests/property/program-macro-creation-correctness.prop.test.ts
- bun run test

Fixes #167

Conversation: https://app.warp.dev/conversation/0d604b25-de4f-4001-b616-d8cfa0adb550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Macro-creating option names declared via syntax are now treated case-insensitively and normalized to lowercase across local and global detection.

* **Tests**
  * Updated property tests to expect lowercase option-name handling and deduplication.
  * Added a unit test confirming syntax-declared option names are normalized to lowercase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->