### PR TITLE
Lazy-load data browser histograms

### DIFF
--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -78,6 +78,25 @@ const MAX_CACHED_PAGES = 10;
 // Upper bound on value-label entries shipped per column to the webview.
 const MAX_SHIPPED_VALUE_LABELS = 10_000;
 
+function can_compute_histogram(
+    dta_file: DtaFile,
+    col_index: number
+): boolean {
+    const my_variable = dta_file.variables[col_index];
+    if (!my_variable) return false;
+    const my_has_value_labels =
+        my_variable.value_label_name !== ''
+        && dta_file.value_label_tables.has(
+            my_variable.value_label_name
+        );
+    const my_kind = classify_sort_kind({
+        type: my_variable.type,
+        format: my_variable.format,
+        has_value_labels: my_has_value_labels,
+    });
+    return my_kind === 'numeric' || my_kind === 'labelledNumeric';
+}
+
 export class DataBrowserPanel implements vscode.Disposable {
     private panel: vscode.WebviewPanel;
     private dta_file: DtaFile | null = null;
@@ -910,12 +929,21 @@ export class DataBrowserPanel implements vscode.Disposable {
     private async handle_request_histogram(
         msg: RequestHistogramMessage
     ): Promise<void> {
-        if (!this.dta_file) return;
+        const post_empty = () => this.post_histogram(
+            msg.col_index,
+            []
+        );
+        if (!this.dta_file) {
+            post_empty();
+            return;
+        }
         const my_col_index = msg.col_index;
         if (
             my_col_index < 0
             || my_col_index >= this.dta_file.nvar
+            || !can_compute_histogram(this.dta_file, my_col_index)
         ) {
+            post_empty();
             return;
         }
 
@@ -928,9 +956,15 @@ export class DataBrowserPanel implements vscode.Disposable {
             // and the webview, having marked the column requested, would
             // never see a brush.
             const my_file = this.dta_file;
-            const the_values = await this.read_full_column(
-                my_col_index
-            );
+            let the_values: RowCell[];
+            try {
+                the_values = await this.read_full_column(
+                    my_col_index
+                );
+            } catch {
+                post_empty();
+                return;
+            }
             if (this.dta_file !== my_file || !this.dta_file) {
                 return;
             }
@@ -946,10 +980,17 @@ export class DataBrowserPanel implements vscode.Disposable {
             this.histogram_cache.set(my_col_index, my_bins);
         }
 
+        this.post_histogram(my_col_index, my_bins);
+    }
+
+    private post_histogram(
+        col_index: number,
+        bins: HistogramBin[]
+    ): void {
         const my_msg: HistogramDataMessage = {
             type: 'histogramData',
-            col_index: my_col_index,
-            bins: my_bins,
+            col_index,
+            bins,
         };
         this.panel.webview.postMessage(my_msg);
     }

--- a/client/src/data-browser/webview/app.tsx
+++ b/client/src/data-browser/webview/app.tsx
@@ -21,8 +21,8 @@ import {
     clamp_column_width,
     collect_sampled_value_width_hints,
     type BrowserGridColumn,
+    describe_browser_row_count,
     describe_subset,
-    describe_visible_rows,
     get_cell_display_value,
     get_variable_header_tooltip,
     merge_persisted_and_default_widths,
@@ -811,13 +811,12 @@ export function App(): ReactElement {
         }
     };
 
-    const row_count_text = metadata
-        ? describe_visible_rows(
-            nobs_effective ?? metadata.nobs,
-            first_visible_row,
-            visible_row_count
-        )
-        : 'Loading...';
+    const row_count_text = describe_browser_row_count(
+        metadata,
+        nobs_effective,
+        first_visible_row,
+        visible_row_count
+    );
 
     const subset_text = describe_subset(metadata);
     // Sort and filter are usually mutually exclusive, but both can be

--- a/client/src/data-browser/webview/grid-model.ts
+++ b/client/src/data-browser/webview/grid-model.ts
@@ -279,6 +279,22 @@ export function describe_visible_rows(
     return `Showing ${my_start.toLocaleString()}-${my_end.toLocaleString()} of ${nobs.toLocaleString()}`;
 }
 
+export function describe_browser_row_count(
+    metadata: MetadataMessage | null,
+    nobs_effective: number | undefined,
+    first_visible_row: number,
+    visible_row_count: number
+): string {
+    if (!metadata) {
+        return 'Loading…';
+    }
+    return describe_visible_rows(
+        nobs_effective ?? metadata.nobs,
+        first_visible_row,
+        visible_row_count
+    );
+}
+
 /** Toolbar subset banner, e.g. "Subsetted (vars: make, price; if
  *  foreign == 1; in 1/10)". Returns null when the browse covers the
  *  full dataset, so callers can skip rendering the row entirely. */

--- a/tests/unit/data-browser/browser-panel.test.ts
+++ b/tests/unit/data-browser/browser-panel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, mock } from 'bun:test';
 import { make_missing_value } from '@jbearak/dta-parser';
 import { build_cell_value } from '../../../client/src/data-browser/cell-format';
 import {
@@ -8,6 +8,7 @@ import {
     compute_default_column_width,
     compute_header_width_px,
     compute_sampled_value_width_px,
+    describe_browser_row_count,
     describe_subset,
     describe_visible_rows,
     get_cell_display_value,
@@ -130,6 +131,11 @@ describe('grid-model helpers', () => {
     it('formats visible row counts', () => {
         expect(describe_visible_rows(1000, 0, 50))
             .toBe('Showing 1-50 of 1,000');
+    });
+
+    it('routes missing metadata to the loading row-count label', () => {
+        expect(describe_browser_row_count(null, undefined, 0, 0))
+            .toBe('Loading…');
     });
 
     it('exposes variable labels for header subtitles', () => {
@@ -372,5 +378,202 @@ describe('grid-model helpers', () => {
 
         expect(compute_default_column_width(my_variable, []))
             .toBe(compute_header_width_px(my_variable));
+    });
+});
+
+mock.module('vscode', () => ({
+    workspace: {
+        getConfiguration: () => ({
+            get: (_key: string, default_value: unknown) => default_value,
+        }),
+    },
+    window: {
+        showErrorMessage: () => undefined,
+    },
+    env: {
+        clipboard: {
+            writeText: async () => undefined,
+        },
+    },
+}));
+
+type PostedMessage = {
+    type: string;
+    col_index?: number;
+    bins?: unknown[];
+};
+
+type HistogramPanelHarness = {
+    panel_like: any;
+    posted: PostedMessage[];
+    read_count: () => number;
+};
+
+async function make_histogram_panel(
+    variable: {
+        name: string;
+        type: string;
+        format: string;
+        value_label_name: string;
+    },
+    values_or_error: number[] | Error,
+    value_label_tables: Map<string, Map<number, string>> = new Map()
+): Promise<HistogramPanelHarness> {
+    const { DataBrowserPanel } = await import(
+        '../../../client/src/data-browser/browser-panel'
+    );
+    const posted: PostedMessage[] = [];
+    let read_count = 0;
+    const panel_like: any = Object.create(DataBrowserPanel.prototype);
+    panel_like.dta_file = {
+        nvar: 1,
+        variables: [variable],
+        value_label_tables,
+    };
+    panel_like.histogram_cache = new Map();
+    panel_like.panel = {
+        webview: {
+            postMessage: (message: PostedMessage) => {
+                posted.push(message);
+                return true;
+            },
+        },
+    };
+    panel_like.read_full_column = async () => {
+        read_count += 1;
+        if (values_or_error instanceof Error) {
+            throw values_or_error;
+        }
+        return values_or_error;
+    };
+
+    return {
+        panel_like,
+        posted,
+        read_count: () => read_count,
+    };
+}
+
+describe('DataBrowserPanel histogram requests', () => {
+    it('lazily computes and caches a numeric histogram on request', async () => {
+        const { panel_like, posted, read_count } =
+            await make_histogram_panel({
+                name: 'price',
+                type: 'double',
+                format: '%9.0g',
+                value_label_name: '',
+            }, [1, 2, 3, 4, 5]);
+
+        await panel_like.handle_request_histogram({
+            type: 'requestHistogram',
+            col_index: 0,
+        });
+        await panel_like.handle_request_histogram({
+            type: 'requestHistogram',
+            col_index: 0,
+        });
+
+        expect(read_count()).toBe(1);
+        expect(posted.length).toBe(2);
+        expect(posted[0]?.type).toBe('histogramData');
+        expect(posted[0]?.col_index).toBe(0);
+        expect(posted[0]?.bins?.length).toBe(50);
+        expect(posted[0]?.bins).toEqual(posted[1]?.bins);
+        expect(
+            (posted[0]?.bins ?? [])
+                .reduce((sum, bin: any) => sum + bin.count, 0)
+        ).toBe(5);
+    });
+
+    it('allows labelled numeric columns to use histogram brushes', async () => {
+        const the_labels = new Map<string, Map<number, string>>([
+            ['origin', new Map([
+                [0, 'Domestic'],
+                [1, 'Foreign'],
+            ])],
+        ]);
+        const { panel_like, posted, read_count } =
+            await make_histogram_panel({
+                name: 'foreign',
+                type: 'byte',
+                format: '%9.0g',
+                value_label_name: 'origin',
+            }, [0, 1, 1], the_labels);
+
+        await panel_like.handle_request_histogram({
+            type: 'requestHistogram',
+            col_index: 0,
+        });
+
+        expect(read_count()).toBe(1);
+        expect(posted[0]?.bins?.length).toBe(50);
+        expect(
+            (posted[0]?.bins ?? [])
+                .reduce((sum, bin: any) => sum + bin.count, 0)
+        ).toBe(3);
+    });
+
+    it('replies with empty bins for out-of-range histogram requests', async () => {
+        const { panel_like, posted, read_count } =
+            await make_histogram_panel({
+                name: 'price',
+                type: 'double',
+                format: '%9.0g',
+                value_label_name: '',
+            }, [1, 2, 3]);
+
+        await panel_like.handle_request_histogram({
+            type: 'requestHistogram',
+            col_index: 99,
+        });
+
+        expect(posted).toEqual([{
+            type: 'histogramData',
+            col_index: 99,
+            bins: [],
+        }]);
+        expect(read_count()).toBe(0);
+    });
+
+    it('does not scan non-numeric columns for histogram requests', async () => {
+        const { panel_like, posted, read_count } =
+            await make_histogram_panel({
+                name: 'make',
+                type: 'str18',
+                format: '%18s',
+                value_label_name: '',
+            }, [1, 2, 3]);
+
+        await panel_like.handle_request_histogram({
+            type: 'requestHistogram',
+            col_index: 0,
+        });
+
+        expect(read_count()).toBe(0);
+        expect(posted).toEqual([{
+            type: 'histogramData',
+            col_index: 0,
+            bins: [],
+        }]);
+    });
+
+    it('settles scan failures with an empty histogram reply', async () => {
+        const { panel_like, posted } = await make_histogram_panel({
+            name: 'price',
+            type: 'double',
+            format: '%9.0g',
+            value_label_name: '',
+        }, new Error('decode failed'));
+
+        await expect(panel_like.handle_request_histogram({
+            type: 'requestHistogram',
+            col_index: 0,
+        })).resolves.toBeUndefined();
+
+        expect(posted).toEqual([{
+            type: 'histogramData',
+            col_index: 0,
+            bins: [],
+        }]);
     });
 });


### PR DESCRIPTION
## Summary

- Lazy-load data-browser histograms on `requestHistogram` and cache computed bins.
- Return empty histogram replies for invalid, non-histogrammable, and scan-error cases so the webview does not stay stuck loading.
- Show an explicit row-count loading label while metadata is unavailable.

## Verification

- `bun test tests/unit/data-browser/browser-panel.test.ts`
- `bun run test`
- `bun run lint`
- `bun run build`
- `git diff --check`

## Review

- Ran the requested `reviewing-until-clean-twice` process.
- Fixed two surviving findings during the loop:
  - Kept loading state in the browser-specific row-count helper rather than the generic row formatter.
  - Added coverage that out-of-range histogram requests do not scan the column.
- Final two full-diff review passes were clean across correctness, invariants, tests, docs/user-facing text, and maintainability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Histogram computation now gracefully handles unavailable or unsupported columns by displaying empty histograms instead of failing silently.
  * Improved data read error handling—failures during histogram computation are now settled with empty histograms instead of propagating errors.
  * Enhanced row count display accuracy in the data browser interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->