### PR TITLE
Fix flaky quoted-path-parsing property test

### DIFF
--- a/tests/property/quoted-path-parsing.prop.test.ts
+++ b/tests/property/quoted-path-parsing.prop.test.ts
@@ -3,6 +3,7 @@ import * as fc from 'fast-check';
 import { StataLexer } from '../../src/lexer';
 import { StataParser } from '../../src/parser';
 import { CommandNode } from '../../src/types';
+import { arbitrary_non_reserved_identifier } from './generators';
 
 /**
  * Property tests for quoted path parsing fix.
@@ -73,9 +74,13 @@ describe('Quoted Path Parsing Property Tests', () => {
 
   /**
    * Generator for valid Stata identifiers (WORD tokens).
+   * Excludes reserved qualifier keywords (`if`, `in`), prefix commands
+   * (`by`, `bysort`, `quietly`, ...), and file commands (`do`, `use`, ...)
+   * which are parsed specially when they appear as the first identifier
+   * after a command. See tests/property/generators/primitives.ts.
    */
   function arbitrary_identifier(): fc.Arbitrary<string> {
-    return arbitrary_macro_name();
+    return arbitrary_non_reserved_identifier();
   }
 
   /**


### PR DESCRIPTION
## Problem

The property test `Quoted Path Parsing Property Tests > Property 2: Comma Boundary Respected > should capture all arguments before comma` fails intermittently in CI.

The local `arbitrary_identifier()` generator in this file could randomly produce Stata reserved qualifier keywords (\`if\`, \`in\`) or prefix/file commands (\`by\`, \`do\`, etc.). When fast-check sampled such a keyword as a varlist argument to \`display\`/\`list\`/\`gen\`, the parser correctly treated it as a qualifier rather than a variable, so \`varlist\` came back as \`undefined\` and the assertion that \`my_cmd_node.varlist?.length === my_args.length\` failed.

Reproduction:

\`\`\`
display if, opt   →  varlist: undefined, options: [\"opt\"]
display in, opt   →  varlist: undefined, options: [\"opt\"]
\`\`\`

This is exactly the failure mode \`AGENTS.md\` warns about:

> Stata treats \`if\` and \`in\` as qualifiers in many statement contexts, so generating them as \"ordinary identifiers\" can produce misleading property-test failures.

## Fix

Delegate the file-local \`arbitrary_identifier()\` to the shared \`arbitrary_non_reserved_identifier()\` from \`tests/property/generators/primitives.ts\`, which filters out \`RESERVED_QUALIFIER_KEYWORDS\`, \`PREFIX_COMMANDS\`, and \`FILE_COMMANDS\`.

## Validation

- \`bun run typecheck\` clean
- Full suite: 5532 pass, 0 fail
- 10 consecutive runs of the affected test file pass cleanly

[Conversation](https://app.warp.dev/conversation/a12c1ad1-92b3-4e2f-9a46-0979d0181360)