### PR TITLE
fix(diagnostics): stop parent-close flicker; skip VCS dirs in workspace scan

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -47,6 +47,10 @@ const MAX_PARALLEL = 4;
 const YIELD_INTERVAL_MS = 100;
 const INDEX_DEBOUNCE_MS = 200;
 
+// Version-control metadata directories skipped during workspace scans.
+// They contain no Stata source and recursing them is wasted work.
+const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
+
 export interface IndexedFileData {
     uri: string;
     tokens: Token[];
@@ -303,6 +307,13 @@ export class WorkspaceIndexer {
                 const entry_path = path.join(dir_path, entry.name);
 
                 if (entry.isDirectory()) {
+                    // Skip version-control metadata directories. They hold no
+                    // Stata source, can be very large, and recursing them is
+                    // pure scan overhead — the standard convention for code
+                    // indexers and language servers.
+                    if (VCS_METADATA_DIRS.has(entry.name)) {
+                        continue;
+                    }
                     await this.scan_directory(entry_path);
                 } else if (entry.isFile()) {
                     if (

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1079,17 +1079,31 @@ export async function create_server(options: ServerOptions): Promise<void> {
         if (scope_resolver) {
             scope_resolver.remove_caller_from_reverse_deps(e.document.uri);
         }
-        // Immediately clear stale in-memory graph edges on close.
-        // In-memory edits may have changed do/run/include edges that differ
-        // from the on-disk state; clearing them and cascade-invalidating
-        // ensures callees don't resolve against a stale parent set.
+        // On close, the buffer's in-memory edges/symbols are discarded, so
+        // callees that inherited from this file must re-resolve against its
+        // on-disk content. Revalidate the current callees with this file's
+        // parent edge still INTACT, then re-index from disk to correct any
+        // edges that existed only in the unsaved buffer.
+        //
+        // We deliberately do NOT clear this file's edges to empty first.
+        // Doing so makes callees momentarily resolve against an empty parent
+        // set and publish a false "undefined symbol" warning that the
+        // subsequent re-index immediately clears — the user perceives this
+        // as a red-squiggle flicker. The captured callee set is identical to
+        // what `update_caller(uri, [])` would report as changed (every
+        // callee), so revalidation coverage is unchanged; only the spurious
+        // empty-edge window is removed.
         if (dependency_graph) {
-            const graph_result = dependency_graph.update_caller(e.document.uri, []);
-            if (graph_result.changed_callees.size > 0) {
-                invalidate_and_revalidate_callees(graph_result.changed_callees);
+            const affected_callees = new Set(
+                dependency_graph.get_callees(e.document.uri)
+            );
+            if (affected_callees.size > 0) {
+                invalidate_and_revalidate_callees(affected_callees);
             }
         }
-        // Restore disk-state edges via re-indexing.
+        // Restore disk-state edges via re-indexing (corrects edges that were
+        // only present in the unsaved buffer; fires its own callee
+        // revalidation via on_graph_change if the edge set actually changed).
         if (dependency_graph && workspace_indexer) {
             workspace_indexer.schedule_update(
                 URI.parse(e.document.uri).fsPath

--- a/tests/integration/cmd-hover-peek-flicker.test.ts
+++ b/tests/integration/cmd-hover-peek-flicker.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Regression test for the Cmd-hover (definition peek) diagnostic flicker.
+ *
+ * User-visible bug: open `demo_child.do` LOCALLY (parent never shown as a
+ * tab) and Cmd-hover over `` `fruit' ``. An "Undefined local macro" warning
+ * briefly flashed then cleared.
+ *
+ * Root cause: VS Code's Cmd-hover peek opens the *definition target*
+ * (`demo_parent.do`) invisibly to render the preview, then closes it again —
+ * firing onDidOpen + onDidClose for the parent even though no tab is shown.
+ * The pre-#177 onDidClose ran `update_caller(parent, [])`, transiently
+ * emptying the parent's include edge, so the open child momentarily resolved
+ * against an empty parent set and warned. This is the same #177 edge-churn,
+ * just triggered by the peek lifecycle rather than a user-driven close.
+ *
+ * This test models the full peek lifecycle against the real subsystems and
+ * asserts:
+ *   1. the OLD close behavior (emptying the parent edge) DOES flicker the
+ *      child — proving the lifecycle reproduces the bug, and
+ *   2. the FIXED close behavior (revalidate callees with the edge intact)
+ *      keeps the child clean across the entire open→close sequence.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { DocumentStore } from '../../src/document-store';
+import { DiagnosticsProvider } from '../../src/providers/diagnostics';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
+
+let tmp_dir: string;
+
+function build_config(): StataLSPConfig {
+    return {
+        diagnostics: {
+            enabled: true,
+            severity: {
+                undefinedMacro: 'warning',
+                undefinedVariable: 'off',
+                styleWarnings: 'hint',
+                malformedOperator: 'warning',
+                invalidOperatorSequence: 'error',
+                cStyleLogicalInControlFlow: 'information',
+                mixedLogicalOperators: 'warning',
+            },
+            indentation: false,
+        },
+        completion: { cacheSize: 200, prefixMaxItems: 200 },
+        formatting: {
+            indentSize: 4,
+            indentStyle: 'spaces',
+            lineWidth: 80,
+            preferredCommentStyle: 'line',
+            normalizeCommentStyle: false,
+            commentLineWidth: 72,
+            mode: 'source-preserving',
+            preserve_alignment: true,
+        },
+        lineCommentStyle: '//',
+        indexing: { maxFileSizeBytes: 500000 },
+        adoPaths: [],
+        indexWorkspace: true,
+        cross_file: {
+            index_workspace: true,
+            max_indexed_files: 1000,
+            assume_call_site: 'end',
+            backward_dependencies: 'auto',
+            max_backward_depth: 10,
+            max_forward_depth: 10,
+            max_chain_depth: 20,
+            max_callee_revalidations: 10,
+            diagnostics: { missing_file: 'warning', max_depth: 'information' },
+        },
+        debug: false,
+    };
+}
+
+// Buffer-aware content provider mirroring the server's disk-for-closed /
+// buffer-for-open switch (server-factory.ts content provider).
+function make_provider(open_buffers: Map<string, string>) {
+    return {
+        read_file: async (uri: string) => {
+            const buf = open_buffers.get(uri);
+            if (buf !== undefined) return buf;
+            return fs.promises.readFile(URI.parse(uri).fsPath, 'utf8');
+        },
+        exists: async (uri: string) => {
+            if (open_buffers.has(uri)) return true;
+            try {
+                await fs.promises.access(URI.parse(uri).fsPath);
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        stat: async (uri: string) => {
+            try {
+                const stats = await fs.promises.stat(URI.parse(uri).fsPath);
+                return { mtimeMs: stats.mtimeMs, size: stats.size };
+            } catch {
+                return undefined;
+            }
+        },
+    };
+}
+
+function has_undefined_macro(diags: { code?: unknown; message?: string }[]): boolean {
+    return diags.some(d =>
+        d.code === StataDiagnosticCode.UNDEFINED_MACRO
+        || (typeof d.message === 'string'
+            && d.message.toLowerCase().includes('undefined local macro')));
+}
+
+describe('Cmd-hover peek lifecycle flicker (parent open then close)', () => {
+    let child_uri: string;
+    let parent_uri: string;
+    let child_content: string;
+    let parent_content: string;
+    let graph: DependencyGraph;
+    let indexer: WorkspaceIndexer;
+    let scope_resolver: ScopeResolver;
+    let provider: DiagnosticsProvider;
+    let store: DocumentStore;
+    let open_buffers: Map<string, string>;
+
+    beforeEach(async () => {
+        tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'peek-flicker-'));
+        const parent_path = path.join(tmp_dir, 'demo_parent.do');
+        const child_path = path.join(tmp_dir, 'demo_child.do');
+        parent_content =
+            '* demo_parent.do\nlocal fruit apple\ninclude demo_child.do \n';
+        child_content = '* demo_child.do\ndi "fruit: `fruit\'"\n';
+        fs.writeFileSync(parent_path, parent_content);
+        fs.writeFileSync(child_path, child_content);
+        child_uri = URI.file(child_path).toString();
+        parent_uri = URI.file(parent_path).toString();
+
+        open_buffers = new Map();
+        graph = new DependencyGraph();
+        indexer = new WorkspaceIndexer();
+        indexer.set_dependency_graph(graph);
+        indexer.configure(build_config());
+        scope_resolver = new ScopeResolver(undefined, make_provider(open_buffers));
+        scope_resolver.set_dependency_graph(graph);
+        provider = new DiagnosticsProvider({ sendDiagnostics() {} } as never);
+        provider.set_dependency_graph(graph);
+        store = new DocumentStore();
+        store.set_scope_resolver(scope_resolver);
+
+        // Open the CHILD (the file the user is looking at). Parent stays closed.
+        open_buffers.set(child_uri, child_content);
+        await store.open(child_uri, child_content, 1);
+
+        // Workspace scan completes -> parent edge present, scan_complete=true.
+        await indexer.initialize([tmp_dir], []);
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmp_dir, { recursive: true, force: true });
+    });
+
+    async function child_diagnostics() {
+        provider.clear_published_version(child_uri);
+        return provider.get_diagnostics(
+            store.get(child_uri) as never,
+            build_config(),
+            indexer.get_all_symbols(),
+            scope_resolver,
+        );
+    }
+
+    // The peek transiently OPENS the parent (definition target) to render the
+    // preview: buffer now backs the parent and it is analyzed.
+    async function peek_open_parent() {
+        open_buffers.set(parent_uri, parent_content);
+        scope_resolver.invalidate_scope_cache(parent_uri);
+        await store.open(parent_uri, parent_content, 1);
+    }
+
+    it('steady state after scan resolves `fruit` (no warning)', async () => {
+        expect(graph.is_scan_complete()).toBe(true);
+        expect(graph.get_parents(child_uri).length).toBe(1);
+        expect(has_undefined_macro(await child_diagnostics())).toBe(false);
+    });
+
+    it('OLD close behavior: peek open then edge-emptying close flickers the child', async () => {
+        await peek_open_parent();
+        expect(has_undefined_macro(await child_diagnostics())).toBe(false);
+
+        // Pre-#177 onDidClose: empty the parent's edges first, then revalidate.
+        open_buffers.delete(parent_uri);
+        store.close(parent_uri);
+        graph.update_caller(parent_uri, []);
+        scope_resolver.cascade_invalidate(new Set([child_uri]));
+
+        // Edge gone with the scan complete -> the open child warns (flicker).
+        expect(has_undefined_macro(await child_diagnostics())).toBe(true);
+    });
+
+    it('FIX: peek open then close keeps the child clean throughout', async () => {
+        const samples: boolean[] = [];
+        samples.push(has_undefined_macro(await child_diagnostics()));
+
+        await peek_open_parent();
+        samples.push(has_undefined_macro(await child_diagnostics()));
+
+        // Fixed onDidClose: capture the parent's current callees with the edge
+        // still INTACT, drop the buffer, then revalidate (no edge emptying).
+        const affected_callees = new Set(graph.get_callees(parent_uri));
+        expect(affected_callees.has(child_uri)).toBe(true);
+        open_buffers.delete(parent_uri);
+        store.close(parent_uri);
+        scope_resolver.cascade_invalidate(affected_callees);
+        samples.push(has_undefined_macro(await child_diagnostics()));
+
+        // Edge intact throughout -> `fruit` always resolves via the parent.
+        expect(graph.get_parents(child_uri).length).toBe(1);
+        expect(samples.some(Boolean)).toBe(false);
+    });
+});

--- a/tests/integration/cross-file-close-flicker.test.ts
+++ b/tests/integration/cross-file-close-flicker.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression test for the cross-file diagnostic flicker on PARENT CLOSE.
+ *
+ * Bug: when a parent file (e.g. `demo_parent.do`, which `include`s
+ * `demo_child.do` and defines `` `fruit' ``) is closed, the server's
+ * onDidClose handler used to call `dependency_graph.update_caller(uri, [])`,
+ * transiently emptying the parent's edges. That made the open callee
+ * (`demo_child.do`) momentarily resolve against an empty parent set and
+ * publish an "Undefined local macro" warning, which the subsequent
+ * re-index immediately cleared — a red-squiggle flicker. This happens even
+ * though the workspace scan is long complete, so the #175 scan-completion
+ * deferral does not guard it.
+ *
+ * Fix: on close, revalidate the parent's current callees with the parent
+ * edge still INTACT (then re-index from disk to correct unsaved-buffer
+ * edges), instead of emptying the edges first.
+ *
+ * This test exercises the real ScopeResolver + DependencyGraph +
+ * DiagnosticsProvider + WorkspaceIndexer and asserts:
+ *   1. steady state after the scan is clean,
+ *   2. emptying the parent's edges (the OLD behavior) DOES produce
+ *      UNDEFINED_MACRO — proving the test reproduces the bug, and
+ *   3. revalidating the callee with the edge intact (the FIX) does NOT.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { DocumentStore } from '../../src/document-store';
+import { DiagnosticsProvider } from '../../src/providers/diagnostics';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
+
+let tmp_dir: string;
+
+function build_config(): StataLSPConfig {
+    return {
+        diagnostics: {
+            enabled: true,
+            severity: {
+                undefinedMacro: 'warning',
+                undefinedVariable: 'off',
+                styleWarnings: 'hint',
+                malformedOperator: 'warning',
+                invalidOperatorSequence: 'error',
+                cStyleLogicalInControlFlow: 'information',
+                mixedLogicalOperators: 'warning',
+            },
+            indentation: false,
+        },
+        completion: { cacheSize: 200, prefixMaxItems: 200 },
+        formatting: {
+            indentSize: 4,
+            indentStyle: 'spaces',
+            lineWidth: 80,
+            preferredCommentStyle: 'line',
+            normalizeCommentStyle: false,
+            commentLineWidth: 72,
+            mode: 'source-preserving',
+            preserve_alignment: true,
+        },
+        lineCommentStyle: '//',
+        indexing: { maxFileSizeBytes: 500000 },
+        adoPaths: [],
+        indexWorkspace: true,
+        cross_file: {
+            index_workspace: true,
+            max_indexed_files: 1000,
+            assume_call_site: 'end',
+            backward_dependencies: 'auto',
+            max_backward_depth: 10,
+            max_forward_depth: 10,
+            max_chain_depth: 20,
+            max_callee_revalidations: 10,
+            diagnostics: { missing_file: 'warning', max_depth: 'information' },
+        },
+        debug: false,
+    };
+}
+
+function file_provider() {
+    return {
+        read_file: async (uri: string) =>
+            fs.promises.readFile(URI.parse(uri).fsPath, 'utf8'),
+        exists: async (uri: string) => {
+            try {
+                await fs.promises.access(URI.parse(uri).fsPath);
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        stat: async (uri: string) => {
+            try {
+                const stats = await fs.promises.stat(URI.parse(uri).fsPath);
+                return { mtimeMs: stats.mtimeMs, size: stats.size };
+            } catch {
+                return undefined;
+            }
+        },
+    };
+}
+
+function has_undefined_macro(diags: { code?: unknown; message?: string }[]): boolean {
+    return diags.some(d =>
+        d.code === StataDiagnosticCode.UNDEFINED_MACRO
+        || (typeof d.message === 'string'
+            && d.message.toLowerCase().includes('undefined local macro')));
+}
+
+describe('cross-file diagnostic flicker on parent close', () => {
+    let child_uri: string;
+    let parent_uri: string;
+    let child_content: string;
+    let graph: DependencyGraph;
+    let indexer: WorkspaceIndexer;
+    let scope_resolver: ScopeResolver;
+    let provider: DiagnosticsProvider;
+    let store: DocumentStore;
+
+    beforeEach(async () => {
+        tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'close-flicker-'));
+        const parent_path = path.join(tmp_dir, 'demo_parent.do');
+        const child_path = path.join(tmp_dir, 'demo_child.do');
+        fs.writeFileSync(
+            parent_path,
+            '* demo_parent.do\nlocal fruit apple\ninclude demo_child.do \n',
+        );
+        child_content = '* demo_child.do\ndi "fruit: `fruit\'"\n';
+        fs.writeFileSync(child_path, child_content);
+        child_uri = URI.file(child_path).toString();
+        parent_uri = URI.file(parent_path).toString();
+
+        graph = new DependencyGraph();
+        indexer = new WorkspaceIndexer();
+        indexer.set_dependency_graph(graph);
+        indexer.configure(build_config());
+        scope_resolver = new ScopeResolver(undefined, file_provider());
+        scope_resolver.set_dependency_graph(graph);
+        provider = new DiagnosticsProvider(
+            { sendDiagnostics() { } } as never,
+        );
+        provider.set_dependency_graph(graph);
+        store = new DocumentStore();
+        await store.open(child_uri, child_content, 1);
+
+        // Initial workspace scan completes: parent edge present.
+        await indexer.initialize([tmp_dir], []);
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmp_dir, { recursive: true, force: true });
+    });
+
+    async function child_diagnostics() {
+        provider.clear_published_version(child_uri);
+        return provider.get_diagnostics(
+            store.get(child_uri) as never,
+            build_config(),
+            indexer.get_all_symbols(),
+            scope_resolver,
+        );
+    }
+
+    it('steady state after scan resolves `fruit` (no warning)', async () => {
+        expect(graph.is_scan_complete()).toBe(true);
+        expect(graph.get_parents(child_uri).length).toBe(1);
+        expect(has_undefined_macro(await child_diagnostics())).toBe(false);
+    });
+
+    it('OLD behavior: emptying the parent edge produces the flicker warning', async () => {
+        // Reproduce the pre-fix onDidClose step.
+        graph.update_caller(parent_uri, []);
+        scope_resolver.cascade_invalidate(new Set([child_uri]));
+        // With the edge gone but the scan complete, the callee warns.
+        expect(has_undefined_macro(await child_diagnostics())).toBe(true);
+    });
+
+    it('FIX: revalidating callees with the edge intact does not flicker', async () => {
+        // The fixed onDidClose captures the parent's current callees and
+        // revalidates them WITHOUT first emptying the parent's edges.
+        const affected_callees = new Set(graph.get_callees(parent_uri));
+        expect(affected_callees.has(child_uri)).toBe(true);
+
+        scope_resolver.cascade_invalidate(affected_callees);
+        // Edge still present -> `fruit` resolves via the include parent.
+        expect(graph.get_parents(child_uri).length).toBe(1);
+        expect(has_undefined_macro(await child_diagnostics())).toBe(false);
+    });
+});

--- a/tests/integration/indexer-skips-vcs-dirs.test.ts
+++ b/tests/integration/indexer-skips-vcs-dirs.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The workspace scan must skip version-control metadata directories
+ * (`.git`, `.hg`, `.svn`). They contain no Stata source and recursing
+ * them is pure overhead. A `.do` file planted inside `.git` must NOT be
+ * indexed; a sibling `.do` outside it must be.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { StataLSPConfig } from '../../src/types';
+
+let tmp_dir: string;
+
+function build_config(): StataLSPConfig {
+    return {
+        diagnostics: { enabled: true, severity: {} as never, indentation: false },
+        completion: { cacheSize: 200, prefixMaxItems: 200 },
+        formatting: {
+            indentSize: 4, indentStyle: 'spaces', lineWidth: 80,
+            preferredCommentStyle: 'line', normalizeCommentStyle: false,
+            commentLineWidth: 72, mode: 'source-preserving',
+            preserve_alignment: true,
+        },
+        lineCommentStyle: '//',
+        indexing: { maxFileSizeBytes: 500000 },
+        adoPaths: [],
+        indexWorkspace: true,
+        cross_file: {
+            index_workspace: true, max_indexed_files: 1000,
+            assume_call_site: 'end', backward_dependencies: 'auto',
+            max_backward_depth: 10, max_forward_depth: 10, max_chain_depth: 20,
+            max_callee_revalidations: 10,
+            diagnostics: { missing_file: 'warning', max_depth: 'information' },
+        },
+        debug: false,
+    };
+}
+
+describe('indexer skips VCS metadata directories', () => {
+    beforeEach(() => {
+        tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vcs-skip-'));
+    });
+    afterEach(() => {
+        fs.rmSync(tmp_dir, { recursive: true, force: true });
+    });
+
+    it('does not index .do files inside .git, .hg, or .svn', async () => {
+        const tracked = path.join(tmp_dir, 'tracked.do');
+        fs.writeFileSync(tracked, 'program define foo\nend\n');
+
+        for (const vcs of ['.git', '.hg', '.svn']) {
+            const dir = path.join(tmp_dir, vcs, 'hooks');
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(path.join(dir, 'buried.do'), 'program define bar\nend\n');
+        }
+
+        const indexer = new WorkspaceIndexer();
+        indexer.configure(build_config());
+        await indexer.initialize([tmp_dir], []);
+
+        const indexed = indexer.get_indexed_files();
+        const tracked_uri = URI.file(tracked).toString();
+
+        // The tracked file outside VCS dirs must be indexed.
+        expect(indexed.has(tracked_uri)).toBe(true);
+
+        // No file under any VCS metadata directory may be indexed.
+        for (const vcs of ['.git', '.hg', '.svn']) {
+            const buried_uri = URI.file(
+                path.join(tmp_dir, vcs, 'hooks', 'buried.do'),
+            ).toString();
+            expect(indexed.has(buried_uri)).toBe(false);
+        }
+    });
+});


### PR DESCRIPTION
Two fixes for a cross-file "Undefined local macro" flicker, plus a scan optimization. The originally-reported open-and-Cmd-hover flicker turned out to be the **same** parent-close edge-churn as fix #1, triggered by VS Code's peek lifecycle (see Root cause below).

## 1. Edge-churn flicker on parent close

`onDidClose` (`server-factory.ts`) called `dependency_graph.update_caller(uri, [])`, transiently **emptying** the closing file's `do`/`run`/`include` edges. An open callee (e.g. `demo_child.do`, whose `` `fruit' `` is defined in the just-closed `demo_parent.do`) then momentarily resolved against an empty parent set and published an undefined-macro warning that the follow-up re-index immediately cleared — a red-squiggle flicker. The workspace scan is long complete here, so the #175 scan-completion deferral doesn't guard it.

**Fix:** capture the closing file's current callees from the graph and revalidate them with the parent edge still **intact**, then re-index from disk to correct any edges that existed only in the unsaved buffer. The captured callee set is identical to what `update_caller(uri, [])` reported as changed, so revalidation coverage is unchanged — only the spurious empty-edge window is removed.

## 2. Workspace scan skips VCS metadata dirs (`.git`, `.hg`, `.svn`)

They contain no Stata source and recursing them is pure overhead (a full repo scan otherwise traverses all of `.git`). Standard convention for code indexers / language servers.

## Root cause of the Cmd-hover flicker (confirmed)

The user-reported trigger — open `demo_child.do` locally, Cmd-hover over `` `fruit' `` — is the **same** edge-churn as fix #1. Ground-truth logging from an instrumented build showed that a Cmd-hover peek opens the **definition target** (`demo_parent.do`) invisibly to render the preview, then closes it again:

```
onDidOpen  demo_parent.do
onDidClose demo_parent.do callees=[demo_child.do]
```

No parent tab is ever shown, which is why the earlier analysis assumed "the parent is never opened." The transient `onDidClose` is exactly the pre-fix edge-emptying path, so the open child flickered. On this branch's fix the flicker no longer occurs (verified live in VS Code).

## Tests
- `cross-file-close-flicker.test.ts`: steady state clean; the OLD edge-emptying step DOES warn (reproduces the bug); the FIX does not.
- `cmd-hover-peek-flicker.test.ts`: models the full peek open->close lifecycle; the OLD close flickers the child, the FIX keeps it clean throughout.
- `indexer-skips-vcs-dirs.test.ts`: a `.do` buried in `.git`/`.hg`/`.svn` is not indexed; a sibling outside is.

Full suite green (5687 pass, 2 skip, 0 fail); typecheck clean.

<\!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed diagnostic flicker when closing files with cross-file dependencies.
  * Improved indexing efficiency by skipping version-control metadata directories (`.git`, `.hg`, `.svn`).

* **Tests**
  * Added integration tests for VCS directory exclusion and cross-file dependency handling.

<\!-- review_stack_entry_start -->

[\![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbearak/sight/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<\!-- review_stack_entry_end -->

<\!-- end of auto-generated comment: release notes by coderabbit.ai -->
