### PR TITLE
Distinct codicon icons for viewer editor tabs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "sight",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "dependencies": {
         "@glideapps/glide-data-grid": "^6.0.3",
         "@jbearak/dta-parser": "^0.1.1",
@@ -379,7 +379,7 @@
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
-    "@types/vscode": ["@types/vscode@1.107.0", "", {}, "sha512-XS8YE1jlyTIowP64+HoN30OlC1H9xqSlq1eoLZUgFEC8oUTO6euYZxti1xRiLSfZocs4qytTzR6xCBYtioQTCg=="],
+    "@types/vscode": ["@types/vscode@1.120.0", "", {}, "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 

--- a/client/src/conflict-detector.ts
+++ b/client/src/conflict-detector.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { findConflictingExtensions, formatConflictMessage, formatConflictTooltip, isStataFile, getDisplayName, shouldPersistDismissal, ConflictingExtension } from './conflict-detector-core';
+import { applyViewerTabIcon } from './viewer-tab-icon';
 
 export { ConflictingExtension } from './conflict-detector-core';
 
@@ -154,6 +155,7 @@ export class ConflictDetector {
                 enableScripts: true
             }
         );
+        applyViewerTabIcon(panel, 'extensions');
 
         // Handle webview messages for command execution
         panel.webview.onDidReceiveMessage(async (message) => {

--- a/client/src/data-browser/custom-editor.ts
+++ b/client/src/data-browser/custom-editor.ts
@@ -12,6 +12,7 @@ import {
     build_data_browser_html,
     generate_nonce,
 } from './webview-html';
+import { applyViewerTabIcon } from '../viewer-tab-icon';
 
 class DataBrowserDocument
     implements vscode.CustomDocument {
@@ -49,7 +50,8 @@ export class DataBrowserReadonlyEditorProvider
         );
         const my_nonce = generate_nonce();
 
-        webview_panel.title = `Data: ${my_sidecar.name}`;
+        webview_panel.title = my_sidecar.name;
+        applyViewerTabIcon(webview_panel, 'table');
         webview_panel.webview.options = {
             enableScripts: true,
             localResourceRoots: [

--- a/client/src/data-browser/panel-manager.ts
+++ b/client/src/data-browser/panel-manager.ts
@@ -22,6 +22,7 @@ import {
     generate_nonce,
 } from './webview-html';
 import type { VviewSidecar } from './types';
+import { applyViewerTabIcon } from '../viewer-tab-icon';
 
 export class DataBrowserPanelManager
     implements vscode.Disposable {
@@ -56,7 +57,7 @@ export class DataBrowserPanelManager
         const my_webview_panel =
             vscode.window.createWebviewPanel(
                 DATA_BROWSER_PANEL_VIEW_TYPE,
-                `Data: ${sidecar.name}`,
+                sidecar.name,
                 vscode.ViewColumn.Active,
                 {
                     enableScripts: true,
@@ -70,6 +71,7 @@ export class DataBrowserPanelManager
                     ],
                 }
             );
+        applyViewerTabIcon(my_webview_panel, 'table');
 
         const my_nonce = generate_nonce();
         const my_html = build_data_browser_html(
@@ -118,7 +120,7 @@ export class DataBrowserPanelManager
         const my_webview_panel =
             vscode.window.createWebviewPanel(
                 DATA_BROWSER_PANEL_VIEW_TYPE,
-                `Data: ${my_sidecar.name}`,
+                my_sidecar.name,
                 column,
                 {
                     enableScripts: true,
@@ -132,6 +134,7 @@ export class DataBrowserPanelManager
                     ],
                 }
             );
+        applyViewerTabIcon(my_webview_panel, 'table');
 
         const my_nonce = generate_nonce();
         const my_html = build_data_browser_html(

--- a/client/src/smcl-preview/panel-manager.ts
+++ b/client/src/smcl-preview/panel-manager.ts
@@ -40,7 +40,7 @@ export class SmclPanelManager implements vscode.Disposable {
         const my_name = source_uri.fsPath.split(/[\\/]/).pop() || 'SMCL';
         const my_panel = vscode.window.createWebviewPanel(
             VIEW_TYPE,
-            `Preview ${my_name}`,
+            my_name,
             column,
             {
                 enableScripts: true,

--- a/client/src/smcl-preview/panel-manager.ts
+++ b/client/src/smcl-preview/panel-manager.ts
@@ -9,6 +9,7 @@
 import * as vscode from 'vscode';
 import { SmclPreviewPanel } from './preview-panel';
 import { LanguageClient } from 'vscode-languageclient/node';
+import { applyViewerTabIcon } from '../viewer-tab-icon';
 
 const VIEW_TYPE = 'sightSmclPreview';
 
@@ -46,6 +47,7 @@ export class SmclPanelManager implements vscode.Disposable {
                 retainContextWhenHidden: true,
             }
         );
+        applyViewerTabIcon(my_panel, 'book');
 
         const my_preview = new SmclPreviewPanel(
             source_uri,

--- a/client/src/smcl-preview/preview-panel.ts
+++ b/client/src/smcl-preview/preview-panel.ts
@@ -356,7 +356,7 @@ export class SmclPreviewPanel implements vscode.Disposable {
     private get_title(): string {
         const my_path = this.source_uri.fsPath;
         const my_name = my_path.split(/[\\/]/).pop() || 'SMCL Preview';
-        return `Preview ${my_name}`;
+        return my_name;
     }
 
     private get_current_topic(): string | undefined {

--- a/client/src/version-gate.ts
+++ b/client/src/version-gate.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure semver-ish gate for VSCode runtime version checks.
+ *
+ * Kept free of any `vscode` import so it can be exercised by the bun test
+ * suite (which cannot resolve the `vscode` module). The `vscode`-aware
+ * callers live in modules like `viewer-tab-icon.ts`.
+ */
+
+/**
+ * True when `version` is at least `major.minor`.
+ *
+ * Accepts VSCode version strings such as `"1.110.0"` or
+ * `"1.111.2-insider"` — only the leading `major.minor` integers are
+ * compared; any patch/pre-release suffix is ignored.
+ */
+export function meetsMinVersion(version: string, major: number, minor: number): boolean {
+    const [maj, min] = version.split('.').map((p) => parseInt(p, 10));
+    if (maj !== major) return maj > major;
+    return min >= minor;
+}

--- a/client/src/viewer-tab-icon.ts
+++ b/client/src/viewer-tab-icon.ts
@@ -1,0 +1,62 @@
+/**
+ * Editor-tab icons for sight's webview viewers (data browser, SMCL
+ * preview, extension-conflict help).
+ *
+ * `WebviewPanel.iconPath` only began honoring a `ThemeIcon` (codicon) at
+ * runtime in **VSCode 1.110** (microsoft/vscode#282608, finalized Feb 2026).
+ * Sight targets `engines.vscode: ^1.75.0`, and on older hosts the *only* way
+ * to set a custom tab icon is an image-file `Uri` — which we deliberately do
+ * not ship. So the icon is gated on the running VSCode version: on 1.110+ the
+ * panel gets its codicon; on older hosts `iconPath` is left unset and the tab
+ * keeps VSCode's default page icon (a graceful no-op, never an error).
+ *
+ * This is the single source of truth for that gate. New viewers should call
+ * `applyViewerTabIcon(...)` rather than assigning `iconPath` directly, so both
+ * the version guard and the type-cast below stay in one place.
+ */
+
+import * as vscode from 'vscode';
+import { meetsMinVersion } from './version-gate';
+
+/** First VSCode version whose runtime renders a `ThemeIcon` as a webview tab icon. */
+const THEME_ICON_TAB_MIN = { major: 1, minor: 110 } as const;
+
+/**
+ * Locally-widened view of `WebviewPanel.iconPath`.
+ *
+ * `@types/vscode` is pinned to the `engines.vscode` floor (1.75), whose
+ * `iconPath` is typed `Uri | { light; dark }` only — assigning a `ThemeIcon`
+ * to it would not type-check, even though VSCode >= 1.110 accepts one at
+ * runtime. A `WebviewPanel` is structurally assignable to this interface (its
+ * narrower `iconPath` fits this wider union), so the cast in
+ * `applyViewerTabIcon` needs no `unknown` and the assigned value stays fully
+ * type-checked. Cannot be a `declare module 'vscode'` merge: interface merging
+ * adds members but cannot re-type an existing property like `iconPath`.
+ */
+interface WebviewPanelWithThemeIcon {
+    iconPath?: vscode.Uri | { readonly light: vscode.Uri; readonly dark: vscode.Uri } | vscode.ThemeIcon;
+}
+
+/**
+ * A codicon to assign to a webview panel's `iconPath`, or `undefined` on
+ * hosts that predate `ThemeIcon` tab-icon support. Assigning `undefined` to
+ * `iconPath` is valid and leaves the default page icon in place.
+ */
+export function viewerTabIcon(codiconId: string): vscode.ThemeIcon | undefined {
+    // `vscode.version` is always a string at runtime; guard anyway so test
+    // doubles that omit it fall through to "unsupported" rather than throwing.
+    if (typeof vscode.version !== 'string') return undefined;
+    return meetsMinVersion(vscode.version, THEME_ICON_TAB_MIN.major, THEME_ICON_TAB_MIN.minor)
+        ? new vscode.ThemeIcon(codiconId)
+        : undefined;
+}
+
+/**
+ * Assign a codicon to `panel`'s editor tab, or leave VSCode's default page
+ * icon in place on hosts older than 1.110. Use this rather than assigning
+ * `panel.iconPath` directly so the version guard and the floor-pinned-types
+ * cast stay centralized here.
+ */
+export function applyViewerTabIcon(panel: vscode.WebviewPanel, codiconId: string): void {
+    (panel as WebviewPanelWithThemeIcon).iconPath = viewerTabIcon(codiconId);
+}

--- a/client/test/extension-smoke.js
+++ b/client/test/extension-smoke.js
@@ -150,8 +150,7 @@ async function run() {
             async () => {
                 return the_created_panels.find(
                     (my_panel) =>
-                        my_panel.title
-                        === `Data: ${my_name}`
+                        my_panel.title === my_name
                 );
             },
             5000
@@ -160,7 +159,7 @@ async function run() {
 
         assert.strictEqual(
             my_panel_title.title,
-            `Data: ${my_name}`,
+            my_name,
             `Expected data browser panel. Panels: ${JSON.stringify(the_created_panels)}`
         );
     } finally {

--- a/tests/unit/version-gate.test.ts
+++ b/tests/unit/version-gate.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test';
+import { meetsMinVersion } from '../../client/src/version-gate';
+
+describe('meetsMinVersion', () => {
+    // Gate used by viewer-tab-icon.ts: ThemeIcon webview tab icons require
+    // VSCode >= 1.110, so the cutover point (1.109.x vs 1.110.0) matters.
+    it('rejects versions below the cutoff', () => {
+        expect(meetsMinVersion('1.82.0', 1, 110)).toBe(false);
+        expect(meetsMinVersion('1.109.9', 1, 110)).toBe(false);
+    });
+
+    it('accepts the exact minimum and above', () => {
+        expect(meetsMinVersion('1.110.0', 1, 110)).toBe(true);
+        expect(meetsMinVersion('1.111.0', 1, 110)).toBe(true);
+    });
+
+    it('ignores patch and pre-release suffixes', () => {
+        expect(meetsMinVersion('1.111.2-insider', 1, 110)).toBe(true);
+        expect(meetsMinVersion('1.110.0-insider', 1, 110)).toBe(true);
+    });
+
+    it('compares the major version first', () => {
+        expect(meetsMinVersion('2.0.0', 1, 110)).toBe(true);
+        expect(meetsMinVersion('0.99.0', 1, 110)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Data browser, SMCL preview, and extension-conflict help webview tabs now carry codicons (`table`, `book`, `extensions`) instead of VS Code's generic page icon.
- With the data tab now self-identifying via the icon, the redundant `Data:` title prefix is dropped so the tab reads as just the dataset name.
- `applyViewerTabIcon` centralizes the runtime version gate (VS Code ≥ 1.110, [microsoft/vscode#282608](https://github.com/microsoft/vscode/issues/282608)) and the safe structural cast to a locally-widened `iconPath` interface — `engines.vscode` and `@types/vscode` both stay pinned at `^1.75.0`, so `vsce package` is satisfied and old hosts gracefully fall back to the default icon.
- Ported close to the equivalent change in jbearak/raven@059fc2ec.

## Test plan
- [x] `bun run typecheck` (repo root + client) — clean.
- [x] `bun test tests/unit/version-gate.test.ts` — 4/4 pass.
- [x] `bun test` (full suite) — 5677 pass / 2 skip / 0 fail.
- [x] `bunx vsce ls --no-dependencies` — packs without the `@types/vscode > engines.vscode` rejection.
- [ ] Manual smoke on VS Code ≥ 1.110: open a `.dta` (table icon, no `Data:` prefix), preview a `.sthlp` (book icon), open the Extension Conflicts panel (extensions icon).
- [ ] Manual smoke on VS Code 1.82–1.109: tabs keep the default page icon, no error in the dev console.