### PR TITLE
fix(client): disambiguate extension output channels

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -37,7 +37,7 @@ import {
 
 let client: LanguageClient | null = null;
 let output_channel: OutputChannel | null = window.createOutputChannel(
-    'Sight Language Server'
+    'Sight Extension'
 );
 const DEACTIVATE_TIMEOUT_MS = 200;
 
@@ -62,7 +62,7 @@ const client_lifecycle = new LanguageClientLifecycle<LanguageClient>(
 export function activate(context: ExtensionContext): void {
     if (!output_channel) {
         output_channel = window.createOutputChannel(
-            'Sight Language Server'
+            'Sight Extension'
         );
     }
 


### PR DESCRIPTION
## Summary
- VS Code's Output dropdown showed two entries both labeled **"Sight Language Server"**, which was confusing since they contain different logs.
- The duplication came from two separately-created channels sharing a name: the extension's own log channel and the `LanguageClient`'s channel.
- Renamed the extension's own channel to **"Sight Extension"** (activation, lifecycle, conflict-detector logs), leaving **"Sight Language Server"** for the LSP server traffic.

## Why
Two identically-named entries in the Output menu made it impossible to tell which channel held which logs at a glance.

## Notes for reviewers
- Change is confined to `client/src/extension.ts` (both creation sites of the manual channel).
- The `LanguageClient` constructor name at `extension.ts:252` is intentionally left as "Sight Language Server".
- Requires rebuilding/repackaging the extension to take effect.

## Test plan
- [ ] Rebuild the extension and confirm the Output dropdown shows distinct "Sight Extension" and "Sight Language Server" entries.