### PR TITLE
refactor(diagnostics): drop dead live-read fallback in deferral check

### DIFF
--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -247,10 +247,14 @@ export class DiagnosticsProvider {
         // clears — the user sees a red-squiggly flicker. The snapshot
         // closes that race by keeping both signals consistent.
         const backward_dep_mode = config.cross_file?.backward_dependencies ?? 'auto';
+        // Always use the snapshot, never a live `is_scan_complete()` read. A
+        // live read is exactly what reintroduces the race (see comment above):
+        // it can observe a false→true transition that happened after
+        // `has_auto_parents` was captured. When the snapshot is absent (only
+        // possible if the resolver had no dependency graph), default to `false`
+        // (defer) rather than reading live state.
         const scan_complete_for_deferral =
-            resolved_scope?.scan_complete_at_resolve_time
-                ?? this.dependency_graph?.is_scan_complete()
-                ?? false;
+            resolved_scope?.scan_complete_at_resolve_time ?? false;
         const defer_undefined_diagnostics = backward_dep_mode === 'auto' &&
             this.dependency_graph &&
             !scan_complete_for_deferral &&


### PR DESCRIPTION
## Summary

Follow-up cleanup to #175, prompted by an adversarial multi-agent review of that merged PR (code-simplifier + bug + performance reviews, plus an adversarial judge — all PASS).

#175 fixed a diagnostic-flicker race by having the deferral check use a **snapshot** of `scan_complete` (captured synchronously with `has_auto_parents` in `ScopeResolver.resolve()`) instead of a live `is_scan_complete()` read. But the fallback chain kept a live read as its middle term:

```ts
resolved_scope?.scan_complete_at_resolve_time
    ?? this.dependency_graph?.is_scan_complete()   // <- live read
    ?? false
```

That term is **dead in every real wiring path**: the snapshot is only `undefined` when the resolver had no dependency graph, yet production wires the *same* graph instance into the resolver and the diagnostics provider together. In the one hypothetical path where it could fire (provider has a graph, resolver did not), a live read would reintroduce exactly the `false→true` race #175 set out to eliminate.

## Change

Simplify to `?? false` so deferral **always uses the snapshot, never a live read**. When the snapshot is absent we default to deferring, preserving the prior "defer when unknown" behavior. Behavior-preserving on all real and tested paths.

## Verification

- `bun run typecheck` clean
- 19/19 cross-file flicker + auto-backward regression tests pass
- 263/263 diagnostics tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of undefined-symbol diagnostic deferral in auto backward-dependency mode by using consistent snapshot data for more accurate diagnostic message timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/sight/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->