### PR TITLE
Remove the data-viewer status bar; relocate its signals to the toolbar

### DIFF
--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -367,7 +367,6 @@ export class DataBrowserPanel implements vscode.Disposable {
                 stored_filter: this.filter.entries.length > 0
                     ? this.filter
                     : undefined,
-                dataset_label: this.dta_file.dataset_label,
                 name: this.sidecar.name,
                 dataset_key: this.dataset_key,
                 stored_column_widths:
@@ -380,7 +379,6 @@ export class DataBrowserPanel implements vscode.Disposable {
                         this.dataset_key,
                         this.dataset_key_aliases
                     ),
-                source: this.sidecar.source,
                 subsetted: this.sidecar.subsetted,
                 varlist: this.sidecar.varlist,
                 if_condition: this.sidecar.if,
@@ -390,8 +388,8 @@ export class DataBrowserPanel implements vscode.Disposable {
             this.panel.webview.postMessage(my_metadata);
 
             // A restored filter changes the visible row count; the
-            // webview learns it from filterApplied (metadata.nobs stays
-            // the full dataset size for the status bar).
+            // webview learns the effective count from filterApplied
+            // (metadata.nobs stays the full dataset size).
             if (this.filtered_indices) {
                 this.post_filter_applied();
             }

--- a/client/src/data-browser/types.ts
+++ b/client/src/data-browser/types.ts
@@ -86,7 +86,6 @@ export interface MetadataMessage {
     type: 'metadata';
     nobs: number;
     variables: VariableDescription[];
-    dataset_label: string;
     name: string;
     dataset_key: string;
     schema_hash: string;
@@ -94,7 +93,6 @@ export interface MetadataMessage {
     stored_hidden_columns?: string[];
     stored_sort?: SortState;
     stored_filter?: FilterState;
-    source?: string;
     subsetted?: boolean;
     varlist?: string[];
     if_condition?: string;

--- a/client/src/data-browser/webview/app.tsx
+++ b/client/src/data-browser/webview/app.tsx
@@ -21,7 +21,7 @@ import {
     clamp_column_width,
     collect_sampled_value_width_hints,
     type BrowserGridColumn,
-    describe_status_summary,
+    describe_subset,
     describe_visible_rows,
     get_cell_display_value,
     get_variable_header_tooltip,
@@ -30,7 +30,6 @@ import {
 import {
     build_visible_column_map,
     build_visible_grid_columns,
-    describe_hidden_column_count,
     hide_all_columns,
     show_all_columns,
     toggle_column_hidden,
@@ -50,7 +49,6 @@ import { col_kind } from './filter-column-kind.js';
 import {
     active_direction,
     apply_sort_pick,
-    describe_sort_keys,
     sort_priority_map,
 } from './sort-actions.js';
 import type { FilterEntry, SortKey } from '../types.js';
@@ -821,6 +819,15 @@ export function App(): ReactElement {
         )
         : 'Loading...';
 
+    const subset_text = describe_subset(metadata);
+    // Sort and filter are usually mutually exclusive, but both can be
+    // in flight at once; show every pending operation rather than
+    // letting one mask the other.
+    const the_progress_parts: string[] = [];
+    if (sort_pending) the_progress_parts.push('Sorting…');
+    if (filter_pending) the_progress_parts.push('Filtering…');
+    const sort_filter_progress_text = the_progress_parts.join(' · ');
+
     // Drop the sort/filter chips onto their own row when they would
     // otherwise crowd the action buttons off the toolbar. `hidden_columns.size`
     // is a dependency because it drives the Columns button's count badge,
@@ -834,36 +841,6 @@ export function App(): ReactElement {
         },
         [sort.keys, filter.entries, row_count_text, hidden_columns.size]
     );
-
-    const hidden_count_text = describe_hidden_column_count(
-        hidden_columns.size
-    );
-    const sort_status_text = sort_pending
-        ? 'Sorting…'
-        : sort.keys.length > 0
-            ? `sorted by ${describe_sort_keys(sort.keys, column_names)}`
-            : '';
-    const has_enabled_filter = filter.entries.some(
-        my_entry => my_entry.enabled
-    );
-    const filter_status_text = filter_pending
-        ? 'Filtering…'
-        : has_enabled_filter
-            && metadata
-            && nobs_effective !== undefined
-            ? `filtered to ${nobs_effective} of ${metadata.nobs}`
-                + ` (${metadata.nobs > 0
-                    ? Math.round(
-                        (100 * nobs_effective) / metadata.nobs
-                    )
-                    : 0}%)`
-            : '';
-    const status_text = [
-        describe_status_summary(metadata),
-        hidden_count_text,
-        sort_status_text,
-        filter_status_text,
-    ].filter(Boolean).join(' | ');
 
     const clamp_position = (
         left: number,
@@ -1150,6 +1127,14 @@ export function App(): ReactElement {
                     </div>
                 </div>
             </div>
+            {sort_filter_progress_text && (
+                <div className="toolbar-progress" role="status">
+                    {sort_filter_progress_text}
+                </div>
+            )}
+            {subset_text && (
+                <div className="toolbar-subset-row">{subset_text}</div>
+            )}
             <div className="grid-shell" ref={grid_shell_ref}>
                 <DataEditor
                     theme={vscode_theme}
@@ -1416,7 +1401,6 @@ export function App(): ReactElement {
                     />
                 )}
             </div>
-            <div className="status-bar">{status_text}</div>
         </div>
     );
 }

--- a/client/src/data-browser/webview/column-visibility-model.ts
+++ b/client/src/data-browser/webview/column-visibility-model.ts
@@ -48,15 +48,3 @@ export function hide_all_columns(
 export function show_all_columns(): Set<string> {
     return new Set();
 }
-
-export function describe_hidden_column_count(
-    hidden_count: number
-): string | null {
-    if (hidden_count <= 0) {
-        return null;
-    }
-    if (hidden_count === 1) {
-        return '1 column hidden';
-    }
-    return `${hidden_count} columns hidden`;
-}

--- a/client/src/data-browser/webview/grid-model.ts
+++ b/client/src/data-browser/webview/grid-model.ts
@@ -279,50 +279,30 @@ export function describe_visible_rows(
     return `Showing ${my_start.toLocaleString()}-${my_end.toLocaleString()} of ${nobs.toLocaleString()}`;
 }
 
-export function describe_status_summary(
+/** Toolbar subset banner, e.g. "Subsetted (vars: make, price; if
+ *  foreign == 1; in 1/10)". Returns null when the browse covers the
+ *  full dataset, so callers can skip rendering the row entirely. */
+export function describe_subset(
     metadata: MetadataMessage | null
-): string {
-    if (!metadata) {
-        return '';
+): string | null {
+    if (!metadata || !metadata.subsetted) {
+        return null;
     }
 
     const the_parts: string[] = [];
-    the_parts.push(metadata.name);
-
-    if (metadata.dataset_label) {
-        the_parts.push(metadata.dataset_label);
+    if (metadata.varlist && metadata.varlist.length > 0) {
+        the_parts.push(`vars: ${metadata.varlist.join(', ')}`);
     }
-    if (metadata.source) {
-        the_parts.push(metadata.source);
+    if (metadata.if_condition) {
+        the_parts.push(`if ${metadata.if_condition}`);
     }
-
-    if (metadata.subsetted) {
-        const the_subset_parts: string[] = [];
-        if (metadata.varlist && metadata.varlist.length > 0) {
-            the_subset_parts.push(
-                `vars: ${metadata.varlist.join(', ')}`
-            );
-        }
-        if (metadata.if_condition) {
-            the_subset_parts.push(
-                `if ${metadata.if_condition}`
-            );
-        }
-        if (metadata.in_condition) {
-            the_subset_parts.push(
-                `in ${metadata.in_condition}`
-            );
-        }
-        the_parts.push(
-            the_subset_parts.length > 0
-                ? `Subsetted (${the_subset_parts.join('; ')})`
-                : 'Subsetted'
-        );
-    } else {
-        the_parts.push('Full dataset');
+    if (metadata.in_condition) {
+        the_parts.push(`in ${metadata.in_condition}`);
     }
 
-    return the_parts.filter(Boolean).join(' | ');
+    return the_parts.length > 0
+        ? `Subsetted (${the_parts.join('; ')})`
+        : 'Subsetted';
 }
 
 export function get_needed_page_starts(

--- a/client/src/data-browser/webview/predicate-summary.ts
+++ b/client/src/data-browser/webview/predicate-summary.ts
@@ -1,7 +1,7 @@
 /**
- * Pure summarizer for FilterPredicates. Used by chip labels, aria labels,
- * and the status bar. Output is short (chips have limited width) and uses
- * Unicode glyphs (≠, ≤, ∈, ∉) so a chip reads like math without CSS.
+ * Pure summarizer for FilterPredicates. Used by chip labels and aria
+ * labels. Output is short (chips have limited width) and uses Unicode
+ * glyphs (≠, ≤, ∈, ∉) so a chip reads like math without CSS.
  *
  * Set-membership summaries map numeric codes to value labels when the
  * column has a value-label table, and truncate after 4 values.

--- a/client/src/data-browser/webview/sort-actions.ts
+++ b/client/src/data-browser/webview/sort-actions.ts
@@ -81,25 +81,6 @@ export function move_to_first(
     return my_next;
 }
 
-/** Compact status-bar summary, e.g. "mpg ▲, price ▼". Truncates after
- *  four keys with a "+N more" suffix. Empty string when no keys. */
-export function describe_sort_keys(
-    keys: readonly SortKey[],
-    names: readonly string[]
-): string {
-    if (keys.length === 0) return '';
-    const MAX = 4;
-    const the_visible = keys.slice(0, MAX).map(my_key => {
-        const my_name =
-            names[my_key.col_index] ?? `col ${my_key.col_index}`;
-        return `${my_name} ${my_key.direction === 'asc' ? '▲' : '▼'}`;
-    });
-    const my_text = the_visible.join(', ');
-    return keys.length > MAX
-        ? `${my_text}, +${keys.length - MAX} more`
-        : my_text;
-}
-
 /** Map each sorted column to its direction and 1-based priority. */
 export function sort_priority_map(
     keys: readonly SortKey[]

--- a/client/src/data-browser/webview/styles.css
+++ b/client/src/data-browser/webview/styles.css
@@ -20,9 +20,13 @@ body,
     font-size: var(--vscode-editor-font-size, 13px);
 }
 
+/* Column layout: the toolbar and the optional subset row size to their
+   content; the grid below takes the remaining height. A column flexbox
+   (rather than a fixed-track grid) keeps the grid as the single growing
+   region no matter how many header rows are shown. */
 .browser-root {
-    display: grid;
-    grid-template-rows: auto 1fr auto;
+    display: flex;
+    flex-direction: column;
     height: 100%;
     min-height: 0;
 }
@@ -34,19 +38,37 @@ body,
     padding: 6px 8px;
     border-bottom: 1px solid var(--vscode-panel-border);
     background: var(--vscode-editorGroupHeader-tabsBackground, var(--vscode-editor-background));
-    /* The toolbar is a grid item in `.browser-root` (a single auto-track
-       grid). Without this, its automatic minimum (`min-width: auto`)
-       resolves to the chips' content width and forces the grid track wider
-       than the viewport: the toolbar overflows, the action buttons are
-       pushed off-screen, and the chip strips never get narrow enough to
-       engage their own `overflow-x` scroll. `min-width: 0` lets the
-       toolbar shrink to the grid container so the chip row scrolls within
-       it instead. */
+    /* The toolbar is a flex item in the column-flex `.browser-root`.
+       Without this, its automatic minimum (`min-width: auto`) resolves to
+       the chips' content width and forces it wider than the viewport: the
+       toolbar overflows, the action buttons are pushed off-screen, and the
+       chip strips never get narrow enough to engage their own `overflow-x`
+       scroll. `min-width: 0` lets the toolbar shrink to its container so
+       the chip row scrolls within it instead. */
     min-width: 0;
 }
 
 .row-count {
     opacity: 0.85;
+}
+
+/* Secondary header rows beneath the toolbar: the transient sort/filter
+   progress line ("Sorting…" / "Filtering…") and the persistent subset
+   banner (shown when the browse is a partial slice). Both are full-width
+   rows, so — unlike an inline toolbar element — they never enter
+   use-toolbar-wrap's measurement and can't flip the chips to a second
+   row mid-operation. The subset banner keeps a filtered view from being
+   mistaken for the full dataset. */
+.toolbar-progress,
+.toolbar-subset-row {
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    background: var(--vscode-editorGroupHeader-tabsBackground, var(--vscode-editor-background));
+    opacity: 0.85;
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 /* Sort + filter chip strips. Sits between the row count and the action
@@ -101,6 +123,7 @@ body,
 .grid-shell {
     position: relative;
     display: flex;
+    flex: 1 1 0;
     min-width: 0;
     min-height: 0;
     overflow: hidden;
@@ -256,17 +279,6 @@ body,
     font-size: 10px;
     line-height: 16px;
     vertical-align: middle;
-}
-
-.status-bar {
-    padding: 4px 8px;
-    border-top: 1px solid var(--vscode-panel-border);
-    background: var(--vscode-statusBar-background, var(--vscode-editor-background));
-    color: var(--vscode-statusBar-foreground, var(--vscode-foreground));
-    opacity: 0.8;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 /* Context menu — sort section */

--- a/tests/unit/data-browser/browser-panel.test.ts
+++ b/tests/unit/data-browser/browser-panel.test.ts
@@ -8,7 +8,7 @@ import {
     compute_default_column_width,
     compute_header_width_px,
     compute_sampled_value_width_px,
-    describe_status_summary,
+    describe_subset,
     describe_visible_rows,
     get_cell_display_value,
     get_variable_header_subtitle,
@@ -151,7 +151,6 @@ describe('grid-model helpers', () => {
                 label: 'Car origin',
                 has_value_labels: true,
             }],
-            dataset_label: '',
             name: 'auto',
             dataset_key: '/tmp/auto.dta',
         }, {})[0]?.variable_label).toBe('Car origin');
@@ -165,20 +164,46 @@ describe('grid-model helpers', () => {
         })).toBe('Car origin');
     });
 
-    it('builds subset-aware status summaries', () => {
-        expect(describe_status_summary({
+    it('returns null when metadata is missing or not subsetted', () => {
+        expect(describe_subset(null)).toBeNull();
+        expect(describe_subset({
             type: 'metadata',
             nobs: 10,
             variables: [],
-            dataset_label: 'Cars',
             name: 'auto',
             dataset_key: '/tmp/auto.dta',
-            source: '/tmp/auto.dta',
+            schema_hash: 'h',
+            subsetted: false,
+        })).toBeNull();
+    });
+
+    it('describes the subset conditions when subsetted', () => {
+        expect(describe_subset({
+            type: 'metadata',
+            nobs: 10,
+            variables: [],
+            name: 'auto',
+            dataset_key: '/tmp/auto.dta',
+            schema_hash: 'h',
             subsetted: true,
             varlist: ['make', 'price'],
             if_condition: 'foreign == 1',
             in_condition: '1/10',
-        })).toContain('Subsetted');
+        })).toBe(
+            'Subsetted (vars: make, price; if foreign == 1; in 1/10)'
+        );
+    });
+
+    it('falls back to a bare label when subsetted with no conditions', () => {
+        expect(describe_subset({
+            type: 'metadata',
+            nobs: 10,
+            variables: [],
+            name: 'auto',
+            dataset_key: '/tmp/auto.dta',
+            schema_hash: 'h',
+            subsetted: true,
+        })).toBe('Subsetted');
     });
 
     it('normalizes row requests to page starts', () => {
@@ -197,7 +222,6 @@ describe('grid-model helpers', () => {
                 label: 'Car origin',
                 has_value_labels: true,
             }],
-            dataset_label: '',
             name: 'auto',
             dataset_key: '/tmp/auto.dta',
         }, {
@@ -260,7 +284,6 @@ describe('grid-model helpers', () => {
                 label: 'Car origin',
                 has_value_labels: true,
             }],
-            dataset_label: '',
             name: 'auto',
             dataset_key: '/tmp/auto.dta',
         };
@@ -315,7 +338,6 @@ describe('grid-model helpers', () => {
                 label: '',
                 has_value_labels: false,
             }],
-            dataset_label: '',
             name: 'auto',
             dataset_key: '/tmp/auto.dta',
         };

--- a/tests/unit/data-browser/sort-actions.test.ts
+++ b/tests/unit/data-browser/sort-actions.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'bun:test';
 import {
     active_direction,
     apply_sort_pick,
-    describe_sort_keys,
     flip_key,
     move_to_first,
     remove_key,
@@ -55,25 +54,6 @@ describe('data-browser sort key mutations', () => {
     it('move_to_first is a no-op at index 0', () => {
         expect(move_to_first([k(0), k(1)], 0))
             .toEqual([k(0), k(1)]);
-    });
-});
-
-describe('data-browser describe_sort_keys', () => {
-    const names = ['a', 'b', 'c', 'd', 'e', 'f'];
-    it('is empty when no keys', () => {
-        expect(describe_sort_keys([], names)).toBe('');
-    });
-    it('lists columns with direction arrows', () => {
-        expect(describe_sort_keys([k(0, 'asc'), k(1, 'desc')], names))
-            .toBe('a ▲, b ▼');
-    });
-    it('truncates after four keys', () => {
-        const keys = [k(0), k(1), k(2), k(3), k(4), k(5)];
-        expect(describe_sort_keys(keys, names))
-            .toBe('a ▲, b ▲, c ▲, d ▲, +2 more');
-    });
-    it('falls back to a column index label when name missing', () => {
-        expect(describe_sort_keys([k(9)], names)).toBe('col 9 ▲');
     });
 });
 


### PR DESCRIPTION
## What & why

The data viewer's status bar was unnecessary. It displayed the dataset's **source path**, which is redundant with the path already shown in the **panel title bar** (the bar effectively showed the path twice). This removes the status bar entirely and relocates the two signals worth keeping into the toolbar/header area.

## Removed
- The `.status-bar` row and its styles.
- `describe_status_summary`, `describe_hidden_column_count`, and `describe_sort_keys` — the status bar was their only consumer — plus their unit tests.
- The now-unconsumed `source` and `dataset_label` fields from the `MetadataMessage` wire protocol.

## Relocated
- **Subset awareness** → a dedicated `Subsetted (vars …; if …; in …)` row beneath the toolbar, rendered only when a browse is a partial slice (new `describe_subset` helper, unit-tested). Keeps a load-time subset from being mistaken for the full dataset.
- **Sort/filter progress** → a transient `Sorting…` / `Filtering…` header row during async operations. It deliberately sits **outside** the wrap-measured `.toolbar-chips` so it can never flip the chips to a second row mid-operation, and it reports both states when a sort and filter are pending at once.

## Layout
`.browser-root` switches from a fixed 3-track grid (the 3rd track *was* the status bar) to a column flexbox, so the grid stays the single growing region no matter how many header rows show.

## Intentional trade-offs (please confirm)
Removing the status bar drops some text it used to carry. Most is still surfaced elsewhere — hidden-column count (Columns button badge), active sort/filter (the chips), effective row count (the row-count line). Two reductions are by design and worth a look:
- The **dataset label** (e.g. `1978 Automobile Data`) is no longer displayed (only the short name in the tab title). Say the word and I can surface it somewhere non-redundant.
- For an **interactive in-grid filter**, the old `filtered to N of M (X%)` readout is gone; the row-count line shows the filtered total and the active filter chips indicate a filter is applied. I can restore an explicit "of M (X%)" readout if you want it.

## Verification
- `bun run typecheck`, full `bun test` (5685 pass), `client` webview bundle, and `client` eslint all pass.
- Two consecutive high-effort code-review passes are clean of actionable defects; the only remaining findings are the two intentional trade-offs above.

https://claude.ai/code/session_01HuV9vXTVrZG3Cd11A85tL3