### PR TITLE
Add sight check CLI subcommand

### DIFF
--- a/.kiro/settings/lsp.json
+++ b/.kiro/settings/lsp.json
@@ -5,7 +5,7 @@
       "command": "sight",
       "args": ["--stdio"],
       "file_extensions": ["do", "ado", "doh", "mata"],
-      "project_patterns": [".sight.json"],
+      "project_patterns": ["sight.toml", ".sight.json"],
       "exclude_patterns": ["**/node_modules/**", "**/dist/**"],
       "multi_workspace": false
     }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The editor extension enables language server features and further provides:
 ### Guides
 
 - [Configuration](docs/configuration.md) - All settings and options
+- [CLI](docs/cli.md) - `sight check` for CI and command-line diagnostics
 - [Standalone Installation](docs/standalone-installation.md) - CLI usage, release binary, build from source
 - [Editor Integrations](docs/editor-integrations.md) - Generic LSP clients, AI agents
 - [Neovim Setup](docs/neovim-setup.md) - Configure Sight for Neovim

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,9 +33,9 @@ Options:
 Exit codes:
 
 - `0`: no diagnostic exceeded `--max-severity`.
-- `1`: at least one diagnostic exceeded `--max-severity`, or a usage error.
-- `2`: operator error, such as invalid workspace, missing explicit path, or
-  malformed config.
+- `1`: at least one diagnostic exceeded `--max-severity`.
+- `2`: operator or usage error, such as an unknown or malformed flag, invalid
+  workspace, missing explicit path, or malformed config.
 
 Example:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,49 @@
+# CLI
+
+Sight ships a `sight` binary for editor language-server use and command-line
+checks.
+
+## `sight check`
+
+Run the same static diagnostics Sight publishes in the editor, but in a
+headless batch suitable for CI:
+
+```text
+sight check [OPTIONS] [PATHS...]
+```
+
+`sight check` always indexes the whole workspace so `do`, `run`, and `include`
+chains resolve correctly. Positional `PATHS...` only filter which files report
+diagnostics. With no paths, Sight reports every `.do`, `.ado`, `.doh`, and
+`.mata` file under the workspace.
+
+Options:
+
+- `--workspace DIR`: workspace root to index. Defaults to the current directory.
+- `--config PATH`: explicit `sight.toml`, resolved from the invocation
+  directory.
+- `--no-config`: ignore `sight.toml` and use built-in defaults.
+- `--format text|json|sarif`: output format. Defaults to `text`.
+- `--max-severity off|hint|info|warning|error`: highest severity that does not
+  fail the build. Defaults to `info`, so warnings and errors fail.
+- `--quiet`: suppress the text summary line.
+- `--color auto|always|never`: colorize text output.
+- `--no-color`: alias for `--color never`.
+
+Exit codes:
+
+- `0`: no diagnostic exceeded `--max-severity`.
+- `1`: at least one diagnostic exceeded `--max-severity`, or a usage error.
+- `2`: operator error, such as invalid workspace, missing explicit path, or
+  malformed config.
+
+Example:
+
+```yaml
+- name: Check Stata sources
+  run: sight check
+```
+
+`.mata` files are included as report targets because Sight indexes them for
+symbols, but v1 diagnostics for Mata are limited to what the current parser and
+diagnostic pipeline can produce.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,6 +190,12 @@ will use the same discovery from `--workspace`.
 Project config wins over client/editor settings per key. Keys omitted from
 `sight.toml` continue to come from editor settings or built-in defaults.
 
+In a multi-root workspace, the project config is loaded only from the first
+workspace folder and applied to every document; a separate `sight.toml` in
+another folder is not resolved per-root. The server logs a note when it detects
+multiple folders. Open one project per window, or place a single `sight.toml`
+at a shared root, if you need distinct project settings.
+
 `.sight.json` is no longer supported. Convert its contents to TOML syntax;
 renaming the file is not enough because JSON and TOML are different languages.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,29 @@ Project config wins over client/editor settings per key. Keys omitted from
 `.sight.json` is no longer supported. Convert its contents to TOML syntax;
 renaming the file is not enough because JSON and TOML are different languages.
 
+### Naming convention and case aliasing
+
+The canonical spelling for every setting is **camelCase** (e.g.
+`crossFile.maxChainDepth`, `formatting.preserveAlignment`,
+`diagnostics.severity.undefinedMacro`). This is the form used throughout this
+documentation and matches comparable tools (Pyright, rust-analyzer,
+typescript-language-server).
+
+As a permanent guarantee, **every setting also accepts its `snake_case`
+spelling as an equivalent alias, and vice-versa** — so you never have to
+remember which form a given setting uses. `crossFile.maxChainDepth` and
+`cross_file.max_chain_depth` are identical, as are `formatting.preserveAlignment`
+and `formatting.preserve_alignment`. Section names alias too
+(`crossFile` ≡ `cross_file`), and matching is case-insensitive overall
+(`CrossFile` also works). You may even mix conventions within a single config.
+
+This aliasing applies uniformly to **every** configuration entry point:
+`sight.toml`, editor `settings.json` (VS Code), and the `initializationOptions`
+non-VS-Code clients send (Neovim, Helix, Zed, Claude Code). When two spellings
+of the same key appear together and neither is the canonical camelCase form,
+both are ignored and a warning is emitted; when one of them is canonical, the
+canonical spelling wins.
+
 ```toml
 indexWorkspace = true
 adoPaths = []

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -583,6 +583,10 @@ as it indicates a semantic issue that affects symbol inheritance.
 ## Configuration
 
 Cross-file resolution is configured via `sight.toml` in your project root.
+Setting names use camelCase by convention, but the `snake_case` spelling is a
+permanent equivalent alias for every key (e.g. `crossFile.maxChainDepth` ≡
+`cross_file.max_chain_depth`). See
+[Naming convention and case aliasing](configuration.md#naming-convention-and-case-aliasing).
 
 ```toml
 [crossFile]

--- a/docs/superpowers/plans/2026-06-21-sight-check.md
+++ b/docs/superpowers/plans/2026-06-21-sight-check.md
@@ -1,0 +1,2305 @@
+# sight check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `sight check`, a headless CLI diagnostic checker that indexes a Stata workspace and reports editor-parity diagnostics for CI.
+
+**Architecture:** Implement a direct batch pipeline, not an internal LSP client. The CLI will parse `sight check` arguments, load `sight.toml`, build the same indexer/scope/diagnostic provider graph the server uses, collect diagnostics per report target, render text/JSON/SARIF, and return CI-friendly exit codes.
+
+**Tech Stack:** TypeScript, Bun, `vscode-languageserver`, `vscode-uri`, existing Sight lexer/parser/analyzer/indexer/scope providers, Bun test, fast-check.
+
+---
+
+## File Structure
+
+- Create `src/cli/shared.ts`: exit codes, severity ordering, output format parsing, color resolution, deterministic diagnostic sorting, and text/JSON/SARIF rendering.
+- Create `src/cli/source-files.ts`: supported source extension detection, recursive source walking, path resolution from cwd, explicit target collection, UTF-8 source reading, and explicit large-file diagnostics.
+- Create `src/cli/check.ts`: `sight check` argument parsing, help text, config loading, batch context construction, diagnostic collection, and `run_check()` / `run_check_with_cwd()` entry points.
+- Modify `src/cli.ts`: intercept `check` before the existing transport parser.
+- Modify `src/providers/diagnostics.ts`: replace the full `Connection` constructor dependency with a narrow exported diagnostics connection interface.
+- Create tests under `tests/unit/cli/` for shared rendering, source discovery, parser behavior, config loading, and batch context seams.
+- Create tests under `tests/integration/cli-check.test.ts` for same-file diagnostics, workspace-report filtering, cross-file scope, config behavior, encoding, large files, and spawned command routing.
+- Modify `docs/cli.md`: document `sight check`.
+- Modify `README.md`: link the CLI docs.
+
+---
+
+### Task 1: CLI Shared Rendering And Severity Gates
+
+**Files:**
+- Create: `src/cli/shared.ts`
+- Test: `tests/unit/cli/shared.test.ts`
+
+- [ ] **Step 1: Write failing tests for severity, color, sorting, and output formats**
+
+Create `tests/unit/cli/shared.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'bun:test';
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import {
+    ColorChoice,
+    EXIT_CHECK_FAILED,
+    EXIT_OK,
+    OutputFormat,
+    SeverityLevel,
+    compare_diagnostic_records,
+    diagnostic_exceeds_threshold,
+    parse_color_choice,
+    parse_output_format,
+    parse_severity_level,
+    render_json,
+    render_sarif,
+    render_text,
+    resolve_color,
+} from '../../../src/cli/shared';
+
+function diag(
+    severity: DiagnosticSeverity,
+    line: number,
+    character: number,
+    message: string,
+    code: number | string
+) {
+    return {
+        range: {
+            start: { line, character },
+            end: { line, character: character + 1 },
+        },
+        severity,
+        code,
+        source: 'sight',
+        message,
+    };
+}
+
+describe('cli shared parsing', () => {
+    it('parses output formats and rejects unknown values', () => {
+        expect(parse_output_format('text')).toBe(OutputFormat.Text);
+        expect(parse_output_format('json')).toBe(OutputFormat.Json);
+        expect(parse_output_format('sarif')).toBe(OutputFormat.Sarif);
+        expect(() => parse_output_format('xml')).toThrow(
+            'unknown --format value: xml'
+        );
+    });
+
+    it('parses severity levels and rejects unknown values', () => {
+        expect(parse_severity_level('off')).toBe(SeverityLevel.Off);
+        expect(parse_severity_level('hint')).toBe(SeverityLevel.Hint);
+        expect(parse_severity_level('info')).toBe(SeverityLevel.Info);
+        expect(parse_severity_level('warning')).toBe(SeverityLevel.Warning);
+        expect(parse_severity_level('error')).toBe(SeverityLevel.Error);
+        expect(() => parse_severity_level('warn')).toThrow(
+            'unknown --max-severity value: warn'
+        );
+    });
+
+    it('parses color choices and rejects unknown values', () => {
+        expect(parse_color_choice('auto')).toBe(ColorChoice.Auto);
+        expect(parse_color_choice('always')).toBe(ColorChoice.Always);
+        expect(parse_color_choice('never')).toBe(ColorChoice.Never);
+        expect(() => parse_color_choice('sometimes')).toThrow(
+            'unknown --color value: sometimes'
+        );
+    });
+});
+
+describe('cli shared severity gates', () => {
+    it('uses strict greater-than comparison for max severity', () => {
+        expect(
+            diagnostic_exceeds_threshold(
+                diag(DiagnosticSeverity.Information, 0, 0, 'info', 6003),
+                SeverityLevel.Info
+            )
+        ).toBe(false);
+        expect(
+            diagnostic_exceeds_threshold(
+                diag(DiagnosticSeverity.Hint, 0, 0, 'hint', 1004),
+                SeverityLevel.Info
+            )
+        ).toBe(false);
+        expect(
+            diagnostic_exceeds_threshold(
+                diag(DiagnosticSeverity.Warning, 0, 0, 'warning', 2001),
+                SeverityLevel.Info
+            )
+        ).toBe(true);
+    });
+
+    it('exports stable exit code constants', () => {
+        expect(EXIT_OK).toBe(0);
+        expect(EXIT_CHECK_FAILED).toBe(1);
+    });
+});
+
+describe('cli shared color resolution', () => {
+    it('explicit always and never override environment signals', () => {
+        expect(resolve_color(ColorChoice.Always, true, false, false)).toBe(true);
+        expect(resolve_color(ColorChoice.Never, false, true, true)).toBe(false);
+    });
+
+    it('auto honors NO_COLOR before FORCE_COLOR before TTY', () => {
+        expect(resolve_color(ColorChoice.Auto, true, true, true)).toBe(false);
+        expect(resolve_color(ColorChoice.Auto, false, true, false)).toBe(true);
+        expect(resolve_color(ColorChoice.Auto, false, false, true)).toBe(true);
+        expect(resolve_color(ColorChoice.Auto, false, false, false)).toBe(false);
+    });
+});
+
+describe('cli shared renderers', () => {
+    const records = [
+        {
+            path: '/repo/b.do',
+            relative_path: 'b.do',
+            diagnostic: diag(DiagnosticSeverity.Warning, 2, 4, 'B warning', 2001),
+        },
+        {
+            path: '/repo/a.do',
+            relative_path: 'a.do',
+            diagnostic: diag(DiagnosticSeverity.Error, 0, 1, 'A error', 3000),
+        },
+    ];
+
+    it('sorts by path, range, severity, code, and message', () => {
+        const sorted = [...records].sort(compare_diagnostic_records);
+        expect(sorted.map((record) => record.relative_path)).toEqual([
+            'a.do',
+            'b.do',
+        ]);
+    });
+
+    it('renders text with one-based coordinates and summary', () => {
+        const text = render_text(records, { quiet: false, use_color: false });
+        expect(text).toContain('a.do:1:2 error: A error [3000]');
+        expect(text).toContain('b.do:3:5 warning: B warning [2001]');
+        expect(text).toContain('2 issues (1 errors, 1 warnings, 0 infos, 0 hints, 0 notes)');
+    });
+
+    it('renders JSON as parseable path and diagnostic records', () => {
+        const parsed = JSON.parse(render_json(records));
+        expect(parsed).toHaveLength(2);
+        expect(parsed[0].path).toBe('a.do');
+        expect(parsed[0].diagnostic.message).toBe('A error');
+    });
+
+    it('renders SARIF 2.1.0 with string rule IDs and tool metadata', () => {
+        const parsed = JSON.parse(render_sarif(records, '0.7.2'));
+        expect(parsed.version).toBe('2.1.0');
+        expect(parsed.runs[0].tool.driver.name).toBe('sight');
+        expect(parsed.runs[0].tool.driver.version).toBe('0.7.2');
+        expect(parsed.runs[0].results[0].ruleId).toBe('SIGHT3000');
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+bun test tests/unit/cli/shared.test.ts
+```
+
+Expected: FAIL because `src/cli/shared.ts` does not exist.
+
+- [ ] **Step 3: Implement shared CLI helpers**
+
+Create `src/cli/shared.ts`:
+
+```typescript
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import { stdout } from 'process';
+
+export const EXIT_OK = 0;
+export const EXIT_CHECK_FAILED = 1;
+export const EXIT_OPERATOR_ERROR = 2;
+
+export enum OutputFormat {
+    Text = 'text',
+    Json = 'json',
+    Sarif = 'sarif',
+}
+
+export enum ColorChoice {
+    Auto = 'auto',
+    Always = 'always',
+    Never = 'never',
+}
+
+export enum SeverityLevel {
+    Off = 0,
+    Hint = 1,
+    Info = 2,
+    Warning = 3,
+    Error = 4,
+}
+
+export interface DiagnosticRecord {
+    path: string;
+    relative_path: string;
+    diagnostic: Diagnostic;
+}
+
+export function parse_output_format(value: string): OutputFormat {
+    switch (value) {
+        case 'text':
+            return OutputFormat.Text;
+        case 'json':
+            return OutputFormat.Json;
+        case 'sarif':
+            return OutputFormat.Sarif;
+        default:
+            throw new Error(`unknown --format value: ${value}`);
+    }
+}
+
+export function parse_severity_level(value: string): SeverityLevel {
+    switch (value) {
+        case 'off':
+            return SeverityLevel.Off;
+        case 'hint':
+            return SeverityLevel.Hint;
+        case 'info':
+            return SeverityLevel.Info;
+        case 'warning':
+            return SeverityLevel.Warning;
+        case 'error':
+            return SeverityLevel.Error;
+        default:
+            throw new Error(`unknown --max-severity value: ${value}`);
+    }
+}
+
+export function parse_color_choice(value: string): ColorChoice {
+    switch (value) {
+        case 'auto':
+            return ColorChoice.Auto;
+        case 'always':
+            return ColorChoice.Always;
+        case 'never':
+            return ColorChoice.Never;
+        default:
+            throw new Error(`unknown --color value: ${value}`);
+    }
+}
+
+function severity_level(diagnostic: Diagnostic): SeverityLevel {
+    switch (diagnostic.severity) {
+        case DiagnosticSeverity.Error:
+            return SeverityLevel.Error;
+        case DiagnosticSeverity.Warning:
+            return SeverityLevel.Warning;
+        case DiagnosticSeverity.Information:
+            return SeverityLevel.Info;
+        case DiagnosticSeverity.Hint:
+            return SeverityLevel.Hint;
+        default:
+            return SeverityLevel.Off;
+    }
+}
+
+export function diagnostic_exceeds_threshold(
+    diagnostic: Diagnostic,
+    max_severity: SeverityLevel
+): boolean {
+    return severity_level(diagnostic) > max_severity;
+}
+
+export function env_flag_is_set(value: string | undefined): boolean {
+    return value !== undefined && value.length > 0;
+}
+
+export function resolve_color(
+    choice: ColorChoice,
+    no_color: boolean,
+    force_color: boolean,
+    stdout_is_tty: boolean
+): boolean {
+    if (choice === ColorChoice.Always) return true;
+    if (choice === ColorChoice.Never) return false;
+    if (no_color) return false;
+    if (force_color) return true;
+    return stdout_is_tty;
+}
+
+export function resolve_color_from_env(choice: ColorChoice): boolean {
+    return resolve_color(
+        choice,
+        env_flag_is_set(process.env.NO_COLOR),
+        env_flag_is_set(process.env.FORCE_COLOR),
+        stdout.isTTY === true
+    );
+}
+
+function code_text(code: Diagnostic['code']): string {
+    if (typeof code === 'number') return String(code);
+    if (typeof code === 'string') return code;
+    return '';
+}
+
+function sarif_rule_id(code: Diagnostic['code']): string {
+    const value = code_text(code);
+    return /^\d+$/.test(value) ? `SIGHT${value}` : value || 'SIGHT';
+}
+
+function severity_word(diagnostic: Diagnostic): string {
+    switch (diagnostic.severity) {
+        case DiagnosticSeverity.Error:
+            return 'error';
+        case DiagnosticSeverity.Warning:
+            return 'warning';
+        case DiagnosticSeverity.Information:
+            return 'info';
+        case DiagnosticSeverity.Hint:
+            return 'hint';
+        default:
+            return 'note';
+    }
+}
+
+function sarif_level(diagnostic: Diagnostic): string {
+    switch (diagnostic.severity) {
+        case DiagnosticSeverity.Error:
+            return 'error';
+        case DiagnosticSeverity.Warning:
+            return 'warning';
+        default:
+            return 'note';
+    }
+}
+
+function colorize(word: string, use_color: boolean): string {
+    if (!use_color) return word;
+    switch (word) {
+        case 'error':
+            return `\u001b[31m${word}\u001b[0m`;
+        case 'warning':
+            return `\u001b[33m${word}\u001b[0m`;
+        case 'info':
+            return `\u001b[34m${word}\u001b[0m`;
+        case 'hint':
+            return `\u001b[36m${word}\u001b[0m`;
+        default:
+            return word;
+    }
+}
+
+export function compare_diagnostic_records(
+    a: DiagnosticRecord,
+    b: DiagnosticRecord
+): number {
+    return a.relative_path.localeCompare(b.relative_path)
+        || a.diagnostic.range.start.line - b.diagnostic.range.start.line
+        || a.diagnostic.range.start.character - b.diagnostic.range.start.character
+        || severity_level(b.diagnostic) - severity_level(a.diagnostic)
+        || code_text(a.diagnostic.code).localeCompare(code_text(b.diagnostic.code))
+        || a.diagnostic.message.localeCompare(b.diagnostic.message);
+}
+
+function sorted_records(records: DiagnosticRecord[]): DiagnosticRecord[] {
+    return [...records].sort(compare_diagnostic_records);
+}
+
+export function render_text(
+    records: DiagnosticRecord[],
+    options: { quiet: boolean; use_color: boolean }
+): string {
+    const counts = { error: 0, warning: 0, info: 0, hint: 0, note: 0 };
+    const lines: string[] = [];
+
+    for (const record of sorted_records(records)) {
+        const word = severity_word(record.diagnostic);
+        counts[word as keyof typeof counts]++;
+        const code = code_text(record.diagnostic.code);
+        const code_suffix = code ? ` [${code}]` : '';
+        lines.push(
+            `${record.relative_path}:` +
+            `${record.diagnostic.range.start.line + 1}:` +
+            `${record.diagnostic.range.start.character + 1} ` +
+            `${colorize(word, options.use_color)}: ` +
+            `${record.diagnostic.message}${code_suffix}`
+        );
+    }
+
+    if (!options.quiet) {
+        lines.push(
+            `${records.length} issues (` +
+            `${counts.error} errors, ` +
+            `${counts.warning} warnings, ` +
+            `${counts.info} infos, ` +
+            `${counts.hint} hints, ` +
+            `${counts.note} notes)`
+        );
+    }
+
+    if (lines.length === 0) {
+        return '';
+    }
+    return lines.join('\n') + '\n';
+}
+
+export function render_json(records: DiagnosticRecord[]): string {
+    return JSON.stringify(
+        sorted_records(records).map((record) => ({
+            path: record.relative_path,
+            diagnostic: record.diagnostic,
+        })),
+        null,
+        2
+    ) + '\n';
+}
+
+export function render_sarif(
+    records: DiagnosticRecord[],
+    version: string
+): string {
+    const rule_ids = Array.from(
+        new Set(sorted_records(records).map((record) =>
+            sarif_rule_id(record.diagnostic.code)
+        ))
+    ).sort();
+
+    return JSON.stringify({
+        version: '2.1.0',
+        $schema:
+            'https://json.schemastore.org/sarif-2.1.0.json',
+        runs: [{
+            tool: {
+                driver: {
+                    name: 'sight',
+                    version,
+                    rules: rule_ids.map((id) => ({
+                        id,
+                        name: id,
+                        shortDescription: { text: id },
+                    })),
+                },
+            },
+            results: sorted_records(records).map((record) => ({
+                ruleId: sarif_rule_id(record.diagnostic.code),
+                level: sarif_level(record.diagnostic),
+                message: { text: record.diagnostic.message },
+                locations: [{
+                    physicalLocation: {
+                        artifactLocation: { uri: record.relative_path },
+                        region: {
+                            startLine:
+                                record.diagnostic.range.start.line + 1,
+                            startColumn:
+                                record.diagnostic.range.start.character + 1,
+                            endLine: record.diagnostic.range.end.line + 1,
+                            endColumn:
+                                record.diagnostic.range.end.character + 1,
+                        },
+                    },
+                }],
+            })),
+        }],
+    }, null, 2) + '\n';
+}
+```
+
+- [ ] **Step 4: Run the focused shared tests**
+
+Run:
+
+```bash
+bun test tests/unit/cli/shared.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add src/cli/shared.ts tests/unit/cli/shared.test.ts
+git commit -m "Add sight check output helpers"
+```
+
+---
+
+### Task 2: Source Discovery And Source Read Helpers
+
+**Files:**
+- Create: `src/cli/source-files.ts`
+- Test: `tests/unit/cli/source-files.test.ts`
+
+- [ ] **Step 1: Write failing tests for source matching, recursive walking, target collection, large files, and UTF-8 errors**
+
+Create `tests/unit/cli/source-files.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import {
+    collect_report_targets,
+    is_stata_source_path,
+    read_source_file,
+    size_limit_diagnostic,
+} from '../../../src/cli/source-files';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-source-'));
+}
+
+describe('sight check source files', () => {
+    it('recognizes Stata source extensions case-insensitively', () => {
+        expect(is_stata_source_path('/x/a.do')).toBe(true);
+        expect(is_stata_source_path('/x/a.DO')).toBe(true);
+        expect(is_stata_source_path('/x/a.ado')).toBe(true);
+        expect(is_stata_source_path('/x/a.doh')).toBe(true);
+        expect(is_stata_source_path('/x/a.mata')).toBe(true);
+        expect(is_stata_source_path('/x/a.txt')).toBe(false);
+    });
+
+    it('collects supported source files from directories and skips VCS dirs', () => {
+        const root = temp_dir();
+        fs.mkdirSync(path.join(root, 'analysis'));
+        fs.mkdirSync(path.join(root, '.git'));
+        fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
+        fs.writeFileSync(path.join(root, 'analysis', 'helper.ADO'), 'program x\nend\n');
+        fs.writeFileSync(path.join(root, '.git', 'ignored.do'), 'bad\n');
+        fs.writeFileSync(path.join(root, 'notes.txt'), 'ignored\n');
+
+        const result = collect_report_targets([], root, root);
+
+        expect(result.operator_errors).toEqual([]);
+        expect(result.targets.map((target) => target.relative_path)).toEqual([
+            'analysis/helper.ADO',
+            'main.do',
+        ]);
+    });
+
+    it('resolves explicit paths from cwd and reports missing paths as operator errors', () => {
+        const root = temp_dir();
+        const cwd = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
+
+        const result = collect_report_targets(
+            [path.relative(cwd, path.join(root, 'main.do')), 'missing.do'],
+            root,
+            cwd
+        );
+
+        expect(result.targets.map((target) => target.path)).toEqual([
+            path.join(root, 'main.do'),
+        ]);
+        expect(result.operator_errors).toHaveLength(1);
+        expect(result.operator_errors[0]).toContain('missing.do');
+    });
+
+    it('ignores explicit existing non-source files', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'notes.txt'), 'ignored\n');
+
+        const result = collect_report_targets(['notes.txt'], root, root);
+
+        expect(result.targets).toEqual([]);
+        expect(result.operator_errors).toEqual([]);
+    });
+
+    it('turns oversize explicit targets into error diagnostics', () => {
+        const diagnostic = size_limit_diagnostic('/x/main.do', 11, 10);
+
+        expect(diagnostic.severity).toBe(DiagnosticSeverity.Error);
+        expect(diagnostic.range.start).toEqual({ line: 0, character: 0 });
+        expect(diagnostic.message).toContain('exceeds');
+        expect(diagnostic.message).toContain('10 bytes');
+    });
+
+    it('reads UTF-8 and reports invalid UTF-8 as a diagnostic input error', () => {
+        const root = temp_dir();
+        const good = path.join(root, 'good.do');
+        const bad = path.join(root, 'bad.do');
+        fs.writeFileSync(good, 'display 1\n');
+        fs.writeFileSync(bad, Buffer.from([0x64, 0x69, 0x80]));
+
+        expect(read_source_file(good).kind).toBe('ok');
+        const result = read_source_file(bad);
+
+        expect(result.kind).toBe('decode-error');
+        if (result.kind === 'decode-error') {
+            expect(result.diagnostic.message).toContain('offset 2');
+            expect(result.diagnostic.severity).toBe(DiagnosticSeverity.Error);
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+bun test tests/unit/cli/source-files.test.ts
+```
+
+Expected: FAIL because `src/cli/source-files.ts` does not exist.
+
+- [ ] **Step 3: Implement source-file helpers**
+
+Create `src/cli/source-files.ts`:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+import { TextDecoder } from 'util';
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+
+const SOURCE_EXTENSIONS = new Set(['.do', '.ado', '.doh', '.mata']);
+const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
+
+export interface ReportTarget {
+    path: string;
+    relative_path: string;
+    explicit: boolean;
+}
+
+export interface ReportTargetResult {
+    targets: ReportTarget[];
+    operator_errors: string[];
+}
+
+export type SourceReadResult =
+    | { kind: 'ok'; text: string }
+    | { kind: 'decode-error'; diagnostic: Diagnostic }
+    | { kind: 'read-error'; message: string };
+
+export function is_stata_source_path(file_path: string): boolean {
+    return SOURCE_EXTENSIONS.has(path.extname(file_path).toLowerCase());
+}
+
+export function relative_path(workspace_root: string, file_path: string): string {
+    const relative = path.relative(workspace_root, file_path);
+    return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+        ? relative.split(path.sep).join('/')
+        : file_path;
+}
+
+function walk_sources(dir_path: string, out: string[]): void {
+    const entries = fs.readdirSync(dir_path, { withFileTypes: true });
+    for (const entry of entries) {
+        const entry_path = path.join(dir_path, entry.name);
+        if (entry.isDirectory()) {
+            if (VCS_METADATA_DIRS.has(entry.name)) continue;
+            walk_sources(entry_path, out);
+        } else if (entry.isFile() && is_stata_source_path(entry_path)) {
+            out.push(entry_path);
+        }
+    }
+}
+
+export function collect_report_targets(
+    input_paths: string[],
+    workspace_root: string,
+    cwd: string
+): ReportTargetResult {
+    const operator_errors: string[] = [];
+    const source_paths: string[] = [];
+    const normalized_root = path.resolve(workspace_root);
+    const has_explicit_paths = input_paths.length > 0;
+    const paths_to_collect = input_paths.length > 0
+        ? input_paths
+        : [normalized_root];
+
+    for (const input_path of paths_to_collect) {
+        const absolute_path = path.resolve(cwd, input_path);
+        if (!fs.existsSync(absolute_path)) {
+            operator_errors.push(`path does not exist: ${input_path}`);
+            continue;
+        }
+
+        const stat = fs.statSync(absolute_path);
+        if (stat.isDirectory()) {
+            walk_sources(absolute_path, source_paths);
+        } else if (stat.isFile() && is_stata_source_path(absolute_path)) {
+            source_paths.push(absolute_path);
+        }
+    }
+
+    const unique_sorted_paths = Array.from(new Set(source_paths))
+        .sort((a, b) =>
+            relative_path(normalized_root, a)
+                .localeCompare(relative_path(normalized_root, b))
+        );
+
+    return {
+        targets: unique_sorted_paths.map((file_path) => ({
+            path: file_path,
+            relative_path: relative_path(normalized_root, file_path),
+            explicit: has_explicit_paths,
+        })),
+        operator_errors,
+    };
+}
+
+export function size_limit_diagnostic(
+    file_path: string,
+    actual_bytes: number,
+    limit_bytes: number
+): Diagnostic {
+    return {
+        range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+        },
+        severity: DiagnosticSeverity.Error,
+        source: 'sight',
+        code: 'SIGHT_FILE_TOO_LARGE',
+        message:
+            `${file_path} is ${actual_bytes} bytes, which exceeds ` +
+            `the configured limit of ${limit_bytes} bytes.`,
+    };
+}
+
+export function index_limit_diagnostic(file_path: string): Diagnostic {
+    return {
+        range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+        },
+        severity: DiagnosticSeverity.Error,
+        source: 'sight',
+        code: 'SIGHT_FILE_NOT_INDEXED',
+        message:
+            `${file_path} was not indexed before Sight reached ` +
+            'crossFile.maxIndexedFiles. Raise maxIndexedFiles or check fewer files.',
+    };
+}
+
+function utf8_error_offset(bytes: Buffer): number {
+    const decoder = new TextDecoder('utf-8', { fatal: true });
+    for (let i = 0; i <= bytes.length; i++) {
+        try {
+            decoder.decode(bytes.subarray(0, i));
+        } catch {
+            return Math.max(0, i - 1);
+        }
+    }
+    return 0;
+}
+
+function decode_error_diagnostic(file_path: string, offset: number): Diagnostic {
+    return {
+        range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+        },
+        severity: DiagnosticSeverity.Error,
+        source: 'sight',
+        code: 'SIGHT_INVALID_ENCODING',
+        message:
+            `${file_path} is not valid UTF-8 at byte offset ${offset}. ` +
+            'Re-save the file as UTF-8.',
+    };
+}
+
+export function read_source_file(file_path: string): SourceReadResult {
+    let bytes: Buffer;
+    try {
+        bytes = fs.readFileSync(file_path);
+    } catch (error) {
+        return {
+            kind: 'read-error',
+            message: `${file_path}: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        };
+    }
+
+    try {
+        return {
+            kind: 'ok',
+            text: new TextDecoder('utf-8', { fatal: true }).decode(bytes),
+        };
+    } catch {
+        return {
+            kind: 'decode-error',
+            diagnostic: decode_error_diagnostic(
+                file_path,
+                utf8_error_offset(bytes)
+            ),
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run the focused source-file tests**
+
+Run:
+
+```bash
+bun test tests/unit/cli/source-files.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add src/cli/source-files.ts tests/unit/cli/source-files.test.ts
+git commit -m "Add sight check source discovery"
+```
+
+---
+
+### Task 3: Check Argument Parser And Top-Level Routing
+
+**Files:**
+- Create: `src/cli/check.ts`
+- Modify: `src/cli.ts`
+- Test: `tests/unit/cli/check-args.test.ts`
+
+- [ ] **Step 1: Write failing check parser tests**
+
+Create `tests/unit/cli/check-args.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'bun:test';
+import {
+    parse_check_args,
+} from '../../../src/cli/check';
+import {
+    ColorChoice,
+    OutputFormat,
+    SeverityLevel,
+} from '../../../src/cli/shared';
+import { parse_args } from '../../../src/cli';
+
+describe('sight check args', () => {
+    it('uses Raven-parity defaults', () => {
+        const result = parse_check_args([]);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.args.paths).toEqual([]);
+            expect(result.args.workspace).toBeUndefined();
+            expect(result.args.config_path).toBeUndefined();
+            expect(result.args.no_config).toBe(false);
+            expect(result.args.format).toBe(OutputFormat.Text);
+            expect(result.args.max_severity).toBe(SeverityLevel.Info);
+            expect(result.args.quiet).toBe(false);
+            expect(result.args.color).toBe(ColorChoice.Auto);
+            expect(result.args.help).toBe(false);
+        }
+    });
+
+    it('parses all supported options', () => {
+        const result = parse_check_args([
+            '--workspace', 'analysis',
+            '--config', '../sight.toml',
+            '--format', 'sarif',
+            '--max-severity', 'warning',
+            '--quiet',
+            '--color', 'always',
+            'main.do',
+        ]);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.args.workspace).toBe('analysis');
+            expect(result.args.config_path).toBe('../sight.toml');
+            expect(result.args.format).toBe(OutputFormat.Sarif);
+            expect(result.args.max_severity).toBe(SeverityLevel.Warning);
+            expect(result.args.quiet).toBe(true);
+            expect(result.args.color).toBe(ColorChoice.Always);
+            expect(result.args.paths).toEqual(['main.do']);
+        }
+    });
+
+    it('treats --no-color as --color never with last flag winning', () => {
+        const first = parse_check_args(['--no-color', '--color', 'always']);
+        const second = parse_check_args(['--color', 'always', '--no-color']);
+
+        expect(first.success && first.args.color).toBe(ColorChoice.Always);
+        expect(second.success && second.args.color).toBe(ColorChoice.Never);
+    });
+
+    it('rejects --config with --no-config', () => {
+        const result = parse_check_args(['--config', 'sight.toml', '--no-config']);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error).toContain('Cannot specify both');
+        }
+    });
+
+    it('rejects unknown flags and missing option values', () => {
+        expect(parse_check_args(['--wat']).success).toBe(false);
+        const workspace = parse_check_args(['--workspace']);
+        expect(workspace.success).toBe(false);
+        if (!workspace.success) {
+            expect(workspace.error).toBe('--workspace needs a path');
+        }
+    });
+});
+
+describe('top-level parser remains transport-only', () => {
+    it('still rejects check when called directly so main can route first', () => {
+        const result = parse_args(['check']);
+
+        expect(result.success).toBe(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+bun test tests/unit/cli/check-args.test.ts
+```
+
+Expected: FAIL because `src/cli/check.ts` does not exist.
+
+- [ ] **Step 3: Implement `parse_check_args()` and help text**
+
+Create `src/cli/check.ts` with the parser and temporary run stub:
+
+```typescript
+import {
+    ColorChoice,
+    EXIT_OPERATOR_ERROR,
+    OutputFormat,
+    SeverityLevel,
+    parse_color_choice,
+    parse_output_format,
+    parse_severity_level,
+} from './shared';
+
+export interface CheckArgs {
+    paths: string[];
+    workspace?: string;
+    config_path?: string;
+    no_config: boolean;
+    format: OutputFormat;
+    max_severity: SeverityLevel;
+    quiet: boolean;
+    color: ColorChoice;
+    help: boolean;
+}
+
+export type CheckParseResult =
+    | { success: true; args: CheckArgs }
+    | { success: false; error: string };
+
+export function parse_check_args(argv: string[]): CheckParseResult {
+    const args: CheckArgs = {
+        paths: [],
+        no_config: false,
+        format: OutputFormat.Text,
+        max_severity: SeverityLevel.Info,
+        quiet: false,
+        color: ColorChoice.Auto,
+        help: false,
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        switch (arg) {
+            case '--workspace':
+                if (argv[i + 1] === undefined) {
+                    return { success: false, error: '--workspace needs a path' };
+                }
+                args.workspace = argv[++i];
+                break;
+            case '--config':
+                if (argv[i + 1] === undefined) {
+                    return { success: false, error: '--config needs a path' };
+                }
+                args.config_path = argv[++i];
+                break;
+            case '--no-config':
+                args.no_config = true;
+                break;
+            case '--format':
+                if (argv[i + 1] === undefined) {
+                    return { success: false, error: '--format needs a value' };
+                }
+                try {
+                    args.format = parse_output_format(argv[++i]);
+                } catch (error) {
+                    return {
+                        success: false,
+                        error: error instanceof Error ? error.message : String(error),
+                    };
+                }
+                break;
+            case '--max-severity':
+                if (argv[i + 1] === undefined) {
+                    return {
+                        success: false,
+                        error: '--max-severity needs a value',
+                    };
+                }
+                try {
+                    args.max_severity = parse_severity_level(argv[++i]);
+                } catch (error) {
+                    return {
+                        success: false,
+                        error: error instanceof Error ? error.message : String(error),
+                    };
+                }
+                break;
+            case '--quiet':
+                args.quiet = true;
+                break;
+            case '--color':
+                if (argv[i + 1] === undefined) {
+                    return { success: false, error: '--color needs a value' };
+                }
+                try {
+                    args.color = parse_color_choice(argv[++i]);
+                } catch (error) {
+                    return {
+                        success: false,
+                        error: error instanceof Error ? error.message : String(error),
+                    };
+                }
+                break;
+            case '--no-color':
+                args.color = ColorChoice.Never;
+                break;
+            case '--help':
+            case '-h':
+                args.help = true;
+                break;
+            default:
+                if (arg.startsWith('-')) {
+                    return { success: false, error: `Unknown flag: ${arg}` };
+                }
+                args.paths.push(arg);
+        }
+    }
+
+    if (args.no_config && args.config_path !== undefined) {
+        return {
+            success: false,
+            error: 'Cannot specify both --config and --no-config',
+        };
+    }
+
+    return { success: true, args };
+}
+
+export async function run_check(argv: string[]): Promise<number> {
+    const result = parse_check_args(argv);
+    if (!result.success) {
+        console.error(`sight check: ${result.error}`);
+        return 1;
+    }
+    if (result.args.help) {
+        return 0;
+    }
+    console.error('sight check: batch diagnostics are unavailable before Task 6');
+    return EXIT_OPERATOR_ERROR;
+}
+```
+
+- [ ] **Step 4: Route `check` before the existing top-level parser**
+
+Modify `src/cli.ts` in `main()` before `const result = parse_args(argv);`:
+
+```typescript
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+    if (argv[0] === 'check') {
+        const { run_check } = await import('./cli/check');
+        return run_check(argv.slice(1));
+    }
+
+    const result = parse_args(argv);
+```
+
+Keep the existing transport parser unchanged so the transport-selection property
+tests still prove the old flags work.
+
+- [ ] **Step 5: Run parser and transport tests**
+
+Run:
+
+```bash
+bun test tests/unit/cli/check-args.test.ts tests/property/cli-transport-selection.prop.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add src/cli.ts src/cli/check.ts tests/unit/cli/check-args.test.ts
+git commit -m "Route sight check subcommand"
+```
+
+---
+
+### Task 4: Narrow DiagnosticsProvider Connection Interface
+
+**Files:**
+- Modify: `src/providers/diagnostics.ts`
+- Test: `tests/unit/cli/diagnostics-connection.test.ts`
+
+- [ ] **Step 1: Write a failing compile-focused test for a no-op diagnostics connection**
+
+Create `tests/unit/cli/diagnostics-connection.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'bun:test';
+import {
+    DiagnosticsConnection,
+    DiagnosticsProvider,
+} from '../../../src/providers/diagnostics';
+
+describe('DiagnosticsProvider connection surface', () => {
+    it('accepts the narrow CLI diagnostics connection', () => {
+        const connection: DiagnosticsConnection = {
+            sendDiagnostics: () => undefined,
+        };
+        const provider = new DiagnosticsProvider(connection);
+
+        expect(provider).toBeInstanceOf(DiagnosticsProvider);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+bun test tests/unit/cli/diagnostics-connection.test.ts
+```
+
+Expected: FAIL because `DiagnosticsConnection` is not exported and the
+constructor still requires the full LSP `Connection`.
+
+- [ ] **Step 3: Refactor `DiagnosticsProvider` constructor type**
+
+Modify the imports and constructor type in `src/providers/diagnostics.ts`:
+
+```typescript
+import { Diagnostic, DiagnosticSeverity, Position, CancellationToken, Range } from 'vscode-languageserver';
+```
+
+Add near the top:
+
+```typescript
+export interface DiagnosticsConnection {
+    sendDiagnostics(params: { uri: string; diagnostics: Diagnostic[] }): void;
+}
+```
+
+Change the class field and constructor:
+
+```typescript
+export class DiagnosticsProvider {
+    private connection: DiagnosticsConnection;
+    private debounce_manager: DocumentDebounceManager | null = null;
+
+    constructor(
+        connection: DiagnosticsConnection,
+        debounce_manager?: DocumentDebounceManager
+    ) {
+        this.connection = connection;
+        this.debounce_manager = debounce_manager || null;
+    }
+```
+
+Do not change diagnostic logic in this task.
+
+- [ ] **Step 4: Run the focused test**
+
+Run:
+
+```bash
+bun test tests/unit/cli/diagnostics-connection.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run representative diagnostics and server type checks**
+
+Run:
+
+```bash
+bun test tests/unit/default-settings.test.ts tests/property/handler-deps-mutation.prop.test.ts
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add src/providers/diagnostics.ts tests/unit/cli/diagnostics-connection.test.ts
+git commit -m "Narrow diagnostics provider connection"
+```
+
+---
+
+### Task 5: Config Loading And Batch Context Construction
+
+**Files:**
+- Modify: `src/cli/check.ts`
+- Test: `tests/unit/cli/check-config.test.ts`
+- Test: `tests/unit/cli/check-context.test.ts`
+
+- [ ] **Step 1: Write failing tests for config loading**
+
+Create `tests/unit/cli/check-config.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    load_check_config,
+} from '../../../src/cli/check';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-config-'));
+}
+
+describe('sight check config loading', () => {
+    it('uses built-in defaults under --no-config', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[diagnostics]\nenabled = false\n');
+
+        const result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: true,
+        });
+
+        expect(result.kind).toBe('loaded');
+        if (result.kind === 'loaded') {
+            expect(result.config.diagnostics.enabled).toBe(true);
+        }
+    });
+
+    it('loads explicit config relative to cwd', () => {
+        const cwd = temp_dir();
+        const workspace = temp_dir();
+        fs.writeFileSync(path.join(cwd, 'custom.toml'), '[diagnostics]\nenabled = false\n');
+
+        const result = load_check_config({
+            cwd,
+            workspace_root: workspace,
+            config_path: 'custom.toml',
+            no_config: false,
+        });
+
+        expect(result.kind).toBe('loaded');
+        if (result.kind === 'loaded') {
+            expect(result.config.diagnostics.enabled).toBe(false);
+        }
+    });
+
+    it('discovers config from workspace root and reports stale json warnings', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, '.sight.json'), '{}\n');
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[diagnostics]\nindentation = true\n');
+
+        const result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: false,
+        });
+
+        expect(result.kind).toBe('loaded');
+        if (result.kind === 'loaded') {
+            expect(result.config.diagnostics.indentation).toBe(true);
+            expect(result.warnings.some((warning) =>
+                warning.message.includes('.sight.json is no longer supported')
+            )).toBe(true);
+        }
+    });
+
+    it('returns operator error for malformed discovered config', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), 'bad = = toml\n');
+
+        const result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: false,
+        });
+
+        expect(result.kind).toBe('operator-error');
+        if (result.kind === 'operator-error') {
+            expect(result.message).toContain('failed to load');
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Write failing tests for batch context wiring**
+
+Create `tests/unit/cli/check-context.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    build_check_context,
+    load_check_config,
+} from '../../../src/cli/check';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-context-'));
+}
+
+describe('sight check batch context', () => {
+    it('marks dependency graph scan complete and indexes workspace symbols', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'parent.do'), 'global g 1\ndo child.do\n');
+        fs.writeFileSync(path.join(root, 'child.do'), 'display \"$g\"\n');
+        const config_result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: true,
+        });
+        expect(config_result.kind).toBe('loaded');
+        if (config_result.kind !== 'loaded') return;
+
+        const context = await build_check_context(root, config_result.config);
+
+        expect(context.dependency_graph.is_scan_complete()).toBe(true);
+        expect(context.workspace_indexer.get_all_symbols().globalMacros.has('g')).toBe(true);
+        expect(context.scope_resolver).toBeDefined();
+        await context.document_store.dispose();
+    });
+});
+```
+
+- [ ] **Step 3: Run the tests and verify they fail**
+
+Run:
+
+```bash
+bun test tests/unit/cli/check-config.test.ts tests/unit/cli/check-context.test.ts
+```
+
+Expected: FAIL because `load_check_config()` and `build_check_context()` are not
+implemented.
+
+- [ ] **Step 4: Implement config loading**
+
+Modify `src/cli/check.ts` imports:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
+import {
+    deep_merge_config,
+    discover_and_load_project_config,
+    load_toml_file,
+    type ProjectConfigWarning,
+} from '../config-file';
+import { DependencyGraph } from '../dependency-graph';
+import { DocumentStore } from '../document-store';
+import { ForwardScopeResolver } from '../forward-scope-resolver';
+import { WorkspaceIndexer } from '../indexer';
+import { DiagnosticsProvider } from '../providers/diagnostics';
+import { ScopeResolver } from '../scope-resolver';
+import { DEFAULT_SETTINGS } from '../server-handlers';
+import { StataLSPConfig } from '../types';
+import { validate_comment_formatting_config } from '../utils/config-validator';
+```
+
+Add:
+
+```typescript
+export type CheckConfigResult =
+    | {
+        kind: 'loaded';
+        config: StataLSPConfig;
+        warnings: ProjectConfigWarning[];
+        config_path?: string;
+    }
+    | { kind: 'operator-error'; message: string };
+
+export function load_check_config(options: {
+    cwd: string;
+    workspace_root: string;
+    config_path?: string;
+    no_config: boolean;
+}): CheckConfigResult {
+    if (options.no_config) {
+        return {
+            kind: 'loaded',
+            config: validate_comment_formatting_config(DEFAULT_SETTINGS),
+            warnings: [],
+        };
+    }
+
+    const loaded = options.config_path
+        ? load_toml_file(path.resolve(options.cwd, options.config_path))
+        : discover_and_load_project_config(options.workspace_root);
+
+    if (loaded.kind === 'load-failed') {
+        return {
+            kind: 'operator-error',
+            message: `failed to load ${loaded.path}: ${loaded.error}`,
+        };
+    }
+
+    if (loaded.kind === 'none') {
+        return {
+            kind: 'loaded',
+            config: validate_comment_formatting_config(DEFAULT_SETTINGS),
+            warnings: loaded.warnings,
+        };
+    }
+
+    return {
+        kind: 'loaded',
+        config: validate_comment_formatting_config(
+            deep_merge_config(DEFAULT_SETTINGS, loaded.partial_config)
+        ),
+        warnings: loaded.warnings,
+        config_path: loaded.path,
+    };
+}
+```
+
+- [ ] **Step 5: Implement batch context construction with explicit wiring**
+
+Add to `src/cli/check.ts`:
+
+```typescript
+export interface CheckContext {
+    dependency_graph: DependencyGraph;
+    workspace_indexer: WorkspaceIndexer;
+    scope_resolver: ScopeResolver;
+    forward_scope_resolver: ForwardScopeResolver;
+    document_store: DocumentStore;
+    diagnostics_provider: DiagnosticsProvider;
+}
+
+export async function build_check_context(
+    workspace_root: string,
+    config: StataLSPConfig
+): Promise<CheckContext> {
+    const dependency_graph = new DependencyGraph();
+    const workspace_indexer = new WorkspaceIndexer();
+    const scope_resolver = new ScopeResolver({
+        log: (msg) => {
+            if (config.debug === true) {
+                console.error(msg);
+            }
+        },
+        warn: (msg) => console.error(msg),
+    }, {
+        read_file: async (uri: string) =>
+            fs.promises.readFile(URI.parse(uri).fsPath, 'utf8'),
+        exists: async (uri: string) => {
+            try {
+                await fs.promises.access(URI.parse(uri).fsPath);
+                return true;
+            } catch {
+                return false;
+            }
+        },
+    });
+    const forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+        max_forward_depth: config.cross_file.max_forward_depth,
+    });
+    const document_store = new DocumentStore();
+    const diagnostics_provider = new DiagnosticsProvider({
+        sendDiagnostics: () => undefined,
+    });
+
+    workspace_indexer.configure(config);
+    workspace_indexer.set_max_indexed_files(
+        config.cross_file.max_indexed_files
+    );
+    workspace_indexer.set_dependency_graph(dependency_graph);
+    scope_resolver.set_dependency_graph(dependency_graph);
+    scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+    diagnostics_provider.set_dependency_graph(dependency_graph);
+    document_store.set_workspace_roots([workspace_root]);
+    document_store.set_scope_resolver(scope_resolver);
+    document_store.set_on_backward_directives_parsed((uri, directives) => {
+        workspace_indexer.set_buffer_directives(uri, directives);
+    });
+
+    await workspace_indexer.initialize([workspace_root], config.adoPaths);
+
+    return {
+        dependency_graph,
+        workspace_indexer,
+        scope_resolver,
+        forward_scope_resolver,
+        document_store,
+        diagnostics_provider,
+    };
+}
+```
+
+- [ ] **Step 6: Run config and context tests**
+
+Run:
+
+```bash
+bun test tests/unit/cli/check-config.test.ts tests/unit/cli/check-context.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add src/cli/check.ts tests/unit/cli/check-config.test.ts tests/unit/cli/check-context.test.ts
+git commit -m "Build sight check batch context"
+```
+
+---
+
+### Task 6: Collect Diagnostics And Return Gated Exit Codes
+
+**Files:**
+- Modify: `src/cli/check.ts`
+- Test: `tests/integration/cli-check.test.ts`
+
+- [ ] **Step 1: Write failing integration tests for same-file diagnostics, config, exit gates, large files, and invalid UTF-8**
+
+Create `tests/integration/cli-check.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    run_check_with_cwd,
+} from '../../src/cli/check';
+import {
+    EXIT_CHECK_FAILED,
+    EXIT_OK,
+    EXIT_OPERATOR_ERROR,
+} from '../../src/cli/shared';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-integration-'));
+}
+
+async function run_capture(argv: string[], cwd: string) {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await run_check_with_cwd(argv, cwd, {
+        stdout: (text) => stdout.push(text),
+        stderr: (text) => stderr.push(text),
+    });
+    return { code, stdout: stdout.join(''), stderr: stderr.join('') };
+}
+
+describe('sight check integration', () => {
+    it('reports same-file undefined macro diagnostics', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+
+        const result = await run_capture(['--workspace', root, '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('main.do:1:');
+        expect(result.stdout).toContain('Undefined macro');
+    });
+
+    it('honors editor default undefinedVariable off', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), 'regress y x\n');
+
+        const result = await run_capture(['--workspace', root, '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.stdout).toBe('');
+    });
+
+    it('uses strict max severity gating', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(
+            path.join(root, 'sight.toml'),
+            '[diagnostics.severity]\nundefinedMacro = "information"\n'
+        );
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+
+        const result = await run_capture(['--workspace', root, '--max-severity', 'info'], root);
+
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.stdout).toContain('info:');
+    });
+
+    it('indexes whole workspace while report paths filter output', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'parent.do'), 'global project_root /tmp\ndo child.do\n');
+        fs.writeFileSync(path.join(root, 'child.do'), 'display "$project_root"\n');
+
+        const result = await run_capture(['--workspace', root, 'child.do', '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.stdout).toBe('');
+    });
+
+    it('reports malformed config as operator error', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), 'bad = = toml\n');
+
+        const result = await run_capture(['--workspace', root], root);
+
+        expect(result.code).toBe(EXIT_OPERATOR_ERROR);
+        expect(result.stderr).toContain('failed to load');
+    });
+
+    it('reports missing explicit path as operator error', async () => {
+        const root = temp_dir();
+
+        const result = await run_capture(['--workspace', root, 'missing.do'], root);
+
+        expect(result.code).toBe(EXIT_OPERATOR_ERROR);
+        expect(result.stderr).toContain('path does not exist');
+    });
+
+    it('reports explicitly oversized source files as error diagnostics', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[indexing]\nmaxFileSizeBytes = 1\n');
+        fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
+
+        const result = await run_capture(['--workspace', root, 'main.do', '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('exceeds the configured limit');
+    });
+
+    it('reports explicit source files skipped by max indexed files', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[crossFile]\nmaxIndexedFiles = 1\n');
+        fs.writeFileSync(path.join(root, 'a.do'), 'display 1\n');
+        fs.writeFileSync(path.join(root, 'b.do'), 'display 2\n');
+
+        const result = await run_capture(
+            ['--workspace', root, 'a.do', 'b.do', '--quiet'],
+            root
+        );
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('was not indexed');
+        expect(result.stdout).toContain('maxIndexedFiles');
+    });
+
+    it('reports invalid UTF-8 as an error diagnostic', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'bad.do'), Buffer.from([0x64, 0x80]));
+
+        const result = await run_capture(['--workspace', root, 'bad.do', '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('not valid UTF-8');
+        expect(result.stdout).toContain('byte offset');
+    });
+});
+```
+
+- [ ] **Step 2: Run the integration tests and verify they fail**
+
+Run:
+
+```bash
+bun test tests/integration/cli-check.test.ts
+```
+
+Expected: FAIL because `run_check_with_cwd()` and diagnostic collection are not
+implemented.
+
+- [ ] **Step 3: Implement injectable output and diagnostic collection**
+
+Modify `src/cli/check.ts` to add:
+
+```typescript
+import { Diagnostic } from 'vscode-languageserver';
+import {
+    collect_report_targets,
+    index_limit_diagnostic,
+    relative_path,
+    read_source_file,
+    size_limit_diagnostic,
+} from './source-files';
+import {
+    DiagnosticRecord,
+    EXIT_CHECK_FAILED,
+    EXIT_OK,
+    EXIT_OPERATOR_ERROR,
+    compare_diagnostic_records,
+    diagnostic_exceeds_threshold,
+    render_json,
+    render_sarif,
+    render_text,
+    resolve_color_from_env,
+} from './shared';
+
+export interface CheckOutput {
+    stdout(text: string): void;
+    stderr(text: string): void;
+}
+
+const DEFAULT_OUTPUT: CheckOutput = {
+    stdout: (text) => process.stdout.write(text),
+    stderr: (text) => process.stderr.write(text),
+};
+
+function diagnostic_record(
+    workspace_root: string,
+    file_path: string,
+    diagnostic: Diagnostic
+): DiagnosticRecord {
+    return {
+        path: file_path,
+        relative_path: relative_path(workspace_root, file_path),
+        diagnostic,
+    };
+}
+```
+
+Add `collect_check_diagnostics()`:
+
+```typescript
+export async function collect_check_diagnostics(
+    context: CheckContext,
+    workspace_root: string,
+    config: StataLSPConfig,
+    targets: Array<{ path: string; relative_path: string; explicit: boolean }>
+): Promise<DiagnosticRecord[]> {
+    const records: DiagnosticRecord[] = [];
+    const workspace_symbols = context.workspace_indexer.get_all_symbols();
+    const indexed_files = context.workspace_indexer.get_indexed_files();
+
+    for (const target of targets) {
+        const stats = fs.statSync(target.path);
+        const uri = URI.file(target.path).toString();
+        if (target.explicit && stats.size > config.indexing.maxFileSizeBytes) {
+            records.push(diagnostic_record(
+                workspace_root,
+                target.path,
+                size_limit_diagnostic(
+                    target.path,
+                    stats.size,
+                    config.indexing.maxFileSizeBytes
+                )
+            ));
+            continue;
+        }
+        if (
+            target.explicit &&
+            context.workspace_indexer.get_metrics().files_indexed
+                >= config.cross_file.max_indexed_files &&
+            !indexed_files.has(uri)
+        ) {
+            records.push(diagnostic_record(
+                workspace_root,
+                target.path,
+                index_limit_diagnostic(target.path)
+            ));
+            continue;
+        }
+
+        const read_result = read_source_file(target.path);
+        if (read_result.kind === 'read-error') {
+            throw new Error(read_result.message);
+        }
+        if (read_result.kind === 'decode-error') {
+            records.push(diagnostic_record(
+                workspace_root,
+                target.path,
+                read_result.diagnostic
+            ));
+            continue;
+        }
+
+        await context.document_store.open(
+            uri,
+            read_result.text,
+            1,
+            workspace_symbols
+        );
+        const state = context.document_store.get(uri);
+        if (!state) {
+            throw new Error(`failed to analyze ${target.path}`);
+        }
+
+        const diagnostics = await context.diagnostics_provider.get_diagnostics(
+            state,
+            config,
+            workspace_symbols,
+            context.scope_resolver
+        );
+        for (const diagnostic of diagnostics) {
+            records.push(diagnostic_record(workspace_root, target.path, diagnostic));
+        }
+        context.document_store.close(uri);
+    }
+
+    return records.sort(compare_diagnostic_records);
+}
+```
+
+- [ ] **Step 4: Implement `run_check_with_cwd()`**
+
+Replace the temporary `run_check()` body and add:
+
+```typescript
+export async function run_check_with_cwd(
+    argv: string[],
+    cwd: string,
+    output: CheckOutput = DEFAULT_OUTPUT
+): Promise<number> {
+    const result = parse_check_args(argv);
+    if (!result.success) {
+        output.stderr(`sight check: ${result.error}\n`);
+        return EXIT_CHECK_FAILED;
+    }
+    if (result.args.help) {
+        output.stdout(`${check_help_text()}\n`);
+        return EXIT_OK;
+    }
+
+    const workspace_root = path.resolve(
+        cwd,
+        result.args.workspace ?? '.'
+    );
+    if (!fs.existsSync(workspace_root) ||
+        !fs.statSync(workspace_root).isDirectory()) {
+        output.stderr(`sight check: invalid workspace: ${workspace_root}\n`);
+        return EXIT_OPERATOR_ERROR;
+    }
+
+    const config_result = load_check_config({
+        cwd,
+        workspace_root,
+        config_path: result.args.config_path,
+        no_config: result.args.no_config,
+    });
+    if (config_result.kind === 'operator-error') {
+        output.stderr(`sight check: ${config_result.message}\n`);
+        return EXIT_OPERATOR_ERROR;
+    }
+    for (const warning of config_result.warnings) {
+        output.stderr(`sight check: ${warning.message}\n`);
+    }
+
+    const target_result = collect_report_targets(
+        result.args.paths,
+        workspace_root,
+        cwd
+    );
+    if (target_result.operator_errors.length > 0) {
+        for (const message of target_result.operator_errors) {
+            output.stderr(`sight check: ${message}\n`);
+        }
+        return EXIT_OPERATOR_ERROR;
+    }
+
+    let context: CheckContext | undefined;
+    try {
+        context = await build_check_context(
+            workspace_root,
+            config_result.config
+        );
+        const diagnostics = await collect_check_diagnostics(
+            context,
+            workspace_root,
+            config_result.config,
+            target_result.targets
+        );
+        const any_failure = diagnostics.some((record) =>
+            diagnostic_exceeds_threshold(
+                record.diagnostic,
+                result.args.max_severity
+            )
+        );
+
+        if (result.args.format === OutputFormat.Json) {
+            output.stdout(render_json(diagnostics));
+        } else if (result.args.format === OutputFormat.Sarif) {
+            output.stdout(render_sarif(diagnostics, package_json.version));
+        } else {
+            output.stdout(render_text(diagnostics, {
+                quiet: result.args.quiet,
+                use_color: resolve_color_from_env(result.args.color),
+            }));
+        }
+
+        return any_failure ? EXIT_CHECK_FAILED : EXIT_OK;
+    } catch (error) {
+        output.stderr(
+            `sight check: ${
+                error instanceof Error ? error.message : String(error)
+            }\n`
+        );
+        return EXIT_OPERATOR_ERROR;
+    } finally {
+        if (context) {
+            await context.document_store.dispose();
+        }
+    }
+}
+
+function check_help_text(): string {
+    return `
+sight check ${package_json.version} - full Stata diagnostics for CI
+
+USAGE:
+    sight check [OPTIONS] [PATHS...]
+
+OPTIONS:
+    --workspace DIR             Workspace root to index (default: current directory)
+    --config PATH               Explicit sight.toml path
+    --no-config                 Ignore sight.toml and use built-in defaults
+    --format text|json|sarif    Output format (default: text)
+    --max-severity LEVEL        Highest severity that does not fail the build
+                                (off, hint, info, warning, error; default: info)
+    --quiet                     Suppress text summary line
+    --color auto|always|never   Colorize text output (default: auto)
+    --no-color                  Alias for --color never
+    -h, --help                  Show this help message
+`.trim();
+}
+
+export function print_check_help(): void {
+    console.log(check_help_text());
+}
+
+export async function run_check(argv: string[]): Promise<number> {
+    return run_check_with_cwd(argv, process.cwd(), DEFAULT_OUTPUT);
+}
+```
+
+Task 3 intentionally did not add `print_check_help()`, so this is the only help
+implementation in the plan.
+
+- [ ] **Step 5: Run the integration tests**
+
+Run:
+
+```bash
+bun test tests/integration/cli-check.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run focused unit tests from previous tasks**
+
+Run:
+
+```bash
+bun test tests/unit/cli/shared.test.ts tests/unit/cli/source-files.test.ts tests/unit/cli/check-args.test.ts tests/unit/cli/check-config.test.ts tests/unit/cli/check-context.test.ts tests/unit/cli/diagnostics-connection.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add src/cli/check.ts tests/integration/cli-check.test.ts
+git commit -m "Collect diagnostics for sight check"
+```
+
+---
+
+### Task 7: Spawned CLI Smoke Tests, SARIF/JSON Checks, And Docs
+
+**Files:**
+- Modify: `docs/cli.md`
+- Modify: `README.md`
+- Test: `tests/integration/cli-check-spawn.test.ts`
+- Test: `tests/integration/cli-check-output.test.ts`
+
+- [ ] **Step 1: Write spawned command and output tests**
+
+Create `tests/integration/cli-check-output.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { run_check_with_cwd } from '../../src/cli/check';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-output-'));
+}
+
+async function run_capture(argv: string[], cwd: string) {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await run_check_with_cwd(argv, cwd, {
+        stdout: (text) => stdout.push(text),
+        stderr: (text) => stderr.push(text),
+    });
+    return { code, stdout: stdout.join(''), stderr: stderr.join('') };
+}
+
+describe('sight check machine output', () => {
+    it('emits parseable JSON records', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+
+        const result = await run_capture(['--workspace', root, '--format', 'json'], root);
+        const parsed = JSON.parse(result.stdout);
+
+        expect(parsed[0].path).toBe('main.do');
+        expect(parsed[0].diagnostic.source).toBe('sight');
+    });
+
+    it('emits SARIF 2.1.0 records', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+
+        const result = await run_capture(['--workspace', root, '--format', 'sarif'], root);
+        const parsed = JSON.parse(result.stdout);
+
+        expect(parsed.version).toBe('2.1.0');
+        expect(parsed.runs[0].tool.driver.name).toBe('sight');
+        expect(parsed.runs[0].results[0].ruleId).toMatch(/^SIGHT/);
+    });
+});
+```
+
+Create `tests/integration/cli-check-spawn.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-spawn-'));
+}
+
+const repo_root = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../..'
+);
+
+describe('sight check spawned CLI', () => {
+    it('routes sight check --help through the top-level CLI', () => {
+        const result = spawnSync(
+            'bun',
+            ['src/cli.ts', 'check', '--help'],
+            { cwd: repo_root, encoding: 'utf8' }
+        );
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('sight check');
+        expect(result.stdout).toContain('--workspace DIR');
+    });
+
+    it('returns exit 1 for check diagnostics through the top-level CLI', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+        const result = spawnSync(
+            'bun',
+            ['src/cli.ts', 'check', '--workspace', root, '--quiet'],
+            { cwd: repo_root, encoding: 'utf8' }
+        );
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain('Undefined macro');
+    });
+});
+```
+
+- [ ] **Step 2: Run the new tests and verify docs are still missing**
+
+Run:
+
+```bash
+bun test tests/integration/cli-check-output.test.ts tests/integration/cli-check-spawn.test.ts
+```
+
+Expected: PASS for tests if previous tasks are complete. Continue to docs in the
+next step.
+
+- [ ] **Step 3: Add CLI documentation**
+
+Create or modify `docs/cli.md`:
+
+```markdown
+# CLI
+
+Sight ships a `sight` binary for editor language-server use and command-line
+checks.
+
+## `sight check`
+
+Run the same static diagnostics Sight publishes in the editor, but in a
+headless batch suitable for CI:
+
+```text
+sight check [OPTIONS] [PATHS...]
+```
+
+`sight check` always indexes the whole workspace so `do`, `run`, and `include`
+chains resolve correctly. Positional `PATHS...` only filter which files report
+diagnostics. With no paths, Sight reports every `.do`, `.ado`, `.doh`, and
+`.mata` file under the workspace.
+
+Options:
+
+- `--workspace DIR`: workspace root to index. Defaults to the current directory.
+- `--config PATH`: explicit `sight.toml`, resolved from the invocation
+  directory.
+- `--no-config`: ignore `sight.toml` and use built-in defaults.
+- `--format text|json|sarif`: output format. Defaults to `text`.
+- `--max-severity off|hint|info|warning|error`: highest severity that does not
+  fail the build. Defaults to `info`, so warnings and errors fail.
+- `--quiet`: suppress the text summary line.
+- `--color auto|always|never`: colorize text output.
+- `--no-color`: alias for `--color never`.
+
+Exit codes:
+
+- `0`: no diagnostic exceeded `--max-severity`.
+- `1`: at least one diagnostic exceeded `--max-severity`, or a usage error.
+- `2`: operator error, such as invalid workspace, missing explicit path, or
+  malformed config.
+
+Example:
+
+```yaml
+- name: Check Stata sources
+  run: sight check
+```
+
+`.mata` files are included as report targets because Sight indexes them for
+symbols, but v1 diagnostics for Mata are limited to what the current parser and
+diagnostic pipeline can produce.
+```
+
+Modify `README.md` to add a CLI docs link near the existing docs list:
+
+```markdown
+- [CLI](docs/cli.md) - `sight check` for CI and command-line diagnostics
+```
+
+- [ ] **Step 4: Run docs/output tests**
+
+Run:
+
+```bash
+bun test tests/integration/cli-check-output.test.ts tests/integration/cli-check-spawn.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full project verification**
+
+Run:
+
+```bash
+bun run test
+```
+
+Expected: PASS for typecheck and the full Bun test suite.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add docs/cli.md README.md tests/integration/cli-check-output.test.ts tests/integration/cli-check-spawn.test.ts
+git commit -m "Document sight check CLI"
+```
+
+---
+
+## Adversarial Review Checklist
+
+Before opening a PR or handing this branch back, verify these review-derived
+failure modes explicitly:
+
+- [ ] `sight check` routes before `parse_args()` rejects `check`.
+- [ ] `DiagnosticsProvider` accepts a narrow CLI connection without `as any`.
+- [ ] `WorkspaceIndexer`, `ScopeResolver`, `ForwardScopeResolver`, and
+  `DiagnosticsProvider` are all wired to the same `DependencyGraph`.
+- [ ] `workspace_indexer.set_max_indexed_files()` is called from validated
+  config.
+- [ ] Diagnostics use `workspace_indexer.get_all_symbols()`.
+- [ ] Each report target is opened, diagnosed, and closed before the next target.
+- [ ] CLI logging never writes warnings/debug text to stdout.
+- [ ] `--max-severity info` does not fail `information` diagnostics.
+- [ ] JSON and SARIF output are deterministic and parseable.
+- [ ] Invalid UTF-8 in a reported source file is a diagnostic, not exit `2`.
+- [ ] Missing explicit paths and unreadable files are exit `2`.
+- [ ] `bun run test` passes.

--- a/docs/superpowers/specs/2026-06-21-sight-check-design.md
+++ b/docs/superpowers/specs/2026-06-21-sight-check-design.md
@@ -74,6 +74,20 @@ Defaults:
 `--config PATH` and `--no-config` conflict. Usage errors such as an unknown flag
 or a missing option value should print a concise error and exit `1`.
 
+The existing top-level `parse_args()` rejects non-flag positional tokens, so
+`src/cli.ts` must intercept `argv[0] === 'check'` before calling the existing
+transport parser. `sight check --help` should print check-specific help and
+exit `0`.
+
+Severity gating is strict. Use this ordering:
+
+```text
+off(0) < hint(1) < info(2) < warning(3) < error(4)
+```
+
+A run fails only when `diagnosticSeverity > maxSeverity`. Therefore the default
+`--max-severity info` fails warnings and errors, but not information or hints.
+
 ## Source Scope
 
 The checker reports the same source extensions the workspace indexer handles:
@@ -87,6 +101,10 @@ Extension matching should be case-insensitive for CLI filesystem friendliness.
 Directory walks should recurse and skip VCS metadata directories such as `.git`,
 `.hg`, and `.svn`. Existing non-source files passed as explicit paths are
 ignored. Missing explicit paths are operator errors.
+
+Resolve `--workspace`, `--config`, and every positional path from the invocation
+cwd before canonicalization. Do not resolve `--config` or positional paths
+relative to `--workspace`.
 
 The whole workspace is always indexed. `PATHS...` only decide which files are
 reported:
@@ -106,6 +124,10 @@ reported:
 
 Project config is merged over built-in defaults through the same merge semantics
 used by the LSP, then validated by the existing config validator.
+
+The CLI has no LSP client or initialization-options layer. Build its settings as
+`validate_comment_formatting_config(deep_merge_config(DEFAULT_SETTINGS,
+projectPartial || {}))`.
 
 Malformed or unreadable config is an operator error in `sight check` and exits
 `2`. This intentionally differs from the LSP, which logs the problem and starts
@@ -137,6 +159,20 @@ Suggested responsibilities:
 - `src/cli/source-files.ts`: supported source predicates, directory walking, and
   report-target collection.
 
+`DiagnosticsProvider` currently depends on the full
+`vscode-languageserver` `Connection` type even though it only uses
+`sendDiagnostics`. Before instantiating it from CLI code, introduce a narrow
+exported connection interface for diagnostics, for example:
+
+```typescript
+export interface DiagnosticsConnection {
+    sendDiagnostics(params: { uri: string; diagnostics: Diagnostic[] }): void;
+}
+```
+
+Then update `DiagnosticsProvider` to accept that interface. The LSP server still
+passes the real connection, and the CLI can pass a no-op implementation.
+
 The batch analysis context should own:
 
 - `DependencyGraph`
@@ -146,8 +182,9 @@ The batch analysis context should own:
 - `DocumentStore`
 - `DiagnosticsProvider`
 
-The CLI can provide a minimal mock `Connection` for `DiagnosticsProvider`
-because `get_diagnostics()` does not publish results.
+`ScopeResolver` logging callbacks in CLI mode must write warnings and debug logs
+to stderr or no-op based on config/debug mode. They must never write to stdout,
+because stdout carries JSON and SARIF machine output.
 
 ## Data Flow
 
@@ -158,18 +195,27 @@ because `get_diagnostics()` does not publish results.
    diagnostics provider.
 5. Configure the indexer from the validated config.
 6. Wire the graph and resolvers the same way the server does:
-   - indexer writes dependency edges to `DependencyGraph`;
+   - `workspace_indexer.set_dependency_graph(dependency_graph)`;
+   - `workspace_indexer.set_max_indexed_files(config.cross_file.max_indexed_files)`;
    - scope resolver reads from the dependency graph;
+   - `scope_resolver.set_dependency_graph(dependency_graph)`;
    - forward resolver is injected into scope resolver;
+   - `scope_resolver.set_forward_scope_resolver(forward_scope_resolver)`;
+   - `diagnostics_provider.set_dependency_graph(dependency_graph)`;
    - document store receives workspace roots and scope resolver.
 7. Run `WorkspaceIndexer.initialize([workspace], config.adoPaths)`.
 8. Collect report targets from `PATHS...`.
 9. For each target:
    - read source;
-   - open it in `DocumentStore` with a file URI;
+   - convert the filesystem path to a URI with `URI.file(path).toString()`;
+   - open it in `DocumentStore` with `await document_store.open(...)`;
+   - read the committed `DocumentState` with `document_store.get(uri)`;
    - collect diagnostics with `DiagnosticsProvider.get_diagnostics()`, passing
-     workspace symbols and the scope resolver;
-   - store `(path, diagnostic)` pairs.
+     `workspace_indexer.get_all_symbols()` and the scope resolver;
+   - store `(path, diagnostic)` pairs;
+   - close the document with `document_store.close(uri)` before moving to the
+     next target, so the CLI does not trip the store's LRU limits on large
+     workspaces.
 10. Render all diagnostics.
 11. Return the gated exit code.
 
@@ -186,6 +232,10 @@ unless normal logging is enabled. However, an explicitly reported source file
 that exceeds the configured size limit should produce an error diagnostic rather
 than silently passing. That diagnostic should point at `1:1` and explain the
 configured byte limit.
+
+If `cross_file.max_indexed_files` prevents the workspace scan from indexing an
+explicitly reported source file, produce an error diagnostic for that file rather
+than silently passing it.
 
 This keeps CI honest: when a user names a file, `sight check` either analyzes it
 or reports why it did not.
@@ -216,6 +266,15 @@ Rules:
 - the diagnostic code is included in brackets when present;
 - `--quiet` suppresses only the trailing text summary.
 
+Sort output deterministically by workspace-relative path, then start line, start
+column, severity, code, and message.
+
+The text summary should match this shape:
+
+```text
+N issues (E errors, W warnings, I infos, H hints, O notes)
+```
+
 JSON output should be an array:
 
 ```json
@@ -238,7 +297,9 @@ JSON output should be an array:
 
 SARIF output should emit SARIF 2.1.0 with diagnostic codes as rule IDs. A
 pragmatic v1 mapping is enough: `error` and `warning` map directly; information
-and hint map to SARIF `note`.
+and hint map to SARIF `note`. Rule IDs must be strings, using `SIGHT<code>` for
+numeric diagnostic codes. Include `tool.driver.name = "sight"` and the package
+version in `tool.driver.version`.
 
 Color applies only to text output. `--color auto` should respect terminal TTY
 status plus `NO_COLOR` and `FORCE_COLOR`. `--no-color` is an alias for
@@ -262,8 +323,11 @@ Unit and property tests:
 - parser rejects unknown flags, missing option values, bad enum values, and
   `--config` with `--no-config`;
 - severity ordering and `--max-severity` gating are deterministic;
+- `--max-severity info` does not fail information or hint diagnostics;
 - text, JSON, and SARIF render stable path, range, severity, message, source,
   and code data;
+- text output sorts diagnostics deterministically and prints the documented
+  summary;
 - color resolution follows explicit flag, `NO_COLOR`, `FORCE_COLOR`, and TTY
   precedence;
 - source discovery includes `.do`, `.ado`, `.doh`, and `.mata`;
@@ -285,6 +349,8 @@ Integration tests:
 - A malformed `sight.toml` exits `2`.
 - A missing explicit path exits `2`.
 - A large explicitly reported source file produces an error diagnostic.
+- A mis-encoded reported source file produces an error diagnostic with byte
+  offset information.
 - JSON output is parseable.
 - SARIF output has the required top-level 2.1.0 shape.
 

--- a/docs/superpowers/specs/2026-06-21-sight-check-design.md
+++ b/docs/superpowers/specs/2026-06-21-sight-check-design.md
@@ -1,0 +1,329 @@
+# Design: `sight check`
+
+## Context
+
+Sight already has the foundations needed for a command-line checker:
+
+- the `sight` binary name and CLI entrypoint from the binary rename work;
+- a shared `sight.toml` project config module intended for LSP and CLI use;
+- `WorkspaceIndexer`, `DependencyGraph`, `ScopeResolver`, and
+  `ForwardScopeResolver` for cross-file scope;
+- `DocumentStore` for parsing source text into cached document state; and
+- `DiagnosticsProvider.get_diagnostics()` for collecting LSP diagnostics without
+  publishing them.
+
+Raven's `raven check` provides the model. It is a headless direct pipeline, not
+an LSP client: it indexes the workspace, reports diagnostics for requested
+targets, renders text/JSON/SARIF, and exits with CI-friendly status codes.
+`sight check` should follow that shape closely.
+
+## Goals
+
+- Add `sight check` as a real subcommand of the existing `sight` binary.
+- Reuse the same parser, analyzer, workspace index, scope resolution, config,
+  and diagnostic providers as the editor.
+- Index the whole workspace before reporting so cross-file diagnostics match the
+  LSP after its startup scan completes.
+- Treat positional paths as report filters only; they must not shrink the
+  workspace used for cross-file resolution.
+- Support Raven-parity output and gating options for CI.
+- Keep editor diagnostic defaults. In particular, `undefinedVariable` remains
+  off unless enabled by config.
+
+## Non-Goals
+
+- Do not implement `sight check` by spawning or driving the LSP protocol.
+- Do not add stricter CI-only diagnostic defaults.
+- Do not implement a separate style-only `sight lint` command in this feature.
+- Do not materially expand Mata diagnostics. `.mata` files participate as
+  report targets, but v1 reports only what the current pipeline can produce.
+
+## CLI Surface
+
+The top-level CLI should route subcommands before transport startup:
+
+```text
+sight check [OPTIONS] [PATHS...]
+sight --stdio
+sight --node-ipc
+```
+
+`sight check` options:
+
+```text
+--workspace DIR
+--config PATH
+--no-config
+--format text|json|sarif
+--max-severity off|hint|info|warning|error
+--quiet
+--color auto|always|never
+--no-color
+--help
+```
+
+Defaults:
+
+- `--workspace`: current directory.
+- `PATHS...`: empty means every Stata source file under the workspace.
+- `--format`: `text`.
+- `--max-severity`: `info`, so warnings and errors fail CI while hints and
+  information do not.
+- `--color`: `auto`.
+
+`--config PATH` and `--no-config` conflict. Usage errors such as an unknown flag
+or a missing option value should print a concise error and exit `1`.
+
+## Source Scope
+
+The checker reports the same source extensions the workspace indexer handles:
+
+- `.do`
+- `.ado`
+- `.doh`
+- `.mata`
+
+Extension matching should be case-insensitive for CLI filesystem friendliness.
+Directory walks should recurse and skip VCS metadata directories such as `.git`,
+`.hg`, and `.svn`. Existing non-source files passed as explicit paths are
+ignored. Missing explicit paths are operator errors.
+
+The whole workspace is always indexed. `PATHS...` only decide which files are
+reported:
+
+- no paths: report every source file under `--workspace`;
+- file path: report it if it is a supported source file;
+- directory path: recursively report supported source files under it.
+
+## Configuration
+
+`sight check` should consume the shared `src/config-file` module:
+
+1. If `--no-config` is set, skip discovery and use no project layer.
+2. If `--config PATH` is set, load that explicit `sight.toml`, resolving
+   relative paths from the invocation cwd.
+3. Otherwise discover the nearest `sight.toml` at or above `--workspace`.
+
+Project config is merged over built-in defaults through the same merge semantics
+used by the LSP, then validated by the existing config validator.
+
+Malformed or unreadable config is an operator error in `sight check` and exits
+`2`. This intentionally differs from the LSP, which logs the problem and starts
+without a project layer.
+
+Config warnings, including stale `.sight.json` warnings and unknown keys, should
+go to stderr.
+
+## Architecture
+
+Add small CLI-focused modules while keeping the existing LSP server lifecycle out
+of the checker:
+
+```text
+src/cli.ts
+src/cli/check.ts
+src/cli/shared.ts
+src/cli/source-files.ts
+```
+
+Suggested responsibilities:
+
+- `src/cli.ts`: top-level routing for `check`, help/version, and LSP transport
+  startup.
+- `src/cli/check.ts`: parse `sight check` args, build the batch analysis
+  context, collect diagnostics, and return an exit code.
+- `src/cli/shared.ts`: output formats, severity ordering, color resolution, and
+  exit code constants.
+- `src/cli/source-files.ts`: supported source predicates, directory walking, and
+  report-target collection.
+
+The batch analysis context should own:
+
+- `DependencyGraph`
+- `WorkspaceIndexer`
+- `ScopeResolver`
+- `ForwardScopeResolver`
+- `DocumentStore`
+- `DiagnosticsProvider`
+
+The CLI can provide a minimal mock `Connection` for `DiagnosticsProvider`
+because `get_diagnostics()` does not publish results.
+
+## Data Flow
+
+1. Resolve cwd.
+2. Resolve and canonicalize `--workspace`.
+3. Load/merge/validate config.
+4. Build dependency graph, indexer, scope resolvers, document store, and
+   diagnostics provider.
+5. Configure the indexer from the validated config.
+6. Wire the graph and resolvers the same way the server does:
+   - indexer writes dependency edges to `DependencyGraph`;
+   - scope resolver reads from the dependency graph;
+   - forward resolver is injected into scope resolver;
+   - document store receives workspace roots and scope resolver.
+7. Run `WorkspaceIndexer.initialize([workspace], config.adoPaths)`.
+8. Collect report targets from `PATHS...`.
+9. For each target:
+   - read source;
+   - open it in `DocumentStore` with a file URI;
+   - collect diagnostics with `DiagnosticsProvider.get_diagnostics()`, passing
+     workspace symbols and the scope resolver;
+   - store `(path, diagnostic)` pairs.
+10. Render all diagnostics.
+11. Return the gated exit code.
+
+The workspace scan completes before diagnostics are collected, so the existing
+auto-backward undefined-diagnostic deferral should not suppress warnings
+permanently.
+
+## Large Files
+
+The indexer already honors `indexing.maxFileSizeBytes`.
+
+For v1, a file skipped only as part of workspace indexing may remain silent
+unless normal logging is enabled. However, an explicitly reported source file
+that exceeds the configured size limit should produce an error diagnostic rather
+than silently passing. That diagnostic should point at `1:1` and explain the
+configured byte limit.
+
+This keeps CI honest: when a user names a file, `sight check` either analyzes it
+or reports why it did not.
+
+## Encoding And Read Errors
+
+Missing explicit paths are operator errors. Existing files that cannot be read
+because of permissions or other I/O failures are also operator errors.
+
+Reported source files that can be read but cannot be decoded as UTF-8 are
+error-severity diagnostics, not operator errors. A small CLI read helper should
+validate UTF-8 bytes before parsing so mis-encoded source is treated as a code
+finding. The message should include the byte offset where decoding failed.
+
+## Output
+
+Text output should be concise and grep-friendly:
+
+```text
+analysis/main.do:12:8 warning: Undefined macro: project_root [2001]
+```
+
+Rules:
+
+- paths are relative to the workspace when possible;
+- line and column are one-based;
+- severity words are lower-case;
+- the diagnostic code is included in brackets when present;
+- `--quiet` suppresses only the trailing text summary.
+
+JSON output should be an array:
+
+```json
+[
+  {
+    "path": "analysis/main.do",
+    "diagnostic": {
+      "range": {
+        "start": { "line": 11, "character": 7 },
+        "end": { "line": 11, "character": 19 }
+      },
+      "severity": 2,
+      "code": 2001,
+      "source": "sight",
+      "message": "Undefined macro: project_root"
+    }
+  }
+]
+```
+
+SARIF output should emit SARIF 2.1.0 with diagnostic codes as rule IDs. A
+pragmatic v1 mapping is enough: `error` and `warning` map directly; information
+and hint map to SARIF `note`.
+
+Color applies only to text output. `--color auto` should respect terminal TTY
+status plus `NO_COLOR` and `FORCE_COLOR`. `--no-color` is an alias for
+`--color never`.
+
+## Exit Codes
+
+- `0`: no diagnostic exceeded `--max-severity`.
+- `1`: at least one diagnostic exceeded `--max-severity`, or a usage error.
+- `2`: operator error while running, such as invalid workspace, unreadable
+  explicit path, or config load failure.
+
+Operator errors take priority over diagnostic threshold failures. A partially
+read run should not appear as an ordinary diagnostic-only failure.
+
+## Testing
+
+Unit and property tests:
+
+- parser accepts all `sight check` flags;
+- parser rejects unknown flags, missing option values, bad enum values, and
+  `--config` with `--no-config`;
+- severity ordering and `--max-severity` gating are deterministic;
+- text, JSON, and SARIF render stable path, range, severity, message, source,
+  and code data;
+- color resolution follows explicit flag, `NO_COLOR`, `FORCE_COLOR`, and TTY
+  precedence;
+- source discovery includes `.do`, `.ado`, `.doh`, and `.mata`;
+- source discovery treats extensions case-insensitively;
+- source discovery skips VCS metadata directories;
+- config loading covers no-config, explicit config, discovery, warnings, and
+  load failures.
+
+Integration tests:
+
+- `sight check` reports lexer, parser, and semantic diagnostics for a single
+  file.
+- `sight check` indexes the whole workspace even when report paths filter output.
+- Auto-discovered `do` / `run` / `include` chains suppress valid inherited
+  symbols.
+- Missing cross-file targets and out-of-scope references are reported.
+- `sight.toml` changes diagnostic severities and indexing settings for the CLI
+  the same way it does for the LSP.
+- A malformed `sight.toml` exits `2`.
+- A missing explicit path exits `2`.
+- A large explicitly reported source file produces an error diagnostic.
+- JSON output is parseable.
+- SARIF output has the required top-level 2.1.0 shape.
+
+Tests should prefer the direct `check.run_with_cwd(...)` seam for focused cases
+and a small number of spawned CLI smoke tests for end-to-end command routing.
+
+## Documentation
+
+Add `docs/cli.md` and link it from `README.md`.
+
+The docs should cover:
+
+- what `sight check` reports;
+- workspace indexing versus report filters;
+- `sight.toml` discovery and `--config` / `--no-config`;
+- output formats;
+- exit codes;
+- source extensions;
+- limitations for `.mata` diagnostics;
+- a minimal CI example.
+
+Example:
+
+```yaml
+- name: Check Stata sources
+  run: sight check
+```
+
+## Implementation Notes
+
+The natural implementation order is:
+
+1. CLI parser, help text, source discovery, output rendering, and severity
+   gating.
+2. Config loading and batch context construction.
+3. Same-file diagnostic collection.
+4. Workspace indexing and cross-file diagnostic parity.
+5. Large-file and encoding diagnostics.
+6. Docs and spawned smoke tests.
+
+This can remain one stacked feature branch, but keeping those internal
+milestones distinct will make review easier.

--- a/scripts/build-binary.ts
+++ b/scripts/build-binary.ts
@@ -12,13 +12,17 @@
 import { $ } from 'bun';
 import * as fs from 'fs';
 import * as path from 'path';
+import type {
+    BinaryArch,
+    BinaryPlatform,
+} from '../src/cli-binary-names';
 
 /**
  * Build target configuration.
  */
 export interface BuildTarget {
-    platform: 'darwin' | 'linux' | 'windows';
-    arch: 'x64' | 'arm64';
+    platform: BinaryPlatform;
+    arch: BinaryArch;
     output_name: string;
 }
 
@@ -28,8 +32,8 @@ type BinaryBuilder = (target: BuildTarget) => Promise<void>;
  * Platform detection result.
  */
 export interface PlatformInfo {
-    platform: 'darwin' | 'linux' | 'windows';
-    arch: 'arm64' | 'x64';
+    platform: BinaryPlatform;
+    arch: BinaryArch;
     binary_name: string;
 }
 
@@ -60,6 +64,7 @@ export function detect_platform(): PlatformInfo | undefined {
 
 /**
  * All supported build targets.
+ * darwin-x64 is intentionally not built.
  */
 const TARGETS: BuildTarget[] = [
     { platform: 'darwin', arch: 'arm64', output_name: 'sight-darwin-arm64' },

--- a/src/cli-binary-names.ts
+++ b/src/cli-binary-names.ts
@@ -6,3 +6,17 @@ export const PRIMARY_BINARY_NAME = 'sight';
 export const LEGACY_BINARY_NAME = 'sight-language-server';
 export const CLI_HELP_BANNER =
     'Sight - Language Server Protocol implementation for Stata';
+export const SUPPORTED_BINARY_PLATFORMS = [
+    'darwin',
+    'linux',
+    'windows',
+] as const;
+export const SUPPORTED_BINARY_ARCHS = ['x64', 'arm64'] as const;
+
+export type BinaryPlatform = typeof SUPPORTED_BINARY_PLATFORMS[number];
+export type BinaryArch = typeof SUPPORTED_BINARY_ARCHS[number];
+
+export const NATIVE_BINARY_NAME_PATTERN = new RegExp(
+    `^sight-(${SUPPORTED_BINARY_PLATFORMS.join('|')})-` +
+    `(${SUPPORTED_BINARY_ARCHS.join('|')})(\\.exe)?$`
+);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,6 +186,11 @@ export function print_error(message: string): void {
  * Parses arguments and starts the server or prints help/version.
  */
 export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+    if (argv[0] === 'check') {
+        const { run_check } = await import('./cli/check');
+        return run_check(argv.slice(1));
+    }
+
     const result = parse_args(argv);
 
     if (!result.success) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,6 +147,11 @@ ${CLI_HELP_BANNER}
 
 USAGE:
     sight [OPTIONS]
+    sight check [OPTIONS] [PATHS...]
+
+COMMANDS:
+    check             Run full Stata diagnostics over a workspace (for CI).
+                      See "sight check --help" for its options.
 
 OPTIONS:
     -s, --stdio       Use stdio transport (default)
@@ -159,6 +164,7 @@ EXAMPLES:
     sight --stdio           Start server with stdio transport
     sight --node-ipc        Start server with Node IPC (VS Code)
     sight                   Start server with stdio (default)
+    sight check --help      Show options for the check command
 
 For more information, visit: https://github.com/jbearak/sight
 `.trim();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import package_json from '../package.json' with { type: 'json' };
 import {
     CLI_HELP_BANNER,
     LEGACY_BINARY_NAME,
+    NATIVE_BINARY_NAME_PATTERN,
     PRIMARY_BINARY_NAME,
 } from './cli-binary-names';
 
@@ -238,8 +239,6 @@ export function is_cli_entry_point(
 
     const normalized_script_path = script_path.replace(/\\/g, '/');
     const script_filename = normalized_script_path.split('/').pop() ?? '';
-    const native_binary_pattern =
-        /^sight-(darwin|linux|windows)-(x64|arm64)(\.exe)?$/;
 
     return (
         script_path === cli_filename ||
@@ -248,7 +247,7 @@ export function is_cli_entry_point(
         normalized_script_path.endsWith(`/${LEGACY_BINARY_NAME}`) ||
         normalized_script_path.endsWith(`/${LEGACY_BINARY_NAME}.exe`) ||
         normalized_script_path.endsWith('/sight-server.js') ||
-        native_binary_pattern.test(script_filename)
+        NATIVE_BINARY_NAME_PATTERN.test(script_filename)
     );
 }
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -37,6 +37,7 @@ import {
     OutputFormat,
     SeverityLevel,
     diagnostic_exceeds_threshold,
+    error_message,
     parse_color_choice,
     parse_output_format,
     parse_severity_level,
@@ -92,7 +93,7 @@ function parse_enum_option<T>(
     } catch (error) {
         return {
             success: false,
-            error: error instanceof Error ? error.message : String(error),
+            error: error_message(error),
         };
     }
 }
@@ -485,9 +486,7 @@ export async function run_check_with_cwd(
         workspace_root = canonicalize_existing_path(resolved_workspace_root);
     } catch (error) {
         output.stderr(
-            `sight check: invalid workspace: ${
-                error instanceof Error ? error.message : String(error)
-            }\n`
+            `sight check: invalid workspace: ${error_message(error)}\n`
         );
         return EXIT_OPERATOR_ERROR;
     }
@@ -551,9 +550,7 @@ export async function run_check_with_cwd(
         return any_failure ? EXIT_CHECK_FAILED : EXIT_OK;
     } catch (error) {
         output.stderr(
-            `sight check: ${
-                error instanceof Error ? error.message : String(error)
-            }\n`
+            `sight check: ${error_message(error)}\n`
         );
         return EXIT_OPERATOR_ERROR;
     } finally {

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -27,6 +27,7 @@ import {
     is_within_workspace,
     read_source_file,
     size_limit_diagnostic,
+    unreadable_diagnostic,
 } from './source-files';
 import {
     ColorChoice,
@@ -67,8 +68,20 @@ function parse_required_option_value(
     argv: string[],
     index: number,
     flag: string,
-    value_kind: string
+    value_kind: string,
+    inline_value: string | undefined
 ): { success: true; value: string } | { success: false; error: string } {
+    // `--flag=value` form: the value travels with the flag, so it may legally
+    // begin with '-' (e.g. a path like `-odd-name.toml`).
+    if (inline_value !== undefined) {
+        if (inline_value.length === 0) {
+            return { success: false, error: `${flag} needs ${value_kind}` };
+        }
+        return { success: true, value: inline_value };
+    }
+
+    // `--flag value` form: a following token that begins with '-' is treated
+    // as the next flag, i.e. this flag is missing its value.
     const value = argv[index + 1];
     if (value === undefined || value.startsWith('-')) {
         return {
@@ -84,9 +97,16 @@ function parse_enum_option<T>(
     argv: string[],
     index: number,
     flag: string,
-    parse: (value: string) => T
+    parse: (value: string) => T,
+    inline_value: string | undefined
 ): { success: true; value: T } | { success: false; error: string } {
-    const parsed = parse_required_option_value(argv, index, flag, 'a value');
+    const parsed = parse_required_option_value(
+        argv,
+        index,
+        flag,
+        'a value',
+        inline_value
+    );
     if (!parsed.success) return parsed;
     try {
         return { success: true, value: parse(parsed.value) };
@@ -110,7 +130,18 @@ export function parse_check_args(argv: string[]): CheckParseResult {
     };
 
     for (let i = 0; i < argv.length; i++) {
-        const arg = argv[i];
+        const raw = argv[i];
+        // Support both `--flag value` and `--flag=value`. Splitting on the
+        // first '=' lets a value legally begin with '-' (e.g. an odd path).
+        let arg = raw;
+        let inline_value: string | undefined;
+        if (raw.startsWith('--')) {
+            const eq = raw.indexOf('=');
+            if (eq !== -1) {
+                arg = raw.slice(0, eq);
+                inline_value = raw.slice(eq + 1);
+            }
+        }
         switch (arg) {
             case '--workspace':
                 {
@@ -118,11 +149,12 @@ export function parse_check_args(argv: string[]): CheckParseResult {
                         argv,
                         i,
                         '--workspace',
-                        'a path'
+                        'a path',
+                        inline_value
                     );
                     if (!parsed.success) return parsed;
                     args.workspace = parsed.value;
-                    i++;
+                    if (inline_value === undefined) i++;
                 }
                 break;
             case '--config':
@@ -131,11 +163,12 @@ export function parse_check_args(argv: string[]): CheckParseResult {
                         argv,
                         i,
                         '--config',
-                        'a path'
+                        'a path',
+                        inline_value
                     );
                     if (!parsed.success) return parsed;
                     args.config_path = parsed.value;
-                    i++;
+                    if (inline_value === undefined) i++;
                 }
                 break;
             case '--no-config':
@@ -147,11 +180,12 @@ export function parse_check_args(argv: string[]): CheckParseResult {
                         argv,
                         i,
                         '--format',
-                        parse_output_format
+                        parse_output_format,
+                        inline_value
                     );
                     if (!parsed.success) return parsed;
                     args.format = parsed.value;
-                    i++;
+                    if (inline_value === undefined) i++;
                 }
                 break;
             case '--max-severity':
@@ -160,11 +194,12 @@ export function parse_check_args(argv: string[]): CheckParseResult {
                         argv,
                         i,
                         '--max-severity',
-                        parse_severity_level
+                        parse_severity_level,
+                        inline_value
                     );
                     if (!parsed.success) return parsed;
                     args.max_severity = parsed.value;
-                    i++;
+                    if (inline_value === undefined) i++;
                 }
                 break;
             case '--quiet':
@@ -176,11 +211,12 @@ export function parse_check_args(argv: string[]): CheckParseResult {
                         argv,
                         i,
                         '--color',
-                        parse_color_choice
+                        parse_color_choice,
+                        inline_value
                     );
                     if (!parsed.success) return parsed;
                     args.color = parsed.value;
-                    i++;
+                    if (inline_value === undefined) i++;
                 }
                 break;
             case '--no-color':
@@ -355,9 +391,26 @@ export async function collect_check_diagnostics(
 
     for (const target of targets) {
         const uri = URI.file(target.path).toString();
-        if (target.explicit) {
-            const stats = fs.statSync(target.path);
-            if (stats.size > config.indexing.maxFileSizeBytes) {
+
+        // Size guard runs for every target, not just explicit ones: a
+        // directory-walked oversized file would otherwise be read and analyzed
+        // whole (OOM risk). statSync is guarded so a file removed after
+        // discovery becomes a per-file diagnostic, not a whole-batch abort.
+        let stats: fs.Stats;
+        try {
+            stats = fs.statSync(target.path);
+        } catch (error) {
+            records.push(diagnostic_record(
+                target.relative_path,
+                unreadable_diagnostic(`${target.path}: ${error_message(error)}`)
+            ));
+            continue;
+        }
+        if (stats.size > config.indexing.maxFileSizeBytes) {
+            // Explicit targets get a visible diagnostic so the user learns why
+            // a file they named was skipped; walked targets are skipped
+            // silently, matching the indexer's own size handling.
+            if (target.explicit) {
                 records.push(diagnostic_record(
                     target.relative_path,
                     size_limit_diagnostic(
@@ -366,8 +419,8 @@ export async function collect_check_diagnostics(
                         config.indexing.maxFileSizeBytes
                     )
                 ));
-                continue;
             }
+            continue;
         }
         if (
             target.explicit &&
@@ -384,7 +437,13 @@ export async function collect_check_diagnostics(
 
         const read_result = read_source_file(target.path);
         if (read_result.kind === 'read-error') {
-            throw new Error(read_result.message);
+            // Per-file failure (e.g. file vanished or permissions changed after
+            // discovery) is reported rather than aborting the whole batch.
+            records.push(diagnostic_record(
+                target.relative_path,
+                unreadable_diagnostic(read_result.message)
+            ));
+            continue;
         }
         if (read_result.kind === 'decode-error') {
             records.push(diagnostic_record(

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -1,3 +1,21 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
+import {
+    deep_merge_config,
+    discover_and_load_project_config,
+    load_toml_file,
+    type ProjectConfigWarning,
+} from '../config-file';
+import { DependencyGraph } from '../dependency-graph';
+import { DocumentStore } from '../document-store';
+import { ForwardScopeResolver } from '../forward-scope-resolver';
+import { WorkspaceIndexer } from '../indexer';
+import { DiagnosticsProvider } from '../providers/diagnostics';
+import { ScopeResolver } from '../scope-resolver';
+import { DEFAULT_SETTINGS } from '../server-handlers';
+import { StataLSPConfig } from '../types';
+import { validate_comment_formatting_config } from '../utils/config-validator';
 import {
     ColorChoice,
     EXIT_OPERATOR_ERROR,
@@ -127,6 +145,128 @@ export function parse_check_args(argv: string[]): CheckParseResult {
     }
 
     return { success: true, args };
+}
+
+export type CheckConfigResult =
+    | {
+        kind: 'loaded';
+        config: StataLSPConfig;
+        warnings: ProjectConfigWarning[];
+        config_path?: string;
+    }
+    | { kind: 'operator-error'; message: string };
+
+export function load_check_config(options: {
+    cwd: string;
+    workspace_root: string;
+    config_path?: string;
+    no_config: boolean;
+}): CheckConfigResult {
+    if (options.no_config) {
+        return {
+            kind: 'loaded',
+            config: validate_comment_formatting_config(DEFAULT_SETTINGS),
+            warnings: [],
+        };
+    }
+
+    const loaded = options.config_path
+        ? load_toml_file(path.resolve(options.cwd, options.config_path))
+        : discover_and_load_project_config(options.workspace_root);
+
+    if (loaded.kind === 'load-failed') {
+        return {
+            kind: 'operator-error',
+            message: `failed to load ${loaded.path}: ${loaded.error}`,
+        };
+    }
+
+    if (loaded.kind === 'none') {
+        return {
+            kind: 'loaded',
+            config: validate_comment_formatting_config(DEFAULT_SETTINGS),
+            warnings: loaded.warnings,
+        };
+    }
+
+    return {
+        kind: 'loaded',
+        config: validate_comment_formatting_config(
+            deep_merge_config(DEFAULT_SETTINGS, loaded.partial_config)
+        ),
+        warnings: loaded.warnings,
+        config_path: loaded.path,
+    };
+}
+
+export interface CheckContext {
+    dependency_graph: DependencyGraph;
+    workspace_indexer: WorkspaceIndexer;
+    scope_resolver: ScopeResolver;
+    forward_scope_resolver: ForwardScopeResolver;
+    document_store: DocumentStore;
+    diagnostics_provider: DiagnosticsProvider;
+}
+
+export async function build_check_context(
+    workspace_root: string,
+    config: StataLSPConfig
+): Promise<CheckContext> {
+    const dependency_graph = new DependencyGraph();
+    const workspace_indexer = new WorkspaceIndexer();
+    const scope_resolver = new ScopeResolver({
+        log: (message) => {
+            if (config.debug === true) {
+                console.error(message);
+            }
+        },
+        warn: (message) => console.error(message),
+    }, {
+        read_file: async (uri: string) =>
+            fs.promises.readFile(URI.parse(uri).fsPath, 'utf8'),
+        exists: async (uri: string) => {
+            try {
+                await fs.promises.access(URI.parse(uri).fsPath);
+                return true;
+            } catch {
+                return false;
+            }
+        },
+    });
+    const forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+        max_forward_depth: config.cross_file.max_forward_depth,
+    });
+    const document_store = new DocumentStore();
+    const diagnostics_provider = new DiagnosticsProvider({
+        sendDiagnostics: () => undefined,
+    });
+
+    workspace_indexer.configure(config);
+    workspace_indexer.set_max_indexed_files(
+        config.cross_file.max_indexed_files
+    );
+    workspace_indexer.set_dependency_graph(dependency_graph);
+    scope_resolver.set_dependency_graph(dependency_graph);
+    scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+    diagnostics_provider.set_dependency_graph(dependency_graph);
+    scope_resolver.set_workspace_roots([workspace_root]);
+    forward_scope_resolver.set_workspace_roots([workspace_root]);
+    document_store.set_workspace_roots([workspace_root]);
+    document_store.set_scope_resolver(scope_resolver);
+    document_store.set_on_backward_directives_parsed((uri, directives) => {
+        workspace_indexer.set_buffer_directives(uri, directives);
+    });
+
+    await workspace_indexer.initialize([workspace_root], config.adoPaths);
+
+    return {
+        dependency_graph,
+        workspace_indexer,
+        scope_resolver,
+        forward_scope_resolver,
+        document_store,
+        diagnostics_provider,
+    };
 }
 
 export async function run_check(argv: string[]): Promise<number> {

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -14,7 +14,7 @@ import { DocumentStore } from '../document-store';
 import { ForwardScopeResolver } from '../forward-scope-resolver';
 import { WorkspaceIndexer } from '../indexer';
 import { DiagnosticsProvider } from '../providers/diagnostics';
-import { ScopeResolver } from '../scope-resolver';
+import { ScopeResolver, scope_resolver_config_for } from '../scope-resolver';
 import { DEFAULT_SETTINGS } from '../server-handlers';
 import { StataLSPConfig } from '../types';
 import { validate_comment_formatting_config } from '../utils/config-validator';
@@ -48,6 +48,8 @@ import {
     render_text,
     resolve_color_from_env,
 } from './shared';
+
+const CHECK_MAX_PARALLEL = 4;
 
 export interface CheckArgs {
     paths: string[];
@@ -347,6 +349,9 @@ export async function build_check_context(
     forward_scope_resolver.set_workspace_roots([workspace_root]);
     document_store.set_workspace_roots([workspace_root]);
     document_store.set_scope_resolver(scope_resolver);
+    document_store.set_scope_resolver_config(
+        scope_resolver_config_for(config)
+    );
     document_store.set_on_backward_directives_parsed((uri, directives) => {
         workspace_indexer.set_buffer_directives(uri, directives);
     });
@@ -386,11 +391,14 @@ export async function collect_check_diagnostics(
     config: StataLSPConfig,
     targets: ReportTarget[]
 ): Promise<DiagnosticRecord[]> {
-    const records: DiagnosticRecord[] = [];
     const workspace_symbols = context.workspace_indexer.get_all_symbols();
     const files_indexed = context.workspace_indexer.get_metrics().files_indexed;
+    const the_slots: DiagnosticRecord[][] = new Array(targets.length);
 
-    for (const target of targets) {
+    async function collect_target_diagnostics(
+        target: ReportTarget
+    ): Promise<DiagnosticRecord[]> {
+        const records: DiagnosticRecord[] = [];
         const uri = URI.file(target.path).toString();
 
         // Size guard runs for every target, not just explicit ones: a
@@ -405,7 +413,7 @@ export async function collect_check_diagnostics(
                 target.relative_path,
                 unreadable_diagnostic(read_error_detail(error))
             ));
-            continue;
+            return records;
         }
         if (stats.size > config.indexing.maxFileSizeBytes) {
             // Explicit targets get a visible diagnostic so the user learns why
@@ -420,7 +428,7 @@ export async function collect_check_diagnostics(
                     )
                 ));
             }
-            continue;
+            return records;
         }
         // Once the index cap is reached, an in-workspace target that never made
         // it into the index would be analyzed against an incomplete cross-file
@@ -437,7 +445,7 @@ export async function collect_check_diagnostics(
                 target.relative_path,
                 index_limit_diagnostic()
             ));
-            continue;
+            return records;
         }
 
         const read_result = read_source_file(target.path);
@@ -448,14 +456,14 @@ export async function collect_check_diagnostics(
                 target.relative_path,
                 unreadable_diagnostic(read_result.message)
             ));
-            continue;
+            return records;
         }
         if (read_result.kind === 'decode-error') {
             records.push(diagnostic_record(
                 target.relative_path,
                 read_result.diagnostic
             ));
-            continue;
+            return records;
         }
 
         let opened = false;
@@ -490,9 +498,30 @@ export async function collect_check_diagnostics(
                 context.document_store.close(uri);
             }
         }
+
+        return records;
     }
 
-    return records;
+    let file_index = 0;
+    const worker_count = Math.min(CHECK_MAX_PARALLEL, targets.length);
+    const the_workers = Array.from(
+        { length: worker_count },
+        async () => {
+            while (true) {
+                const my_index = file_index++;
+                if (my_index >= targets.length) {
+                    break;
+                }
+                the_slots[my_index] = await collect_target_diagnostics(
+                    targets[my_index]
+                );
+            }
+        }
+    );
+
+    await Promise.all(the_workers);
+
+    return the_slots.flat();
 }
 
 function check_help_text(): string {

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -365,6 +365,14 @@ function diagnostic_record(
     };
 }
 
+function is_under_workspace(workspace_root: string, file_path: string): boolean {
+    const relative = path.relative(workspace_root, file_path);
+    return relative === ''
+        || (relative.length > 0 &&
+            !relative.startsWith('..') &&
+            !path.isAbsolute(relative));
+}
+
 export async function collect_check_diagnostics(
     context: CheckContext,
     workspace_root: string,
@@ -392,6 +400,7 @@ export async function collect_check_diagnostics(
         }
         if (
             target.explicit &&
+            is_under_workspace(workspace_root, target.path) &&
             context.workspace_indexer.get_metrics().files_indexed
                 >= config.cross_file.max_indexed_files &&
             !indexed_files.has(uri)

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -278,7 +278,11 @@ export type CheckConfigResult =
         warnings: ProjectConfigWarning[];
         config_path?: string;
     }
-    | { kind: 'operator-error'; message: string };
+    | {
+        kind: 'operator-error';
+        message: string;
+        warnings: ProjectConfigWarning[];
+    };
 
 export function load_check_config(options: {
     cwd: string;
@@ -299,27 +303,36 @@ export function load_check_config(options: {
         : discover_and_load_project_config(options.workspace_root);
 
     if (loaded.kind === 'load-failed') {
+        // Surface any warnings collected before the parse failed (e.g. the
+        // stale-.sight.json migration hint from discovery) so the operator
+        // still gets the conversion guidance alongside the error.
         return {
             kind: 'operator-error',
             message: `failed to load ${loaded.path}: ${loaded.error}`,
-        };
-    }
-
-    if (loaded.kind === 'none') {
-        return {
-            kind: 'loaded',
-            config: validate_comment_formatting_config(DEFAULT_SETTINGS),
             warnings: loaded.warnings,
         };
     }
 
+    // Collect comment-formatting validation warnings (invalid indentSize,
+    // unknown comment style, etc.) the same way the LSP server logs them, so
+    // `sight check` does not silently swallow them.
+    const validation_warnings: ProjectConfigWarning[] = [];
+    const collect_validation_warning = (message: string): void => {
+        validation_warnings.push({ code: 'invalid-value', message });
+    };
+
+    const partial_config = loaded.kind === 'none'
+        ? undefined
+        : deep_merge_config(DEFAULT_SETTINGS, loaded.partial_config);
+
     return {
         kind: 'loaded',
         config: validate_comment_formatting_config(
-            deep_merge_config(DEFAULT_SETTINGS, loaded.partial_config)
+            partial_config ?? DEFAULT_SETTINGS,
+            collect_validation_warning
         ),
-        warnings: loaded.warnings,
-        config_path: loaded.path,
+        warnings: [...loaded.warnings, ...validation_warnings],
+        config_path: loaded.kind === 'none' ? undefined : loaded.path,
     };
 }
 
@@ -614,11 +627,14 @@ export async function run_check_with_cwd(
         no_config: result.args.no_config,
     });
     if (config_result.kind === 'operator-error') {
+        for (const my_warning of config_result.warnings) {
+            output.stderr(`sight check: ${my_warning.message}\n`);
+        }
         output.stderr(`sight check: ${config_result.message}\n`);
         return EXIT_OPERATOR_ERROR;
     }
-    for (const warning of config_result.warnings) {
-        output.stderr(`sight check: ${warning.message}\n`);
+    for (const my_warning of config_result.warnings) {
+        output.stderr(`sight check: ${my_warning.message}\n`);
     }
 
     const target_result = collect_report_targets(

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -25,6 +25,7 @@ import {
     collect_report_targets,
     index_limit_diagnostic,
     is_within_workspace,
+    read_error_detail,
     read_source_file,
     size_limit_diagnostic,
     unreadable_diagnostic,
@@ -402,7 +403,7 @@ export async function collect_check_diagnostics(
         } catch (error) {
             records.push(diagnostic_record(
                 target.relative_path,
-                unreadable_diagnostic(`${target.path}: ${error_message(error)}`)
+                unreadable_diagnostic(read_error_detail(error))
             ));
             continue;
         }
@@ -414,7 +415,6 @@ export async function collect_check_diagnostics(
                 records.push(diagnostic_record(
                     target.relative_path,
                     size_limit_diagnostic(
-                        target.path,
                         stats.size,
                         config.indexing.maxFileSizeBytes
                     )
@@ -422,15 +422,20 @@ export async function collect_check_diagnostics(
             }
             continue;
         }
+        // Once the index cap is reached, an in-workspace target that never made
+        // it into the index would be analyzed against an incomplete cross-file
+        // graph, yielding unreliable diagnostics with no signal in CI. Report
+        // it for every in-workspace target (not just explicit ones, so the
+        // default `sight check .` surfaces the problem too) rather than emitting
+        // silently-wrong results.
         if (
-            target.explicit &&
             is_within_workspace(workspace_root, target.path) &&
             files_indexed >= config.cross_file.max_indexed_files &&
             !context.workspace_indexer.has_indexed_file(uri)
         ) {
             records.push(diagnostic_record(
                 target.relative_path,
-                index_limit_diagnostic(target.path)
+                index_limit_diagnostic()
             ));
             continue;
         }

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -290,11 +290,22 @@ export function load_check_config(options: {
     config_path?: string;
     no_config: boolean;
 }): CheckConfigResult {
+    // Collect comment-formatting validation warnings (invalid indentSize,
+    // unknown comment style, etc.) the same way the LSP server logs them, so
+    // `sight check` does not silently swallow them on any config path.
+    const validation_warnings: ProjectConfigWarning[] = [];
+    const collect_validation_warning = (message: string): void => {
+        validation_warnings.push({ code: 'invalid-value', message });
+    };
+
     if (options.no_config) {
         return {
             kind: 'loaded',
-            config: validate_comment_formatting_config(DEFAULT_SETTINGS),
-            warnings: [],
+            config: validate_comment_formatting_config(
+                DEFAULT_SETTINGS,
+                collect_validation_warning
+            ),
+            warnings: validation_warnings,
         };
     }
 
@@ -313,26 +324,25 @@ export function load_check_config(options: {
         };
     }
 
-    // Collect comment-formatting validation warnings (invalid indentSize,
-    // unknown comment style, etc.) the same way the LSP server logs them, so
-    // `sight check` does not silently swallow them.
-    const validation_warnings: ProjectConfigWarning[] = [];
-    const collect_validation_warning = (message: string): void => {
-        validation_warnings.push({ code: 'invalid-value', message });
-    };
-
-    const partial_config = loaded.kind === 'none'
-        ? undefined
-        : deep_merge_config(DEFAULT_SETTINGS, loaded.partial_config);
+    if (loaded.kind === 'none') {
+        return {
+            kind: 'loaded',
+            config: validate_comment_formatting_config(
+                DEFAULT_SETTINGS,
+                collect_validation_warning
+            ),
+            warnings: [...loaded.warnings, ...validation_warnings],
+        };
+    }
 
     return {
         kind: 'loaded',
         config: validate_comment_formatting_config(
-            partial_config ?? DEFAULT_SETTINGS,
+            deep_merge_config(DEFAULT_SETTINGS, loaded.partial_config),
             collect_validation_warning
         ),
         warnings: [...loaded.warnings, ...validation_warnings],
-        config_path: loaded.kind === 'none' ? undefined : loaded.path,
+        config_path: loaded.path,
     };
 }
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -626,15 +626,14 @@ export async function run_check_with_cwd(
         config_path: result.args.config_path,
         no_config: result.args.no_config,
     });
-    if (config_result.kind === 'operator-error') {
-        for (const my_warning of config_result.warnings) {
-            output.stderr(`sight check: ${my_warning.message}\n`);
-        }
-        output.stderr(`sight check: ${config_result.message}\n`);
-        return EXIT_OPERATOR_ERROR;
-    }
+    // Both result variants carry warnings (e.g. the stale-.sight.json
+    // migration hint); emit them once regardless of which branch follows.
     for (const my_warning of config_result.warnings) {
         output.stderr(`sight check: ${my_warning.message}\n`);
+    }
+    if (config_result.kind === 'operator-error') {
+        output.stderr(`sight check: ${config_result.message}\n`);
+        return EXIT_OPERATOR_ERROR;
     }
 
     const target_result = collect_report_targets(

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -636,8 +636,9 @@ export async function run_check_with_cwd(
         config_path: result.args.config_path,
         no_config: result.args.no_config,
     });
-    // Both result variants carry warnings (e.g. the stale-.sight.json
-    // migration hint); emit them once regardless of which branch follows.
+    // Both result variants carry a warnings array (auto-discovery may attach
+    // a stale-.sight.json migration hint to either), so emit them once here
+    // before branching on the result kind.
     for (const my_warning of config_result.warnings) {
         output.stderr(`sight check: ${my_warning.message}\n`);
     }

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -460,7 +460,7 @@ export async function run_check_with_cwd(
     const result = parse_check_args(argv);
     if (!result.success) {
         output.stderr(`sight check: ${result.error}\n`);
-        return EXIT_CHECK_FAILED;
+        return EXIT_OPERATOR_ERROR;
     }
     if (result.args.help) {
         output.stdout(`${check_help_text()}\n`);

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -351,7 +351,6 @@ export async function collect_check_diagnostics(
 ): Promise<DiagnosticRecord[]> {
     const records: DiagnosticRecord[] = [];
     const workspace_symbols = context.workspace_indexer.get_all_symbols();
-    const indexed_files = context.workspace_indexer.get_indexed_files();
     const files_indexed = context.workspace_indexer.get_metrics().files_indexed;
 
     for (const target of targets) {
@@ -374,7 +373,7 @@ export async function collect_check_diagnostics(
             target.explicit &&
             is_within_workspace(workspace_root, target.path) &&
             files_indexed >= config.cross_file.max_indexed_files &&
-            !indexed_files.has(uri)
+            !context.workspace_indexer.has_indexed_file(uri)
         ) {
             records.push(diagnostic_record(
                 target.relative_path,

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -1,0 +1,143 @@
+import {
+    ColorChoice,
+    EXIT_OPERATOR_ERROR,
+    OutputFormat,
+    SeverityLevel,
+    parse_color_choice,
+    parse_output_format,
+    parse_severity_level,
+} from './shared';
+
+export interface CheckArgs {
+    paths: string[];
+    workspace?: string;
+    config_path?: string;
+    no_config: boolean;
+    format: OutputFormat;
+    max_severity: SeverityLevel;
+    quiet: boolean;
+    color: ColorChoice;
+    help: boolean;
+}
+
+export type CheckParseResult =
+    | { success: true; args: CheckArgs }
+    | { success: false; error: string };
+
+export function parse_check_args(argv: string[]): CheckParseResult {
+    const args: CheckArgs = {
+        paths: [],
+        no_config: false,
+        format: OutputFormat.Text,
+        max_severity: SeverityLevel.Info,
+        quiet: false,
+        color: ColorChoice.Auto,
+        help: false,
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        switch (arg) {
+            case '--workspace':
+                if (argv[i + 1] === undefined) {
+                    return { success: false, error: '--workspace needs a path' };
+                }
+                args.workspace = argv[++i];
+                break;
+            case '--config':
+                if (argv[i + 1] === undefined) {
+                    return { success: false, error: '--config needs a path' };
+                }
+                args.config_path = argv[++i];
+                break;
+            case '--no-config':
+                args.no_config = true;
+                break;
+            case '--format':
+                if (argv[i + 1] === undefined) {
+                    return { success: false, error: '--format needs a value' };
+                }
+                try {
+                    args.format = parse_output_format(argv[++i]);
+                } catch (error) {
+                    return {
+                        success: false,
+                        error: error instanceof Error
+                            ? error.message
+                            : String(error),
+                    };
+                }
+                break;
+            case '--max-severity':
+                if (argv[i + 1] === undefined) {
+                    return {
+                        success: false,
+                        error: '--max-severity needs a value',
+                    };
+                }
+                try {
+                    args.max_severity = parse_severity_level(argv[++i]);
+                } catch (error) {
+                    return {
+                        success: false,
+                        error: error instanceof Error
+                            ? error.message
+                            : String(error),
+                    };
+                }
+                break;
+            case '--quiet':
+                args.quiet = true;
+                break;
+            case '--color':
+                if (argv[i + 1] === undefined) {
+                    return { success: false, error: '--color needs a value' };
+                }
+                try {
+                    args.color = parse_color_choice(argv[++i]);
+                } catch (error) {
+                    return {
+                        success: false,
+                        error: error instanceof Error
+                            ? error.message
+                            : String(error),
+                    };
+                }
+                break;
+            case '--no-color':
+                args.color = ColorChoice.Never;
+                break;
+            case '--help':
+            case '-h':
+                args.help = true;
+                break;
+            default:
+                if (arg.startsWith('-')) {
+                    return { success: false, error: `Unknown flag: ${arg}` };
+                }
+                args.paths.push(arg);
+        }
+    }
+
+    if (args.no_config && args.config_path !== undefined) {
+        return {
+            success: false,
+            error: 'Cannot specify both --config and --no-config',
+        };
+    }
+
+    return { success: true, args };
+}
+
+export async function run_check(argv: string[]): Promise<number> {
+    const result = parse_check_args(argv);
+    if (!result.success) {
+        console.error(`sight check: ${result.error}`);
+        return 1;
+    }
+    if (result.args.help) {
+        return 0;
+    }
+    console.error('sight check: batch diagnostics are unavailable before Task 6');
+    return EXIT_OPERATOR_ERROR;
+}

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -25,7 +25,6 @@ import {
     collect_report_targets,
     index_limit_diagnostic,
     is_within_workspace,
-    relative_path,
     read_source_file,
     size_limit_diagnostic,
 } from './source-files';
@@ -280,6 +279,8 @@ export async function build_check_context(
 
     const dependency_graph = new DependencyGraph();
     const workspace_indexer = new WorkspaceIndexer();
+    // ScopeResolver's default content provider already reads from disk
+    // (read_file/exists/stat via fsPath), which is exactly what the CLI needs.
     const scope_resolver = new ScopeResolver({
         log: (message) => {
             if (config.debug === true) {
@@ -287,17 +288,6 @@ export async function build_check_context(
             }
         },
         warn: (message) => console.error(message),
-    }, {
-        read_file: async (uri: string) =>
-            fs.promises.readFile(URI.parse(uri).fsPath, 'utf8'),
-        exists: async (uri: string) => {
-            try {
-                await fs.promises.access(URI.parse(uri).fsPath);
-                return true;
-            } catch {
-                return false;
-            }
-        },
     });
     const forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
         max_forward_depth: config.cross_file.max_forward_depth,
@@ -346,14 +336,10 @@ const DEFAULT_OUTPUT: CheckOutput = {
 };
 
 function diagnostic_record(
-    workspace_root: string,
-    file_path: string,
+    relative_path: string,
     diagnostic: Diagnostic
 ): DiagnosticRecord {
-    return {
-        relative_path: relative_path(workspace_root, file_path),
-        diagnostic,
-    };
+    return { relative_path, diagnostic };
 }
 
 export async function collect_check_diagnostics(
@@ -373,8 +359,7 @@ export async function collect_check_diagnostics(
             const stats = fs.statSync(target.path);
             if (stats.size > config.indexing.maxFileSizeBytes) {
                 records.push(diagnostic_record(
-                    workspace_root,
-                    target.path,
+                    target.relative_path,
                     size_limit_diagnostic(
                         target.path,
                         stats.size,
@@ -391,8 +376,7 @@ export async function collect_check_diagnostics(
             !indexed_files.has(uri)
         ) {
             records.push(diagnostic_record(
-                workspace_root,
-                target.path,
+                target.relative_path,
                 index_limit_diagnostic(target.path)
             ));
             continue;
@@ -404,8 +388,7 @@ export async function collect_check_diagnostics(
         }
         if (read_result.kind === 'decode-error') {
             records.push(diagnostic_record(
-                workspace_root,
-                target.path,
+                target.relative_path,
                 read_result.diagnostic
             ));
             continue;
@@ -434,8 +417,7 @@ export async function collect_check_diagnostics(
                 );
             for (const diagnostic of diagnostics) {
                 records.push(diagnostic_record(
-                    workspace_root,
-                    target.path,
+                    target.relative_path,
                     diagnostic
                 ));
             }

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -20,9 +20,11 @@ import { StataLSPConfig } from '../types';
 import { validate_comment_formatting_config } from '../utils/config-validator';
 import { Logger } from '../utils/logger';
 import {
+    ReportTarget,
     canonicalize_existing_path,
     collect_report_targets,
     index_limit_diagnostic,
+    is_within_workspace,
     relative_path,
     read_source_file,
     size_limit_diagnostic,
@@ -35,7 +37,6 @@ import {
     EXIT_OPERATOR_ERROR,
     OutputFormat,
     SeverityLevel,
-    compare_diagnostic_records,
     diagnostic_exceeds_threshold,
     parse_color_choice,
     parse_output_format,
@@ -77,6 +78,24 @@ function parse_required_option_value(
     }
 
     return { success: true, value };
+}
+
+function parse_enum_option<T>(
+    argv: string[],
+    index: number,
+    flag: string,
+    parse: (value: string) => T
+): { success: true; value: T } | { success: false; error: string } {
+    const parsed = parse_required_option_value(argv, index, flag, 'a value');
+    if (!parsed.success) return parsed;
+    try {
+        return { success: true, value: parse(parsed.value) };
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+        };
+    }
 }
 
 export function parse_check_args(argv: string[]): CheckParseResult {
@@ -124,46 +143,28 @@ export function parse_check_args(argv: string[]): CheckParseResult {
                 break;
             case '--format':
                 {
-                    const parsed = parse_required_option_value(
+                    const parsed = parse_enum_option(
                         argv,
                         i,
                         '--format',
-                        'a value'
+                        parse_output_format
                     );
                     if (!parsed.success) return parsed;
-                    try {
-                        args.format = parse_output_format(parsed.value);
-                        i++;
-                    } catch (error) {
-                        return {
-                            success: false,
-                            error: error instanceof Error
-                                ? error.message
-                                : String(error),
-                        };
-                    }
+                    args.format = parsed.value;
+                    i++;
                 }
                 break;
             case '--max-severity':
                 {
-                    const parsed = parse_required_option_value(
+                    const parsed = parse_enum_option(
                         argv,
                         i,
                         '--max-severity',
-                        'a value'
+                        parse_severity_level
                     );
                     if (!parsed.success) return parsed;
-                    try {
-                        args.max_severity = parse_severity_level(parsed.value);
-                        i++;
-                    } catch (error) {
-                        return {
-                            success: false,
-                            error: error instanceof Error
-                                ? error.message
-                                : String(error),
-                        };
-                    }
+                    args.max_severity = parsed.value;
+                    i++;
                 }
                 break;
             case '--quiet':
@@ -171,24 +172,15 @@ export function parse_check_args(argv: string[]): CheckParseResult {
                 break;
             case '--color':
                 {
-                    const parsed = parse_required_option_value(
+                    const parsed = parse_enum_option(
                         argv,
                         i,
                         '--color',
-                        'a value'
+                        parse_color_choice
                     );
                     if (!parsed.success) return parsed;
-                    try {
-                        args.color = parse_color_choice(parsed.value);
-                        i++;
-                    } catch (error) {
-                        return {
-                            success: false,
-                            error: error instanceof Error
-                                ? error.message
-                                : String(error),
-                        };
-                    }
+                    args.color = parsed.value;
+                    i++;
                 }
                 break;
             case '--no-color':
@@ -359,50 +351,43 @@ function diagnostic_record(
     diagnostic: Diagnostic
 ): DiagnosticRecord {
     return {
-        path: file_path,
         relative_path: relative_path(workspace_root, file_path),
         diagnostic,
     };
-}
-
-function is_under_workspace(workspace_root: string, file_path: string): boolean {
-    const relative = path.relative(workspace_root, file_path);
-    return relative === ''
-        || (relative.length > 0 &&
-            !relative.startsWith('..') &&
-            !path.isAbsolute(relative));
 }
 
 export async function collect_check_diagnostics(
     context: CheckContext,
     workspace_root: string,
     config: StataLSPConfig,
-    targets: Array<{ path: string; relative_path: string; explicit: boolean }>
+    targets: ReportTarget[]
 ): Promise<DiagnosticRecord[]> {
     const records: DiagnosticRecord[] = [];
     const workspace_symbols = context.workspace_indexer.get_all_symbols();
     const indexed_files = context.workspace_indexer.get_indexed_files();
+    const files_indexed = context.workspace_indexer.get_metrics().files_indexed;
 
     for (const target of targets) {
-        const stats = fs.statSync(target.path);
         const uri = URI.file(target.path).toString();
-        if (target.explicit && stats.size > config.indexing.maxFileSizeBytes) {
-            records.push(diagnostic_record(
-                workspace_root,
-                target.path,
-                size_limit_diagnostic(
+        if (target.explicit) {
+            const stats = fs.statSync(target.path);
+            if (stats.size > config.indexing.maxFileSizeBytes) {
+                records.push(diagnostic_record(
+                    workspace_root,
                     target.path,
-                    stats.size,
-                    config.indexing.maxFileSizeBytes
-                )
-            ));
-            continue;
+                    size_limit_diagnostic(
+                        target.path,
+                        stats.size,
+                        config.indexing.maxFileSizeBytes
+                    )
+                ));
+                continue;
+            }
         }
         if (
             target.explicit &&
-            is_under_workspace(workspace_root, target.path) &&
-            context.workspace_indexer.get_metrics().files_indexed
-                >= config.cross_file.max_indexed_files &&
+            is_within_workspace(workspace_root, target.path) &&
+            files_indexed >= config.cross_file.max_indexed_files &&
             !indexed_files.has(uri)
         ) {
             records.push(diagnostic_record(
@@ -461,7 +446,7 @@ export async function collect_check_diagnostics(
         }
     }
 
-    return records.sort(compare_diagnostic_records);
+    return records;
 }
 
 function check_help_text(): string {
@@ -483,10 +468,6 @@ OPTIONS:
     --no-color                  Alias for --color never
     -h, --help                  Show this help message
 `.trim();
-}
-
-export function print_check_help(): void {
-    console.log(check_help_text());
 }
 
 export async function run_check_with_cwd(

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -62,6 +62,23 @@ export type CheckParseResult =
     | { success: true; args: CheckArgs }
     | { success: false; error: string };
 
+function parse_required_option_value(
+    argv: string[],
+    index: number,
+    flag: string,
+    value_kind: string
+): { success: true; value: string } | { success: false; error: string } {
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('-')) {
+        return {
+            success: false,
+            error: `${flag} needs ${value_kind}`,
+        };
+    }
+
+    return { success: true, value };
+}
+
 export function parse_check_args(argv: string[]): CheckParseResult {
     const args: CheckArgs = {
         paths: [],
@@ -77,69 +94,101 @@ export function parse_check_args(argv: string[]): CheckParseResult {
         const arg = argv[i];
         switch (arg) {
             case '--workspace':
-                if (argv[i + 1] === undefined) {
-                    return { success: false, error: '--workspace needs a path' };
+                {
+                    const parsed = parse_required_option_value(
+                        argv,
+                        i,
+                        '--workspace',
+                        'a path'
+                    );
+                    if (!parsed.success) return parsed;
+                    args.workspace = parsed.value;
+                    i++;
                 }
-                args.workspace = argv[++i];
                 break;
             case '--config':
-                if (argv[i + 1] === undefined) {
-                    return { success: false, error: '--config needs a path' };
+                {
+                    const parsed = parse_required_option_value(
+                        argv,
+                        i,
+                        '--config',
+                        'a path'
+                    );
+                    if (!parsed.success) return parsed;
+                    args.config_path = parsed.value;
+                    i++;
                 }
-                args.config_path = argv[++i];
                 break;
             case '--no-config':
                 args.no_config = true;
                 break;
             case '--format':
-                if (argv[i + 1] === undefined) {
-                    return { success: false, error: '--format needs a value' };
-                }
-                try {
-                    args.format = parse_output_format(argv[++i]);
-                } catch (error) {
-                    return {
-                        success: false,
-                        error: error instanceof Error
-                            ? error.message
-                            : String(error),
-                    };
+                {
+                    const parsed = parse_required_option_value(
+                        argv,
+                        i,
+                        '--format',
+                        'a value'
+                    );
+                    if (!parsed.success) return parsed;
+                    try {
+                        args.format = parse_output_format(parsed.value);
+                        i++;
+                    } catch (error) {
+                        return {
+                            success: false,
+                            error: error instanceof Error
+                                ? error.message
+                                : String(error),
+                        };
+                    }
                 }
                 break;
             case '--max-severity':
-                if (argv[i + 1] === undefined) {
-                    return {
-                        success: false,
-                        error: '--max-severity needs a value',
-                    };
-                }
-                try {
-                    args.max_severity = parse_severity_level(argv[++i]);
-                } catch (error) {
-                    return {
-                        success: false,
-                        error: error instanceof Error
-                            ? error.message
-                            : String(error),
-                    };
+                {
+                    const parsed = parse_required_option_value(
+                        argv,
+                        i,
+                        '--max-severity',
+                        'a value'
+                    );
+                    if (!parsed.success) return parsed;
+                    try {
+                        args.max_severity = parse_severity_level(parsed.value);
+                        i++;
+                    } catch (error) {
+                        return {
+                            success: false,
+                            error: error instanceof Error
+                                ? error.message
+                                : String(error),
+                        };
+                    }
                 }
                 break;
             case '--quiet':
                 args.quiet = true;
                 break;
             case '--color':
-                if (argv[i + 1] === undefined) {
-                    return { success: false, error: '--color needs a value' };
-                }
-                try {
-                    args.color = parse_color_choice(argv[++i]);
-                } catch (error) {
-                    return {
-                        success: false,
-                        error: error instanceof Error
-                            ? error.message
-                            : String(error),
-                    };
+                {
+                    const parsed = parse_required_option_value(
+                        argv,
+                        i,
+                        '--color',
+                        'a value'
+                    );
+                    if (!parsed.success) return parsed;
+                    try {
+                        args.color = parse_color_choice(parsed.value);
+                        i++;
+                    } catch (error) {
+                        return {
+                            success: false,
+                            error: error instanceof Error
+                                ? error.message
+                                : String(error),
+                        };
+                    }
                 }
                 break;
             case '--no-color':

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -20,6 +20,7 @@ import { StataLSPConfig } from '../types';
 import { validate_comment_formatting_config } from '../utils/config-validator';
 import { Logger } from '../utils/logger';
 import {
+    canonicalize_existing_path,
     collect_report_targets,
     index_limit_diagnostic,
     relative_path,
@@ -445,12 +446,28 @@ export async function run_check_with_cwd(
         return EXIT_OK;
     }
 
-    const workspace_root = path.resolve(cwd, result.args.workspace ?? '.');
+    const resolved_workspace_root = path.resolve(
+        cwd,
+        result.args.workspace ?? '.'
+    );
     if (
-        !fs.existsSync(workspace_root) ||
-        !fs.statSync(workspace_root).isDirectory()
+        !fs.existsSync(resolved_workspace_root) ||
+        !fs.statSync(resolved_workspace_root).isDirectory()
     ) {
-        output.stderr(`sight check: invalid workspace: ${workspace_root}\n`);
+        output.stderr(
+            `sight check: invalid workspace: ${resolved_workspace_root}\n`
+        );
+        return EXIT_OPERATOR_ERROR;
+    }
+    let workspace_root: string;
+    try {
+        workspace_root = canonicalize_existing_path(resolved_workspace_root);
+    } catch (error) {
+        output.stderr(
+            `sight check: invalid workspace: ${
+                error instanceof Error ? error.message : String(error)
+            }\n`
+        );
         return EXIT_OPERATOR_ERROR;
     }
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -133,107 +133,131 @@ export function parse_check_args(argv: string[]): CheckParseResult {
     };
 
     for (let i = 0; i < argv.length; i++) {
-        const raw = argv[i];
+        const my_raw = argv[i];
         // Support both `--flag value` and `--flag=value`. Splitting on the
         // first '=' lets a value legally begin with '-' (e.g. an odd path).
-        let arg = raw;
-        let inline_value: string | undefined;
-        if (raw.startsWith('--')) {
-            const eq = raw.indexOf('=');
+        let my_arg = my_raw;
+        let my_inline_value: string | undefined;
+        if (my_raw.startsWith('--')) {
+            const eq = my_raw.indexOf('=');
             if (eq !== -1) {
-                arg = raw.slice(0, eq);
-                inline_value = raw.slice(eq + 1);
+                my_arg = my_raw.slice(0, eq);
+                my_inline_value = my_raw.slice(eq + 1);
             }
         }
-        switch (arg) {
+        switch (my_arg) {
             case '--workspace':
                 {
-                    const parsed = parse_required_option_value(
+                    const my_parsed = parse_required_option_value(
                         argv,
                         i,
                         '--workspace',
                         'a path',
-                        inline_value
+                        my_inline_value
                     );
-                    if (!parsed.success) return parsed;
-                    args.workspace = parsed.value;
-                    if (inline_value === undefined) i++;
+                    if (!my_parsed.success) return my_parsed;
+                    args.workspace = my_parsed.value;
+                    if (my_inline_value === undefined) i++;
                 }
                 break;
             case '--config':
                 {
-                    const parsed = parse_required_option_value(
+                    const my_parsed = parse_required_option_value(
                         argv,
                         i,
                         '--config',
                         'a path',
-                        inline_value
+                        my_inline_value
                     );
-                    if (!parsed.success) return parsed;
-                    args.config_path = parsed.value;
-                    if (inline_value === undefined) i++;
+                    if (!my_parsed.success) return my_parsed;
+                    args.config_path = my_parsed.value;
+                    if (my_inline_value === undefined) i++;
                 }
                 break;
             case '--no-config':
+                if (my_inline_value !== undefined) {
+                    return {
+                        success: false,
+                        error: `${my_arg} does not take a value`,
+                    };
+                }
                 args.no_config = true;
                 break;
             case '--format':
                 {
-                    const parsed = parse_enum_option(
+                    const my_parsed = parse_enum_option(
                         argv,
                         i,
                         '--format',
                         parse_output_format,
-                        inline_value
+                        my_inline_value
                     );
-                    if (!parsed.success) return parsed;
-                    args.format = parsed.value;
-                    if (inline_value === undefined) i++;
+                    if (!my_parsed.success) return my_parsed;
+                    args.format = my_parsed.value;
+                    if (my_inline_value === undefined) i++;
                 }
                 break;
             case '--max-severity':
                 {
-                    const parsed = parse_enum_option(
+                    const my_parsed = parse_enum_option(
                         argv,
                         i,
                         '--max-severity',
                         parse_severity_level,
-                        inline_value
+                        my_inline_value
                     );
-                    if (!parsed.success) return parsed;
-                    args.max_severity = parsed.value;
-                    if (inline_value === undefined) i++;
+                    if (!my_parsed.success) return my_parsed;
+                    args.max_severity = my_parsed.value;
+                    if (my_inline_value === undefined) i++;
                 }
                 break;
             case '--quiet':
+                if (my_inline_value !== undefined) {
+                    return {
+                        success: false,
+                        error: `${my_arg} does not take a value`,
+                    };
+                }
                 args.quiet = true;
                 break;
             case '--color':
                 {
-                    const parsed = parse_enum_option(
+                    const my_parsed = parse_enum_option(
                         argv,
                         i,
                         '--color',
                         parse_color_choice,
-                        inline_value
+                        my_inline_value
                     );
-                    if (!parsed.success) return parsed;
-                    args.color = parsed.value;
-                    if (inline_value === undefined) i++;
+                    if (!my_parsed.success) return my_parsed;
+                    args.color = my_parsed.value;
+                    if (my_inline_value === undefined) i++;
                 }
                 break;
             case '--no-color':
+                if (my_inline_value !== undefined) {
+                    return {
+                        success: false,
+                        error: `${my_arg} does not take a value`,
+                    };
+                }
                 args.color = ColorChoice.Never;
                 break;
             case '--help':
             case '-h':
+                if (my_inline_value !== undefined) {
+                    return {
+                        success: false,
+                        error: `${my_arg} does not take a value`,
+                    };
+                }
                 args.help = true;
                 break;
             default:
-                if (arg.startsWith('-')) {
-                    return { success: false, error: `Unknown flag: ${arg}` };
+                if (my_arg.startsWith('-')) {
+                    return { success: false, error: `Unknown flag: ${my_arg}` };
                 }
-                args.paths.push(arg);
+                args.paths.push(my_arg);
         }
     }
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -290,9 +290,10 @@ export function load_check_config(options: {
     config_path?: string;
     no_config: boolean;
 }): CheckConfigResult {
-    // Collect comment-formatting validation warnings (invalid indentSize,
-    // unknown comment style, etc.) the same way the LSP server logs them, so
-    // `sight check` does not silently swallow them on any config path.
+    // Collect comment-formatting validation warnings (invalid
+    // indentSize, unknown comment style, etc.) the same way the LSP
+    // server logs them, so `sight check` does not silently swallow them
+    // on any config path.
     const validation_warnings: ProjectConfigWarning[] = [];
     const collect_validation_warning = (message: string): void => {
         validation_warnings.push({ code: 'invalid-value', message });
@@ -314,9 +315,9 @@ export function load_check_config(options: {
         : discover_and_load_project_config(options.workspace_root);
 
     if (loaded.kind === 'load-failed') {
-        // Surface any warnings collected before the parse failed (e.g. the
-        // stale-.sight.json migration hint from discovery) so the operator
-        // still gets the conversion guidance alongside the error.
+        // Surface any warnings collected before the parse failed (e.g.
+        // the stale-.sight.json migration hint from discovery) so the
+        // operator still gets conversion guidance with the error.
         return {
             kind: 'operator-error',
             message: `failed to load ${loaded.path}: ${loaded.error}`,
@@ -636,9 +637,9 @@ export async function run_check_with_cwd(
         config_path: result.args.config_path,
         no_config: result.args.no_config,
     });
-    // Both result variants carry a warnings array (auto-discovery may attach
-    // a stale-.sight.json migration hint to either), so emit them once here
-    // before branching on the result kind.
+    // Both result variants carry a warnings array (auto-discovery may
+    // attach a stale-.sight.json migration hint to either), so emit
+    // them once here before branching on the result kind.
     for (const my_warning of config_result.warnings) {
         output.stderr(`sight check: ${my_warning.message}\n`);
     }

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { Diagnostic } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
+import package_json from '../../package.json' with { type: 'json' };
 import {
     deep_merge_config,
     discover_and_load_project_config,
@@ -16,14 +18,31 @@ import { ScopeResolver } from '../scope-resolver';
 import { DEFAULT_SETTINGS } from '../server-handlers';
 import { StataLSPConfig } from '../types';
 import { validate_comment_formatting_config } from '../utils/config-validator';
+import { Logger } from '../utils/logger';
+import {
+    collect_report_targets,
+    index_limit_diagnostic,
+    relative_path,
+    read_source_file,
+    size_limit_diagnostic,
+} from './source-files';
 import {
     ColorChoice,
+    DiagnosticRecord,
+    EXIT_CHECK_FAILED,
+    EXIT_OK,
     EXIT_OPERATOR_ERROR,
     OutputFormat,
     SeverityLevel,
+    compare_diagnostic_records,
+    diagnostic_exceeds_threshold,
     parse_color_choice,
     parse_output_format,
     parse_severity_level,
+    render_json,
+    render_sarif,
+    render_text,
+    resolve_color_from_env,
 } from './shared';
 
 export interface CheckArgs {
@@ -212,6 +231,11 @@ export async function build_check_context(
     workspace_root: string,
     config: StataLSPConfig
 ): Promise<CheckContext> {
+    Logger.initialize({
+        verbosity: config.debug === true ? 'debug' : 'error',
+        channel: (message) => console.error(message),
+    });
+
     const dependency_graph = new DependencyGraph();
     const workspace_indexer = new WorkspaceIndexer();
     const scope_resolver = new ScopeResolver({
@@ -269,15 +293,238 @@ export async function build_check_context(
     };
 }
 
-export async function run_check(argv: string[]): Promise<number> {
+export interface CheckOutput {
+    stdout(text: string): void;
+    stderr(text: string): void;
+}
+
+const DEFAULT_OUTPUT: CheckOutput = {
+    stdout: (text) => process.stdout.write(text),
+    stderr: (text) => process.stderr.write(text),
+};
+
+function diagnostic_record(
+    workspace_root: string,
+    file_path: string,
+    diagnostic: Diagnostic
+): DiagnosticRecord {
+    return {
+        path: file_path,
+        relative_path: relative_path(workspace_root, file_path),
+        diagnostic,
+    };
+}
+
+export async function collect_check_diagnostics(
+    context: CheckContext,
+    workspace_root: string,
+    config: StataLSPConfig,
+    targets: Array<{ path: string; relative_path: string; explicit: boolean }>
+): Promise<DiagnosticRecord[]> {
+    const records: DiagnosticRecord[] = [];
+    const workspace_symbols = context.workspace_indexer.get_all_symbols();
+    const indexed_files = context.workspace_indexer.get_indexed_files();
+
+    for (const target of targets) {
+        const stats = fs.statSync(target.path);
+        const uri = URI.file(target.path).toString();
+        if (target.explicit && stats.size > config.indexing.maxFileSizeBytes) {
+            records.push(diagnostic_record(
+                workspace_root,
+                target.path,
+                size_limit_diagnostic(
+                    target.path,
+                    stats.size,
+                    config.indexing.maxFileSizeBytes
+                )
+            ));
+            continue;
+        }
+        if (
+            target.explicit &&
+            context.workspace_indexer.get_metrics().files_indexed
+                >= config.cross_file.max_indexed_files &&
+            !indexed_files.has(uri)
+        ) {
+            records.push(diagnostic_record(
+                workspace_root,
+                target.path,
+                index_limit_diagnostic(target.path)
+            ));
+            continue;
+        }
+
+        const read_result = read_source_file(target.path);
+        if (read_result.kind === 'read-error') {
+            throw new Error(read_result.message);
+        }
+        if (read_result.kind === 'decode-error') {
+            records.push(diagnostic_record(
+                workspace_root,
+                target.path,
+                read_result.diagnostic
+            ));
+            continue;
+        }
+
+        let opened = false;
+        try {
+            await context.document_store.open(
+                uri,
+                read_result.text,
+                1,
+                workspace_symbols
+            );
+            opened = true;
+            const state = context.document_store.get(uri);
+            if (!state) {
+                throw new Error(`failed to analyze ${target.path}`);
+            }
+
+            const diagnostics =
+                await context.diagnostics_provider.get_diagnostics(
+                    state,
+                    config,
+                    workspace_symbols,
+                    context.scope_resolver
+                );
+            for (const diagnostic of diagnostics) {
+                records.push(diagnostic_record(
+                    workspace_root,
+                    target.path,
+                    diagnostic
+                ));
+            }
+        } finally {
+            if (opened) {
+                context.document_store.close(uri);
+            }
+        }
+    }
+
+    return records.sort(compare_diagnostic_records);
+}
+
+function check_help_text(): string {
+    return `
+sight check ${package_json.version} - full Stata diagnostics for CI
+
+USAGE:
+    sight check [OPTIONS] [PATHS...]
+
+OPTIONS:
+    --workspace DIR             Workspace root to index (default: current directory)
+    --config PATH               Explicit sight.toml path
+    --no-config                 Ignore sight.toml and use built-in defaults
+    --format text|json|sarif    Output format (default: text)
+    --max-severity LEVEL        Highest severity that does not fail the build
+                                (off, hint, info, warning, error; default: info)
+    --quiet                     Suppress text summary line
+    --color auto|always|never   Colorize text output (default: auto)
+    --no-color                  Alias for --color never
+    -h, --help                  Show this help message
+`.trim();
+}
+
+export function print_check_help(): void {
+    console.log(check_help_text());
+}
+
+export async function run_check_with_cwd(
+    argv: string[],
+    cwd: string,
+    output: CheckOutput = DEFAULT_OUTPUT
+): Promise<number> {
     const result = parse_check_args(argv);
     if (!result.success) {
-        console.error(`sight check: ${result.error}`);
-        return 1;
+        output.stderr(`sight check: ${result.error}\n`);
+        return EXIT_CHECK_FAILED;
     }
     if (result.args.help) {
-        return 0;
+        output.stdout(`${check_help_text()}\n`);
+        return EXIT_OK;
     }
-    console.error('sight check: batch diagnostics are unavailable before Task 6');
-    return EXIT_OPERATOR_ERROR;
+
+    const workspace_root = path.resolve(cwd, result.args.workspace ?? '.');
+    if (
+        !fs.existsSync(workspace_root) ||
+        !fs.statSync(workspace_root).isDirectory()
+    ) {
+        output.stderr(`sight check: invalid workspace: ${workspace_root}\n`);
+        return EXIT_OPERATOR_ERROR;
+    }
+
+    const config_result = load_check_config({
+        cwd,
+        workspace_root,
+        config_path: result.args.config_path,
+        no_config: result.args.no_config,
+    });
+    if (config_result.kind === 'operator-error') {
+        output.stderr(`sight check: ${config_result.message}\n`);
+        return EXIT_OPERATOR_ERROR;
+    }
+    for (const warning of config_result.warnings) {
+        output.stderr(`sight check: ${warning.message}\n`);
+    }
+
+    const target_result = collect_report_targets(
+        result.args.paths,
+        workspace_root,
+        cwd
+    );
+    if (target_result.operator_errors.length > 0) {
+        for (const message of target_result.operator_errors) {
+            output.stderr(`sight check: ${message}\n`);
+        }
+        return EXIT_OPERATOR_ERROR;
+    }
+
+    let context: CheckContext | undefined;
+    try {
+        context = await build_check_context(
+            workspace_root,
+            config_result.config
+        );
+        const diagnostics = await collect_check_diagnostics(
+            context,
+            workspace_root,
+            config_result.config,
+            target_result.targets
+        );
+        const any_failure = diagnostics.some((record) =>
+            diagnostic_exceeds_threshold(
+                record.diagnostic,
+                result.args.max_severity
+            )
+        );
+
+        if (result.args.format === OutputFormat.Json) {
+            output.stdout(render_json(diagnostics));
+        } else if (result.args.format === OutputFormat.Sarif) {
+            output.stdout(render_sarif(diagnostics, package_json.version));
+        } else {
+            output.stdout(render_text(diagnostics, {
+                quiet: result.args.quiet,
+                use_color: resolve_color_from_env(result.args.color),
+            }));
+        }
+
+        return any_failure ? EXIT_CHECK_FAILED : EXIT_OK;
+    } catch (error) {
+        output.stderr(
+            `sight check: ${
+                error instanceof Error ? error.message : String(error)
+            }\n`
+        );
+        return EXIT_OPERATOR_ERROR;
+    } finally {
+        if (context) {
+            await context.document_store.dispose();
+        }
+    }
+}
+
+export async function run_check(argv: string[]): Promise<number> {
+    return run_check_with_cwd(argv, process.cwd(), DEFAULT_OUTPUT);
 }

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -26,7 +26,6 @@ export enum SeverityLevel {
 }
 
 export interface DiagnosticRecord {
-    path: string;
     relative_path: string;
     diagnostic: Diagnostic;
 }
@@ -246,8 +245,9 @@ export function render_sarif(
     records: DiagnosticRecord[],
     version: string
 ): string {
+    const sorted = sorted_records(records);
     const rule_ids = Array.from(
-        new Set(sorted_records(records).map((record) =>
+        new Set(sorted.map((record) =>
             sarif_rule_id(record.diagnostic.code)
         ))
     ).sort();
@@ -267,7 +267,7 @@ export function render_sarif(
                     })),
                 },
             },
-            results: sorted_records(records).map((record) => ({
+            results: sorted.map((record) => ({
                 ruleId: sarif_rule_id(record.diagnostic.code),
                 level: sarif_level(record.diagnostic),
                 message: { text: record.diagnostic.message },

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -1,5 +1,8 @@
 import { stdout } from 'process';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import { error_message } from '../utils/error-message';
+
+export { error_message };
 
 export const EXIT_OK = 0;
 export const EXIT_CHECK_FAILED = 1;
@@ -28,10 +31,6 @@ export enum SeverityLevel {
 export interface DiagnosticRecord {
     relative_path: string;
     diagnostic: Diagnostic;
-}
-
-export function error_message(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
 }
 
 export function parse_output_format(value: string): OutputFormat {

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -99,8 +99,19 @@ export function diagnostic_exceeds_threshold(
     return severity_level(diagnostic) > max_severity;
 }
 
+// NO_COLOR semantics (https://no-color.org): present and non-empty disables
+// color regardless of the value, so "0"/"false" still count as set here.
 export function env_flag_is_set(value: string | undefined): boolean {
     return value !== undefined && value.length > 0;
+}
+
+// FORCE_COLOR semantics (de-facto, per supports-color): "0"/"false"/"off"
+// explicitly disable forced color; any other non-empty value enables it.
+const FORCE_COLOR_DISABLED_VALUES = new Set(['0', 'false', 'off']);
+
+export function force_color_is_enabled(value: string | undefined): boolean {
+    if (value === undefined || value.length === 0) return false;
+    return !FORCE_COLOR_DISABLED_VALUES.has(value.trim().toLowerCase());
 }
 
 export function resolve_color(
@@ -120,7 +131,7 @@ export function resolve_color_from_env(choice: ColorChoice): boolean {
     return resolve_color(
         choice,
         env_flag_is_set(process.env.NO_COLOR),
-        env_flag_is_set(process.env.FORCE_COLOR),
+        force_color_is_enabled(process.env.FORCE_COLOR),
         stdout.isTTY === true
     );
 }

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -192,7 +192,7 @@ function colorize(word: string, use_color: boolean): string {
 // Locale-independent code-unit ordering. localeCompare's order depends on the
 // runtime's default ICU locale (LANG/LC_*), which would make report output
 // differ across machines and break golden/snapshot comparisons in CI.
-function compare_strings(a: string, b: string): number {
+export function compare_strings(a: string, b: string): number {
     return a < b ? -1 : a > b ? 1 : 0;
 }
 

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -189,18 +189,27 @@ function colorize(word: string, use_color: boolean): string {
     }
 }
 
+// Locale-independent code-unit ordering. localeCompare's order depends on the
+// runtime's default ICU locale (LANG/LC_*), which would make report output
+// differ across machines and break golden/snapshot comparisons in CI.
+function compare_strings(a: string, b: string): number {
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+
 export function compare_diagnostic_records(
     a: DiagnosticRecord,
     b: DiagnosticRecord
 ): number {
-    return a.relative_path.localeCompare(b.relative_path)
+    return compare_strings(a.relative_path, b.relative_path)
         || a.diagnostic.range.start.line - b.diagnostic.range.start.line
         || a.diagnostic.range.start.character -
             b.diagnostic.range.start.character
         || severity_level(b.diagnostic) - severity_level(a.diagnostic)
-        || code_text(a.diagnostic.code)
-            .localeCompare(code_text(b.diagnostic.code))
-        || a.diagnostic.message.localeCompare(b.diagnostic.message);
+        || compare_strings(
+            code_text(a.diagnostic.code),
+            code_text(b.diagnostic.code)
+        )
+        || compare_strings(a.diagnostic.message, b.diagnostic.message);
 }
 
 function sorted_records(records: DiagnosticRecord[]): DiagnosticRecord[] {

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -30,6 +30,10 @@ export interface DiagnosticRecord {
     diagnostic: Diagnostic;
 }
 
+export function error_message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
 export function parse_output_format(value: string): OutputFormat {
     switch (value) {
         case 'text':

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -1,0 +1,291 @@
+import { stdout } from 'process';
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+
+export const EXIT_OK = 0;
+export const EXIT_CHECK_FAILED = 1;
+export const EXIT_OPERATOR_ERROR = 2;
+
+export enum OutputFormat {
+    Text = 'text',
+    Json = 'json',
+    Sarif = 'sarif',
+}
+
+export enum ColorChoice {
+    Auto = 'auto',
+    Always = 'always',
+    Never = 'never',
+}
+
+export enum SeverityLevel {
+    Off = 0,
+    Hint = 1,
+    Info = 2,
+    Warning = 3,
+    Error = 4,
+}
+
+export interface DiagnosticRecord {
+    path: string;
+    relative_path: string;
+    diagnostic: Diagnostic;
+}
+
+export function parse_output_format(value: string): OutputFormat {
+    switch (value) {
+        case 'text':
+            return OutputFormat.Text;
+        case 'json':
+            return OutputFormat.Json;
+        case 'sarif':
+            return OutputFormat.Sarif;
+        default:
+            throw new Error(`unknown --format value: ${value}`);
+    }
+}
+
+export function parse_severity_level(value: string): SeverityLevel {
+    switch (value) {
+        case 'off':
+            return SeverityLevel.Off;
+        case 'hint':
+            return SeverityLevel.Hint;
+        case 'info':
+            return SeverityLevel.Info;
+        case 'warning':
+            return SeverityLevel.Warning;
+        case 'error':
+            return SeverityLevel.Error;
+        default:
+            throw new Error(`unknown --max-severity value: ${value}`);
+    }
+}
+
+export function parse_color_choice(value: string): ColorChoice {
+    switch (value) {
+        case 'auto':
+            return ColorChoice.Auto;
+        case 'always':
+            return ColorChoice.Always;
+        case 'never':
+            return ColorChoice.Never;
+        default:
+            throw new Error(`unknown --color value: ${value}`);
+    }
+}
+
+function severity_level(diagnostic: Diagnostic): SeverityLevel {
+    switch (diagnostic.severity) {
+        case DiagnosticSeverity.Error:
+            return SeverityLevel.Error;
+        case DiagnosticSeverity.Warning:
+            return SeverityLevel.Warning;
+        case DiagnosticSeverity.Information:
+            return SeverityLevel.Info;
+        case DiagnosticSeverity.Hint:
+            return SeverityLevel.Hint;
+        default:
+            return SeverityLevel.Off;
+    }
+}
+
+export function diagnostic_exceeds_threshold(
+    diagnostic: Diagnostic,
+    max_severity: SeverityLevel
+): boolean {
+    return severity_level(diagnostic) > max_severity;
+}
+
+export function env_flag_is_set(value: string | undefined): boolean {
+    return value !== undefined && value.length > 0;
+}
+
+export function resolve_color(
+    choice: ColorChoice,
+    no_color: boolean,
+    force_color: boolean,
+    stdout_is_tty: boolean
+): boolean {
+    if (choice === ColorChoice.Always) return true;
+    if (choice === ColorChoice.Never) return false;
+    if (no_color) return false;
+    if (force_color) return true;
+    return stdout_is_tty;
+}
+
+export function resolve_color_from_env(choice: ColorChoice): boolean {
+    return resolve_color(
+        choice,
+        env_flag_is_set(process.env.NO_COLOR),
+        env_flag_is_set(process.env.FORCE_COLOR),
+        stdout.isTTY === true
+    );
+}
+
+function code_text(code: Diagnostic['code']): string {
+    if (typeof code === 'number') return String(code);
+    if (typeof code === 'string') return code;
+    return '';
+}
+
+function sarif_rule_id(code: Diagnostic['code']): string {
+    const value = code_text(code);
+    return /^\d+$/.test(value) ? `SIGHT${value}` : value || 'SIGHT';
+}
+
+function severity_word(diagnostic: Diagnostic): string {
+    switch (diagnostic.severity) {
+        case DiagnosticSeverity.Error:
+            return 'error';
+        case DiagnosticSeverity.Warning:
+            return 'warning';
+        case DiagnosticSeverity.Information:
+            return 'info';
+        case DiagnosticSeverity.Hint:
+            return 'hint';
+        default:
+            return 'note';
+    }
+}
+
+function sarif_level(diagnostic: Diagnostic): string {
+    switch (diagnostic.severity) {
+        case DiagnosticSeverity.Error:
+            return 'error';
+        case DiagnosticSeverity.Warning:
+            return 'warning';
+        default:
+            return 'note';
+    }
+}
+
+function colorize(word: string, use_color: boolean): string {
+    if (!use_color) return word;
+    switch (word) {
+        case 'error':
+            return `\u001b[31m${word}\u001b[0m`;
+        case 'warning':
+            return `\u001b[33m${word}\u001b[0m`;
+        case 'info':
+            return `\u001b[34m${word}\u001b[0m`;
+        case 'hint':
+            return `\u001b[36m${word}\u001b[0m`;
+        default:
+            return word;
+    }
+}
+
+export function compare_diagnostic_records(
+    a: DiagnosticRecord,
+    b: DiagnosticRecord
+): number {
+    return a.relative_path.localeCompare(b.relative_path)
+        || a.diagnostic.range.start.line - b.diagnostic.range.start.line
+        || a.diagnostic.range.start.character -
+            b.diagnostic.range.start.character
+        || severity_level(b.diagnostic) - severity_level(a.diagnostic)
+        || code_text(a.diagnostic.code)
+            .localeCompare(code_text(b.diagnostic.code))
+        || a.diagnostic.message.localeCompare(b.diagnostic.message);
+}
+
+function sorted_records(records: DiagnosticRecord[]): DiagnosticRecord[] {
+    return [...records].sort(compare_diagnostic_records);
+}
+
+export function render_text(
+    records: DiagnosticRecord[],
+    options: { quiet: boolean; use_color: boolean }
+): string {
+    const counts = { error: 0, warning: 0, info: 0, hint: 0, note: 0 };
+    const lines: string[] = [];
+
+    for (const record of sorted_records(records)) {
+        const word = severity_word(record.diagnostic);
+        counts[word as keyof typeof counts]++;
+        const code = code_text(record.diagnostic.code);
+        const code_suffix = code ? ` [${code}]` : '';
+        lines.push(
+            `${record.relative_path}:` +
+            `${record.diagnostic.range.start.line + 1}:` +
+            `${record.diagnostic.range.start.character + 1} ` +
+            `${colorize(word, options.use_color)}: ` +
+            `${record.diagnostic.message}${code_suffix}`
+        );
+    }
+
+    if (!options.quiet) {
+        lines.push(
+            `${records.length} issues (` +
+            `${counts.error} errors, ` +
+            `${counts.warning} warnings, ` +
+            `${counts.info} infos, ` +
+            `${counts.hint} hints, ` +
+            `${counts.note} notes)`
+        );
+    }
+
+    if (lines.length === 0) {
+        return '';
+    }
+    return lines.join('\n') + '\n';
+}
+
+export function render_json(records: DiagnosticRecord[]): string {
+    return JSON.stringify(
+        sorted_records(records).map((record) => ({
+            path: record.relative_path,
+            diagnostic: record.diagnostic,
+        })),
+        null,
+        2
+    ) + '\n';
+}
+
+export function render_sarif(
+    records: DiagnosticRecord[],
+    version: string
+): string {
+    const rule_ids = Array.from(
+        new Set(sorted_records(records).map((record) =>
+            sarif_rule_id(record.diagnostic.code)
+        ))
+    ).sort();
+
+    return JSON.stringify({
+        version: '2.1.0',
+        $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+        runs: [{
+            tool: {
+                driver: {
+                    name: 'sight',
+                    version,
+                    rules: rule_ids.map((id) => ({
+                        id,
+                        name: id,
+                        shortDescription: { text: id },
+                    })),
+                },
+            },
+            results: sorted_records(records).map((record) => ({
+                ruleId: sarif_rule_id(record.diagnostic.code),
+                level: sarif_level(record.diagnostic),
+                message: { text: record.diagnostic.message },
+                locations: [{
+                    physicalLocation: {
+                        artifactLocation: { uri: record.relative_path },
+                        region: {
+                            startLine:
+                                record.diagnostic.range.start.line + 1,
+                            startColumn:
+                                record.diagnostic.range.start.character + 1,
+                            endLine: record.diagnostic.range.end.line + 1,
+                            endColumn:
+                                record.diagnostic.range.end.character + 1,
+                        },
+                    },
+                }],
+            })),
+        }],
+    }, null, 2) + '\n';
+}

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -2,9 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { TextDecoder } from 'util';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
-import { hasStataExtension } from '../utils/file-path-utils';
-
-const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
+import { hasStataExtension, VCS_METADATA_DIRS } from '../utils/file-path-utils';
 
 export interface ReportTarget {
     path: string;
@@ -131,20 +129,15 @@ export function collect_report_targets(
         }
     }
 
-    const unique_sorted_paths = Array.from(new Set(source_paths))
-        .sort((a, b) =>
-            relative_path(normalized_root, a)
-                .localeCompare(relative_path(normalized_root, b))
-        );
-
-    return {
-        targets: unique_sorted_paths.map((file_path) => ({
+    const targets: ReportTarget[] = Array.from(new Set(source_paths))
+        .map((file_path) => ({
             path: file_path,
             relative_path: relative_path(normalized_root, file_path),
             explicit: has_explicit_paths,
-        })),
-        operator_errors,
-    };
+        }));
+    targets.sort((a, b) => a.relative_path.localeCompare(b.relative_path));
+
+    return { targets, operator_errors };
 }
 
 export function size_limit_diagnostic(

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -171,13 +171,22 @@ export function index_limit_diagnostic(file_path: string): Diagnostic {
 }
 
 function utf8_error_offset(bytes: Buffer): number {
+    // Feed bytes incrementally so each step is O(1) — re-decoding a growing
+    // prefix every iteration would be O(n^2) on large files. Valid multi-byte
+    // sequences are buffered across stream chunks, so only a genuinely invalid
+    // byte throws.
     const decoder = new TextDecoder('utf-8', { fatal: true });
-    for (let i = 0; i <= bytes.length; i++) {
+    for (let i = 0; i < bytes.length; i++) {
         try {
-            decoder.decode(bytes.subarray(0, i));
+            decoder.decode(bytes.subarray(i, i + 1), { stream: true });
         } catch {
-            return Math.max(0, i - 1);
+            return i;
         }
+    }
+    try {
+        decoder.decode(); // flush: throws on a trailing incomplete sequence
+    } catch {
+        return Math.max(0, bytes.length - 1);
     }
     return 0;
 }

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -26,6 +26,10 @@ export function is_stata_source_path(file_path: string): boolean {
     return SOURCE_EXTENSIONS.has(path.extname(file_path).toLowerCase());
 }
 
+export function canonicalize_existing_path(file_path: string): string {
+    return fs.realpathSync.native(file_path);
+}
+
 export function relative_path(workspace_root: string, file_path: string): string {
     const relative = path.relative(workspace_root, file_path);
     return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
@@ -33,13 +37,30 @@ export function relative_path(workspace_root: string, file_path: string): string
         : file_path;
 }
 
-function walk_sources(dir_path: string, out: string[]): void {
-    const entries = fs.readdirSync(dir_path, { withFileTypes: true });
+function error_message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function walk_sources(
+    dir_path: string,
+    out: string[],
+    operator_errors: string[]
+): void {
+    let entries: fs.Dirent[];
+    try {
+        entries = fs.readdirSync(dir_path, { withFileTypes: true });
+    } catch (error) {
+        operator_errors.push(
+            `cannot read directory: ${dir_path}: ${error_message(error)}`
+        );
+        return;
+    }
+
     for (const entry of entries) {
         const entry_path = path.join(dir_path, entry.name);
         if (entry.isDirectory()) {
             if (VCS_METADATA_DIRS.has(entry.name)) continue;
-            walk_sources(entry_path, out);
+            walk_sources(entry_path, out, operator_errors);
         } else if (entry.isFile() && is_stata_source_path(entry_path)) {
             out.push(entry_path);
         }
@@ -53,22 +74,45 @@ export function collect_report_targets(
 ): ReportTargetResult {
     const operator_errors: string[] = [];
     const source_paths: string[] = [];
-    const normalized_root = path.resolve(workspace_root);
+    let normalized_root = path.resolve(workspace_root);
+    try {
+        normalized_root = canonicalize_existing_path(normalized_root);
+    } catch {
+        // Workspace validation happens before target collection in check.ts.
+    }
     const has_explicit_paths = input_paths.length > 0;
     const paths_to_collect = input_paths.length > 0
         ? input_paths
         : [normalized_root];
 
     for (const input_path of paths_to_collect) {
-        const absolute_path = path.resolve(cwd, input_path);
-        if (!fs.existsSync(absolute_path)) {
+        const resolved_path = path.resolve(cwd, input_path);
+        if (!fs.existsSync(resolved_path)) {
             operator_errors.push(`path does not exist: ${input_path}`);
             continue;
         }
 
-        const stat = fs.statSync(absolute_path);
+        let absolute_path: string;
+        try {
+            absolute_path = canonicalize_existing_path(resolved_path);
+        } catch (error) {
+            operator_errors.push(
+                `cannot access path: ${input_path}: ${error_message(error)}`
+            );
+            continue;
+        }
+
+        let stat: fs.Stats;
+        try {
+            stat = fs.statSync(absolute_path);
+        } catch (error) {
+            operator_errors.push(
+                `cannot stat path: ${input_path}: ${error_message(error)}`
+            );
+            continue;
+        }
         if (stat.isDirectory()) {
-            walk_sources(absolute_path, source_paths);
+            walk_sources(absolute_path, source_paths, operator_errors);
         } else if (stat.isFile() && is_stata_source_path(absolute_path)) {
             source_paths.push(absolute_path);
         }

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { TextDecoder } from 'util';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { hasStataExtension, VCS_METADATA_DIRS } from '../utils/file-path-utils';
+import { error_message } from './shared';
 
 export interface ReportTarget {
     path: string;
@@ -46,10 +47,6 @@ export function is_within_workspace(
 ): boolean {
     const { relative, inside } = workspace_relative(workspace_root, file_path);
     return relative === '' || (relative.length > 0 && inside);
-}
-
-function error_message(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
 }
 
 function walk_sources(
@@ -140,38 +137,37 @@ export function collect_report_targets(
     return { targets, operator_errors };
 }
 
+function file_level_diagnostic(code: string, message: string): Diagnostic {
+    return {
+        range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+        },
+        severity: DiagnosticSeverity.Error,
+        source: 'sight',
+        code,
+        message,
+    };
+}
+
 export function size_limit_diagnostic(
     file_path: string,
     actual_bytes: number,
     limit_bytes: number
 ): Diagnostic {
-    return {
-        range: {
-            start: { line: 0, character: 0 },
-            end: { line: 0, character: 0 },
-        },
-        severity: DiagnosticSeverity.Error,
-        source: 'sight',
-        code: 'SIGHT_FILE_TOO_LARGE',
-        message:
-            `${file_path} is ${actual_bytes} bytes, which exceeds ` +
-            `the configured limit of ${limit_bytes} bytes.`,
-    };
+    return file_level_diagnostic(
+        'SIGHT_FILE_TOO_LARGE',
+        `${file_path} is ${actual_bytes} bytes, which exceeds ` +
+        `the configured limit of ${limit_bytes} bytes.`
+    );
 }
 
 export function index_limit_diagnostic(file_path: string): Diagnostic {
-    return {
-        range: {
-            start: { line: 0, character: 0 },
-            end: { line: 0, character: 0 },
-        },
-        severity: DiagnosticSeverity.Error,
-        source: 'sight',
-        code: 'SIGHT_FILE_NOT_INDEXED',
-        message:
-            `${file_path} was not indexed before Sight reached ` +
-            'crossFile.maxIndexedFiles. Raise maxIndexedFiles or check fewer files.',
-    };
+    return file_level_diagnostic(
+        'SIGHT_FILE_NOT_INDEXED',
+        `${file_path} was not indexed before Sight reached ` +
+        'crossFile.maxIndexedFiles. Raise maxIndexedFiles or check fewer files.'
+    );
 }
 
 function utf8_error_offset(bytes: Buffer): number {
@@ -187,18 +183,11 @@ function utf8_error_offset(bytes: Buffer): number {
 }
 
 function decode_error_diagnostic(file_path: string, offset: number): Diagnostic {
-    return {
-        range: {
-            start: { line: 0, character: 0 },
-            end: { line: 0, character: 0 },
-        },
-        severity: DiagnosticSeverity.Error,
-        source: 'sight',
-        code: 'SIGHT_INVALID_ENCODING',
-        message:
-            `${file_path} is not valid UTF-8 at byte offset ${offset}. ` +
-            'Re-save the file as UTF-8.',
-    };
+    return file_level_diagnostic(
+        'SIGHT_INVALID_ENCODING',
+        `${file_path} is not valid UTF-8 at byte offset ${offset}. ` +
+        'Re-save the file as UTF-8.'
+    );
 }
 
 export function read_source_file(file_path: string): SourceReadResult {
@@ -208,9 +197,7 @@ export function read_source_file(file_path: string): SourceReadResult {
     } catch (error) {
         return {
             kind: 'read-error',
-            message: `${file_path}: ${
-                error instanceof Error ? error.message : String(error)
-            }`,
+            message: `${file_path}: ${error_message(error)}`,
         };
     }
 

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -170,25 +170,69 @@ export function index_limit_diagnostic(file_path: string): Diagnostic {
     );
 }
 
+// Per-file diagnostic for a target that cannot be stat-ed or read (e.g. it was
+// deleted or its permissions changed after discovery). Reported per file so a
+// benign race does not abort the whole check batch.
+export function unreadable_diagnostic(message: string): Diagnostic {
+    return file_level_diagnostic(
+        'SIGHT_UNREADABLE',
+        `Could not read file: ${message}`
+    );
+}
+
 function utf8_error_offset(bytes: Buffer): number {
-    // Feed bytes incrementally so each step is O(1) — re-decoding a growing
-    // prefix every iteration would be O(n^2) on large files. Valid multi-byte
-    // sequences are buffered across stream chunks, so only a genuinely invalid
-    // byte throws.
-    const decoder = new TextDecoder('utf-8', { fatal: true });
-    for (let i = 0; i < bytes.length; i++) {
-        try {
-            decoder.decode(bytes.subarray(i, i + 1), { stream: true });
-        } catch {
+    // Return the byte offset where the first invalid UTF-8 sequence BEGINS
+    // (its lead byte), not the trailing byte that proved it invalid, so the
+    // diagnostic points a user at the actual start of the bad bytes. Single
+    // O(n) pass validating lead/continuation bytes and the tightened ranges
+    // that reject overlong encodings, surrogates, and out-of-range code points.
+    const length = bytes.length;
+    let i = 0;
+    while (i < length) {
+        const lead = bytes[i];
+        if (lead <= 0x7f) {
+            i++;
+            continue;
+        }
+
+        let extra: number;
+        let lower = 0x80;
+        let upper = 0xbf;
+        if (lead >= 0xc2 && lead <= 0xdf) {
+            extra = 1;
+        } else if (lead >= 0xe0 && lead <= 0xef) {
+            extra = 2;
+            if (lead === 0xe0) lower = 0xa0;       // reject overlong
+            else if (lead === 0xed) upper = 0x9f;  // reject surrogates
+        } else if (lead >= 0xf0 && lead <= 0xf4) {
+            extra = 3;
+            if (lead === 0xf0) lower = 0x90;       // reject overlong
+            else if (lead === 0xf4) upper = 0x8f;  // reject > U+10FFFF
+        } else {
+            // Invalid lead byte: lone continuation, 0xc0/0xc1, or 0xf5..0xff.
             return i;
         }
+
+        if (i + extra >= length) {
+            return i; // truncated multi-byte sequence at end of input
+        }
+        // The first continuation byte uses the tightened [lower, upper] range;
+        // remaining continuations only need to be 0x80..0xbf.
+        if (bytes[i + 1] < lower || bytes[i + 1] > upper) {
+            return i;
+        }
+        for (let k = 2; k <= extra; k++) {
+            if (bytes[i + k] < 0x80 || bytes[i + k] > 0xbf) {
+                return i;
+            }
+        }
+
+        i += extra + 1;
     }
-    try {
-        decoder.decode(); // flush: throws on a trailing incomplete sequence
-    } catch {
-        return Math.max(0, bytes.length - 1);
-    }
-    return 0;
+
+    // Only reached if the caller's decode error was spurious; fall back to the
+    // final byte rather than claiming offset 0.
+    return Math.max(0, length - 1);
 }
 
 function decode_error_diagnostic(file_path: string, offset: number): Diagnostic {

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { TextDecoder } from 'util';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { hasStataExtension, VCS_METADATA_DIRS } from '../utils/file-path-utils';
-import { error_message } from './shared';
+import { compare_strings, error_message } from './shared';
 
 export interface ReportTarget {
     path: string;
@@ -35,10 +35,19 @@ function workspace_relative(
 }
 
 export function relative_path(workspace_root: string, file_path: string): string {
-    const { relative, inside } = workspace_relative(workspace_root, file_path);
-    return relative && inside
-        ? relative.split(path.sep).join('/')
-        : file_path;
+    const { relative } = workspace_relative(workspace_root, file_path);
+    if (relative === '') {
+        return '.';
+    }
+    // Emit a workspace-relative path even for out-of-workspace targets (a
+    // `../`-prefixed path) so report output is deterministic and free of the
+    // absolute, machine-specific prefix that would otherwise leak into JSON /
+    // SARIF and break golden-file comparisons across machines. Only a path that
+    // cannot be made relative (e.g. a different Windows drive, where
+    // path.relative returns an absolute path) falls back to the absolute path.
+    return path.isAbsolute(relative)
+        ? file_path
+        : relative.split(path.sep).join('/');
 }
 
 export function is_within_workspace(
@@ -132,7 +141,7 @@ export function collect_report_targets(
             relative_path: relative_path(normalized_root, file_path),
             explicit: has_explicit_paths,
         }));
-    targets.sort((a, b) => a.relative_path.localeCompare(b.relative_path));
+    targets.sort((a, b) => compare_strings(a.relative_path, b.relative_path));
 
     return { targets, operator_errors };
 }
@@ -150,33 +159,45 @@ function file_level_diagnostic(code: string, message: string): Diagnostic {
     };
 }
 
+// File-level diagnostic messages deliberately omit the file path: the renderer
+// already prefixes each diagnostic with its (workspace-relative) location, so
+// repeating an absolute path in the message body is both redundant and
+// machine-specific (it would break golden/snapshot comparisons in CI and leak
+// the filesystem layout).
 export function size_limit_diagnostic(
-    file_path: string,
     actual_bytes: number,
     limit_bytes: number
 ): Diagnostic {
     return file_level_diagnostic(
         'SIGHT_FILE_TOO_LARGE',
-        `${file_path} is ${actual_bytes} bytes, which exceeds ` +
+        `File is ${actual_bytes} bytes, which exceeds ` +
         `the configured limit of ${limit_bytes} bytes.`
     );
 }
 
-export function index_limit_diagnostic(file_path: string): Diagnostic {
+export function index_limit_diagnostic(): Diagnostic {
     return file_level_diagnostic(
         'SIGHT_FILE_NOT_INDEXED',
-        `${file_path} was not indexed before Sight reached ` +
+        'File was not indexed before Sight reached ' +
         'crossFile.maxIndexedFiles. Raise maxIndexedFiles or check fewer files.'
     );
+}
+
+// Deterministic detail for a read/stat failure: the errno code (ENOENT,
+// EACCES, ...) when present, else the error message. The OS error message
+// embeds an absolute path, so prefer the code to keep output reproducible.
+export function read_error_detail(error: unknown): string {
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    return typeof code === 'string' ? code : error_message(error);
 }
 
 // Per-file diagnostic for a target that cannot be stat-ed or read (e.g. it was
 // deleted or its permissions changed after discovery). Reported per file so a
 // benign race does not abort the whole check batch.
-export function unreadable_diagnostic(message: string): Diagnostic {
+export function unreadable_diagnostic(detail: string): Diagnostic {
     return file_level_diagnostic(
         'SIGHT_UNREADABLE',
-        `Could not read file: ${message}`
+        `File could not be read: ${detail}`
     );
 }
 
@@ -235,10 +256,10 @@ function utf8_error_offset(bytes: Buffer): number {
     return Math.max(0, length - 1);
 }
 
-function decode_error_diagnostic(file_path: string, offset: number): Diagnostic {
+function decode_error_diagnostic(offset: number): Diagnostic {
     return file_level_diagnostic(
         'SIGHT_INVALID_ENCODING',
-        `${file_path} is not valid UTF-8 at byte offset ${offset}. ` +
+        `File is not valid UTF-8 at byte offset ${offset}. ` +
         'Re-save the file as UTF-8.'
     );
 }
@@ -250,7 +271,7 @@ export function read_source_file(file_path: string): SourceReadResult {
     } catch (error) {
         return {
             kind: 'read-error',
-            message: `${file_path}: ${error_message(error)}`,
+            message: read_error_detail(error),
         };
     }
 
@@ -262,10 +283,7 @@ export function read_source_file(file_path: string): SourceReadResult {
     } catch {
         return {
             kind: 'decode-error',
-            diagnostic: decode_error_diagnostic(
-                file_path,
-                utf8_error_offset(bytes)
-            ),
+            diagnostic: decode_error_diagnostic(utf8_error_offset(bytes)),
         };
     }
 }

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -72,7 +72,7 @@ function walk_sources(
         if (entry.isDirectory()) {
             if (VCS_METADATA_DIRS.has(entry.name)) continue;
             walk_sources(entry_path, out, operator_errors);
-        } else if (entry.isFile() && hasStataExtension(entry_path)) {
+        } else if (entry.isFile() && hasStataExtension(entry.name)) {
             out.push(entry_path);
         }
     }

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -1,0 +1,181 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { TextDecoder } from 'util';
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+
+const SOURCE_EXTENSIONS = new Set(['.do', '.ado', '.doh', '.mata']);
+const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
+
+export interface ReportTarget {
+    path: string;
+    relative_path: string;
+    explicit: boolean;
+}
+
+export interface ReportTargetResult {
+    targets: ReportTarget[];
+    operator_errors: string[];
+}
+
+export type SourceReadResult =
+    | { kind: 'ok'; text: string }
+    | { kind: 'decode-error'; diagnostic: Diagnostic }
+    | { kind: 'read-error'; message: string };
+
+export function is_stata_source_path(file_path: string): boolean {
+    return SOURCE_EXTENSIONS.has(path.extname(file_path).toLowerCase());
+}
+
+export function relative_path(workspace_root: string, file_path: string): string {
+    const relative = path.relative(workspace_root, file_path);
+    return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+        ? relative.split(path.sep).join('/')
+        : file_path;
+}
+
+function walk_sources(dir_path: string, out: string[]): void {
+    const entries = fs.readdirSync(dir_path, { withFileTypes: true });
+    for (const entry of entries) {
+        const entry_path = path.join(dir_path, entry.name);
+        if (entry.isDirectory()) {
+            if (VCS_METADATA_DIRS.has(entry.name)) continue;
+            walk_sources(entry_path, out);
+        } else if (entry.isFile() && is_stata_source_path(entry_path)) {
+            out.push(entry_path);
+        }
+    }
+}
+
+export function collect_report_targets(
+    input_paths: string[],
+    workspace_root: string,
+    cwd: string
+): ReportTargetResult {
+    const operator_errors: string[] = [];
+    const source_paths: string[] = [];
+    const normalized_root = path.resolve(workspace_root);
+    const has_explicit_paths = input_paths.length > 0;
+    const paths_to_collect = input_paths.length > 0
+        ? input_paths
+        : [normalized_root];
+
+    for (const input_path of paths_to_collect) {
+        const absolute_path = path.resolve(cwd, input_path);
+        if (!fs.existsSync(absolute_path)) {
+            operator_errors.push(`path does not exist: ${input_path}`);
+            continue;
+        }
+
+        const stat = fs.statSync(absolute_path);
+        if (stat.isDirectory()) {
+            walk_sources(absolute_path, source_paths);
+        } else if (stat.isFile() && is_stata_source_path(absolute_path)) {
+            source_paths.push(absolute_path);
+        }
+    }
+
+    const unique_sorted_paths = Array.from(new Set(source_paths))
+        .sort((a, b) =>
+            relative_path(normalized_root, a)
+                .localeCompare(relative_path(normalized_root, b))
+        );
+
+    return {
+        targets: unique_sorted_paths.map((file_path) => ({
+            path: file_path,
+            relative_path: relative_path(normalized_root, file_path),
+            explicit: has_explicit_paths,
+        })),
+        operator_errors,
+    };
+}
+
+export function size_limit_diagnostic(
+    file_path: string,
+    actual_bytes: number,
+    limit_bytes: number
+): Diagnostic {
+    return {
+        range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+        },
+        severity: DiagnosticSeverity.Error,
+        source: 'sight',
+        code: 'SIGHT_FILE_TOO_LARGE',
+        message:
+            `${file_path} is ${actual_bytes} bytes, which exceeds ` +
+            `the configured limit of ${limit_bytes} bytes.`,
+    };
+}
+
+export function index_limit_diagnostic(file_path: string): Diagnostic {
+    return {
+        range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+        },
+        severity: DiagnosticSeverity.Error,
+        source: 'sight',
+        code: 'SIGHT_FILE_NOT_INDEXED',
+        message:
+            `${file_path} was not indexed before Sight reached ` +
+            'crossFile.maxIndexedFiles. Raise maxIndexedFiles or check fewer files.',
+    };
+}
+
+function utf8_error_offset(bytes: Buffer): number {
+    const decoder = new TextDecoder('utf-8', { fatal: true });
+    for (let i = 0; i <= bytes.length; i++) {
+        try {
+            decoder.decode(bytes.subarray(0, i));
+        } catch {
+            return Math.max(0, i - 1);
+        }
+    }
+    return 0;
+}
+
+function decode_error_diagnostic(file_path: string, offset: number): Diagnostic {
+    return {
+        range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+        },
+        severity: DiagnosticSeverity.Error,
+        source: 'sight',
+        code: 'SIGHT_INVALID_ENCODING',
+        message:
+            `${file_path} is not valid UTF-8 at byte offset ${offset}. ` +
+            'Re-save the file as UTF-8.',
+    };
+}
+
+export function read_source_file(file_path: string): SourceReadResult {
+    let bytes: Buffer;
+    try {
+        bytes = fs.readFileSync(file_path);
+    } catch (error) {
+        return {
+            kind: 'read-error',
+            message: `${file_path}: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        };
+    }
+
+    try {
+        return {
+            kind: 'ok',
+            text: new TextDecoder('utf-8', { fatal: true }).decode(bytes),
+        };
+    } catch {
+        return {
+            kind: 'decode-error',
+            diagnostic: decode_error_diagnostic(
+                file_path,
+                utf8_error_offset(bytes)
+            ),
+        };
+    }
+}

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -2,8 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { TextDecoder } from 'util';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import { hasStataExtension } from '../utils/file-path-utils';
 
-const SOURCE_EXTENSIONS = new Set(['.do', '.ado', '.doh', '.mata']);
 const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
 
 export interface ReportTarget {
@@ -22,19 +22,32 @@ export type SourceReadResult =
     | { kind: 'decode-error'; diagnostic: Diagnostic }
     | { kind: 'read-error'; message: string };
 
-export function is_stata_source_path(file_path: string): boolean {
-    return SOURCE_EXTENSIONS.has(path.extname(file_path).toLowerCase());
-}
-
 export function canonicalize_existing_path(file_path: string): string {
     return fs.realpathSync.native(file_path);
 }
 
-export function relative_path(workspace_root: string, file_path: string): string {
+function workspace_relative(
+    workspace_root: string,
+    file_path: string
+): { relative: string; inside: boolean } {
     const relative = path.relative(workspace_root, file_path);
-    return relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+    const inside = !relative.startsWith('..') && !path.isAbsolute(relative);
+    return { relative, inside };
+}
+
+export function relative_path(workspace_root: string, file_path: string): string {
+    const { relative, inside } = workspace_relative(workspace_root, file_path);
+    return relative && inside
         ? relative.split(path.sep).join('/')
         : file_path;
+}
+
+export function is_within_workspace(
+    workspace_root: string,
+    file_path: string
+): boolean {
+    const { relative, inside } = workspace_relative(workspace_root, file_path);
+    return relative === '' || (relative.length > 0 && inside);
 }
 
 function error_message(error: unknown): string {
@@ -61,7 +74,7 @@ function walk_sources(
         if (entry.isDirectory()) {
             if (VCS_METADATA_DIRS.has(entry.name)) continue;
             walk_sources(entry_path, out, operator_errors);
-        } else if (entry.isFile() && is_stata_source_path(entry_path)) {
+        } else if (entry.isFile() && hasStataExtension(entry_path)) {
             out.push(entry_path);
         }
     }
@@ -113,7 +126,7 @@ export function collect_report_targets(
         }
         if (stat.isDirectory()) {
             walk_sources(absolute_path, source_paths, operator_errors);
-        } else if (stat.isFile() && is_stata_source_path(absolute_path)) {
+        } else if (stat.isFile() && hasStataExtension(absolute_path)) {
             source_paths.push(absolute_path);
         }
     }

--- a/src/config-file/schema.ts
+++ b/src/config-file/schema.ts
@@ -40,6 +40,34 @@ const LINE_COMMENT_STYLES = ['//', '*'] as const;
 const ASSUME_CALL_SITE_VALUES = ['start', 'end'] as const;
 const BACKWARD_DEPENDENCY_VALUES = ['auto', 'explicit'] as const;
 
+// Server-side public settings the mapper understands and maps into the
+// internal StataLSPConfig. Both camelCase and snake_case spellings of each
+// are accepted (pick_key/normalize_name normalize on `_` and case), so every
+// public setting has a permanent equivalent alias in either form.
+const SERVER_TOP_LEVEL_KEYS = [
+    'indexWorkspace',
+    'adoPaths',
+    'lineCommentStyle',
+    'debug',
+    'diagnostics',
+    'formatting',
+    'completion',
+    'indexing',
+    'crossFile',
+] as const;
+
+// Top-level `sight.*` sections owned by the VS Code client, not the server.
+// They legitimately appear in a full `sight` settings tree pushed via
+// workspace/configuration or didChangeConfiguration, so the mapper recognizes
+// (and ignores) them rather than emitting a misleading "unknown key" warning.
+// The server never reads these; the client extension consumes them directly.
+const CLIENT_ONLY_TOP_LEVEL_KEYS = [
+    'sendToStata',
+    'dataBrowser',
+    'depthColors',
+    'personalAdoDir',
+] as const;
+
 function is_object(value: unknown): value is JsonObject {
     return typeof value === 'object'
         && value !== null
@@ -566,19 +594,12 @@ export function map_public_config_to_partial_config(
         return {};
     }
 
+    // Recognize both server-mapped keys and client-only sections so a full
+    // `sight` settings tree (which carries sendToStata/dataBrowser/... for the
+    // VS Code client) does not produce spurious unknown-key warnings.
     warn_unknown_keys(
         raw,
-        [
-            'indexWorkspace',
-            'adoPaths',
-            'lineCommentStyle',
-            'debug',
-            'diagnostics',
-            'formatting',
-            'completion',
-            'indexing',
-            'crossFile',
-        ],
+        [...SERVER_TOP_LEVEL_KEYS, ...CLIENT_ONLY_TOP_LEVEL_KEYS],
         'sight',
         warn
     );

--- a/src/config-file/toml-loader.ts
+++ b/src/config-file/toml-loader.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import { parse } from 'smol-toml';
 import type { LoadedProjectConfig, ProjectConfigWarning } from './types';
 import { map_public_config_to_partial_config } from './schema';
+import { error_message } from '../utils/error-message';
 
 function load_failed(
     path: string,
@@ -11,9 +12,7 @@ function load_failed(
     return {
         kind: 'load-failed',
         path,
-        error: `${path}: ${
-            error instanceof Error ? error.message : String(error)
-        }`,
+        error: `${path}: ${error_message(error)}`,
         warnings,
         candidate_dirs: [],
     };

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -650,7 +650,18 @@ export class DocumentStore {
       );
     }
 
-    // Parse directives to get working_directory and check for backward directives
+    // Parse directives to get working_directory and check for backward directives.
+    //
+    // KNOWN LIMITATION (tracked in https://github.com/jbearak/sight/issues/184):
+    // these cross-file side effects are applied during the parse, before
+    // commit_state decides whether the parse is accepted. Per-URI serialization
+    // makes a stale out-of-order *update* hit the read-time version guard before
+    // this runs, but a `close()` racing an in-flight parse is not serialized, so
+    // a parse finishing after close can briefly leave a stale backward-directive
+    // relationship until the next reparse/reindex. The full fix is to stage these
+    // side effects and apply them only after commit_state's guards pass (issue
+    // #184); it is deferred because the correct rollback requires a transactional
+    // refactor (including a non-registering resolve() probe), not a coarse clear.
     const directive_parser = new DirectiveParser();
     let resolved_working_directory: string | undefined;
     try {

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -72,6 +72,7 @@ export class DocumentStore {
 
   // Generation counters for close-vs-update safety (Req 16.1, 16.2)
   private generations: Map<string, number> = new Map();
+  private committed_generations: Map<string, number> = new Map();
   private closed_generations: Map<string, number> = new Map();
 
   private metrics: DocumentStoreMetrics = {
@@ -318,6 +319,7 @@ export class DocumentStore {
     const current = (this.generations.get(uri) ?? 0) + 1;
     this.generations.set(uri, current);
     this.closed_generations.set(uri, current);
+    this.committed_generations.delete(uri);
     this.documents.delete(uri);
     this.access_order.delete(uri);
   }
@@ -358,12 +360,30 @@ export class DocumentStore {
     if (closed_gen !== undefined && generation <= closed_gen) {
       return; // Discard stale update (document closed)
     }
+    // Operation generations increment per call, not per document
+    // version. A later-started older-version update can therefore
+    // have a higher generation than a newer committed state; never
+    // let it overwrite that newer document version. Equal versions
+    // are allowed for same-version reparses such as scope config
+    // changes and error-state recovery.
+    const existing = this.documents.get(uri);
+    if (existing && existing.version > state.version) {
+      return;
+    }
+
     // Discard if a newer update has already committed (Req 16.2)
-    const current_gen = this.generations.get(uri) ?? 0;
-    if (generation < current_gen) {
+    const current_gen = this.committed_generations.get(uri) ?? 0;
+    if (
+      generation < current_gen &&
+      (!existing || existing.version >= state.version)
+    ) {
       return; // A newer update has already committed
     }
     this.documents.set(uri, state);
+    this.committed_generations.set(
+      uri,
+      Math.max(current_gen, generation)
+    );
     this.touch_access(uri);
   }
 
@@ -397,6 +417,7 @@ export class DocumentStore {
       if (!this.documents.has(uri)) {
         this.closed_generations.delete(uri);
         this.generations.delete(uri);
+        this.committed_generations.delete(uri);
       }
       return;
     }
@@ -405,6 +426,7 @@ export class DocumentStore {
       if (!this.documents.has(uri)) {
         this.closed_generations.delete(uri);
         this.generations.delete(uri);
+        this.committed_generations.delete(uri);
       }
     } else {
       this.in_flight_counts.set(uri, count);

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -185,7 +185,13 @@ export class DocumentStore {
    * Open a document and parse it.
    * Async to support parse timeout wrapper.
    */
-  async open(uri: string, content: string, version: number, workspace_symbols?: SymbolTable): Promise<void> {
+  async open(
+    uri: string,
+    content: string,
+    version: number,
+    workspace_symbols?: SymbolTable,
+    scope_resolver_config?: Partial<ScopeResolverConfig>
+  ): Promise<void> {
     this.check_disposed();
     // Capture generation at start of operation (Req 16.2)
     const generation = (this.generations.get(uri) ?? 0) + 1;
@@ -194,7 +200,13 @@ export class DocumentStore {
 
     const operation = async () => {
       this.evict_if_needed(content.length);
-      const state = await this.create_document_state(uri, content, version, workspace_symbols);
+      const state = await this.create_document_state(
+        uri,
+        content,
+        version,
+        workspace_symbols,
+        scope_resolver_config
+      );
       this.commit_state(uri, state, generation);
     };
 
@@ -219,7 +231,8 @@ export class DocumentStore {
     uri: string,
     changes: TextDocumentContentChangeEvent[],
     version: number,
-    workspace_symbols?: SymbolTable
+    workspace_symbols?: SymbolTable,
+    scope_resolver_config?: Partial<ScopeResolverConfig>
   ): Promise<void> {
     this.check_disposed();
     // Capture generation at start of operation (Req 16.2)
@@ -232,9 +245,11 @@ export class DocumentStore {
       if (!state) {
         return;
       }
+      const should_reparse_for_scope_config =
+        scope_resolver_config !== undefined;
 
       // Skip if version hasn't changed (idempotent)
-      if (state.version >= version) {
+      if (state.version >= version && !should_reparse_for_scope_config) {
         this.metrics.cache_hits++;
         return;
       }
@@ -248,7 +263,7 @@ export class DocumentStore {
       // Safe to mutate in place: this path is synchronous (no await
       // between the .get() above and this mutation), so close()
       // cannot interleave.
-      if (new_content === state.content) {
+      if (new_content === state.content && !should_reparse_for_scope_config) {
         state.version = version;
         this.metrics.cache_hits++;
         return;
@@ -259,7 +274,8 @@ export class DocumentStore {
         uri,
         new_content,
         version,
-        workspace_symbols
+        workspace_symbols,
+        scope_resolver_config
       );
       this.commit_state(uri, new_state, generation);
     };
@@ -521,7 +537,8 @@ export class DocumentStore {
     uri: string,
     content: string,
     version: number,
-    workspace_symbols?: SymbolTable
+    workspace_symbols?: SymbolTable,
+    scope_resolver_config?: Partial<ScopeResolverConfig>
   ): Promise<DocumentState> {
     const start_time = Date.now();
     this.metrics.parse_count++;
@@ -595,10 +612,12 @@ export class DocumentStore {
         // File has no own working directory. Try to inherit one from parent
         // files via ScopeResolver, including auto-discovered parents.
         try {
+          const effective_scope_resolver_config =
+            scope_resolver_config ?? this.scope_resolver_config;
           const scope_result = await this.scope_resolver.resolve(
             uri,
             content,
-            this.scope_resolver_config
+            effective_scope_resolver_config
           );
           if (scope_result.inherited_working_directory) {
             resolved_working_directory = scope_result.inherited_working_directory;

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -248,8 +248,18 @@ export class DocumentStore {
       const should_reparse_for_scope_config =
         scope_resolver_config !== undefined;
 
-      // Skip if version hasn't changed (idempotent)
-      if (state.version >= version && !should_reparse_for_scope_config) {
+      // Strictly older snapshots are always stale. commit_state only
+      // guards by operation generation, which increments per call rather
+      // than by document version, so a later-but-older update could
+      // otherwise overwrite newer state.
+      if (state.version > version) {
+        this.metrics.cache_hits++;
+        return;
+      }
+
+      // Same-version updates are idempotent unless scope config is
+      // provided, in which case config-derived state must be recomputed.
+      if (state.version === version && !should_reparse_for_scope_config) {
         this.metrics.cache_hits++;
         return;
       }

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -543,6 +543,7 @@ export class DocumentStore {
       if (oldest) {
         this.documents.delete(oldest);
         this.access_order.delete(oldest);
+        this.discard_generation_metadata(oldest);
         this.metrics.evictions++;
       } else {
         break; // Safety: prevent infinite loop if access_order is inconsistent
@@ -559,12 +560,26 @@ export class DocumentStore {
       if (oldest) {
         this.documents.delete(oldest);
         this.access_order.delete(oldest);
+        this.discard_generation_metadata(oldest);
         this.metrics.evictions++;
         total_bytes = this.estimate_total_bytes();
       } else {
         break; // Safety: prevent infinite loop if access_order is inconsistent
       }
     }
+  }
+
+  /**
+   * Drop per-URI generation bookkeeping for an evicted document.
+   * Eviction only targets URIs returned by find_oldest_uri (in-flight
+   * count zero), so no pending operation can still reference these
+   * generations. Mirrors the cleanup in decrement_in_flight/close so
+   * these maps do not grow unbounded across a long session.
+   */
+  private discard_generation_metadata(uri: string): void {
+    this.generations.delete(uri);
+    this.closed_generations.delete(uri);
+    this.committed_generations.delete(uri);
   }
 
   /**

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -1,5 +1,16 @@
 import { TextDocumentContentChangeEvent, Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
-import { StataAST, SymbolTable, Token, DocumentStoreMetrics, ForwardCall, WorkingDirectoryDirective, Directive, LexerError, ParseError } from './types';
+import {
+  StataAST,
+  SymbolTable,
+  Token,
+  DocumentStoreMetrics,
+  ForwardCall,
+  WorkingDirectoryDirective,
+  Directive,
+  LexerError,
+  ParseError,
+  ScopeResolverConfig,
+} from './types';
 import { StataLexer } from './lexer';
 import { StataParser } from './parser';
 import { SemanticAnalyzer, SemanticDiagnostic } from './analyzer';
@@ -53,6 +64,7 @@ export class DocumentStore {
   private readonly MAX_TOKEN_BYTES = 100 * 1024 * 1024; // 100MB
   private workspace_roots: string[] = [];
   private scope_resolver: ScopeResolver | undefined;
+  private scope_resolver_config: Partial<ScopeResolverConfig> = {};
   private on_backward_directives_parsed:
     | ((uri: string, directives: Directive[]) => void)
     | undefined;
@@ -115,6 +127,12 @@ export class DocumentStore {
         }
       }
     }
+  }
+
+  set_scope_resolver_config(
+    config: Partial<ScopeResolverConfig>
+  ): void {
+    this.scope_resolver_config = config;
   }
 
   /**
@@ -471,11 +489,15 @@ export class DocumentStore {
   }
 
   /**
-   * Find the URI with the oldest access (first in Map insertion order).
-   * O(1) - Map maintains insertion order, so first entry is oldest.
+   * Find the oldest URI that is not currently being updated.
    */
   private find_oldest_uri(): string | undefined {
-    return this.access_order.values().next().value;
+    for (const my_uri of this.access_order) {
+      if ((this.in_flight_counts.get(my_uri) ?? 0) === 0) {
+        return my_uri;
+      }
+    }
+    return undefined;
   }
 
   /**
@@ -573,7 +595,11 @@ export class DocumentStore {
         // File has no own working directory. Try to inherit one from parent
         // files via ScopeResolver, including auto-discovered parents.
         try {
-          const scope_result = await this.scope_resolver.resolve(uri, content);
+          const scope_result = await this.scope_resolver.resolve(
+            uri,
+            content,
+            this.scope_resolver_config
+          );
           if (scope_result.inherited_working_directory) {
             resolved_working_directory = scope_result.inherited_working_directory;
           }

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -198,8 +198,22 @@ export class DocumentStore {
     const generation = (this.generations.get(uri) ?? 0) + 1;
     this.generations.set(uri, generation);
     this.increment_in_flight(uri);
+    const prior = this.active_updates.get(uri);
 
     const operation = async () => {
+      // Per-URI serialization is the primary guarantee that newer state
+      // and cross-file side effects cannot be overwritten by a
+      // later-finishing older parse.
+      if (prior) {
+        try {
+          await prior;
+        } catch {
+          // A prior operation's failure must not block this one.
+        }
+      }
+      if (this.disposed) {
+        return;
+      }
       this.evict_if_needed(content.length);
       const state = await this.create_document_state(
         uri,
@@ -240,8 +254,22 @@ export class DocumentStore {
     const generation = (this.generations.get(uri) ?? 0) + 1;
     this.generations.set(uri, generation);
     this.increment_in_flight(uri);
+    const prior = this.active_updates.get(uri);
 
     const operation = async () => {
+      // Per-URI serialization is the primary guarantee that newer state
+      // and cross-file side effects cannot be overwritten by a
+      // later-finishing older parse.
+      if (prior) {
+        try {
+          await prior;
+        } catch {
+          // A prior operation's failure must not block this one.
+        }
+      }
+      if (this.disposed) {
+        return;
+      }
       const state = this.documents.get(uri);
       if (!state) {
         return;
@@ -254,6 +282,9 @@ export class DocumentStore {
       // than by document version, so a later-but-older update could
       // otherwise overwrite newer state.
       if (state.version > version) {
+        // With per-URI serialization, chained stale updates stop here
+        // before create_document_state can apply stale cross-file
+        // directive side effects.
         this.metrics.cache_hits++;
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,11 @@ export * from './providers/formatter';
 export { CommandDatabase, command_database } from './command-database';
 export { ForwardScopeResolver } from './forward-scope-resolver';
 export type { ForwardScopeConfig } from './forward-scope-resolver';
-export { ScopeResolver, build_scope_resolver_config } from './scope-resolver';
+export {
+    ScopeResolver,
+    build_scope_resolver_config,
+    scope_resolver_config_for,
+} from './scope-resolver';
 export { DependencyGraph } from './dependency-graph';
 export type { AutoBackwardEdge, GraphUpdateResult } from './dependency-graph';
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -42,15 +42,14 @@ import {
     FindaliasResolver,
     HelpAliasResolver,
 } from '../utils/findalias-resolver';
-import { hasStataExtension } from '../utils/file-path-utils';
+import {
+    hasStataExtension,
+    VCS_METADATA_DIRS,
+} from '../utils/file-path-utils';
 
 const MAX_PARALLEL = 4;
 const YIELD_INTERVAL_MS = 100;
 const INDEX_DEBOUNCE_MS = 200;
-
-// Version-control metadata directories skipped during workspace scans.
-// They contain no Stata source and recursing them is wasted work.
-const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
 
 export interface IndexedFileData {
     uri: string;

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -400,6 +400,15 @@ export class WorkspaceIndexer {
         this.context_ranges_index.delete(file_uri);
         if (was_indexed) {
             this.version++;
+            // Evicting an already-counted file (size growth, re-index error,
+            // or removal) must drop the distinct-file count; otherwise
+            // files_indexed inflates over edits and trips max_indexed_files
+            // early, hiding genuinely-new files and emitting spurious
+            // SIGHT_FILE_NOT_INDEXED diagnostics.
+            this.metrics.files_indexed = Math.max(
+                0,
+                this.metrics.files_indexed - 1
+            );
         }
         if (graph_result && graph_result.changed_callees.size > 0 && this.on_graph_change_callback) {
             this.on_graph_change_callback(graph_result.changed_callees);

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -332,7 +332,7 @@ export class WorkspaceIndexer {
                     await this.scan_directory(entry_path, generation);
                 } else if (
                     entry.isFile() &&
-                    hasStataExtension(entry_path)
+                    hasStataExtension(entry.name)
                 ) {
                     file_paths.push(entry_path);
                 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -42,19 +42,15 @@ import {
     FindaliasResolver,
     HelpAliasResolver,
 } from '../utils/findalias-resolver';
+import { hasStataExtension } from '../utils/file-path-utils';
 
 const MAX_PARALLEL = 4;
 const YIELD_INTERVAL_MS = 100;
 const INDEX_DEBOUNCE_MS = 200;
-const SOURCE_EXTENSIONS = new Set(['.do', '.ado', '.doh', '.mata']);
 
 // Version-control metadata directories skipped during workspace scans.
 // They contain no Stata source and recursing them is wasted work.
 const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
-
-function is_stata_source_file(file_path: string): boolean {
-    return SOURCE_EXTENSIONS.has(path.extname(file_path).toLowerCase());
-}
 
 export interface IndexedFileData {
     uri: string;
@@ -337,7 +333,7 @@ export class WorkspaceIndexer {
                     await this.scan_directory(entry_path, generation);
                 } else if (
                     entry.isFile() &&
-                    is_stata_source_file(entry_path)
+                    hasStataExtension(entry_path)
                 ) {
                     file_paths.push(entry_path);
                 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -411,6 +411,22 @@ export class WorkspaceIndexer {
         }
     }
 
+    private should_skip_for_max_indexed_files(file_uri: string): boolean {
+        if (this.metrics.files_indexed < this.max_indexed_files) {
+            return false;
+        }
+
+        if (!this.max_files_reached) {
+            this.max_files_reached = true;
+            logger.info(
+                `Reached max_indexed_files limit (${this.max_indexed_files}). ` +
+                `Skipping remaining files.`
+            );
+        }
+        this.clear_stale_entry(file_uri);
+        return true;
+    }
+
     /**
      * Index a single file.
      */
@@ -422,17 +438,7 @@ export class WorkspaceIndexer {
         const file_uri = URI.file(file_path).toString();
 
         // Check max files limit
-        if (this.metrics.files_indexed >= this.max_indexed_files) {
-            if (!this.max_files_reached) {
-                this.max_files_reached = true;
-                logger.info(
-                    `Reached max_indexed_files limit (${this.max_indexed_files}). ` +
-                    `Skipping remaining files.`
-                );
-            }
-            this.clear_stale_entry(file_uri);
-            return;
-        }
+        if (this.should_skip_for_max_indexed_files(file_uri)) return;
 
         try {
             // Check file size
@@ -456,6 +462,7 @@ export class WorkspaceIndexer {
                 'utf8'
             );
             if (!this.is_active_generation(generation)) return;
+            if (this.should_skip_for_max_indexed_files(file_uri)) return;
 
             // Handle .mata files differently
             if (path.extname(file_path).toLowerCase() === '.mata') {
@@ -486,17 +493,7 @@ export class WorkspaceIndexer {
             const context_ranges = context_tracker.get_all_context_ranges();
             if (!this.is_active_generation(generation)) return;
 
-            if (this.metrics.files_indexed >= this.max_indexed_files) {
-                if (!this.max_files_reached) {
-                    this.max_files_reached = true;
-                    logger.info(
-                        `Reached max_indexed_files limit (${this.max_indexed_files}). ` +
-                        `Skipping remaining files.`
-                    );
-                }
-                this.clear_stale_entry(file_uri);
-                return;
-            }
+            if (this.should_skip_for_max_indexed_files(file_uri)) return;
 
             // Combine forward calls from analyzer (command-detected)
             // and directive parser (directive-detected)

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -436,9 +436,15 @@ export class WorkspaceIndexer {
     ): Promise<void> {
         if (!this.is_active_generation(generation) || !this.enabled) return;
         const file_uri = URI.file(file_path).toString();
+        // Re-indexing a file already in the index does not grow the distinct-
+        // file count, so the cap must not block it; otherwise an edit to an
+        // already-indexed file is silently skipped once the cap is reached,
+        // leaving stale symbols. The cap gates only genuinely new files.
+        const already_indexed = this.symbol_index.has(file_uri);
 
-        // Check max files limit
-        if (this.should_skip_for_max_indexed_files(file_uri)) return;
+        // Check max files limit (new files only)
+        if (!already_indexed
+            && this.should_skip_for_max_indexed_files(file_uri)) return;
 
         try {
             // Check file size
@@ -462,11 +468,17 @@ export class WorkspaceIndexer {
                 'utf8'
             );
             if (!this.is_active_generation(generation)) return;
-            if (this.should_skip_for_max_indexed_files(file_uri)) return;
+            if (!already_indexed
+                && this.should_skip_for_max_indexed_files(file_uri)) return;
 
             // Handle .mata files differently
             if (path.extname(file_path).toLowerCase() === '.mata') {
-                await this.index_mata_file(content, file_uri, generation);
+                await this.index_mata_file(
+                    content,
+                    file_uri,
+                    generation,
+                    already_indexed
+                );
                 return;
             }
 
@@ -493,7 +505,8 @@ export class WorkspaceIndexer {
             const context_ranges = context_tracker.get_all_context_ranges();
             if (!this.is_active_generation(generation)) return;
 
-            if (this.should_skip_for_max_indexed_files(file_uri)) return;
+            if (!already_indexed
+                && this.should_skip_for_max_indexed_files(file_uri)) return;
 
             // Combine forward calls from analyzer (command-detected)
             // and directive parser (directive-detected)
@@ -530,7 +543,7 @@ export class WorkspaceIndexer {
                 directives: directive_result.directives
             });
             this.version++;
-            this.metrics.files_indexed++;
+            if (!already_indexed) this.metrics.files_indexed++;
         } catch (error) {
             if (!this.is_active_generation(generation)) return;
             this.clear_stale_entry(file_uri);
@@ -545,7 +558,8 @@ export class WorkspaceIndexer {
     private async index_mata_file(
         content: string,
         file_uri: string,
-        generation: number
+        generation: number,
+        already_indexed: boolean = this.symbol_index.has(file_uri)
     ): Promise<void> {
         if (!this.is_active_generation(generation)) return;
 
@@ -592,7 +606,7 @@ export class WorkspaceIndexer {
             directives: []
         });
         this.version++;
-        this.metrics.files_indexed++;
+        if (!already_indexed) this.metrics.files_indexed++;
     }
 
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -790,8 +790,16 @@ export class WorkspaceIndexer {
                 context_ranges,
             });
         }
-        
+
         return indexed_files;
+    }
+
+    /**
+     * Whether a file URI has been indexed. Cheaper than get_indexed_files()
+     * when only membership is needed.
+     */
+    has_indexed_file(uri: string): boolean {
+        return this.symbol_index.has(uri);
     }
 
     /**

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -485,6 +485,18 @@ export class WorkspaceIndexer {
             const context_ranges = context_tracker.get_all_context_ranges();
             if (!this.is_active_generation(generation)) return;
 
+            if (this.metrics.files_indexed >= this.max_indexed_files) {
+                if (!this.max_files_reached) {
+                    this.max_files_reached = true;
+                    logger.info(
+                        `Reached max_indexed_files limit (${this.max_indexed_files}). ` +
+                        `Skipping remaining files.`
+                    );
+                }
+                this.clear_stale_entry(file_uri);
+                return;
+            }
+
             // Combine forward calls from analyzer (command-detected)
             // and directive parser (directive-detected)
             let all_forward_calls = analyzeResult.forward_calls;

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -418,7 +418,12 @@ export class WorkspaceIndexer {
                 `Skipping remaining files.`
             );
         }
-        this.clear_stale_entry(file_uri);
+        // Only evict files that are new to the index. An already-indexed file
+        // re-indexed after the cap is reached should keep its existing entry
+        // (it is already counted toward the cap) rather than lose coverage.
+        if (!this.symbol_index.has(file_uri)) {
+            this.clear_stale_entry(file_uri);
+        }
         return true;
     }
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -46,10 +46,15 @@ import {
 const MAX_PARALLEL = 4;
 const YIELD_INTERVAL_MS = 100;
 const INDEX_DEBOUNCE_MS = 200;
+const SOURCE_EXTENSIONS = new Set(['.do', '.ado', '.doh', '.mata']);
 
 // Version-control metadata directories skipped during workspace scans.
 // They contain no Stata source and recursing them is wasted work.
 const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
+
+function is_stata_source_file(file_path: string): boolean {
+    return SOURCE_EXTENSIONS.has(path.extname(file_path).toLowerCase());
+}
 
 export interface IndexedFileData {
     uri: string;
@@ -330,15 +335,11 @@ export class WorkspaceIndexer {
                         continue;
                     }
                     await this.scan_directory(entry_path, generation);
-                } else if (entry.isFile()) {
-                    if (
-                        entry.name.endsWith('.do') ||
-                        entry.name.endsWith('.ado') ||
-                        entry.name.endsWith('.doh') ||
-                        entry.name.endsWith('.mata')
-                    ) {
-                        file_paths.push(entry_path);
-                    }
+                } else if (
+                    entry.isFile() &&
+                    is_stata_source_file(entry_path)
+                ) {
+                    file_paths.push(entry_path);
                 }
             }
 
@@ -457,7 +458,7 @@ export class WorkspaceIndexer {
             if (!this.is_active_generation(generation)) return;
 
             // Handle .mata files differently
-            if (file_path.endsWith('.mata')) {
+            if (path.extname(file_path).toLowerCase() === '.mata') {
                 await this.index_mata_file(content, file_uri, generation);
                 return;
             }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -1480,7 +1480,7 @@ export class CompletionProvider {
             
             while (current_dir !== path.dirname(current_dir)) {
                 // Check for common workspace markers
-                const markers = ['.git', 'sight.toml', 'package.json', '.vscode'];
+                const markers = ['.git', 'sight.toml', '.sight.json', 'package.json', '.vscode'];
                 
                 for (const marker of markers) {
                     if (fs.existsSync(path.join(current_dir, marker))) {

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -12,7 +12,11 @@ import {
     ResolvedScope,
     DirectiveDiagnostic
 } from '../types';
-import { ScopeResolver, build_scope_resolver_config, get_visible_forward_call_sites } from '../scope-resolver';
+import {
+    ScopeResolver,
+    get_visible_forward_call_sites,
+    scope_resolver_config_for,
+} from '../scope-resolver';
 import { createHash } from 'crypto';
 import { DocumentDebounceManager } from '../utils/debounce-manager';
 import { get_line_text, get_line_count } from '../utils/line-utils';
@@ -222,18 +226,9 @@ export class DiagnosticsProvider {
 
         // Add semantic diagnostics from cached analyzer results
         // If scope_resolver is provided, check against cross-file scope first
-        // Only pass config if assume_call_site is explicitly set to avoid
-        // overriding the default with undefined
-        const resolve_config = build_scope_resolver_config({
-            assume_call_site: config.cross_file?.assume_call_site,
-            backward_dependencies: config.cross_file?.backward_dependencies,
-            max_forward_depth: config.cross_file?.max_forward_depth,
-            diagnostics: {
-                max_depth: config.cross_file?.diagnostics?.max_depth,
-                call_site_identification:
-                    config.cross_file?.diagnostics?.call_site_identification,
-            },
-        });
+        // Use the same filtered resolver config shape as other call sites so
+        // cache keys stay aligned.
+        const resolve_config = scope_resolver_config_for(config);
         const resolved_scope = scope_resolver ? await scope_resolver.resolve(
             document.uri,
             document.content,

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -1,4 +1,4 @@
-import { Diagnostic, DiagnosticSeverity, Connection, Position, CancellationToken, Range } from 'vscode-languageserver';
+import { Diagnostic, DiagnosticSeverity, Position, CancellationToken, Range } from 'vscode-languageserver';
 import { DocumentState } from '../document-store';
 import { LanguageContext, ContextDiagnostic, ContextRange } from '../context-tracker/types';
 import {
@@ -37,6 +37,13 @@ type OutOfScopeRewriteMatch = {
     reason: OutOfScopeMessageReason;
 };
 
+export interface DiagnosticsConnection {
+    sendDiagnostics(params: {
+        uri: string;
+        diagnostics: Diagnostic[];
+    }): void;
+}
+
 /**
  * DiagnosticsProvider aggregates diagnostics from cached parse results.
  * 
@@ -57,7 +64,7 @@ type OutOfScopeRewriteMatch = {
  * - Context Tracker: unclosed mata/python blocks, mismatched delimiters
  */
 export class DiagnosticsProvider {
-    private connection: Connection;
+    private connection: DiagnosticsConnection;
     private debounce_manager: DocumentDebounceManager | null = null;
     private indentation_analyzer = new IndentationDiagnosticAnalyzer();
     private operator_sequence_analyzer = new OperatorSequenceAnalyzer();
@@ -70,7 +77,10 @@ export class DiagnosticsProvider {
     // Cache filtered diagnostics by (uri, version, config_hash)
     private filtered_cache: Map<string, Map<string, Diagnostic[]>> = new Map();
 
-    constructor(connection: Connection, debounce_manager?: DocumentDebounceManager) {
+    constructor(
+        connection: DiagnosticsConnection,
+        debounce_manager?: DocumentDebounceManager
+    ) {
         this.connection = connection;
         this.debounce_manager = debounce_manager || null;
     }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -228,11 +228,11 @@ export class DiagnosticsProvider {
         // If scope_resolver is provided, check against cross-file scope first
         // Use the same filtered resolver config shape as other call sites so
         // cache keys stay aligned.
-        const resolve_config = scope_resolver_config_for(config);
+        const my_resolve_config = scope_resolver_config_for(config);
         const resolved_scope = scope_resolver ? await scope_resolver.resolve(
             document.uri,
             document.content,
-            resolve_config,
+            my_resolve_config,
             cancellation_token
         ) : undefined;
         

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -37,6 +37,7 @@ import { StataLexer } from '../lexer';
 import { StataParser } from '../parser';
 import { SemanticAnalyzer, create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 import { logger } from '../utils/logger';
+import { error_message } from '../utils/error-message';
 import { get_line_text, get_line_count, compute_line_offsets } from '../utils/line-utils';
 import { get_workspace_root_for_uri } from '../utils/workspace-roots';
 import { build_do_include_pattern } from '../utils/stata-call-patterns';
@@ -1702,7 +1703,7 @@ export class ScopeResolver {
                 diagnostics: my_parse_result.diagnostics,
             };
         } catch (error) {
-            this.warn(`ScopeResolver: Parse error for ${uri}: ${error instanceof Error ? error.message : String(error)}`);
+            this.warn(`ScopeResolver: Parse error for ${uri}: ${error_message(error)}`);
 
             // Return empty results on parse failure
             const empty_symbols = create_empty_symbol_table();
@@ -1919,14 +1920,14 @@ export class ScopeResolver {
                     // Both paths failed
                     this.file_cache.delete(cache_key);
                     this.cache_metrics.file.misses++;
-                    const original_error = error instanceof Error ? error.message : String(error);
+                    const original_error = error_message(error);
                     return { error: `${original_error} (also tried ${fallback_path})` };
                 }
             } else {
                 // Original path ends in .do, no fallback to try
                 this.file_cache.delete(cache_key);
                 this.cache_metrics.file.misses++;
-                return { error: error instanceof Error ? error.message : String(error) };
+                return { error: error_message(error) };
             }
         }
 
@@ -1990,7 +1991,7 @@ export class ScopeResolver {
 
             return { content, ...parse_result };
         } catch (error) {
-            this.warn(`ScopeResolver: Parse error for ${actual_uri}: ${error instanceof Error ? error.message : String(error)}`);
+            this.warn(`ScopeResolver: Parse error for ${actual_uri}: ${error_message(error)}`);
 
             // Return empty results on parse failure
             const empty_symbols = create_empty_symbol_table();

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -29,6 +29,7 @@ import {
     CallEdgeDiff,
     ContentProvider,
     WorkingDirectoryDirective,
+    StataLSPConfig,
 } from '../types';
 import { Range } from 'vscode-languageserver-textdocument';
 import { DirectiveParser } from '../directive-parser';
@@ -92,6 +93,21 @@ export function build_scope_resolver_config(
         }
     }
     return result;
+}
+
+export function scope_resolver_config_for(
+    config: StataLSPConfig
+): Partial<ScopeResolverConfig> {
+    return build_scope_resolver_config({
+        assume_call_site: config.cross_file?.assume_call_site,
+        backward_dependencies: config.cross_file?.backward_dependencies,
+        max_forward_depth: config.cross_file?.max_forward_depth,
+        diagnostics: {
+            max_depth: config.cross_file?.diagnostics?.max_depth,
+            call_site_identification:
+                config.cross_file?.diagnostics?.call_site_identification,
+        },
+    });
 }
 
 /**

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -101,7 +101,9 @@ export function scope_resolver_config_for(
     return build_scope_resolver_config({
         assume_call_site: config.cross_file?.assume_call_site,
         backward_dependencies: config.cross_file?.backward_dependencies,
+        max_backward_depth: config.cross_file?.max_backward_depth,
         max_forward_depth: config.cross_file?.max_forward_depth,
+        max_chain_depth: config.cross_file?.max_chain_depth,
         diagnostics: {
             max_depth: config.cross_file?.diagnostics?.max_depth,
             call_site_identification:

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -354,18 +354,19 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 scopeUri: scope_uri,
                 section: 'sight',
             }).then((config) => {
-                // The getConfiguration result is the live, per-scope `sight`
-                // tree in the public camelCase schema. Route it through the
-                // shared merge/validate pipeline as the client layer so this
-                // path and the global build_non_capability_settings stay in
-                // lockstep (precedence: init → client → project_file).
-                // select_pushed_client_settings keeps this symmetric with the
-                // push path: a no-op for spec-compliant clients (section
-                // 'sight' already returns the bare tree), but it unwraps a
-                // `{ sight: {...} }` response from clients that send one.
+                // The getConfiguration result is the live, per-scope
+                // `sight` tree in the public camelCase schema. Route it
+                // through the shared merge/validate pipeline as the client
+                // layer so this path and the global
+                // build_non_capability_settings stay in lockstep
+                // (precedence: init -> client -> project_file).
+                //
+                // Unlike the push path (didChangeConfiguration), the result
+                // needs no `.sight` unwrap: the `section: 'sight'` query
+                // already returns the bare config subtree per the LSP spec.
                 return build_non_capability_settings_from_sources({
                     init_options_config,
-                    last_client_settings: select_pushed_client_settings(config),
+                    last_client_settings: config,
                     project_file_config,
                     log_warning: log_config_warning,
                 });

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -40,6 +40,7 @@ import { ScopeResolver, scope_resolver_config_for } from './scope-resolver';
 import { ForwardScopeResolver } from './forward-scope-resolver';
 import { DocumentDebounceManager } from './utils/debounce-manager';
 import { validate_comment_formatting_config } from './utils/config-validator';
+import { error_message } from './utils/error-message';
 import { RenameHandler } from './utils/file-rename-handler';
 import { Logger } from './utils/logger';
 import { DependencyGraph } from './dependency-graph';
@@ -402,8 +403,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 log_config_warning(
                     'Failed to resolve settings for '
                     + `${scope_uri ?? '(workspace root)'}: `
-                    + (error instanceof Error
-                        ? error.message : String(error))
+                    + error_message(error)
                 );
                 return build_non_capability_settings();
             });

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -15,6 +15,7 @@ import {
     type FileSystemWatcher,
 } from 'vscode-languageserver/node';
 
+import * as path from 'path';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DocumentStore } from './document-store';
 import { DiagnosticsProvider } from './providers/diagnostics';
@@ -30,6 +31,7 @@ import type { DeepPartial } from './config-file';
 import {
     deep_merge_config,
     discover_and_load_project_config,
+    map_public_config_to_partial_config,
     type LoadedProjectConfig,
 } from './config-file';
 import { WorkspaceIndexer } from './indexer';
@@ -181,11 +183,20 @@ export async function create_server(options: ServerOptions): Promise<void> {
 
     function apply_loaded_project_config(loaded: LoadedProjectConfig): void {
         log_project_config_warnings(loaded);
-        project_config_candidate_dirs = loaded.candidate_dirs;
-        if (loaded.kind === 'loaded') {
-            project_file_config = loaded.partial_config;
-        } else {
+        // Watch only the directory that actually holds the resolved config
+        // (plus the workspace roots, added in project_config_watch_dirs). When
+        // no config exists, candidate_dirs spans every ancestor up to
+        // MAX_DISCOVERY_DEPTH (~32); registering watchers for all of them (×2
+        // patterns) would flood the client with ~64 watchers for a project
+        // that has no config at all. The workspace-root watcher still catches a
+        // config later created at the root.
+        if (loaded.kind === 'none') {
+            project_config_candidate_dirs = [];
             project_file_config = undefined;
+        } else {
+            project_config_candidate_dirs = [path.dirname(loaded.path)];
+            project_file_config =
+                loaded.kind === 'loaded' ? loaded.partial_config : undefined;
         }
     }
 
@@ -236,6 +247,17 @@ export async function create_server(options: ServerOptions): Promise<void> {
         );
     }
 
+    // initializationOptions arrive in the public (README) camelCase schema —
+    // the same shape sight.toml uses. Map them into the internal config shape
+    // the validator reads (crossFile -> cross_file, preserveAlignment ->
+    // preserve_alignment, ...); otherwise those settings are silently dropped
+    // for clients (Neovim/Helix/Zed/Claude Code) that configure this way.
+    function map_init_options(raw: unknown): DeepPartial<StataLSPConfig> {
+        return map_public_config_to_partial_config(raw, (warning) => {
+            connection.console.log(`Configuration warning: ${warning.message}`);
+        });
+    }
+
     /**
      * Get document-specific settings or fall back to global settings.
      */
@@ -256,7 +278,9 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 const init_record = (init_options_config && typeof init_options_config === 'object'
                     ? (init_options_config as Record<string, unknown>)
                     : undefined);
-                const init_partial = init_record?.['sight'] ?? init_options_config;
+                const init_partial = map_init_options(
+                    init_record?.['sight'] ?? init_options_config
+                );
                 const client_partial = deep_merge_config(init_partial || {}, config || {});
                 const merged_partial = deep_merge_config(
                     client_partial,
@@ -610,15 +634,37 @@ export async function create_server(options: ServerOptions): Promise<void> {
         }
     }
 
-    async function reload_project_config_from_active_root(): Promise<void> {
+    function same_string_set(a: string[], b: string[]): boolean {
+        if (a.length !== b.length) return false;
+        const set_a = new Set(a);
+        return b.every((value) => set_a.has(value));
+    }
+
+    async function reload_project_config_once(): Promise<void> {
         const active_root = active_workspace_roots[0];
         if (!active_root) {
             return;
         }
 
+        const previous_config_json = JSON.stringify(project_file_config ?? null);
+        const previous_watch_dirs = project_config_watch_dirs();
+
         apply_loaded_project_config(
             discover_and_load_project_config(active_root)
         );
+
+        const config_changed =
+            JSON.stringify(project_file_config ?? null) !== previous_config_json;
+        if (!same_string_set(previous_watch_dirs, project_config_watch_dirs())) {
+            await refresh_project_config_watchers();
+        }
+        if (!config_changed) {
+            // A watched event fired (e.g. an edit to an unsupported .sight.json,
+            // or a no-op save) but the effective project config is unchanged,
+            // so skip the expensive full workspace reset and re-index.
+            return;
+        }
+
         document_settings.clear();
 
         const settings = await get_document_settings('');
@@ -627,7 +673,30 @@ export async function create_server(options: ServerOptions): Promise<void> {
         }
 
         configure_workspace_indexing(settings, active_workspace_roots, true);
-        await refresh_project_config_watchers();
+    }
+
+    // Serialize reloads: a DidChangeWatchedFiles batch can deliver several
+    // config events at once (e.g. delete+create on save), and each would
+    // otherwise spawn a concurrent reload that disposes/re-registers watchers
+    // and re-indexes while another is mid-flight. Run one at a time and
+    // coalesce any overlapping requests into a single trailing run.
+    let project_config_reload_in_progress = false;
+    let project_config_reload_pending = false;
+
+    async function reload_project_config_from_active_root(): Promise<void> {
+        if (project_config_reload_in_progress) {
+            project_config_reload_pending = true;
+            return;
+        }
+        project_config_reload_in_progress = true;
+        try {
+            do {
+                project_config_reload_pending = false;
+                await reload_project_config_once();
+            } while (project_config_reload_pending);
+        } finally {
+            project_config_reload_in_progress = false;
+        }
     }
 
     /**
@@ -1117,10 +1186,12 @@ export async function create_server(options: ServerOptions): Promise<void> {
             const init_record = (init_options_config && typeof init_options_config === 'object'
                 ? (init_options_config as Record<string, unknown>)
                 : undefined);
-            const init_partial = init_record?.['sight'] ?? init_options_config;
+            const init_partial = map_init_options(
+                init_record?.['sight'] ?? init_options_config
+            );
             const change_settings = change.settings as Record<string, unknown> | undefined;
             const client_partial = deep_merge_config(
-                init_partial || {},
+                init_partial,
                 change_settings?.['sight'] || {}
             );
             const merged_partial = deep_merge_config(

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -354,29 +354,16 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 scopeUri: scope_uri,
                 section: 'sight',
             }).then((config) => {
-                const init_record = (init_options_config && typeof init_options_config === 'object'
-                    ? (init_options_config as Record<string, unknown>)
-                    : undefined);
-                const init_partial = map_public_settings(
-                    init_record?.['sight'] ?? init_options_config,
-                    log_config_warning
-                );
-                // The getConfiguration result is the live `sight` tree in the
-                // public camelCase schema. Map it (not merge it raw) so its
-                // settings reach the internal hybrid shape regardless of
-                // camelCase/snake_case spelling — the raw merge silently
-                // dropped, e.g., crossFile.* and formatting.preserveAlignment.
-                const client_partial = deep_merge_config(
-                    init_partial,
-                    map_public_settings(config, log_config_warning)
-                );
-                const merged_partial = deep_merge_config(
-                    client_partial,
-                    project_file_config || {}
-                );
-
-                return validate_comment_formatting_config(merged_partial, (msg) => {
-                    log_config_warning(msg);
+                // The getConfiguration result is the live, per-scope `sight`
+                // tree in the public camelCase schema. Route it through the
+                // shared merge/validate pipeline as the client layer so this
+                // path and the global build_non_capability_settings stay in
+                // lockstep (precedence: init → client → project_file).
+                return build_non_capability_settings_from_sources({
+                    init_options_config,
+                    last_client_settings: config,
+                    project_file_config,
+                    log_warning: log_config_warning,
                 });
             });
             document_settings.set(resource, result);

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -123,7 +123,14 @@ export function select_pushed_client_settings(settings: unknown): unknown {
     const change_settings = settings && typeof settings === 'object'
         ? settings as Record<string, unknown>
         : undefined;
-    return change_settings?.['sight'] ?? settings;
+    // Unwrap a `sight` wrapper when the key is present (even if its
+    // value is undefined) rather than `?? settings`: for
+    // `{ sight: undefined }` the latter would feed the whole wrapper
+    // back to the mapper and trip an unknown-top-level-key warning.
+    if (change_settings && 'sight' in change_settings) {
+        return change_settings['sight'];
+    }
+    return settings;
 }
 
 export function build_non_capability_settings_from_sources(
@@ -385,12 +392,13 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     log_warning: log_config_warning,
                 });
             }).catch((error) => {
-                // On failure, cache the init+project fallback
-                // (resolved value, not a rejection) so a failing
-                // client isn't re-queried each request; refreshed
-                // on the next didChangeConfiguration clear. Live
-                // per-scope overrides can't apply — their fetch
-                // is what failed.
+                // On failure, cache the global merged fallback
+                // (build_non_capability_settings: init + pushed
+                // client + project) as a resolved value, not a
+                // rejection, so a failing client isn't re-queried
+                // each request; refreshed on the next
+                // didChangeConfiguration clear. The live per-scope
+                // result can't apply — its fetch is what failed.
                 log_config_warning(
                     `Failed to resolve settings for ${resource}: `
                     + (error instanceof Error ? error.message : String(error))

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -15,7 +15,6 @@ import {
     type FileSystemWatcher,
 } from 'vscode-languageserver/node';
 
-import * as path from 'path';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { DocumentStore } from './document-store';
 import { DiagnosticsProvider } from './providers/diagnostics';
@@ -32,6 +31,8 @@ import {
     deep_merge_config,
     discover_and_load_project_config,
     map_public_config_to_partial_config,
+    PROJECT_CONFIG_FILE,
+    STALE_JSON_CONFIG_FILE,
     type LoadedProjectConfig,
 } from './config-file';
 import { WorkspaceIndexer } from './indexer';
@@ -166,6 +167,12 @@ export async function create_server(options: ServerOptions): Promise<void> {
     // Initialization options config
     let init_options_config: unknown = undefined;
 
+    // Most recent client-pushed `sight` settings from didChangeConfiguration,
+    // for clients without `workspace/configuration` capability. Retained so the
+    // merged global_settings can be rebuilt when project config or folders
+    // change without waiting for another didChangeConfiguration notification.
+    let last_client_settings: unknown = undefined;
+
     // Root URI from initialize params (fallback for clients without
     // workspaceFolders support, e.g., Claude Code, Neovim single-file)
     let init_root_uri: string | null = null;
@@ -183,20 +190,28 @@ export async function create_server(options: ServerOptions): Promise<void> {
 
     function apply_loaded_project_config(loaded: LoadedProjectConfig): void {
         log_project_config_warnings(loaded);
-        // Watch only the directory that actually holds the resolved config
-        // (plus the workspace roots, added in project_config_watch_dirs). When
-        // no config exists, candidate_dirs spans every ancestor up to
-        // MAX_DISCOVERY_DEPTH (~32); registering watchers for all of them (×2
-        // patterns) would flood the client with ~64 watchers for a project
-        // that has no config at all. The workspace-root watcher still catches a
-        // config later created at the root.
         if (loaded.kind === 'none') {
+            // Config genuinely absent: drop any prior project layer. (When no
+            // config exists, candidate_dirs spans every ancestor up to
+            // MAX_DISCOVERY_DEPTH (~32); watching all of them would flood the
+            // client with ~64 watchers, so watch only the workspace roots,
+            // added in project_config_watch_dirs — a config later created at
+            // the root is still detected.)
             project_config_candidate_dirs = [];
             project_file_config = undefined;
+        } else if (loaded.kind === 'load-failed') {
+            // Transient parse error (e.g. a mid-edit save). Keep the last-
+            // known-good config rather than reverting the whole workspace to
+            // defaults; still watch the discovery walk so the fix triggers a
+            // reload. project_file_config is intentionally left unchanged.
+            project_config_candidate_dirs = loaded.candidate_dirs;
         } else {
-            project_config_candidate_dirs = [path.dirname(loaded.path)];
-            project_file_config =
-                loaded.kind === 'loaded' ? loaded.partial_config : undefined;
+            // Config found: watch the bounded discovery walk (workspace root up
+            // to the config directory) so a *nearer* sight.toml created in an
+            // intermediate directory fires an event and correctly wins, instead
+            // of the server staying on the stale ancestor config until restart.
+            project_config_candidate_dirs = loaded.candidate_dirs;
+            project_file_config = loaded.partial_config;
         }
     }
 
@@ -217,7 +232,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
         const watchers: FileSystemWatcher[] = [];
         for (const my_dir of dirs) {
             const baseUri = URI.file(my_dir).toString();
-            for (const my_pattern of ['sight.toml', '.sight.json']) {
+            for (const my_pattern of [PROJECT_CONFIG_FILE, STALE_JSON_CONFIG_FILE]) {
                 watchers.push({
                     globPattern: { baseUri, pattern: my_pattern },
                     kind: WatchKind.Create | WatchKind.Change
@@ -233,18 +248,22 @@ export async function create_server(options: ServerOptions): Promise<void> {
             .has_watched_files_dynamic_registration_capability) {
             return;
         }
-        project_config_watch_registration?.dispose();
+        const previous_registration = project_config_watch_registration;
         const watchers = project_config_watchers_for_dirs(
             project_config_watch_dirs()
         );
+        // Register the new watcher BEFORE disposing the old one so there is no
+        // window during which a config change goes unobserved. A brief overlap
+        // is harmless: duplicate events are coalesced by the reload serializer.
         if (watchers.length === 0) {
             project_config_watch_registration = undefined;
-            return;
+        } else {
+            project_config_watch_registration = await connection.client.register(
+                DidChangeWatchedFilesNotification.type,
+                { watchers }
+            );
         }
-        project_config_watch_registration = await connection.client.register(
-            DidChangeWatchedFilesNotification.type,
-            { watchers }
-        );
+        previous_registration?.dispose();
     }
 
     // initializationOptions arrive in the public (README) camelCase schema —
@@ -255,6 +274,32 @@ export async function create_server(options: ServerOptions): Promise<void> {
     function map_init_options(raw: unknown): DeepPartial<StataLSPConfig> {
         return map_public_config_to_partial_config(raw, (warning) => {
             connection.console.log(`Configuration warning: ${warning.message}`);
+        });
+    }
+
+    // Build merged settings for clients WITHOUT `workspace/configuration`
+    // capability. They cannot be queried per-document, so we fold the static
+    // inputs ourselves: mapped initializationOptions, then the latest pushed
+    // client settings, then project (sight.toml) config (which wins). Without
+    // this, init options and sight.toml are silently ignored until (and unless)
+    // the client happens to send a didChangeConfiguration notification.
+    function build_non_capability_settings(): StataLSPConfig {
+        const init_record = (init_options_config && typeof init_options_config === 'object'
+            ? (init_options_config as Record<string, unknown>)
+            : undefined);
+        const init_partial = map_init_options(
+            init_record?.['sight'] ?? init_options_config
+        );
+        const client_partial = deep_merge_config(
+            init_partial,
+            last_client_settings || {}
+        );
+        const merged_partial = deep_merge_config(
+            client_partial,
+            project_file_config || {}
+        );
+        return validate_comment_formatting_config(merged_partial, (msg) => {
+            connection.console.log(`Configuration warning: ${msg}`);
         });
     }
 
@@ -640,6 +685,25 @@ export async function create_server(options: ServerOptions): Promise<void> {
         return b.every((value) => set_a.has(value));
     }
 
+    // The project-config keys that change WHICH files are indexed (and thus
+    // require a full index teardown + re-scan). Everything else — severities,
+    // formatting, completion, resolution depths, debug — only affects how open
+    // documents are validated/resolved, which a revalidation pass handles
+    // without re-scanning the workspace. Client/init settings are constant
+    // across a config-file reload, so comparing this subset of project_file_config
+    // is sufficient to detect an effective indexing change.
+    function indexing_affecting_signature(
+        config: DeepPartial<StataLSPConfig> | undefined
+    ): string {
+        return JSON.stringify({
+            adoPaths: config?.adoPaths ?? null,
+            indexWorkspace: config?.indexWorkspace ?? null,
+            index_workspace: config?.cross_file?.index_workspace ?? null,
+            max_indexed_files: config?.cross_file?.max_indexed_files ?? null,
+            maxFileSizeBytes: config?.indexing?.maxFileSizeBytes ?? null,
+        });
+    }
+
     async function reload_project_config_once(): Promise<void> {
         const active_root = active_workspace_roots[0];
         if (!active_root) {
@@ -647,6 +711,8 @@ export async function create_server(options: ServerOptions): Promise<void> {
         }
 
         const previous_config_json = JSON.stringify(project_file_config ?? null);
+        const previous_indexing_signature =
+            indexing_affecting_signature(project_file_config);
         const previous_watch_dirs = project_config_watch_dirs();
 
         apply_loaded_project_config(
@@ -665,14 +731,29 @@ export async function create_server(options: ServerOptions): Promise<void> {
             return;
         }
 
+        const indexing_changed =
+            indexing_affecting_signature(project_file_config) !==
+            previous_indexing_signature;
+
         document_settings.clear();
 
-        const settings = await get_document_settings('');
         if (!server_capabilities.has_configuration_capability) {
-            global_settings = settings;
+            global_settings = build_non_capability_settings();
         }
+        const settings = await get_document_settings('');
 
-        configure_workspace_indexing(settings, active_workspace_roots, true);
+        if (indexing_changed) {
+            configure_workspace_indexing(settings, active_workspace_roots, true);
+        } else {
+            // Only non-indexing config changed (severities, formatting,
+            // resolution depths, ...): keep the workspace index intact and just
+            // reconfigure providers and re-validate open documents so the new
+            // settings take effect, instead of tearing down and re-scanning the
+            // whole workspace for a cosmetic edit.
+            configure_completion_provider(settings);
+            workspace_indexer?.configure(settings);
+            revalidate_all_open_docs();
+        }
     }
 
     // Serialize reloads: a DidChangeWatchedFiles batch can deliver several
@@ -743,11 +824,13 @@ export async function create_server(options: ServerOptions): Promise<void> {
         await refresh_project_config_watchers();
 
         // --- Load settings and configure indexer ---
-        const settings = await get_document_settings('');
-
+        // Non-capability clients can't be queried per-document, so build their
+        // merged global_settings from init options + project config here rather
+        // than reading back the (stale) cached value via get_document_settings.
         if (!server_capabilities.has_configuration_capability) {
-            global_settings = settings;
+            global_settings = build_non_capability_settings();
         }
+        const settings = await get_document_settings('');
 
         // --- Scan workspace or mark complete ---
         configure_workspace_indexing(settings, folder_paths, false);
@@ -1183,27 +1266,9 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 );
             });
         } else {
-            const init_record = (init_options_config && typeof init_options_config === 'object'
-                ? (init_options_config as Record<string, unknown>)
-                : undefined);
-            const init_partial = map_init_options(
-                init_record?.['sight'] ?? init_options_config
-            );
             const change_settings = change.settings as Record<string, unknown> | undefined;
-            const client_partial = deep_merge_config(
-                init_partial,
-                change_settings?.['sight'] || {}
-            );
-            const merged_partial = deep_merge_config(
-                client_partial,
-                project_file_config || {}
-            );
-            global_settings = validate_comment_formatting_config(
-                merged_partial,
-                (msg) => {
-                    connection.console.log(`Configuration warning: ${msg}`);
-                }
-            );
+            last_client_settings = change_settings?.['sight'];
+            global_settings = build_non_capability_settings();
             configure_completion_provider(global_settings);
         }
 

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -156,6 +156,27 @@ export function build_non_capability_settings_from_sources(
 }
 
 /**
+ * Resolve effective settings for a single document scope from the live
+ * `workspace/configuration` (getConfiguration) result.
+ *
+ * The live result is the client layer: it is unwrapped (so a client that
+ * still wraps a `section: 'sight'` response as `{ sight: {...} }` is handled,
+ * a no-op for the spec-conformant bare subtree) and then mapped + merged with
+ * init options and project config via the shared builder. Extracted from the
+ * get_document_settings closure so the unwrap + public->internal mapping +
+ * precedence are behaviorally testable without a live server connection.
+ */
+export function resolve_scoped_client_settings(
+    live_config: unknown,
+    sources: Omit<NonCapabilitySettingsSources, 'last_client_settings'>
+): StataLSPConfig {
+    return build_non_capability_settings_from_sources({
+        ...sources,
+        last_client_settings: select_pushed_client_settings(live_config),
+    });
+}
+
+/**
  * Create and start the LSP server with the specified options.
  */
 export async function create_server(options: ServerOptions): Promise<void> {
@@ -355,22 +376,13 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 section: 'sight',
             }).then((config) => {
                 // The getConfiguration result is the live, per-scope `sight`
-                // tree in the public camelCase schema. Route it through the
-                // shared merge/validate pipeline as the client layer so this
-                // path and the global build_non_capability_settings stay in
+                // tree in the public camelCase schema. resolve_scoped_client_
+                // settings unwraps it and routes it through the shared
+                // merge/validate pipeline as the client layer, so this path
+                // and the global build_non_capability_settings stay in
                 // lockstep (precedence: init -> client -> project_file).
-                //
-                // select_pushed_client_settings is a defensive unwrap: a
-                // spec-conformant client answers a `section: 'sight'` query
-                // with the bare subtree (no `sight` wrapper), so it is a
-                // no-op there; for a client that still wraps the response as
-                // `{ sight: {...} }` it recovers the real tree. No `sight.*`
-                // config key exists, so the unwrap can never strip a real
-                // setting.
-                return build_non_capability_settings_from_sources({
+                return resolve_scoped_client_settings(config, {
                     init_options_config,
-                    last_client_settings:
-                        select_pushed_client_settings(config),
                     project_file_config,
                     log_warning: log_config_warning,
                 });

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -159,12 +159,13 @@ export function build_non_capability_settings_from_sources(
  * Resolve effective settings for a single document scope from the live
  * `workspace/configuration` (getConfiguration) result.
  *
- * The live result is the client layer: it is unwrapped (so a client that
- * still wraps a `section: 'sight'` response as `{ sight: {...} }` is handled,
- * a no-op for the spec-conformant bare subtree) and then mapped + merged with
- * init options and project config via the shared builder. Extracted from the
- * get_document_settings closure so the unwrap + public->internal mapping +
- * precedence are behaviorally testable without a live server connection.
+ * The live result is the client layer: it is unwrapped (so a client
+ * that still wraps a `section: 'sight'` response as `{ sight: {...} }`
+ * is handled — a no-op for the spec-conformant bare subtree) and then
+ * mapped + merged with init options and project config via the shared
+ * builder. Extracted from the get_document_settings closure so the
+ * unwrap + public->internal mapping + precedence are behaviorally
+ * testable without a live server connection.
  */
 export function resolve_scoped_client_settings(
     live_config: unknown,
@@ -375,31 +376,24 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 scopeUri: scope_uri,
                 section: 'sight',
             }).then((config) => {
-                // The getConfiguration result is the live, per-scope `sight`
-                // tree in the public camelCase schema. resolve_scoped_client_
-                // settings unwraps it and routes it through the shared
-                // merge/validate pipeline as the client layer, so this path
-                // and the global build_non_capability_settings stay in
-                // lockstep (precedence: init -> client -> project_file).
+                // Live per-scope `sight` tree (public camelCase);
+                // resolve_scoped_client_settings unwraps + maps it
+                // as the client layer (init -> client -> project).
                 return resolve_scoped_client_settings(config, {
                     init_options_config,
                     project_file_config,
                     log_warning: log_config_warning,
                 });
             }).catch((error) => {
-                // getConfiguration rejected (or the mapper threw). Resolve to
-                // the init + project merge so sight.toml / initializationOptions
-                // still apply (bare global_settings stays at DEFAULT_SETTINGS
-                // for configuration-capable clients). This resolved value — not
-                // a rejection — is what stays cached, so a persistently-failing
-                // client is not re-queried on every request (no retry storm or
-                // log spam); the entry is refreshed on the next
-                // didChangeConfiguration, which clears document_settings.
-                //
-                // The live per-scope client overrides are necessarily absent
-                // here: the fetch that would have supplied them is what failed.
+                // On failure, cache the init+project fallback
+                // (resolved value, not a rejection) so a failing
+                // client isn't re-queried each request; refreshed
+                // on the next didChangeConfiguration clear. Live
+                // per-scope overrides can't apply — their fetch
+                // is what failed.
                 log_config_warning(
-                    `Failed to resolve settings for ${resource}: ${error}`
+                    `Failed to resolve settings for ${resource}: `
+                    + (error instanceof Error ? error.message : String(error))
                 );
                 return build_non_capability_settings();
             });

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -359,9 +359,13 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 // shared merge/validate pipeline as the client layer so this
                 // path and the global build_non_capability_settings stay in
                 // lockstep (precedence: init → client → project_file).
+                // select_pushed_client_settings keeps this symmetric with the
+                // push path: a no-op for spec-compliant clients (section
+                // 'sight' already returns the bare tree), but it unwraps a
+                // `{ sight: {...} }` response from clients that send one.
                 return build_non_capability_settings_from_sources({
                     init_options_config,
-                    last_client_settings: config,
+                    last_client_settings: select_pushed_client_settings(config),
                     project_file_config,
                     log_warning: log_config_warning,
                 });

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -387,21 +387,20 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     log_warning: log_config_warning,
                 });
             }).catch((error) => {
-                // A transient getConfiguration rejection (or a throw while
-                // mapping the result) must not be cached as a poisoned
-                // promise. Drop only OUR entry (identity guard) so a config
-                // change that already replaced it via document_settings.clear()
-                // is not clobbered; the next request then retries. Fall back
-                // to the init + project merge (the live per-scope layer is
-                // what just failed) so sight.toml / initializationOptions
-                // still apply, rather than bare global_settings, which stays
-                // at DEFAULT_SETTINGS for configuration-capable clients.
+                // getConfiguration rejected (or the mapper threw). Resolve to
+                // the init + project merge so sight.toml / initializationOptions
+                // still apply (bare global_settings stays at DEFAULT_SETTINGS
+                // for configuration-capable clients). This resolved value — not
+                // a rejection — is what stays cached, so a persistently-failing
+                // client is not re-queried on every request (no retry storm or
+                // log spam); the entry is refreshed on the next
+                // didChangeConfiguration, which clears document_settings.
+                //
+                // The live per-scope client overrides are necessarily absent
+                // here: the fetch that would have supplied them is what failed.
                 log_config_warning(
                     `Failed to resolve settings for ${resource}: ${error}`
                 );
-                if (document_settings.get(resource) === result) {
-                    document_settings.delete(resource);
-                }
                 return build_non_capability_settings();
             });
             document_settings.set(resource, result);

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -354,33 +354,43 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 scopeUri: scope_uri,
                 section: 'sight',
             }).then((config) => {
-                // The getConfiguration result is the live, per-scope
-                // `sight` tree in the public camelCase schema. Route it
-                // through the shared merge/validate pipeline as the client
-                // layer so this path and the global
-                // build_non_capability_settings stay in lockstep
-                // (precedence: init -> client -> project_file).
+                // The getConfiguration result is the live, per-scope `sight`
+                // tree in the public camelCase schema. Route it through the
+                // shared merge/validate pipeline as the client layer so this
+                // path and the global build_non_capability_settings stay in
+                // lockstep (precedence: init -> client -> project_file).
                 //
-                // Unlike the push path (didChangeConfiguration), the result
-                // needs no `.sight` unwrap: the `section: 'sight'` query
-                // already returns the bare config subtree per the LSP spec.
+                // select_pushed_client_settings is a defensive unwrap: a
+                // spec-conformant client answers a `section: 'sight'` query
+                // with the bare subtree (no `sight` wrapper), so it is a
+                // no-op there; for a client that still wraps the response as
+                // `{ sight: {...} }` it recovers the real tree. No `sight.*`
+                // config key exists, so the unwrap can never strip a real
+                // setting.
                 return build_non_capability_settings_from_sources({
                     init_options_config,
-                    last_client_settings: config,
+                    last_client_settings:
+                        select_pushed_client_settings(config),
                     project_file_config,
                     log_warning: log_config_warning,
                 });
             }).catch((error) => {
                 // A transient getConfiguration rejection (or a throw while
                 // mapping the result) must not be cached as a poisoned
-                // promise: drop the entry so the next request retries, and
-                // fall back to global_settings meanwhile instead of failing
-                // every later completion/diagnostic for this document.
+                // promise. Drop only OUR entry (identity guard) so a config
+                // change that already replaced it via document_settings.clear()
+                // is not clobbered; the next request then retries. Fall back
+                // to the init + project merge (the live per-scope layer is
+                // what just failed) so sight.toml / initializationOptions
+                // still apply, rather than bare global_settings, which stays
+                // at DEFAULT_SETTINGS for configuration-capable clients.
                 log_config_warning(
                     `Failed to resolve settings for ${resource}: ${error}`
                 );
-                document_settings.delete(resource);
-                return global_settings;
+                if (document_settings.get(resource) === result) {
+                    document_settings.delete(resource);
+                }
+                return build_non_capability_settings();
             });
             document_settings.set(resource, result);
         }

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -103,6 +103,58 @@ function create_transport_connection(transport: TransportType): Connection {
     }
 }
 
+export interface NonCapabilitySettingsSources {
+    init_options_config?: unknown;
+    last_client_settings?: unknown;
+    project_file_config?: DeepPartial<StataLSPConfig>;
+    log_warning?: (message: string) => void;
+}
+
+function map_public_settings(
+    raw: unknown,
+    log_warning?: (message: string) => void
+): DeepPartial<StataLSPConfig> {
+    return map_public_config_to_partial_config(raw, (warning) => {
+        log_warning?.(warning.message);
+    });
+}
+
+export function select_pushed_client_settings(settings: unknown): unknown {
+    const change_settings = settings && typeof settings === 'object'
+        ? settings as Record<string, unknown>
+        : undefined;
+    return change_settings?.['sight'] ?? settings;
+}
+
+export function build_non_capability_settings_from_sources(
+    sources: NonCapabilitySettingsSources
+): StataLSPConfig {
+    const init_options_config = sources.init_options_config;
+    const init_record = (init_options_config
+        && typeof init_options_config === 'object'
+        ? (init_options_config as Record<string, unknown>)
+        : undefined);
+    const init_partial = map_public_settings(
+        init_record?.['sight'] ?? init_options_config,
+        sources.log_warning
+    );
+    const client_partial = deep_merge_config(
+        init_partial,
+        map_public_settings(
+            sources.last_client_settings,
+            sources.log_warning
+        )
+    );
+    const merged_partial = deep_merge_config(
+        client_partial,
+        sources.project_file_config || {}
+    );
+    return validate_comment_formatting_config(
+        merged_partial,
+        sources.log_warning
+    );
+}
+
 /**
  * Create and start the LSP server with the specified options.
  */
@@ -176,6 +228,10 @@ export async function create_server(options: ServerOptions): Promise<void> {
     // Root URI from initialize params (fallback for clients without
     // workspaceFolders support, e.g., Claude Code, Neovim single-file)
     let init_root_uri: string | null = null;
+
+    const log_config_warning = (message: string): void => {
+        connection.console.log(`Configuration warning: ${message}`);
+    };
 
     function log_project_config_warnings(loaded: LoadedProjectConfig): void {
         for (const my_warning of loaded.warnings) {
@@ -266,22 +322,6 @@ export async function create_server(options: ServerOptions): Promise<void> {
         previous_registration?.dispose();
     }
 
-    // Public settings arrive in the README camelCase schema — the same shape
-    // sight.toml uses — from every client entry point: initializationOptions,
-    // workspace/configuration (getConfiguration) results, and pushed
-    // didChangeConfiguration settings. Map them into the internal config shape
-    // the validator reads (crossFile -> cross_file, preserveAlignment ->
-    // preserve_alignment, ...). The mapper normalizes keys on `_` and case, so
-    // each public setting is accepted in either camelCase or snake_case;
-    // without this mapping those settings are silently dropped for clients
-    // (Neovim/Helix/Zed/Claude Code/VS Code) that send camelCase keys the
-    // hybrid internal shape does not match verbatim.
-    function map_public_settings(raw: unknown): DeepPartial<StataLSPConfig> {
-        return map_public_config_to_partial_config(raw, (warning) => {
-            connection.console.log(`Configuration warning: ${warning.message}`);
-        });
-    }
-
     // Build merged settings for clients WITHOUT `workspace/configuration`
     // capability. They cannot be queried per-document, so we fold the static
     // inputs ourselves: mapped initializationOptions, then the latest pushed
@@ -289,24 +329,11 @@ export async function create_server(options: ServerOptions): Promise<void> {
     // this, init options and sight.toml are silently ignored until (and unless)
     // the client happens to send a didChangeConfiguration notification.
     function build_non_capability_settings(): StataLSPConfig {
-        const init_record = (init_options_config && typeof init_options_config === 'object'
-            ? (init_options_config as Record<string, unknown>)
-            : undefined);
-        const init_partial = map_public_settings(
-            init_record?.['sight'] ?? init_options_config
-        );
-        // Pushed client settings also arrive in the public camelCase shape, so
-        // map them too before merging into the internal partial.
-        const client_partial = deep_merge_config(
-            init_partial,
-            map_public_settings(last_client_settings)
-        );
-        const merged_partial = deep_merge_config(
-            client_partial,
-            project_file_config || {}
-        );
-        return validate_comment_formatting_config(merged_partial, (msg) => {
-            connection.console.log(`Configuration warning: ${msg}`);
+        return build_non_capability_settings_from_sources({
+            init_options_config,
+            last_client_settings,
+            project_file_config,
+            log_warning: log_config_warning,
         });
     }
 
@@ -331,7 +358,8 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     ? (init_options_config as Record<string, unknown>)
                     : undefined);
                 const init_partial = map_public_settings(
-                    init_record?.['sight'] ?? init_options_config
+                    init_record?.['sight'] ?? init_options_config,
+                    log_config_warning
                 );
                 // The getConfiguration result is the live `sight` tree in the
                 // public camelCase schema. Map it (not merge it raw) so its
@@ -340,7 +368,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 // dropped, e.g., crossFile.* and formatting.preserveAlignment.
                 const client_partial = deep_merge_config(
                     init_partial,
-                    map_public_settings(config)
+                    map_public_settings(config, log_config_warning)
                 );
                 const merged_partial = deep_merge_config(
                     client_partial,
@@ -348,7 +376,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 );
 
                 return validate_comment_formatting_config(merged_partial, (msg) => {
-                    connection.console.log(`Configuration warning: ${msg}`);
+                    log_config_warning(msg);
                 });
             });
             document_settings.set(resource, result);
@@ -1293,8 +1321,9 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 );
             });
         } else {
-            const change_settings = change.settings as Record<string, unknown> | undefined;
-            last_client_settings = change_settings?.['sight'];
+            last_client_settings = select_pushed_client_settings(
+                change.settings
+            );
             global_settings = build_non_capability_settings();
             configure_completion_provider(global_settings);
         }

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -237,6 +237,10 @@ export async function create_server(options: ServerOptions): Promise<void> {
     // Configuration settings
     let global_settings: StataLSPConfig = DEFAULT_SETTINGS;
     const document_settings: Map<string, Thenable<StataLSPConfig>> = new Map();
+    // Per-resource throttle for getConfiguration failure warnings: warn
+    // once per resource until it resolves successfully again, so a
+    // persistently-failing client does not log once per request.
+    const settings_failures_logged = new Set<string>();
 
     // Shared project config loaded from sight.toml.
     let project_file_config: DeepPartial<StataLSPConfig> | undefined = undefined;
@@ -385,23 +389,31 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 // Live per-scope `sight` tree (public camelCase);
                 // resolve_scoped_client_settings unwraps + maps it
                 // as the client layer (init -> client -> project).
+                settings_failures_logged.delete(resource);
                 return resolve_scoped_client_settings(config, {
                     init_options_config,
                     project_file_config,
                     log_warning: log_config_warning,
                 });
             }).catch((error) => {
-                // On failure, cache the global merged fallback
-                // (build_non_capability_settings: init + pushed
-                // client + project) as a resolved value, not a
-                // rejection, so a failing client isn't re-queried
-                // each request; refreshed on the next
-                // didChangeConfiguration clear. The live per-scope
-                // result can't apply — its fetch is what failed.
-                log_config_warning(
-                    `Failed to resolve settings for ${resource}: `
-                    + (error instanceof Error ? error.message : String(error))
-                );
+                // The live per-scope fetch failed. Drop our entry
+                // (identity-guarded) so the next request retries and
+                // per-scope overrides apply once the client recovers,
+                // instead of caching a stale fallback. Serve the global
+                // merged fallback meanwhile, and warn once per resource
+                // until it recovers (no per-request log spam).
+                if (!settings_failures_logged.has(resource)) {
+                    settings_failures_logged.add(resource);
+                    log_config_warning(
+                        'Failed to resolve settings for '
+                        + `${scope_uri ?? '(workspace root)'}: `
+                        + (error instanceof Error
+                            ? error.message : String(error))
+                    );
+                }
+                if (document_settings.get(resource) === result) {
+                    document_settings.delete(resource);
+                }
                 return build_non_capability_settings();
             });
             document_settings.set(resource, result);

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -36,7 +36,7 @@ import {
     type LoadedProjectConfig,
 } from './config-file';
 import { WorkspaceIndexer } from './indexer';
-import { ScopeResolver } from './scope-resolver';
+import { ScopeResolver, scope_resolver_config_for } from './scope-resolver';
 import { ForwardScopeResolver } from './forward-scope-resolver';
 import { DocumentDebounceManager } from './utils/debounce-manager';
 import { validate_comment_formatting_config } from './utils/config-validator';
@@ -933,6 +933,8 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 // delaying the debounce timer start (Req 8.2, 8.3, 8.4)
                 const settings = await get_document_settings(snapshot_uri);
                 const is_debug = settings.debug === true;
+                const my_scope_resolver_config =
+                    scope_resolver_config_for(settings);
 
                 // --- Lex/parse/analyze inside debounce callback (Req 2.1, 2.2) ---
                 const workspace_symbols = workspace_indexer
@@ -944,14 +946,16 @@ export async function create_server(options: ServerOptions): Promise<void> {
                         snapshot_uri,
                         [{ text: snapshot_content }],
                         snapshot_version,
-                        workspace_symbols
+                        workspace_symbols,
+                        my_scope_resolver_config
                     );
                 } else {
                     await document_store.open(
                         snapshot_uri,
                         snapshot_content,
                         snapshot_version,
-                        workspace_symbols
+                        workspace_symbols,
+                        my_scope_resolver_config
                     );
                 }
 

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -820,6 +820,18 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 forward_scope_resolver.set_workspace_roots(folder_paths);
             }
 
+            // Single-root project config: sight.toml is discovered from the
+            // first workspace folder and applied to every document. Multi-root
+            // workspaces with a distinct sight.toml per root are not resolved
+            // per-root; warn once so the behavior is not silently surprising.
+            if (folder_paths.length > 1) {
+                connection.console.log(
+                    'Sight: multiple workspace folders detected; project ' +
+                    `config is loaded only from the first folder ` +
+                    `(${folder_paths[0]}). A sight.toml in another folder is ` +
+                    'not applied to its own documents.'
+                );
+            }
             apply_loaded_project_config(
                 discover_and_load_project_config(folder_paths[0])
             );

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -370,6 +370,17 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     project_file_config,
                     log_warning: log_config_warning,
                 });
+            }).catch((error) => {
+                // A transient getConfiguration rejection (or a throw while
+                // mapping the result) must not be cached as a poisoned
+                // promise: drop the entry so the next request retries, and
+                // fall back to global_settings meanwhile instead of failing
+                // every later completion/diagnostic for this document.
+                log_config_warning(
+                    `Failed to resolve settings for ${resource}: ${error}`
+                );
+                document_settings.delete(resource);
+                return global_settings;
             });
             document_settings.set(resource, result);
         }

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -237,10 +237,6 @@ export async function create_server(options: ServerOptions): Promise<void> {
     // Configuration settings
     let global_settings: StataLSPConfig = DEFAULT_SETTINGS;
     const document_settings: Map<string, Thenable<StataLSPConfig>> = new Map();
-    // Per-resource throttle for getConfiguration failure warnings: warn
-    // once per resource until it resolves successfully again, so a
-    // persistently-failing client does not log once per request.
-    const settings_failures_logged = new Set<string>();
 
     // Shared project config loaded from sight.toml.
     let project_file_config: DeepPartial<StataLSPConfig> | undefined = undefined;
@@ -389,31 +385,26 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 // Live per-scope `sight` tree (public camelCase);
                 // resolve_scoped_client_settings unwraps + maps it
                 // as the client layer (init -> client -> project).
-                settings_failures_logged.delete(resource);
                 return resolve_scoped_client_settings(config, {
                     init_options_config,
                     project_file_config,
                     log_warning: log_config_warning,
                 });
             }).catch((error) => {
-                // The live per-scope fetch failed. Drop our entry
-                // (identity-guarded) so the next request retries and
-                // per-scope overrides apply once the client recovers,
-                // instead of caching a stale fallback. Serve the global
-                // merged fallback meanwhile, and warn once per resource
-                // until it recovers (no per-request log spam).
-                if (!settings_failures_logged.has(resource)) {
-                    settings_failures_logged.add(resource);
-                    log_config_warning(
-                        'Failed to resolve settings for '
-                        + `${scope_uri ?? '(workspace root)'}: `
-                        + (error instanceof Error
-                            ? error.message : String(error))
-                    );
-                }
-                if (document_settings.get(resource) === result) {
-                    document_settings.delete(resource);
-                }
+                // Defensive fallback for the rare case where the
+                // per-scope getConfiguration rejects (or the mapper
+                // throws): resolve to — and cache — the global merged
+                // fallback, a resolved value (not a rejection), so the
+                // document isn't poisoned and isn't re-queried per
+                // request. Live per-scope overrides can't apply (their
+                // fetch failed); restored on the next
+                // didChangeConfiguration clear.
+                log_config_warning(
+                    'Failed to resolve settings for '
+                    + `${scope_uri ?? '(workspace root)'}: `
+                    + (error instanceof Error
+                        ? error.message : String(error))
+                );
                 return build_non_capability_settings();
             });
             document_settings.set(resource, result);

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -136,13 +136,12 @@ export function select_pushed_client_settings(settings: unknown): unknown {
 export function build_non_capability_settings_from_sources(
     sources: NonCapabilitySettingsSources
 ): StataLSPConfig {
-    const init_options_config = sources.init_options_config;
-    const init_record = (init_options_config
-        && typeof init_options_config === 'object'
-        ? (init_options_config as Record<string, unknown>)
-        : undefined);
+    // Unwrap a `{ sight: {...} }` wrapper from raw init options via the
+    // same helper the client layer's callers use, so the
+    // `{ sight: undefined }` edge has one implementation rather than a
+    // divergent inline `?? init_options_config`.
     const init_partial = map_public_settings(
-        init_record?.['sight'] ?? init_options_config,
+        select_pushed_client_settings(sources.init_options_config),
         sources.log_warning
     );
     const client_partial = deep_merge_config(

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -266,12 +266,17 @@ export async function create_server(options: ServerOptions): Promise<void> {
         previous_registration?.dispose();
     }
 
-    // initializationOptions arrive in the public (README) camelCase schema —
-    // the same shape sight.toml uses. Map them into the internal config shape
+    // Public settings arrive in the README camelCase schema — the same shape
+    // sight.toml uses — from every client entry point: initializationOptions,
+    // workspace/configuration (getConfiguration) results, and pushed
+    // didChangeConfiguration settings. Map them into the internal config shape
     // the validator reads (crossFile -> cross_file, preserveAlignment ->
-    // preserve_alignment, ...); otherwise those settings are silently dropped
-    // for clients (Neovim/Helix/Zed/Claude Code) that configure this way.
-    function map_init_options(raw: unknown): DeepPartial<StataLSPConfig> {
+    // preserve_alignment, ...). The mapper normalizes keys on `_` and case, so
+    // each public setting is accepted in either camelCase or snake_case;
+    // without this mapping those settings are silently dropped for clients
+    // (Neovim/Helix/Zed/Claude Code/VS Code) that send camelCase keys the
+    // hybrid internal shape does not match verbatim.
+    function map_public_settings(raw: unknown): DeepPartial<StataLSPConfig> {
         return map_public_config_to_partial_config(raw, (warning) => {
             connection.console.log(`Configuration warning: ${warning.message}`);
         });
@@ -287,12 +292,14 @@ export async function create_server(options: ServerOptions): Promise<void> {
         const init_record = (init_options_config && typeof init_options_config === 'object'
             ? (init_options_config as Record<string, unknown>)
             : undefined);
-        const init_partial = map_init_options(
+        const init_partial = map_public_settings(
             init_record?.['sight'] ?? init_options_config
         );
+        // Pushed client settings also arrive in the public camelCase shape, so
+        // map them too before merging into the internal partial.
         const client_partial = deep_merge_config(
             init_partial,
-            last_client_settings || {}
+            map_public_settings(last_client_settings)
         );
         const merged_partial = deep_merge_config(
             client_partial,
@@ -323,10 +330,18 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 const init_record = (init_options_config && typeof init_options_config === 'object'
                     ? (init_options_config as Record<string, unknown>)
                     : undefined);
-                const init_partial = map_init_options(
+                const init_partial = map_public_settings(
                     init_record?.['sight'] ?? init_options_config
                 );
-                const client_partial = deep_merge_config(init_partial || {}, config || {});
+                // The getConfiguration result is the live `sight` tree in the
+                // public camelCase schema. Map it (not merge it raw) so its
+                // settings reach the internal hybrid shape regardless of
+                // camelCase/snake_case spelling — the raw merge silently
+                // dropped, e.g., crossFile.* and formatting.preserveAlignment.
+                const client_partial = deep_merge_config(
+                    init_partial,
+                    map_public_settings(config)
+                );
                 const merged_partial = deep_merge_config(
                     client_partial,
                     project_file_config || {}

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -42,7 +42,7 @@ import { CodeFormatter } from './providers/formatter';
 import { WorkspaceIndexer } from './indexer';
 import { StataLSPConfig } from './types';
 import { ContextTracker } from './context-tracker';
-import { ScopeResolver } from './scope-resolver';
+import { ScopeResolver, scope_resolver_config_for } from './scope-resolver';
 import { ForwardScopeResolver } from './forward-scope-resolver';
 import { DependencyGraph } from './dependency-graph';
 import { RenameHandler } from './utils/file-rename-handler';
@@ -341,11 +341,7 @@ export function create_completion_handler(
                 trigger_character,
                 deps.scope_resolver || undefined,
                 workspace_symbols,
-                {
-                    assume_call_site: config.cross_file?.assume_call_site,
-                    backward_dependencies: config.cross_file?.backward_dependencies,
-                    max_forward_depth: config.cross_file?.max_forward_depth,
-                },
+                scope_resolver_config_for(config),
                 workspace_version,
                 token,
                 graph_version
@@ -414,11 +410,7 @@ export function create_hover_handler(
             params.position,
             workspace_symbols,
             deps.scope_resolver || undefined,
-            {
-                assume_call_site: config.cross_file?.assume_call_site,
-                backward_dependencies: config.cross_file?.backward_dependencies,
-                max_forward_depth: config.cross_file?.max_forward_depth,
-            },
+            scope_resolver_config_for(config),
             token,
             workspace_root,
             deps.workspace_indexer || undefined,
@@ -455,11 +447,7 @@ export function create_definition_handler(
             document_state.context_tracker,
             deps.scope_resolver || undefined,
             deps.workspace_indexer || undefined,
-            {
-                assume_call_site: config.cross_file?.assume_call_site,
-                backward_dependencies: config.cross_file?.backward_dependencies,
-                max_forward_depth: config.cross_file?.max_forward_depth,
-            },
+            scope_resolver_config_for(config),
             token
         );
     };
@@ -491,11 +479,7 @@ export function create_references_handler(
             deps.workspace_indexer || undefined,
             document_state.context_tracker,
             token,
-            {
-                assume_call_site: config.cross_file?.assume_call_site,
-                backward_dependencies: config.cross_file?.backward_dependencies,
-                max_forward_depth: config.cross_file?.max_forward_depth,
-            }
+            scope_resolver_config_for(config)
         );
     };
 }

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -6,6 +6,7 @@
  */
 
 import { StataLSPConfig } from '../types';
+import type { DeepPartial } from '../config-file/types';
 import { DEFAULT_SETTINGS } from '../server-handlers';
 
 type CrossFileSeverityLevel = 'error' | 'warning' | 'information' | 'off';
@@ -18,7 +19,7 @@ type CrossFileSeverityLevel = 'error' | 'warning' | 'information' | 'off';
  * @returns A fully populated StataLSPConfig with validated values and defaults applied where necessary
  */
 export function validate_comment_formatting_config(
-    config: Partial<StataLSPConfig> | undefined,
+    config: DeepPartial<StataLSPConfig> | undefined,
     log_warning?: (message: string) => void
 ): StataLSPConfig {
     // Start with defaults

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -242,6 +242,10 @@ export function validate_comment_formatting_config(
         validated_config.indexWorkspace = config.indexWorkspace;
     }
 
+    if (typeof config.debug === 'boolean') {
+        validated_config.debug = config.debug;
+    }
+
     // Validate cross_file section
     if (config.cross_file) {
         const cross_file = config.cross_file;

--- a/src/utils/error-message.ts
+++ b/src/utils/error-message.ts
@@ -1,0 +1,9 @@
+/**
+ * Normalize an unknown thrown value to a human-readable message string.
+ *
+ * Prefer the Error's own message; fall back to String() for non-Error
+ * rejections (objects, strings) so logs never read '[object Object]'.
+ */
+export function error_message(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -50,7 +50,8 @@ export function isPathDirective(directive: string): boolean {
  * Check if a file has a Stata extension
  */
 export function hasStataExtension(filename: string): boolean {
-  return STATA_FILE_EXTENSIONS.some(ext => filename.toLowerCase().endsWith(ext));
+  const lower = filename.toLowerCase();
+  return STATA_FILE_EXTENSIONS.some(ext => lower.endsWith(ext));
 }
 
 /**

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -28,6 +28,10 @@ export const PATH_DIRECTIVES = new Set([
 // Stata file extensions for completion filtering
 export const STATA_FILE_EXTENSIONS = ['.do', '.ado', '.doh', '.mata'];
 
+// Version-control metadata directories skipped during workspace scans.
+// They contain no Stata source and recursing them is wasted work.
+export const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
+
 /**
  * Check if a command accepts file paths as its first argument
  */

--- a/tests/integration/cli-check-output.test.ts
+++ b/tests/integration/cli-check-output.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { run_check_with_cwd } from '../../src/cli/check';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-output-'));
+}
+
+async function run_capture(argv: string[], cwd: string) {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await run_check_with_cwd(argv, cwd, {
+        stdout: (text) => stdout.push(text),
+        stderr: (text) => stderr.push(text),
+    });
+    return { code, stdout: stdout.join(''), stderr: stderr.join('') };
+}
+
+describe('sight check machine output', () => {
+    it('emits parseable JSON records', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+
+        const result = await run_capture(['--workspace', root, '--format', 'json'], root);
+        const parsed = JSON.parse(result.stdout);
+
+        expect(parsed[0].path).toBe('main.do');
+        expect(parsed[0].diagnostic.source).toBe('sight');
+    });
+
+    it('emits SARIF 2.1.0 records', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+
+        const result = await run_capture(['--workspace', root, '--format', 'sarif'], root);
+        const parsed = JSON.parse(result.stdout);
+
+        expect(parsed.version).toBe('2.1.0');
+        expect(parsed.runs[0].tool.driver.name).toBe('sight');
+        expect(parsed.runs[0].results[0].ruleId).toMatch(/^SIGHT/);
+    });
+});

--- a/tests/integration/cli-check-spawn.test.ts
+++ b/tests/integration/cli-check-spawn.test.ts
@@ -40,4 +40,15 @@ describe('sight check spawned CLI', () => {
         expect(result.stdout).toContain('Undefined');
         expect(result.stdout).toContain('macro');
     });
+
+    it('returns exit 2 for an unknown flag (operator error)', () => {
+        const result = spawnSync(
+            'bun',
+            ['src/cli.ts', 'check', '--bogus'],
+            { cwd: repo_root, encoding: 'utf8' }
+        );
+
+        expect(result.status).toBe(2);
+        expect(result.stderr).toContain('Unknown flag: --bogus');
+    });
 });

--- a/tests/integration/cli-check-spawn.test.ts
+++ b/tests/integration/cli-check-spawn.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-spawn-'));
+}
+
+const repo_root = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../..'
+);
+
+describe('sight check spawned CLI', () => {
+    it('routes sight check --help through the top-level CLI', () => {
+        const result = spawnSync(
+            'bun',
+            ['src/cli.ts', 'check', '--help'],
+            { cwd: repo_root, encoding: 'utf8' }
+        );
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('sight check');
+        expect(result.stdout).toContain('--workspace DIR');
+    });
+
+    it('returns exit 1 for check diagnostics through the top-level CLI', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+        const result = spawnSync(
+            'bun',
+            ['src/cli.ts', 'check', '--workspace', root, '--quiet'],
+            { cwd: repo_root, encoding: 'utf8' }
+        );
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain('Undefined');
+        expect(result.stdout).toContain('macro');
+    });
+});

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -3,8 +3,12 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+    build_check_context,
+    collect_check_diagnostics,
+    load_check_config,
     run_check_with_cwd,
 } from '../../src/cli/check';
+import { collect_report_targets } from '../../src/cli/source-files';
 import {
     EXIT_CHECK_FAILED,
     EXIT_OK,
@@ -195,6 +199,60 @@ describe('sight check integration', () => {
         expect(result.stdout).toContain('unexpected closing brace');
         expect(result.stdout).not.toContain('maxIndexedFiles');
         expect(result.stdout).not.toContain('was not indexed');
+    });
+
+    it('reports a target removed after discovery as a per-file diagnostic, not a batch abort', async () => {
+        const root = fs.realpathSync.native(temp_dir());
+        const vanishing = path.join(root, 'vanishing.do');
+        fs.writeFileSync(vanishing, 'display 1\n');
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+
+        const config_result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: true,
+        });
+        expect(config_result.kind).toBe('loaded');
+        if (config_result.kind !== 'loaded') return;
+
+        const targets = collect_report_targets([], root, root);
+        const context = await build_check_context(root, config_result.config);
+        try {
+            // Simulate the race: the file existed at discovery (and indexing)
+            // but is gone by the time diagnostics are collected.
+            fs.unlinkSync(vanishing);
+
+            const records = await collect_check_diagnostics(
+                context,
+                root,
+                config_result.config,
+                targets.targets
+            );
+
+            // The vanished file is reported per-file; the batch still analyzes
+            // main.do rather than throwing and aborting everything.
+            expect(
+                records.some((r) => r.diagnostic.code === 'SIGHT_UNREADABLE')
+            ).toBe(true);
+            expect(records.some((r) => r.relative_path === 'main.do')).toBe(true);
+        } finally {
+            await context.document_store.dispose();
+        }
+    });
+
+    it('skips oversized directory-walked files instead of analyzing them', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[indexing]\nmaxFileSizeBytes = 4\n');
+        // Larger than the 4-byte limit; would otherwise be read+analyzed.
+        fs.writeFileSync(path.join(root, 'big.do'), "display \"`missing'\"\n");
+
+        const result = await run_capture(['--workspace', root], root);
+
+        // Walked (non-explicit) oversized files are skipped silently: no
+        // diagnostics, and no SIGHT_FILE_TOO_LARGE noise.
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.stdout).not.toContain('big.do');
+        expect(result.stdout).not.toContain('exceeds the configured limit');
     });
 
     it('reports invalid UTF-8 as an error diagnostic', async () => {

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -163,6 +163,22 @@ describe('sight check integration', () => {
         expect(result.stdout).toContain('maxIndexedFiles');
     });
 
+    it('reports explicit .mata files skipped by max indexed files', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[crossFile]\nmaxIndexedFiles = 1\n');
+        fs.writeFileSync(path.join(root, 'a.mata'), '// a\n');
+        fs.writeFileSync(path.join(root, 'b.mata'), '// b\n');
+
+        const result = await run_capture(
+            ['--workspace', root, 'a.mata', 'b.mata', '--quiet'],
+            root
+        );
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('was not indexed');
+        expect(result.stdout).toContain('maxIndexedFiles');
+    });
+
     it('reports invalid UTF-8 as an error diagnostic', async () => {
         const root = temp_dir();
         fs.writeFileSync(path.join(root, 'bad.do'), Buffer.from([0x64, 0x80]));

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    run_check_with_cwd,
+} from '../../src/cli/check';
+import {
+    EXIT_CHECK_FAILED,
+    EXIT_OK,
+    EXIT_OPERATOR_ERROR,
+} from '../../src/cli/shared';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-integration-'));
+}
+
+async function run_capture(argv: string[], cwd: string) {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await run_check_with_cwd(argv, cwd, {
+        stdout: (text) => stdout.push(text),
+        stderr: (text) => stderr.push(text),
+    });
+    return { code, stdout: stdout.join(''), stderr: stderr.join('') };
+}
+
+describe('sight check integration', () => {
+    it('reports same-file undefined macro diagnostics', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+
+        const result = await run_capture(['--workspace', root, '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('main.do:1:');
+        expect(result.stdout).toContain('Undefined');
+        expect(result.stdout).toContain('macro');
+    });
+
+    it('honors editor default undefinedVariable off', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), 'regress y x\n');
+
+        const result = await run_capture(['--workspace', root, '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.stdout).toBe('');
+    });
+
+    it('uses strict max severity gating', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(
+            path.join(root, 'sight.toml'),
+            '[diagnostics.severity]\nundefinedMacro = "information"\n'
+        );
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
+
+        const result = await run_capture(['--workspace', root, '--max-severity', 'info'], root);
+
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.stdout).toContain('info:');
+    });
+
+    it('indexes whole workspace while report paths filter output', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'parent.do'), 'global project_root /tmp\ndo child.do\n');
+        fs.writeFileSync(path.join(root, 'child.do'), 'display "$project_root"\n');
+
+        const result = await run_capture(['--workspace', root, 'child.do', '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.stdout).toBe('');
+    });
+
+    it('reports malformed config as operator error', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), 'bad = = toml\n');
+
+        const result = await run_capture(['--workspace', root], root);
+
+        expect(result.code).toBe(EXIT_OPERATOR_ERROR);
+        expect(result.stderr).toContain('failed to load');
+    });
+
+    it('reports missing explicit path as operator error', async () => {
+        const root = temp_dir();
+
+        const result = await run_capture(['--workspace', root, 'missing.do'], root);
+
+        expect(result.code).toBe(EXIT_OPERATOR_ERROR);
+        expect(result.stderr).toContain('path does not exist');
+    });
+
+    it('reports explicitly oversized source files as error diagnostics', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[indexing]\nmaxFileSizeBytes = 1\n');
+        fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
+
+        const result = await run_capture(['--workspace', root, 'main.do', '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('exceeds the configured limit');
+    });
+
+    it('reports explicit source files skipped by max indexed files', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[crossFile]\nmaxIndexedFiles = 1\n');
+        fs.writeFileSync(path.join(root, 'a.do'), 'display 1\n');
+        fs.writeFileSync(path.join(root, 'b.do'), 'display 2\n');
+
+        const result = await run_capture(
+            ['--workspace', root, 'a.do', 'b.do', '--quiet'],
+            root
+        );
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('was not indexed');
+        expect(result.stdout).toContain('maxIndexedFiles');
+    });
+
+    it('reports invalid UTF-8 as an error diagnostic', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'bad.do'), Buffer.from([0x64, 0x80]));
+
+        const result = await run_capture(['--workspace', root, 'bad.do', '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('not valid UTF-8');
+        expect(result.stdout).toContain('byte offset');
+    });
+});

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -2,18 +2,21 @@ import { describe, expect, it } from 'bun:test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { DiagnosticSeverity } from 'vscode-languageserver';
 import {
     build_check_context,
     collect_check_diagnostics,
     load_check_config,
     run_check_with_cwd,
 } from '../../src/cli/check';
+import type { CheckContext } from '../../src/cli/check';
 import { collect_report_targets } from '../../src/cli/source-files';
 import {
     EXIT_CHECK_FAILED,
     EXIT_OK,
     EXIT_OPERATOR_ERROR,
 } from '../../src/cli/shared';
+import { create_empty_symbol_table } from '../../src/analyzer';
 
 function temp_dir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-integration-'));
@@ -280,5 +283,112 @@ describe('sight check integration', () => {
         expect(result.code).toBe(EXIT_CHECK_FAILED);
         expect(result.stdout).toContain('not valid UTF-8');
         expect(result.stdout).toContain('byte offset');
+    });
+
+    it('reuses the document-store scope resolve cache in diagnostics', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(
+            path.join(root, 'sight.toml'),
+            '[crossFile]\nmaxForwardDepth = 4\n'
+        );
+        fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
+
+        const config_result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: false,
+        });
+        expect(config_result.kind).toBe('loaded');
+        if (config_result.kind !== 'loaded') return;
+
+        const targets = collect_report_targets(['main.do'], root, root);
+        const context = await build_check_context(root, config_result.config);
+        try {
+            context.scope_resolver.reset_cache_metrics();
+
+            await collect_check_diagnostics(
+                context,
+                root,
+                config_result.config,
+                targets.targets
+            );
+
+            const metrics = context.scope_resolver.get_cache_metrics();
+            expect(metrics.scope.misses).toBe(1);
+            expect(metrics.scope.hits).toBe(1);
+        } finally {
+            await context.document_store.dispose();
+        }
+    });
+
+    it('processes report targets concurrently while preserving output order', async () => {
+        const root = temp_dir();
+        const targets = ['a.do', 'b.do', 'c.do', 'd.do', 'e.do'].map(
+            (file_name) => {
+                const file_path = path.join(root, file_name);
+                fs.writeFileSync(file_path, 'display 1\n');
+                return {
+                    path: file_path,
+                    relative_path: file_name,
+                    explicit: true,
+                };
+            }
+        );
+
+        let active_opens = 0;
+        let max_active_opens = 0;
+
+        const context = {
+            workspace_indexer: {
+                get_all_symbols: () => create_empty_symbol_table(),
+                get_metrics: () => ({ files_indexed: targets.length }),
+                has_indexed_file: () => true,
+            },
+            document_store: {
+                open: async () => {
+                    active_opens++;
+                    max_active_opens = Math.max(
+                        max_active_opens,
+                        active_opens
+                    );
+                    await new Promise((resolve) => setTimeout(resolve, 20));
+                    active_opens--;
+                },
+                get: (uri: string) => ({ uri }),
+                close: () => undefined,
+            },
+            diagnostics_provider: {
+                get_diagnostics: async (state: { uri: string }) => [{
+                    severity: DiagnosticSeverity.Warning,
+                    message: path.basename(new URL(state.uri).pathname),
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 1 },
+                    },
+                    source: 'sight',
+                }],
+            },
+            scope_resolver: {},
+        } as unknown as CheckContext;
+
+        const config_result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: true,
+        });
+        expect(config_result.kind).toBe('loaded');
+        if (config_result.kind !== 'loaded') return;
+
+        const records = await collect_check_diagnostics(
+            context,
+            root,
+            config_result.config,
+            targets
+        );
+
+        expect(max_active_opens).toBeGreaterThan(1);
+        expect(records.map((record) => record.relative_path)).toEqual(
+            targets.map((target) => target.relative_path)
+        );
     });
 });

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -73,6 +73,33 @@ describe('sight check integration', () => {
         expect(result.stdout).toBe('');
     });
 
+    it('canonicalizes symlinked workspace and explicit target paths', async () => {
+        const real_root = temp_dir();
+        const link_root = `${real_root}-link`;
+        fs.symlinkSync(real_root, link_root, 'dir');
+        fs.writeFileSync(path.join(real_root, 'parent.do'), 'global project_root /tmp\ndo child.do\n');
+        fs.writeFileSync(path.join(real_root, 'child.do'), 'display "$project_root"\n');
+
+        const result = await run_capture(
+            ['--workspace', link_root, path.join(real_root, 'child.do'), '--quiet'],
+            real_root
+        );
+
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.stdout).toBe('');
+    });
+
+    it('indexes uppercase source extensions for cross-file scope', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'parent.DO'), 'global project_root /tmp\ndo child.do\n');
+        fs.writeFileSync(path.join(root, 'child.do'), 'display "$project_root"\n');
+
+        const result = await run_capture(['--workspace', root, 'child.do', '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.stdout).toBe('');
+    });
+
     it('reports malformed config as operator error', async () => {
         const root = temp_dir();
         fs.writeFileSync(path.join(root, 'sight.toml'), 'bad = = toml\n');
@@ -90,6 +117,23 @@ describe('sight check integration', () => {
 
         expect(result.code).toBe(EXIT_OPERATOR_ERROR);
         expect(result.stderr).toContain('path does not exist');
+    });
+
+    it('reports unreadable report directories as operator errors', async () => {
+        const root = temp_dir();
+        const locked = path.join(root, 'locked');
+        fs.mkdirSync(locked);
+        fs.chmodSync(locked, 0);
+        try {
+            const result = await run_capture(['--workspace', root, 'locked'], root);
+
+            expect(result.code).toBe(EXIT_OPERATOR_ERROR);
+            expect(result.stderr).toContain('sight check:');
+            expect(result.stderr).toContain('permission denied');
+            expect(result.stderr).not.toContain(' at ');
+        } finally {
+            fs.chmodSync(locked, 0o700);
+        }
     });
 
     it('reports explicitly oversized source files as error diagnostics', async () => {

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -179,6 +179,24 @@ describe('sight check integration', () => {
         expect(result.stdout).toContain('maxIndexedFiles');
     });
 
+    it('diagnoses explicit outside-workspace files after max indexed files is reached', async () => {
+        const root = temp_dir();
+        const outside = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[crossFile]\nmaxIndexedFiles = 1\n');
+        fs.writeFileSync(path.join(root, 'a.do'), 'display 1\n');
+        fs.writeFileSync(path.join(outside, 'b.do'), '}\n');
+
+        const result = await run_capture(
+            ['--workspace', root, path.join(outside, 'b.do'), '--quiet'],
+            root
+        );
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('unexpected closing brace');
+        expect(result.stdout).not.toContain('maxIndexedFiles');
+        expect(result.stdout).not.toContain('was not indexed');
+    });
+
     it('reports invalid UTF-8 as an error diagnostic', async () => {
         const root = temp_dir();
         fs.writeFileSync(path.join(root, 'bad.do'), Buffer.from([0x64, 0x80]));

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -183,6 +183,22 @@ describe('sight check integration', () => {
         expect(result.stdout).toContain('maxIndexedFiles');
     });
 
+    it('reports walked files skipped by max indexed files on default invocation', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[crossFile]\nmaxIndexedFiles = 1\n');
+        fs.writeFileSync(path.join(root, 'a.do'), 'display 1\n');
+        fs.writeFileSync(path.join(root, 'b.do'), 'display 2\n');
+
+        // No explicit paths: the whole workspace is walked. The file that did
+        // not fit under the cap must still be reported, not silently analyzed
+        // against an incomplete index.
+        const result = await run_capture(['--workspace', root, '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('was not indexed');
+        expect(result.stdout).toContain('maxIndexedFiles');
+    });
+
     it('diagnoses explicit outside-workspace files after max indexed files is reached', async () => {
         const root = temp_dir();
         const outside = temp_dir();

--- a/tests/integration/lsp-working-directory-option.test.ts
+++ b/tests/integration/lsp-working-directory-option.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { URI } from 'vscode-uri';
 import { DocumentStore } from '../../src/document-store';
 import { ScopeResolver } from '../../src/scope-resolver';
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
@@ -89,7 +90,7 @@ describe('LSP Working Directory Option - Integration Tests', () => {
             // Create document with @lsp-cd directive
             const file_path = write_file('scripts/analysis.do', `// @lsp-cd: "../data"
 display "hello"`);
-            const uri = `file://${file_path}`;
+            const uri = URI.file(file_path).toString();
 
             // Open document in store
             const content = fs.readFileSync(file_path, 'utf-8');
@@ -108,7 +109,7 @@ display "hello"`);
         it('should return null for document without @lsp-cd directive', async () => {
             // Create document without @lsp-cd directive
             const file_path = write_file('scripts/simple.do', `display "hello"`);
-            const uri = `file://${file_path}`;
+            const uri = URI.file(file_path).toString();
 
             // Open document in store
             const content = fs.readFileSync(file_path, 'utf-8');
@@ -125,7 +126,7 @@ display "hello"`);
         });
 
         it('should return null for non-existent document', async () => {
-            const uri = `file://${test_dir}/nonexistent.do`;
+            const uri = URI.file(`${test_dir}/nonexistent.do`).toString();
 
             // Create handler and send request
             const deps = create_mock_dependencies(document_store);
@@ -145,7 +146,7 @@ display "hello"`);
             // Create document with @lsp-working-directory directive
             const file_path = write_file('scripts/report.do', `// @lsp-working-directory: "../output"
 display "generating report"`);
-            const uri = `file://${file_path}`;
+            const uri = URI.file(file_path).toString();
 
             // Open document in store
             const content = fs.readFileSync(file_path, 'utf-8');
@@ -169,7 +170,7 @@ display "generating report"`);
             // Create document with @lsp-wd directive
             const file_path = write_file('scripts/compute.do', `// @lsp-wd: "../results"
 gen x = 1`);
-            const uri = `file://${file_path}`;
+            const uri = URI.file(file_path).toString();
 
             // Open document in store
             const content = fs.readFileSync(file_path, 'utf-8');
@@ -206,7 +207,7 @@ do "child.do"`);
             // Create child.do with @lsp-done-by directive
             const child_path = write_file('scripts/child.do', `// @lsp-done-by: "parent.do"
 display \`myvar'`);
-            const child_uri = `file://${child_path}`;
+            const child_uri = URI.file(child_path).toString();
 
             // Open child document in store
             const child_content = fs.readFileSync(child_path, 'utf-8');
@@ -240,7 +241,7 @@ include "helper.do"`);
             // Create helper.do with @lsp-included-by directive
             const helper_path = write_file('scripts/helper.do', `// @lsp-included-by: "main.do"
 display "helper"`);
-            const helper_uri = `file://${helper_path}`;
+            const helper_uri = URI.file(helper_path).toString();
 
             // Open helper document in store
             const helper_content = fs.readFileSync(helper_path, 'utf-8');
@@ -264,7 +265,7 @@ do "child.do"`);
             // Create child.do with @lsp-done-by directive
             const child_path = write_file('scripts/child.do', `// @lsp-done-by: "parent.do"
 display \`myvar'`);
-            const child_uri = `file://${child_path}`;
+            const child_uri = URI.file(child_path).toString();
 
             // Open child document in store
             const child_content = fs.readFileSync(child_path, 'utf-8');
@@ -300,7 +301,7 @@ do "child.do"`);
 
                 const child_path = write_file('scripts/child.do',
                     'display "child"');
-                const child_uri = `file://${child_path}`;
+                const child_uri = URI.file(child_path).toString();
                 const child_content = fs.readFileSync(child_path, 'utf-8');
 
                 await index_workspace_for_auto_discovery();
@@ -326,7 +327,7 @@ do "child.do"`);
 
             const child_path = write_file('scripts/child.do',
                 'display "child"');
-            const child_uri = `file://${child_path}`;
+            const child_uri = URI.file(child_path).toString();
             const child_content = fs.readFileSync(child_path, 'utf-8');
 
             await index_workspace_for_auto_discovery();
@@ -353,7 +354,7 @@ do "child.do"`);
             const child_path = write_file('scripts/child.do',
                 `// @lsp-done-by: "parent.do"
 display "child"`);
-            const child_uri = `file://${child_path}`;
+            const child_uri = URI.file(child_path).toString();
             const child_content = fs.readFileSync(child_path, 'utf-8');
 
             await index_workspace_for_auto_discovery();
@@ -380,7 +381,7 @@ do "child.do"`);
 
                 const child_path = write_file('scripts/child.do',
                     'display "child"');
-                const child_uri = `file://${child_path}`;
+                const child_uri = URI.file(child_path).toString();
                 const child_content = fs.readFileSync(child_path, 'utf-8');
 
                 await index_workspace_for_auto_discovery();

--- a/tests/integration/lsp-working-directory-option.test.ts
+++ b/tests/integration/lsp-working-directory-option.test.ts
@@ -12,6 +12,8 @@ import * as os from 'os';
 import { DocumentStore } from '../../src/document-store';
 import { ScopeResolver } from '../../src/scope-resolver';
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { WorkspaceIndexer } from '../../src/indexer';
 import {
     create_get_working_directory_handler,
     HandlerDependencies,
@@ -277,5 +279,129 @@ display \`myvar'`);
             // Should return null since parent has no working directory
             expect(result.workingDirectory).toBeNull();
         });
+    });
+
+    describe('cross-file dependency mode', () => {
+        async function index_workspace_for_auto_discovery(): Promise<void> {
+            const graph = new DependencyGraph();
+            const indexer = new WorkspaceIndexer();
+            indexer.set_dependency_graph(graph);
+            await indexer.initialize([test_dir]);
+            scope_resolver.set_dependency_graph(graph);
+        }
+
+        it('does not inherit auto-discovered parent cd in explicit mode',
+            async () => {
+                const data_dir = path.join(test_dir, 'data');
+                fs.mkdirSync(data_dir, { recursive: true });
+
+                write_file('scripts/parent.do', `// @lsp-cd: "../data"
+do "child.do"`);
+
+                const child_path = write_file('scripts/child.do',
+                    'display "child"');
+                const child_uri = `file://${child_path}`;
+                const child_content = fs.readFileSync(child_path, 'utf-8');
+
+                await index_workspace_for_auto_discovery();
+                await document_store.open(
+                    child_uri,
+                    child_content,
+                    1,
+                    undefined,
+                    { backward_dependencies: 'explicit' }
+                );
+
+                const document_state = document_store.get(child_uri);
+                expect(document_state).toBeDefined();
+                expect(document_state!.working_directory).toBeUndefined();
+            });
+
+        it('inherits auto-discovered parent cd in auto mode', async () => {
+            const data_dir = path.join(test_dir, 'data');
+            fs.mkdirSync(data_dir, { recursive: true });
+
+            write_file('scripts/parent.do', `// @lsp-cd: "../data"
+do "child.do"`);
+
+            const child_path = write_file('scripts/child.do',
+                'display "child"');
+            const child_uri = `file://${child_path}`;
+            const child_content = fs.readFileSync(child_path, 'utf-8');
+
+            await index_workspace_for_auto_discovery();
+            await document_store.open(
+                child_uri,
+                child_content,
+                1,
+                undefined,
+                { backward_dependencies: 'auto' }
+            );
+
+            const document_state = document_store.get(child_uri);
+            expect(document_state).toBeDefined();
+            expect(document_state!.working_directory).toBe(data_dir);
+        });
+
+        it('inherits explicit parent cd in explicit mode', async () => {
+            const data_dir = path.join(test_dir, 'data');
+            fs.mkdirSync(data_dir, { recursive: true });
+
+            write_file('scripts/parent.do', `// @lsp-cd: "../data"
+do "child.do"`);
+
+            const child_path = write_file('scripts/child.do',
+                `// @lsp-done-by: "parent.do"
+display "child"`);
+            const child_uri = `file://${child_path}`;
+            const child_content = fs.readFileSync(child_path, 'utf-8');
+
+            await index_workspace_for_auto_discovery();
+            await document_store.open(
+                child_uri,
+                child_content,
+                1,
+                undefined,
+                { backward_dependencies: 'explicit' }
+            );
+
+            const document_state = document_store.get(child_uri);
+            expect(document_state).toBeDefined();
+            expect(document_state!.working_directory).toBe(data_dir);
+        });
+
+        it('recomputes inherited cd on same-content config update',
+            async () => {
+                const data_dir = path.join(test_dir, 'data');
+                fs.mkdirSync(data_dir, { recursive: true });
+
+                write_file('scripts/parent.do', `// @lsp-cd: "../data"
+do "child.do"`);
+
+                const child_path = write_file('scripts/child.do',
+                    'display "child"');
+                const child_uri = `file://${child_path}`;
+                const child_content = fs.readFileSync(child_path, 'utf-8');
+
+                await index_workspace_for_auto_discovery();
+                await document_store.open(
+                    child_uri,
+                    child_content,
+                    1,
+                    undefined,
+                    { backward_dependencies: 'auto' }
+                );
+                await document_store.update(
+                    child_uri,
+                    [{ text: child_content }],
+                    2,
+                    undefined,
+                    { backward_dependencies: 'explicit' }
+                );
+
+                const document_state = document_store.get(child_uri);
+                expect(document_state).toBeDefined();
+                expect(document_state!.working_directory).toBeUndefined();
+            });
     });
 });

--- a/tests/integration/sight-toml-config.test.ts
+++ b/tests/integration/sight-toml-config.test.ts
@@ -5,8 +5,10 @@ import * as path from 'path';
 import {
     deep_merge_config,
     discover_and_load_project_config,
+    map_public_config_to_partial_config,
 } from '../../src/config-file';
 import { validate_comment_formatting_config } from '../../src/utils/config-validator';
+import { DEFAULT_SETTINGS } from '../../src/server-handlers';
 
 function make_temp_dir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-lsp-config-'));
@@ -56,6 +58,31 @@ describe('sight.toml server config precedence', () => {
 
             expect(settings.cross_file.backward_dependencies).toBe('explicit');
         }
+    });
+
+    it('maps camelCase initialization options into the internal config shape', () => {
+        // Regression: non-VS-Code clients (Neovim/Helix/Zed/Claude Code) pass
+        // config via LSP initializationOptions in the public camelCase schema.
+        // These must be mapped (crossFile -> cross_file, preserveAlignment ->
+        // preserve_alignment) or the validator silently drops them.
+        const init_options = {
+            crossFile: {
+                maxChainDepth: 5,
+                indexWorkspace: false,
+                backwardDependencies: 'explicit',
+            },
+            formatting: { preserveAlignment: true },
+        };
+
+        const mapped = map_public_config_to_partial_config(init_options);
+        const settings = validate_comment_formatting_config(
+            deep_merge_config(DEFAULT_SETTINGS, mapped)
+        );
+
+        expect(settings.cross_file.max_chain_depth).toBe(5);
+        expect(settings.cross_file.index_workspace).toBe(false);
+        expect(settings.cross_file.backward_dependencies).toBe('explicit');
+        expect(settings.formatting.preserve_alignment).toBe(true);
     });
 
     it('malformed nearest sight.toml yields no project layer', () => {

--- a/tests/unit/binary-command-name.test.ts
+++ b/tests/unit/binary-command-name.test.ts
@@ -31,6 +31,9 @@ import {
 } from '../../scripts/uninstall';
 import {
     CLI_HELP_BANNER,
+    NATIVE_BINARY_NAME_PATTERN,
+    SUPPORTED_BINARY_ARCHS,
+    SUPPORTED_BINARY_PLATFORMS,
 } from '../../src/cli-binary-names';
 import {
     build_all_binaries,
@@ -445,6 +448,28 @@ describe('binary command name', () => {
         for (const [my_platform, expected_command_name] of the_cases) {
             expect(get_binary_name(my_platform)).toBe(expected_command_name);
         }
+    });
+
+    it('defines native binary names from shared platform and arch lists', () => {
+        expect(SUPPORTED_BINARY_PLATFORMS).toEqual([
+            'darwin',
+            'linux',
+            'windows',
+        ]);
+        expect(SUPPORTED_BINARY_ARCHS).toEqual(['x64', 'arm64']);
+
+        for (const my_platform of SUPPORTED_BINARY_PLATFORMS) {
+            for (const my_arch of SUPPORTED_BINARY_ARCHS) {
+                const suffix = my_platform === 'windows' ? '.exe' : '';
+                expect(NATIVE_BINARY_NAME_PATTERN.test(
+                    `sight-${my_platform}-${my_arch}${suffix}`
+                )).toBe(true);
+            }
+        }
+
+        expect(NATIVE_BINARY_NAME_PATTERN.source).toBe(
+            '^sight-(darwin|linux|windows)-(x64|arm64)(\\.exe)?$'
+        );
     });
 
     it('uses Windows-aware spawn modes for command shims', () => {

--- a/tests/unit/binary-command-name.test.ts
+++ b/tests/unit/binary-command-name.test.ts
@@ -460,9 +460,9 @@ describe('binary command name', () => {
 
         for (const my_platform of SUPPORTED_BINARY_PLATFORMS) {
             for (const my_arch of SUPPORTED_BINARY_ARCHS) {
-                const suffix = my_platform === 'windows' ? '.exe' : '';
+                const my_suffix = my_platform === 'windows' ? '.exe' : '';
                 expect(NATIVE_BINARY_NAME_PATTERN.test(
-                    `sight-${my_platform}-${my_arch}${suffix}`
+                    `sight-${my_platform}-${my_arch}${my_suffix}`
                 )).toBe(true);
             }
         }

--- a/tests/unit/build-scope-resolver-config.test.ts
+++ b/tests/unit/build-scope-resolver-config.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'bun:test';
-import { build_scope_resolver_config } from '../../src/scope-resolver';
+import {
+    build_scope_resolver_config,
+    scope_resolver_config_for,
+} from '../../src/scope-resolver';
+import { DEFAULT_SETTINGS } from '../../src/server-handlers';
 
 describe('build_scope_resolver_config', () => {
     it('returns empty object for undefined input', () => {
@@ -89,6 +93,33 @@ describe('build_scope_resolver_config', () => {
             assume_call_site: 'end',
             backward_dependencies: 'explicit',
             diagnostics: { max_depth: 'warning' },
+        });
+    });
+
+    it('builds diagnostic scope config from full LSP config', () => {
+        const config = {
+            ...DEFAULT_SETTINGS,
+            cross_file: {
+                ...DEFAULT_SETTINGS.cross_file,
+                assume_call_site: 'start' as const,
+                backward_dependencies: 'explicit' as const,
+                max_forward_depth: 4,
+                diagnostics: {
+                    ...DEFAULT_SETTINGS.cross_file.diagnostics,
+                    max_depth: 'error' as const,
+                    call_site_identification: 'off' as const,
+                },
+            },
+        };
+
+        expect(scope_resolver_config_for(config)).toEqual({
+            assume_call_site: 'start',
+            backward_dependencies: 'explicit',
+            max_forward_depth: 4,
+            diagnostics: {
+                max_depth: 'error',
+                call_site_identification: 'off',
+            },
         });
     });
 });

--- a/tests/unit/build-scope-resolver-config.test.ts
+++ b/tests/unit/build-scope-resolver-config.test.ts
@@ -103,7 +103,9 @@ describe('build_scope_resolver_config', () => {
                 ...DEFAULT_SETTINGS.cross_file,
                 assume_call_site: 'start' as const,
                 backward_dependencies: 'explicit' as const,
+                max_backward_depth: 3,
                 max_forward_depth: 4,
+                max_chain_depth: 7,
                 diagnostics: {
                     ...DEFAULT_SETTINGS.cross_file.diagnostics,
                     max_depth: 'error' as const,
@@ -115,7 +117,9 @@ describe('build_scope_resolver_config', () => {
         expect(scope_resolver_config_for(config)).toEqual({
             assume_call_site: 'start',
             backward_dependencies: 'explicit',
+            max_backward_depth: 3,
             max_forward_depth: 4,
+            max_chain_depth: 7,
             diagnostics: {
                 max_depth: 'error',
                 call_site_identification: 'off',

--- a/tests/unit/cli/check-args.test.ts
+++ b/tests/unit/cli/check-args.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    parse_check_args,
+} from '../../../src/cli/check';
+import {
+    ColorChoice,
+    OutputFormat,
+    SeverityLevel,
+} from '../../../src/cli/shared';
+import { parse_args } from '../../../src/cli';
+
+describe('sight check args', () => {
+    it('uses Raven-parity defaults', () => {
+        const result = parse_check_args([]);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.args.paths).toEqual([]);
+            expect(result.args.workspace).toBeUndefined();
+            expect(result.args.config_path).toBeUndefined();
+            expect(result.args.no_config).toBe(false);
+            expect(result.args.format).toBe(OutputFormat.Text);
+            expect(result.args.max_severity).toBe(SeverityLevel.Info);
+            expect(result.args.quiet).toBe(false);
+            expect(result.args.color).toBe(ColorChoice.Auto);
+            expect(result.args.help).toBe(false);
+        }
+    });
+
+    it('parses all supported options', () => {
+        const result = parse_check_args([
+            '--workspace', 'analysis',
+            '--config', '../sight.toml',
+            '--format', 'sarif',
+            '--max-severity', 'warning',
+            '--quiet',
+            '--color', 'always',
+            'main.do',
+        ]);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.args.workspace).toBe('analysis');
+            expect(result.args.config_path).toBe('../sight.toml');
+            expect(result.args.format).toBe(OutputFormat.Sarif);
+            expect(result.args.max_severity).toBe(SeverityLevel.Warning);
+            expect(result.args.quiet).toBe(true);
+            expect(result.args.color).toBe(ColorChoice.Always);
+            expect(result.args.paths).toEqual(['main.do']);
+        }
+    });
+
+    it('treats --no-color as --color never with last flag winning', () => {
+        const first = parse_check_args(['--no-color', '--color', 'always']);
+        const second = parse_check_args(['--color', 'always', '--no-color']);
+
+        expect(first.success && first.args.color).toBe(ColorChoice.Always);
+        expect(second.success && second.args.color).toBe(ColorChoice.Never);
+    });
+
+    it('rejects --config with --no-config', () => {
+        const result = parse_check_args(['--config', 'sight.toml', '--no-config']);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error).toContain('Cannot specify both');
+        }
+    });
+
+    it('rejects unknown flags and missing option values', () => {
+        expect(parse_check_args(['--wat']).success).toBe(false);
+        const workspace = parse_check_args(['--workspace']);
+        expect(workspace.success).toBe(false);
+        if (!workspace.success) {
+            expect(workspace.error).toBe('--workspace needs a path');
+        }
+    });
+});
+
+describe('top-level parser remains transport-only', () => {
+    it('still rejects check when called directly so main can route first', () => {
+        const result = parse_args(['check']);
+
+        expect(result.success).toBe(false);
+    });
+});

--- a/tests/unit/cli/check-args.test.ts
+++ b/tests/unit/cli/check-args.test.ts
@@ -95,6 +95,25 @@ describe('sight check args', () => {
         }
     });
 
+    it('rejects an inline value on a valueless flag', () => {
+        const the_cases = [
+            '--no-config=false',
+            '--quiet=1',
+            '--no-color=never',
+            '--help=please',
+        ];
+
+        for (const my_argv of the_cases) {
+            const flag = my_argv.split('=')[0];
+            const result = parse_check_args([my_argv]);
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error).toBe(`${flag} does not take a value`);
+            }
+        }
+    });
+
     it('rejects --config with --no-config', () => {
         const result = parse_check_args(['--config', 'sight.toml', '--no-config']);
 

--- a/tests/unit/cli/check-args.test.ts
+++ b/tests/unit/cli/check-args.test.ts
@@ -75,6 +75,40 @@ describe('sight check args', () => {
             expect(workspace.error).toBe('--workspace needs a path');
         }
     });
+
+    it('rejects flags where option values are required', () => {
+        const the_cases = [
+            {
+                argv: ['--workspace', '--quiet'],
+                error: '--workspace needs a path',
+            },
+            {
+                argv: ['--config', '--no-config'],
+                error: '--config needs a path',
+            },
+            {
+                argv: ['--format', '--quiet'],
+                error: '--format needs a value',
+            },
+            {
+                argv: ['--max-severity', '--quiet'],
+                error: '--max-severity needs a value',
+            },
+            {
+                argv: ['--color', '--quiet'],
+                error: '--color needs a value',
+            },
+        ];
+
+        for (const my_case of the_cases) {
+            const result = parse_check_args(my_case.argv);
+
+            expect(result.success).toBe(false);
+            if (!result.success) {
+                expect(result.error).toBe(my_case.error);
+            }
+        }
+    });
 });
 
 describe('top-level parser remains transport-only', () => {

--- a/tests/unit/cli/check-args.test.ts
+++ b/tests/unit/cli/check-args.test.ts
@@ -7,7 +7,7 @@ import {
     OutputFormat,
     SeverityLevel,
 } from '../../../src/cli/shared';
-import { parse_args } from '../../../src/cli';
+import { parse_args, print_help } from '../../../src/cli';
 
 describe('sight check args', () => {
     it('uses Raven-parity defaults', () => {
@@ -56,6 +56,43 @@ describe('sight check args', () => {
 
         expect(first.success && first.args.color).toBe(ColorChoice.Always);
         expect(second.success && second.args.color).toBe(ColorChoice.Never);
+    });
+
+    it('supports --flag=value, allowing values that begin with a dash', () => {
+        const result = parse_check_args([
+            '--workspace=analysis',
+            '--config=-odd-name.toml',
+            '--format=json',
+            '--max-severity=warning',
+            '--color=always',
+        ]);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.args.workspace).toBe('analysis');
+            expect(result.args.config_path).toBe('-odd-name.toml');
+            expect(result.args.format).toBe(OutputFormat.Json);
+            expect(result.args.max_severity).toBe(SeverityLevel.Warning);
+            expect(result.args.color).toBe(ColorChoice.Always);
+        }
+    });
+
+    it('rejects an empty --flag= value', () => {
+        const result = parse_check_args(['--workspace=']);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error).toBe('--workspace needs a path');
+        }
+    });
+
+    it('rejects an unknown --flag=value flag by its flag name', () => {
+        const result = parse_check_args(['--bogus=1']);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error).toBe('Unknown flag: --bogus');
+        }
     });
 
     it('rejects --config with --no-config', () => {
@@ -116,5 +153,22 @@ describe('top-level parser remains transport-only', () => {
         const result = parse_args(['check']);
 
         expect(result.success).toBe(false);
+    });
+
+    it('top-level help advertises the check subcommand', () => {
+        const lines: string[] = [];
+        const original_log = console.log;
+        console.log = (message?: unknown) => {
+            lines.push(String(message));
+        };
+        try {
+            print_help();
+        } finally {
+            console.log = original_log;
+        }
+
+        const text = lines.join('\n');
+        expect(text).toContain('check');
+        expect(text).toContain('sight check --help');
     });
 });

--- a/tests/unit/cli/check-config.test.ts
+++ b/tests/unit/cli/check-config.test.ts
@@ -80,4 +80,24 @@ describe('sight check config loading', () => {
             expect(result.message).toContain('failed to load');
         }
     });
+
+    it('surfaces stale json warnings even when the config fails to parse', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, '.sight.json'), '{}\n');
+        fs.writeFileSync(path.join(root, 'sight.toml'), 'bad = = toml\n');
+
+        const result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: false,
+        });
+
+        expect(result.kind).toBe('operator-error');
+        if (result.kind === 'operator-error') {
+            expect(result.message).toContain('failed to load');
+            expect(result.warnings.some((warning) =>
+                warning.message.includes('.sight.json is no longer supported')
+            )).toBe(true);
+        }
+    });
 });

--- a/tests/unit/cli/check-config.test.ts
+++ b/tests/unit/cli/check-config.test.ts
@@ -105,7 +105,7 @@ describe('sight check config loading', () => {
         }
     });
 
-    it('surfaces stale json warnings even when the config fails to parse', () => {
+    it('surfaces stale json warnings when the config fails to parse', () => {
         const root = temp_dir();
         fs.writeFileSync(path.join(root, '.sight.json'), '{}\n');
         fs.writeFileSync(path.join(root, 'sight.toml'), 'bad = = toml\n');

--- a/tests/unit/cli/check-config.test.ts
+++ b/tests/unit/cli/check-config.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    load_check_config,
+} from '../../../src/cli/check';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-config-'));
+}
+
+describe('sight check config loading', () => {
+    it('uses built-in defaults under --no-config', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[diagnostics]\nenabled = false\n');
+
+        const result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: true,
+        });
+
+        expect(result.kind).toBe('loaded');
+        if (result.kind === 'loaded') {
+            expect(result.config.diagnostics.enabled).toBe(true);
+        }
+    });
+
+    it('loads explicit config relative to cwd', () => {
+        const cwd = temp_dir();
+        const workspace = temp_dir();
+        fs.writeFileSync(path.join(cwd, 'custom.toml'), '[diagnostics]\nenabled = false\n');
+
+        const result = load_check_config({
+            cwd,
+            workspace_root: workspace,
+            config_path: 'custom.toml',
+            no_config: false,
+        });
+
+        expect(result.kind).toBe('loaded');
+        if (result.kind === 'loaded') {
+            expect(result.config.diagnostics.enabled).toBe(false);
+        }
+    });
+
+    it('discovers config from workspace root and reports stale json warnings', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, '.sight.json'), '{}\n');
+        fs.writeFileSync(path.join(root, 'sight.toml'), '[diagnostics]\nindentation = true\n');
+
+        const result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: false,
+        });
+
+        expect(result.kind).toBe('loaded');
+        if (result.kind === 'loaded') {
+            expect(result.config.diagnostics.indentation).toBe(true);
+            expect(result.warnings.some((warning) =>
+                warning.message.includes('.sight.json is no longer supported')
+            )).toBe(true);
+        }
+    });
+
+    it('returns operator error for malformed discovered config', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'sight.toml'), 'bad = = toml\n');
+
+        const result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: false,
+        });
+
+        expect(result.kind).toBe('operator-error');
+        if (result.kind === 'operator-error') {
+            expect(result.message).toContain('failed to load');
+        }
+    });
+});

--- a/tests/unit/cli/check-config.test.ts
+++ b/tests/unit/cli/check-config.test.ts
@@ -65,6 +65,30 @@ describe('sight check config loading', () => {
         }
     });
 
+    it('surfaces comment-formatting validation warnings', () => {
+        const root = temp_dir();
+        fs.writeFileSync(
+            path.join(root, 'sight.toml'),
+            '[formatting]\nindentSize = -4\n'
+        );
+
+        const result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: false,
+        });
+
+        expect(result.kind).toBe('loaded');
+        if (result.kind === 'loaded') {
+            // Invalid value is reported (not silently swallowed) and the
+            // default is applied.
+            expect(result.warnings.some((warning) =>
+                warning.message.includes('Invalid indentSize')
+            )).toBe(true);
+            expect(result.config.formatting.indentSize).toBe(4);
+        }
+    });
+
     it('returns operator error for malformed discovered config', () => {
         const root = temp_dir();
         fs.writeFileSync(path.join(root, 'sight.toml'), 'bad = = toml\n');

--- a/tests/unit/cli/check-context.test.ts
+++ b/tests/unit/cli/check-context.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    build_check_context,
+    load_check_config,
+} from '../../../src/cli/check';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-context-'));
+}
+
+describe('sight check batch context', () => {
+    it('marks dependency graph scan complete and indexes workspace symbols', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'parent.do'), 'global g 1\ndo child.do\n');
+        fs.writeFileSync(path.join(root, 'child.do'), 'display "$g"\n');
+        const config_result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: true,
+        });
+        expect(config_result.kind).toBe('loaded');
+        if (config_result.kind !== 'loaded') return;
+
+        const context = await build_check_context(root, config_result.config);
+
+        expect(context.dependency_graph.is_scan_complete()).toBe(true);
+        expect(context.workspace_indexer.get_all_symbols().globalMacros.has('g')).toBe(true);
+        expect(context.scope_resolver).toBeDefined();
+        await context.document_store.dispose();
+    });
+});

--- a/tests/unit/cli/diagnostics-connection.test.ts
+++ b/tests/unit/cli/diagnostics-connection.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+    DiagnosticsConnection,
+    DiagnosticsProvider,
+} from '../../../src/providers/diagnostics';
+
+const repo_root = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../..'
+);
+
+describe('DiagnosticsProvider connection surface', () => {
+    it('exports a narrow diagnostics connection interface', () => {
+        const source = fs.readFileSync(
+            path.join(repo_root, 'src/providers/diagnostics.ts'),
+            'utf8'
+        );
+
+        expect(source).toContain('export interface DiagnosticsConnection');
+        expect(source).toContain('connection: DiagnosticsConnection');
+        expect(source).not.toContain('connection: Connection');
+    });
+
+    it('accepts the narrow CLI diagnostics connection', () => {
+        const connection: DiagnosticsConnection = {
+            sendDiagnostics: () => undefined,
+        };
+        const provider = new DiagnosticsProvider(connection);
+
+        expect(provider).toBeInstanceOf(DiagnosticsProvider);
+    });
+});

--- a/tests/unit/cli/diagnostics-connection.test.ts
+++ b/tests/unit/cli/diagnostics-connection.test.ts
@@ -1,27 +1,26 @@
-import { describe, expect, it } from 'bun:test';
-import * as fs from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
+import { describe, expect, it, mock } from 'bun:test';
+import { Diagnostic } from 'vscode-languageserver';
 import {
     DiagnosticsConnection,
     DiagnosticsProvider,
 } from '../../../src/providers/diagnostics';
 
-const repo_root = path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    '../../..'
-);
-
 describe('DiagnosticsProvider connection surface', () => {
-    it('exports a narrow diagnostics connection interface', () => {
-        const source = fs.readFileSync(
-            path.join(repo_root, 'src/providers/diagnostics.ts'),
-            'utf8'
+    it('exports a narrow diagnostics connection contract', () => {
+        // Compile-time: a value exposing only sendDiagnostics satisfies the
+        // interface, so the connection surface stays narrow rather than the
+        // full vscode-languageserver Connection. The typecheck step enforces
+        // this — the assignment fails to compile if the contract widens.
+        const send = mock(
+            (_params: { uri: string; diagnostics: Diagnostic[] }) => undefined
         );
+        const connection: DiagnosticsConnection = { sendDiagnostics: send };
 
-        expect(source).toContain('export interface DiagnosticsConnection');
-        expect(source).toContain('connection: DiagnosticsConnection');
-        expect(source).not.toContain('connection: Connection');
+        // Runtime: the sole member is the publish callback, callable with the
+        // documented params.
+        expect(Object.keys(connection)).toEqual(['sendDiagnostics']);
+        connection.sendDiagnostics({ uri: 'file:///a.do', diagnostics: [] });
+        expect(send).toHaveBeenCalledTimes(1);
     });
 
     it('accepts the narrow CLI diagnostics connection', () => {

--- a/tests/unit/cli/shared.test.ts
+++ b/tests/unit/cli/shared.test.ts
@@ -112,12 +112,10 @@ describe('cli shared color resolution', () => {
 describe('cli shared renderers', () => {
     const records = [
         {
-            path: '/repo/b.do',
             relative_path: 'b.do',
             diagnostic: diag(DiagnosticSeverity.Warning, 2, 4, 'B warning', 2001),
         },
         {
-            path: '/repo/a.do',
             relative_path: 'a.do',
             diagnostic: diag(DiagnosticSeverity.Error, 0, 1, 'A error', 3000),
         },

--- a/tests/unit/cli/shared.test.ts
+++ b/tests/unit/cli/shared.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'bun:test';
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import {
+    ColorChoice,
+    EXIT_CHECK_FAILED,
+    EXIT_OK,
+    OutputFormat,
+    SeverityLevel,
+    compare_diagnostic_records,
+    diagnostic_exceeds_threshold,
+    parse_color_choice,
+    parse_output_format,
+    parse_severity_level,
+    render_json,
+    render_sarif,
+    render_text,
+    resolve_color,
+} from '../../../src/cli/shared';
+
+function diag(
+    severity: DiagnosticSeverity,
+    line: number,
+    character: number,
+    message: string,
+    code: number | string
+) {
+    return {
+        range: {
+            start: { line, character },
+            end: { line, character: character + 1 },
+        },
+        severity,
+        code,
+        source: 'sight',
+        message,
+    };
+}
+
+describe('cli shared parsing', () => {
+    it('parses output formats and rejects unknown values', () => {
+        expect(parse_output_format('text')).toBe(OutputFormat.Text);
+        expect(parse_output_format('json')).toBe(OutputFormat.Json);
+        expect(parse_output_format('sarif')).toBe(OutputFormat.Sarif);
+        expect(() => parse_output_format('xml')).toThrow(
+            'unknown --format value: xml'
+        );
+    });
+
+    it('parses severity levels and rejects unknown values', () => {
+        expect(parse_severity_level('off')).toBe(SeverityLevel.Off);
+        expect(parse_severity_level('hint')).toBe(SeverityLevel.Hint);
+        expect(parse_severity_level('info')).toBe(SeverityLevel.Info);
+        expect(parse_severity_level('warning')).toBe(SeverityLevel.Warning);
+        expect(parse_severity_level('error')).toBe(SeverityLevel.Error);
+        expect(() => parse_severity_level('warn')).toThrow(
+            'unknown --max-severity value: warn'
+        );
+    });
+
+    it('parses color choices and rejects unknown values', () => {
+        expect(parse_color_choice('auto')).toBe(ColorChoice.Auto);
+        expect(parse_color_choice('always')).toBe(ColorChoice.Always);
+        expect(parse_color_choice('never')).toBe(ColorChoice.Never);
+        expect(() => parse_color_choice('sometimes')).toThrow(
+            'unknown --color value: sometimes'
+        );
+    });
+});
+
+describe('cli shared severity gates', () => {
+    it('uses strict greater-than comparison for max severity', () => {
+        expect(
+            diagnostic_exceeds_threshold(
+                diag(DiagnosticSeverity.Information, 0, 0, 'info', 6003),
+                SeverityLevel.Info
+            )
+        ).toBe(false);
+        expect(
+            diagnostic_exceeds_threshold(
+                diag(DiagnosticSeverity.Hint, 0, 0, 'hint', 1004),
+                SeverityLevel.Info
+            )
+        ).toBe(false);
+        expect(
+            diagnostic_exceeds_threshold(
+                diag(DiagnosticSeverity.Warning, 0, 0, 'warning', 2001),
+                SeverityLevel.Info
+            )
+        ).toBe(true);
+    });
+
+    it('exports stable exit code constants', () => {
+        expect(EXIT_OK).toBe(0);
+        expect(EXIT_CHECK_FAILED).toBe(1);
+    });
+});
+
+describe('cli shared color resolution', () => {
+    it('explicit always and never override environment signals', () => {
+        expect(resolve_color(ColorChoice.Always, true, false, false)).toBe(true);
+        expect(resolve_color(ColorChoice.Never, false, true, true)).toBe(false);
+    });
+
+    it('auto honors NO_COLOR before FORCE_COLOR before TTY', () => {
+        expect(resolve_color(ColorChoice.Auto, true, true, true)).toBe(false);
+        expect(resolve_color(ColorChoice.Auto, false, true, false)).toBe(true);
+        expect(resolve_color(ColorChoice.Auto, false, false, true)).toBe(true);
+        expect(resolve_color(ColorChoice.Auto, false, false, false)).toBe(false);
+    });
+});
+
+describe('cli shared renderers', () => {
+    const records = [
+        {
+            path: '/repo/b.do',
+            relative_path: 'b.do',
+            diagnostic: diag(DiagnosticSeverity.Warning, 2, 4, 'B warning', 2001),
+        },
+        {
+            path: '/repo/a.do',
+            relative_path: 'a.do',
+            diagnostic: diag(DiagnosticSeverity.Error, 0, 1, 'A error', 3000),
+        },
+    ];
+
+    it('sorts by path, range, severity, code, and message', () => {
+        const sorted = [...records].sort(compare_diagnostic_records);
+        expect(sorted.map((record) => record.relative_path)).toEqual([
+            'a.do',
+            'b.do',
+        ]);
+    });
+
+    it('renders text with one-based coordinates and summary', () => {
+        const text = render_text(records, { quiet: false, use_color: false });
+        expect(text).toContain('a.do:1:2 error: A error [3000]');
+        expect(text).toContain('b.do:3:5 warning: B warning [2001]');
+        expect(text).toContain('2 issues (1 errors, 1 warnings, 0 infos, 0 hints, 0 notes)');
+    });
+
+    it('renders JSON as parseable path and diagnostic records', () => {
+        const parsed = JSON.parse(render_json(records));
+        expect(parsed).toHaveLength(2);
+        expect(parsed[0].path).toBe('a.do');
+        expect(parsed[0].diagnostic.message).toBe('A error');
+    });
+
+    it('renders SARIF 2.1.0 with string rule IDs and tool metadata', () => {
+        const parsed = JSON.parse(render_sarif(records, '0.7.2'));
+        expect(parsed.version).toBe('2.1.0');
+        expect(parsed.runs[0].tool.driver.name).toBe('sight');
+        expect(parsed.runs[0].tool.driver.version).toBe('0.7.2');
+        expect(parsed.runs[0].results[0].ruleId).toBe('SIGHT3000');
+    });
+});

--- a/tests/unit/cli/shared.test.ts
+++ b/tests/unit/cli/shared.test.ts
@@ -8,6 +8,8 @@ import {
     SeverityLevel,
     compare_diagnostic_records,
     diagnostic_exceeds_threshold,
+    env_flag_is_set,
+    force_color_is_enabled,
     parse_color_choice,
     parse_output_format,
     parse_severity_level,
@@ -106,6 +108,27 @@ describe('cli shared color resolution', () => {
         expect(resolve_color(ColorChoice.Auto, false, true, false)).toBe(true);
         expect(resolve_color(ColorChoice.Auto, false, false, true)).toBe(true);
         expect(resolve_color(ColorChoice.Auto, false, false, false)).toBe(false);
+    });
+});
+
+describe('cli shared color env flags', () => {
+    it('treats NO_COLOR as set for any non-empty value (no-color spec)', () => {
+        expect(env_flag_is_set('0')).toBe(true);
+        expect(env_flag_is_set('false')).toBe(true);
+        expect(env_flag_is_set('1')).toBe(true);
+        expect(env_flag_is_set('')).toBe(false);
+        expect(env_flag_is_set(undefined)).toBe(false);
+    });
+
+    it('treats FORCE_COLOR=0/false/off as disabled, else enabled', () => {
+        expect(force_color_is_enabled('0')).toBe(false);
+        expect(force_color_is_enabled('false')).toBe(false);
+        expect(force_color_is_enabled('FALSE')).toBe(false);
+        expect(force_color_is_enabled('off')).toBe(false);
+        expect(force_color_is_enabled('1')).toBe(true);
+        expect(force_color_is_enabled('true')).toBe(true);
+        expect(force_color_is_enabled('')).toBe(false);
+        expect(force_color_is_enabled(undefined)).toBe(false);
     });
 });
 

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import {
+    collect_report_targets,
+    is_stata_source_path,
+    read_source_file,
+    size_limit_diagnostic,
+} from '../../../src/cli/source-files';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-source-'));
+}
+
+describe('sight check source files', () => {
+    it('recognizes Stata source extensions case-insensitively', () => {
+        expect(is_stata_source_path('/x/a.do')).toBe(true);
+        expect(is_stata_source_path('/x/a.DO')).toBe(true);
+        expect(is_stata_source_path('/x/a.ado')).toBe(true);
+        expect(is_stata_source_path('/x/a.doh')).toBe(true);
+        expect(is_stata_source_path('/x/a.mata')).toBe(true);
+        expect(is_stata_source_path('/x/a.txt')).toBe(false);
+    });
+
+    it('collects supported source files from directories and skips VCS dirs', () => {
+        const root = temp_dir();
+        fs.mkdirSync(path.join(root, 'analysis'));
+        fs.mkdirSync(path.join(root, '.git'));
+        fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
+        fs.writeFileSync(path.join(root, 'analysis', 'helper.ADO'), 'program x\nend\n');
+        fs.writeFileSync(path.join(root, '.git', 'ignored.do'), 'bad\n');
+        fs.writeFileSync(path.join(root, 'notes.txt'), 'ignored\n');
+
+        const result = collect_report_targets([], root, root);
+
+        expect(result.operator_errors).toEqual([]);
+        expect(result.targets.map((target) => target.relative_path)).toEqual([
+            'analysis/helper.ADO',
+            'main.do',
+        ]);
+    });
+
+    it('resolves explicit paths from cwd and reports missing paths as operator errors', () => {
+        const root = temp_dir();
+        const cwd = temp_dir();
+        fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
+
+        const result = collect_report_targets(
+            [path.relative(cwd, path.join(root, 'main.do')), 'missing.do'],
+            root,
+            cwd
+        );
+
+        expect(result.targets.map((target) => target.path)).toEqual([
+            path.join(root, 'main.do'),
+        ]);
+        expect(result.operator_errors).toHaveLength(1);
+        expect(result.operator_errors[0]).toContain('missing.do');
+    });
+
+    it('ignores explicit existing non-source files', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'notes.txt'), 'ignored\n');
+
+        const result = collect_report_targets(['notes.txt'], root, root);
+
+        expect(result.targets).toEqual([]);
+        expect(result.operator_errors).toEqual([]);
+    });
+
+    it('turns oversize explicit targets into error diagnostics', () => {
+        const diagnostic = size_limit_diagnostic('/x/main.do', 11, 10);
+
+        expect(diagnostic.severity).toBe(DiagnosticSeverity.Error);
+        expect(diagnostic.range.start).toEqual({ line: 0, character: 0 });
+        expect(diagnostic.message).toContain('exceeds');
+        expect(diagnostic.message).toContain('10 bytes');
+    });
+
+    it('reads UTF-8 and reports invalid UTF-8 as a diagnostic input error', () => {
+        const root = temp_dir();
+        const good = path.join(root, 'good.do');
+        const bad = path.join(root, 'bad.do');
+        fs.writeFileSync(good, 'display 1\n');
+        fs.writeFileSync(bad, Buffer.from([0x64, 0x69, 0x80]));
+
+        expect(read_source_file(good).kind).toBe('ok');
+        const result = read_source_file(bad);
+
+        expect(result.kind).toBe('decode-error');
+        if (result.kind === 'decode-error') {
+            expect(result.diagnostic.message).toContain('offset 2');
+            expect(result.diagnostic.severity).toBe(DiagnosticSeverity.Error);
+        }
+    });
+});

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -71,12 +71,15 @@ describe('sight check source files', () => {
     });
 
     it('turns oversize explicit targets into error diagnostics', () => {
-        const diagnostic = size_limit_diagnostic('/x/main.do', 11, 10);
+        const diagnostic = size_limit_diagnostic(11, 10);
 
         expect(diagnostic.severity).toBe(DiagnosticSeverity.Error);
         expect(diagnostic.range.start).toEqual({ line: 0, character: 0 });
         expect(diagnostic.message).toContain('exceeds');
         expect(diagnostic.message).toContain('10 bytes');
+        // The message must not embed an absolute path (machine-specific, breaks
+        // golden comparisons); the renderer shows the relative location.
+        expect(diagnostic.message).not.toContain('/');
     });
 
     it('reads UTF-8 and reports invalid UTF-8 as a diagnostic input error', () => {

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -110,6 +110,36 @@ describe('sight check source files', () => {
         }
     });
 
+    it('points at the START of a truncated multi-byte sequence', () => {
+        const root = temp_dir();
+        const bad = path.join(root, 'bad.do');
+        // "a" then lead byte 0xC3 with no continuation byte (truncated at EOF).
+        // The offset must be the lead byte (1), not the trailing byte.
+        fs.writeFileSync(bad, Buffer.from([0x61, 0xC3]));
+
+        const result = read_source_file(bad);
+
+        expect(result.kind).toBe('decode-error');
+        if (result.kind === 'decode-error') {
+            expect(result.diagnostic.message).toContain('offset 1');
+        }
+    });
+
+    it('points at the START of a sequence with an invalid continuation', () => {
+        const root = temp_dir();
+        const bad = path.join(root, 'bad.do');
+        // 0xE2 expects two continuation bytes; 0x28 '(' is not one, so the bad
+        // sequence begins at the lead byte (index 1), not at the 0x28.
+        fs.writeFileSync(bad, Buffer.from([0x61, 0xE2, 0x28, 0xA1]));
+
+        const result = read_source_file(bad);
+
+        expect(result.kind).toBe('decode-error');
+        if (result.kind === 'decode-error') {
+            expect(result.diagnostic.message).toContain('offset 1');
+        }
+    });
+
     it('locates the bad byte offset in a large file without quadratic cost', () => {
         const root = temp_dir();
         const bad = path.join(root, 'big.do');

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -5,10 +5,10 @@ import * as path from 'path';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import {
     collect_report_targets,
-    is_stata_source_path,
     read_source_file,
     size_limit_diagnostic,
 } from '../../../src/cli/source-files';
+import { hasStataExtension } from '../../../src/utils/file-path-utils';
 
 function temp_dir(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-source-'));
@@ -16,12 +16,12 @@ function temp_dir(): string {
 
 describe('sight check source files', () => {
     it('recognizes Stata source extensions case-insensitively', () => {
-        expect(is_stata_source_path('/x/a.do')).toBe(true);
-        expect(is_stata_source_path('/x/a.DO')).toBe(true);
-        expect(is_stata_source_path('/x/a.ado')).toBe(true);
-        expect(is_stata_source_path('/x/a.doh')).toBe(true);
-        expect(is_stata_source_path('/x/a.mata')).toBe(true);
-        expect(is_stata_source_path('/x/a.txt')).toBe(false);
+        expect(hasStataExtension('/x/a.do')).toBe(true);
+        expect(hasStataExtension('/x/a.DO')).toBe(true);
+        expect(hasStataExtension('/x/a.ado')).toBe(true);
+        expect(hasStataExtension('/x/a.doh')).toBe(true);
+        expect(hasStataExtension('/x/a.mata')).toBe(true);
+        expect(hasStataExtension('/x/a.txt')).toBe(false);
     });
 
     it('collects supported source files from directories and skips VCS dirs', () => {

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -95,4 +95,37 @@ describe('sight check source files', () => {
             expect(result.diagnostic.severity).toBe(DiagnosticSeverity.Error);
         }
     });
+
+    it('reports the bad byte offset after valid multi-byte sequences', () => {
+        const root = temp_dir();
+        const bad = path.join(root, 'bad.do');
+        // "d" + "é" (0xC3 0xA9) + lone continuation byte 0x80 at index 3.
+        fs.writeFileSync(bad, Buffer.from([0x64, 0xC3, 0xA9, 0x80]));
+
+        const result = read_source_file(bad);
+
+        expect(result.kind).toBe('decode-error');
+        if (result.kind === 'decode-error') {
+            expect(result.diagnostic.message).toContain('offset 3');
+        }
+    });
+
+    it('locates the bad byte offset in a large file without quadratic cost', () => {
+        const root = temp_dir();
+        const bad = path.join(root, 'big.do');
+        // 500k valid ASCII bytes then one invalid byte: an O(n^2) scan would
+        // stall here, so this doubles as a performance regression guard.
+        const bytes = Buffer.concat([
+            Buffer.alloc(500_000, 0x61),
+            Buffer.from([0x80]),
+        ]);
+        fs.writeFileSync(bad, bytes);
+
+        const result = read_source_file(bad);
+
+        expect(result.kind).toBe('decode-error');
+        if (result.kind === 'decode-error') {
+            expect(result.diagnostic.message).toContain('offset 500000');
+        }
+    });
 });

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -54,7 +54,7 @@ describe('sight check source files', () => {
         );
 
         expect(result.targets.map((target) => target.path)).toEqual([
-            path.join(root, 'main.do'),
+            fs.realpathSync.native(path.join(root, 'main.do')),
         ]);
         expect(result.operator_errors).toHaveLength(1);
         expect(result.operator_errors[0]).toContain('missing.do');

--- a/tests/unit/config-file/case-alias.test.ts
+++ b/tests/unit/config-file/case-alias.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    deep_merge_config,
+    map_public_config_to_partial_config,
+} from '../../../src/config-file';
+import type { ProjectConfigWarning } from '../../../src/config-file';
+import { validate_comment_formatting_config } from '../../../src/utils/config-validator';
+import type { StataLSPConfig } from '../../../src/types';
+
+// The canonical public convention is camelCase, but every public setting must
+// also accept its snake_case spelling (and vice-versa) as a permanent,
+// equivalent alias. These tests resolve a public-shape settings object through
+// the same pipeline the server uses (map -> merge -> validate) and assert that
+// the camelCase and snake_case spellings of every setting produce identical
+// effective StataLSPConfig values, with no warnings.
+
+interface Resolved {
+    config: StataLSPConfig;
+    warnings: string[];
+}
+
+function resolve_public_settings(public_config: unknown): Resolved {
+    const warnings: string[] = [];
+    const mapped = map_public_config_to_partial_config(
+        public_config,
+        (warning: ProjectConfigWarning) => warnings.push(warning.message)
+    );
+    const merged = deep_merge_config({}, mapped);
+    const config = validate_comment_formatting_config(merged);
+    return { config, warnings };
+}
+
+// Convert a camelCase identifier to snake_case. Used to derive the alias form
+// for each leaf key so the table stays single-sourced on the camelCase name.
+function to_snake_case(name: string): string {
+    return name.replace(/([A-Z])/g, '_$1').toLowerCase();
+}
+
+// Build a nested public-config object from a dotted camelCase path and a value.
+function build_nested(path: string[], value: unknown): Record<string, unknown> {
+    const root: Record<string, unknown> = {};
+    let cursor = root;
+    for (let i = 0; i < path.length - 1; i++) {
+        const next: Record<string, unknown> = {};
+        cursor[path[i]] = next;
+        cursor = next;
+    }
+    cursor[path[path.length - 1]] = value;
+    return root;
+}
+
+// Build the same object but with every path segment rewritten to snake_case.
+function build_nested_snake(
+    path: string[],
+    value: unknown
+): Record<string, unknown> {
+    return build_nested(path.map(to_snake_case), value);
+}
+
+// Every public setting, by its dotted camelCase path, paired with a
+// non-default value. Validating against a non-default value proves the setting
+// actually took effect (rather than coinciding with the default).
+const PUBLIC_SETTINGS: ReadonlyArray<{ path: string[]; value: unknown }> = [
+    // Top-level
+    { path: ['indexWorkspace'], value: false },
+    { path: ['adoPaths'], value: ['/custom/ado', '/more/ado'] },
+    { path: ['lineCommentStyle'], value: '*' },
+    { path: ['debug'], value: true },
+
+    // diagnostics
+    { path: ['diagnostics', 'enabled'], value: false },
+    { path: ['diagnostics', 'indentation'], value: true },
+
+    // diagnostics.severity
+    { path: ['diagnostics', 'severity', 'undefinedMacro'], value: 'error' },
+    { path: ['diagnostics', 'severity', 'undefinedVariable'], value: 'warning' },
+    { path: ['diagnostics', 'severity', 'styleWarnings'], value: 'error' },
+    { path: ['diagnostics', 'severity', 'malformedOperator'], value: 'error' },
+    {
+        path: ['diagnostics', 'severity', 'invalidOperatorSequence'],
+        value: 'warning',
+    },
+    {
+        path: ['diagnostics', 'severity', 'cStyleLogicalInControlFlow'],
+        value: 'error',
+    },
+    {
+        path: ['diagnostics', 'severity', 'mixedLogicalOperators'],
+        value: 'error',
+    },
+
+    // formatting
+    { path: ['formatting', 'indentSize'], value: 2 },
+    { path: ['formatting', 'indentStyle'], value: 'tabs' },
+    { path: ['formatting', 'lineWidth'], value: 100 },
+    { path: ['formatting', 'preferredCommentStyle'], value: '*' },
+    { path: ['formatting', 'normalizeCommentStyle'], value: true },
+    { path: ['formatting', 'commentLineWidth'], value: 88 },
+    { path: ['formatting', 'mode'], value: 'ast' },
+    { path: ['formatting', 'preserveAlignment'], value: false },
+
+    // completion
+    { path: ['completion', 'cacheSize'], value: 50 },
+    { path: ['completion', 'prefixMaxItems'], value: 25 },
+
+    // indexing
+    { path: ['indexing', 'maxFileSizeBytes'], value: 12345 },
+
+    // crossFile
+    { path: ['crossFile', 'indexWorkspace'], value: false },
+    { path: ['crossFile', 'maxIndexedFiles'], value: 17 },
+    { path: ['crossFile', 'assumeCallSite'], value: 'start' },
+    { path: ['crossFile', 'backwardDependencies'], value: 'explicit' },
+    { path: ['crossFile', 'maxBackwardDepth'], value: 3 },
+    { path: ['crossFile', 'maxForwardDepth'], value: 4 },
+    { path: ['crossFile', 'maxChainDepth'], value: 5 },
+    { path: ['crossFile', 'maxCalleeRevalidations'], value: 6 },
+
+    // crossFile.diagnostics
+    { path: ['crossFile', 'diagnostics', 'missingFile'], value: 'error' },
+    { path: ['crossFile', 'diagnostics', 'maxDepth'], value: 'off' },
+    {
+        path: ['crossFile', 'diagnostics', 'callSiteIdentification'],
+        value: 'off',
+    },
+];
+
+describe('public config camelCase/snake_case alias guarantee', () => {
+    for (const my_setting of PUBLIC_SETTINGS) {
+        const dotted = my_setting.path.join('.');
+        it(`accepts both spellings for ${dotted}`, () => {
+            const camel = resolve_public_settings(
+                build_nested(my_setting.path, my_setting.value)
+            );
+            const snake = resolve_public_settings(
+                build_nested_snake(my_setting.path, my_setting.value)
+            );
+
+            // Neither spelling produces warnings (both are first-class).
+            expect(camel.warnings).toEqual([]);
+            expect(snake.warnings).toEqual([]);
+
+            // Both spellings produce identical effective settings.
+            expect(snake.config).toEqual(camel.config);
+
+            // And the value actually took effect (differs from a no-op config).
+            const baseline = resolve_public_settings({});
+            expect(camel.config).not.toEqual(baseline.config);
+        });
+    }
+
+    it('produces no warnings for a full sight tree with client-only keys', () => {
+        // A full `sight` settings tree pushed via getConfiguration carries
+        // client-only sections (sendToStata, dataBrowser, depthColors,
+        // personalAdoDir). The mapper must recognize-and-ignore them rather
+        // than warn, so the live VS Code path stays quiet.
+        const { warnings } = resolve_public_settings({
+            crossFile: { maxChainDepth: 7 },
+            formatting: { preserveAlignment: false },
+            sendToStata: { saveBeforeSend: true, workingDirectory: 'lsp' },
+            dataBrowser: { maxStoredLayouts: 5, persistSort: true },
+            depthColors: { enabled: true },
+            personalAdoDir: '/home/user/ado',
+        });
+        expect(warnings).toEqual([]);
+    });
+
+    it('still warns on a genuinely unknown top-level key', () => {
+        const { warnings } = resolve_public_settings({
+            notARealSetting: true,
+        });
+        expect(warnings.join('\n')).toContain('notARealSetting');
+    });
+
+    it('resolves a mixed camelCase/snake_case tree identically', () => {
+        // A user mixing both conventions in one config must get the same
+        // result as either pure-convention spelling.
+        const mixed = resolve_public_settings({
+            crossFile: { max_chain_depth: 5, maxForwardDepth: 4 },
+            formatting: { preserve_alignment: false, indentSize: 2 },
+            diagnostics: { severity: { undefined_macro: 'error' } },
+        });
+        const camel = resolve_public_settings({
+            crossFile: { maxChainDepth: 5, maxForwardDepth: 4 },
+            formatting: { preserveAlignment: false, indentSize: 2 },
+            diagnostics: { severity: { undefinedMacro: 'error' } },
+        });
+        expect(mixed.warnings).toEqual([]);
+        expect(mixed.config).toEqual(camel.config);
+    });
+});

--- a/tests/unit/document-store-eviction.test.ts
+++ b/tests/unit/document-store-eviction.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import { DocumentStore } from '../../src/document-store';
+
+type InspectableDocumentStore = DocumentStore & {
+    documents: Map<string, unknown>;
+    access_order: Set<string>;
+    in_flight_counts: Map<string, number>;
+    MAX_DOCUMENTS: number;
+    evict_if_needed(incoming_bytes: number): void;
+};
+
+describe('DocumentStore eviction', () => {
+    it('skips in-flight documents when evicting by count', () => {
+        const document_store = new DocumentStore();
+        const store = document_store as unknown as InspectableDocumentStore;
+        const in_flight_uri = 'file:///in-flight.do';
+        const evictable_uri = 'file:///evictable.do';
+
+        store.MAX_DOCUMENTS = 2;
+        store.documents.set(in_flight_uri, { content: '', tokens: [] });
+        store.documents.set(evictable_uri, { content: '', tokens: [] });
+        store.access_order.add(in_flight_uri);
+        store.access_order.add(evictable_uri);
+        store.in_flight_counts.set(in_flight_uri, 1);
+
+        store.evict_if_needed(1);
+
+        expect(store.documents.has(in_flight_uri)).toBe(true);
+        expect(store.documents.has(evictable_uri)).toBe(false);
+    });
+});

--- a/tests/unit/document-store-version-guard.test.ts
+++ b/tests/unit/document-store-version-guard.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import { DocumentState, DocumentStore } from '../../src/document-store';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { ScopeResolver } from '../../src/scope-resolver';
+import type { ContentProvider } from '../../src/types';
+import { URI } from 'vscode-uri';
 
 type InspectableDocumentStore = DocumentStore & {
     documents: Map<string, DocumentState>;
@@ -83,6 +88,71 @@ describe('DocumentStore version guard', () => {
         expect(state).toBeDefined();
         expect(state!.version).toBe(3);
         expect(state!.content).toBe('content v3');
+    });
+
+    it('keeps newer backward directive side effects after stale update', async () => {
+        const document_store = new DocumentStore();
+        const workspace_indexer = new WorkspaceIndexer();
+        const dependency_graph = new DependencyGraph();
+        const parent_path = '/tmp/sight-f8-parent.do';
+        const parent_uri = URI.file(parent_path).toString();
+        const child_uri = URI.file('/tmp/sight-f8-child.do').toString();
+        const content_by_uri = new Map<string, string>([
+            [parent_uri, 'display 0\n'],
+            [child_uri, 'display 1\n'],
+        ]);
+        const content_provider: ContentProvider = {
+            read_file: async (uri) => content_by_uri.get(uri) ?? '',
+            exists: async (uri) => content_by_uri.has(uri),
+            stat: async (uri) => {
+                const content = content_by_uri.get(uri);
+                return content === undefined
+                    ? undefined
+                    : { mtimeMs: 0, size: content.length };
+            },
+        };
+        const scope_resolver = new ScopeResolver(undefined, content_provider);
+
+        workspace_indexer.set_dependency_graph(dependency_graph);
+        scope_resolver.set_dependency_graph(dependency_graph);
+        document_store.set_scope_resolver(scope_resolver);
+        document_store.set_on_backward_directives_parsed((uri, directives) => {
+            workspace_indexer.set_buffer_directives(uri, directives);
+        });
+
+        await document_store.open(child_uri, 'display 1', 1);
+
+        const content_with_directive =
+            `// @lsp-done-by: "${parent_path}"\n` +
+            'display 3\n';
+        const content_without_directive = 'display 2\n';
+        content_by_uri.set(child_uri, content_with_directive);
+
+        const update_v3 = document_store.update(
+            child_uri,
+            [{ text: content_with_directive }],
+            3
+        );
+        const update_v2 = document_store.update(
+            child_uri,
+            [{ text: content_without_directive }],
+            2
+        );
+
+        await Promise.all([update_v3, update_v2]);
+
+        const state = document_store.get(child_uri);
+        expect(state).toBeDefined();
+        expect(state!.version).toBe(3);
+        expect(state!.content).toBe(content_with_directive);
+
+        const related_uris = workspace_indexer.get_related_uris(parent_uri);
+        expect(related_uris.has(child_uri)).toBe(true);
+        const directive_children =
+            scope_resolver.get_backward_directive_children(parent_uri);
+        expect(
+            directive_children.has(child_uri)
+        ).toBe(true);
     });
 
     it('rejects older-version updates even when scope config is present', async () => {

--- a/tests/unit/document-store-version-guard.test.ts
+++ b/tests/unit/document-store-version-guard.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test';
+import { DocumentStore } from '../../src/document-store';
+
+describe('DocumentStore version guard', () => {
+    it('rejects older-version updates even when scope config is present', async () => {
+        const document_store = new DocumentStore();
+        const uri = 'file:///version-guard.do';
+
+        await document_store.open(uri, 'content v1', 1);
+        await document_store.update(uri, [{ text: 'content v3' }], 3);
+
+        await document_store.update(
+            uri,
+            [{ text: 'content v2' }],
+            2,
+            undefined,
+            { backward_dependencies: 'auto' }
+        );
+
+        const state = document_store.get(uri);
+        expect(state).toBeDefined();
+        expect(state!.version).toBe(3);
+        expect(state!.content).toBe('content v3');
+    });
+});

--- a/tests/unit/document-store-version-guard.test.ts
+++ b/tests/unit/document-store-version-guard.test.ts
@@ -1,7 +1,90 @@
 import { describe, expect, it } from 'bun:test';
-import { DocumentStore } from '../../src/document-store';
+import { DocumentState, DocumentStore } from '../../src/document-store';
+
+type InspectableDocumentStore = DocumentStore & {
+    documents: Map<string, DocumentState>;
+    generations: Map<string, number>;
+    commit_state(
+        uri: string,
+        state: DocumentState,
+        generation: number
+    ): void;
+    create_document_state(
+        uri: string,
+        content: string,
+        version: number
+    ): Promise<DocumentState>;
+};
 
 describe('DocumentStore version guard', () => {
+    it('rejects older commit state while allowing equal-version reparses', async () => {
+        const document_store = new DocumentStore();
+        const store = document_store as unknown as InspectableDocumentStore;
+        const uri = 'file:///version-guard-commit.do';
+
+        await document_store.open(uri, 'content v3', 3);
+        const state_v3 = document_store.get(uri);
+        expect(state_v3).toBeDefined();
+
+        const stale_state_v2 = {
+            ...state_v3!,
+            version: 2,
+            content: 'content v2',
+        };
+        store.commit_state(uri, stale_state_v2, 2);
+
+        expect(store.documents.get(uri)).toBe(state_v3);
+        expect(store.documents.get(uri)!.version).toBe(3);
+        expect(store.documents.get(uri)!.content).toBe('content v3');
+
+        const reparse_state_v3 = {
+            ...state_v3!,
+            content: 'content v3 reparse',
+        };
+        store.commit_state(uri, reparse_state_v3, 3);
+
+        expect(store.documents.get(uri)).toBe(reparse_state_v3);
+        expect(store.documents.get(uri)!.version).toBe(3);
+        expect(store.documents.get(uri)!.content).toBe('content v3 reparse');
+    });
+
+    it('keeps newer content when concurrent updates commit out of order', async () => {
+        const document_store = new DocumentStore();
+        const store = document_store as unknown as InspectableDocumentStore;
+        const uri = 'file:///version-guard-concurrent.do';
+        let release_v2_parse: (() => void) | undefined;
+        const v2_parse_can_finish = new Promise<void>(resolve => {
+            release_v2_parse = resolve;
+        });
+        const create_document_state = store.create_document_state.bind(store);
+
+        store.create_document_state = async (
+            state_uri: string,
+            content: string,
+            version: number
+        ) => {
+            const state = await create_document_state(state_uri, content, version);
+            if (version === 2) {
+                await v2_parse_can_finish;
+            }
+            return state;
+        };
+
+        await document_store.open(uri, 'content v1', 1);
+
+        const update_v3 = document_store.update(uri, [{ text: 'content v3' }], 3);
+        const update_v2 = document_store.update(uri, [{ text: 'content v2' }], 2);
+
+        await update_v3;
+        release_v2_parse!();
+        await update_v2;
+
+        const state = document_store.get(uri);
+        expect(state).toBeDefined();
+        expect(state!.version).toBe(3);
+        expect(state!.content).toBe('content v3');
+    });
+
     it('rejects older-version updates even when scope config is present', async () => {
         const document_store = new DocumentStore();
         const uri = 'file:///version-guard.do';

--- a/tests/unit/document-store-version-guard.test.ts
+++ b/tests/unit/document-store-version-guard.test.ts
@@ -53,36 +53,22 @@ describe('DocumentStore version guard', () => {
         expect(store.documents.get(uri)!.content).toBe('content v3 reparse');
     });
 
-    it('keeps newer content when concurrent updates commit out of order', async () => {
+    it('rejects a queued stale update and keeps the newer committed content', async () => {
         const document_store = new DocumentStore();
-        const store = document_store as unknown as InspectableDocumentStore;
         const uri = 'file:///version-guard-concurrent.do';
-        let release_v2_parse: (() => void) | undefined;
-        const v2_parse_can_finish = new Promise<void>(resolve => {
-            release_v2_parse = resolve;
-        });
-        const create_document_state = store.create_document_state.bind(store);
-
-        store.create_document_state = async (
-            state_uri: string,
-            content: string,
-            version: number
-        ) => {
-            const state = await create_document_state(state_uri, content, version);
-            if (version === 2) {
-                await v2_parse_can_finish;
-            }
-            return state;
-        };
 
         await document_store.open(uri, 'content v1', 1);
 
+        // A newer update (v3) and an older update (v2) are issued before the
+        // first settles. Per-URI serialization runs them in issue order, so
+        // the queued v2 sees the already-committed v3 and is rejected by the
+        // strict stale-version guard before it can reparse. (Genuine
+        // out-of-order parse completion is impossible by design: each update
+        // awaits the prior one, so parse order always matches issue order.)
         const update_v3 = document_store.update(uri, [{ text: 'content v3' }], 3);
         const update_v2 = document_store.update(uri, [{ text: 'content v2' }], 2);
 
-        await update_v3;
-        release_v2_parse!();
-        await update_v2;
+        await Promise.all([update_v3, update_v2]);
 
         const state = document_store.get(uri);
         expect(state).toBeDefined();

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -443,6 +443,41 @@ describe('WorkspaceIndexer', () => {
         expect(the_related).toContain(my_postest_path);
     });
 
+    it('re-indexes an already-indexed file after the cap is reached', async () => {
+        indexer.set_max_indexed_files(1);
+        const file_path = path.join(temp_dir, 'a.do');
+        fs.writeFileSync(file_path, 'program define first_prog\nend');
+
+        await indexer.index_file(file_path);
+        expect(indexer.get_all_symbols().programs.has('first_prog')).toBe(true);
+        expect(indexer.get_metrics().files_indexed).toBe(1);
+
+        // The cap is now reached (files_indexed == max == 1). Editing an
+        // already-indexed file must still refresh its symbols rather than
+        // silently keep the stale entry, and must not re-increment the count.
+        fs.writeFileSync(file_path, 'program define second_prog\nend');
+        await indexer.index_file(file_path);
+
+        expect(indexer.get_all_symbols().programs.has('second_prog')).toBe(true);
+        expect(indexer.get_all_symbols().programs.has('first_prog')).toBe(false);
+        expect(indexer.get_metrics().files_indexed).toBe(1);
+    });
+
+    it('still skips a genuinely new file once the cap is reached', async () => {
+        indexer.set_max_indexed_files(1);
+        const a_path = path.join(temp_dir, 'a.do');
+        const b_path = path.join(temp_dir, 'b.do');
+        fs.writeFileSync(a_path, 'program define prog_a\nend');
+        fs.writeFileSync(b_path, 'program define prog_b\nend');
+
+        await indexer.index_file(a_path);
+        await indexer.index_file(b_path);
+
+        expect(indexer.get_all_symbols().programs.has('prog_a')).toBe(true);
+        expect(indexer.get_all_symbols().programs.has('prog_b')).toBe(false);
+        expect(indexer.get_metrics().files_indexed).toBe(1);
+    });
+
     it('should debounce rapid file updates', async () => {
         const file_path = path.join(temp_dir, 'debounce.do');
         fs.writeFileSync(file_path, 'program define prog1\nend');

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -443,6 +443,21 @@ describe('WorkspaceIndexer', () => {
         expect(the_related).toContain(my_postest_path);
     });
 
+    it('decrements files_indexed when an already-indexed file is evicted', async () => {
+        const file_path = path.join(temp_dir, 'a.do');
+        fs.writeFileSync(file_path, 'program define p\nend');
+        await indexer.index_file(file_path);
+        expect(indexer.get_metrics().files_indexed).toBe(1);
+
+        // Grow the file past the size threshold; re-indexing evicts it, and
+        // the distinct-file count must drop rather than stay inflated.
+        fs.writeFileSync(file_path, 'a'.repeat(600 * 1024));
+        await indexer.index_file(file_path);
+
+        expect(indexer.get_metrics().files_indexed).toBe(0);
+        expect(indexer.get_metrics().files_skipped).toBeGreaterThan(0);
+    });
+
     it('re-indexes an already-indexed file after the cap is reached', async () => {
         indexer.set_max_indexed_files(1);
         const file_path = path.join(temp_dir, 'a.do');

--- a/tests/unit/server-handlers-scope-config.test.ts
+++ b/tests/unit/server-handlers-scope-config.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    create_completion_handler,
+    create_definition_handler,
+    create_hover_handler,
+    create_references_handler,
+    DEFAULT_SETTINGS,
+    type HandlerDependencies,
+} from '../../src/server-handlers';
+import { DocumentStore } from '../../src/document-store';
+import type { ScopeResolverConfig, StataLSPConfig } from '../../src/types';
+
+type CapturedScopeConfigs = {
+    completion?: Partial<ScopeResolverConfig>;
+    hover?: Partial<ScopeResolverConfig>;
+    definition?: Partial<ScopeResolverConfig>;
+    references?: Partial<ScopeResolverConfig>;
+};
+
+const TEST_SCOPE_CONFIG: Partial<ScopeResolverConfig> = {
+    assume_call_site: 'start',
+    backward_dependencies: 'explicit',
+    max_backward_depth: 3,
+    max_forward_depth: 4,
+    max_chain_depth: 7,
+};
+
+function create_test_config(): StataLSPConfig {
+    return {
+        ...DEFAULT_SETTINGS,
+        cross_file: {
+            ...DEFAULT_SETTINGS.cross_file,
+            ...TEST_SCOPE_CONFIG,
+        },
+    };
+}
+
+function create_capture_deps(
+    captured_configs: CapturedScopeConfigs
+): HandlerDependencies {
+    const document_store = new DocumentStore();
+
+    return {
+        debounce_manager: null,
+        document_store,
+        diagnostics_provider: null,
+        completion_provider: {
+            get_completions: async (...the_args) => {
+                captured_configs.completion = the_args[5];
+                return [];
+            },
+        } as NonNullable<HandlerDependencies['completion_provider']>,
+        hover_provider: {
+            get_hover: async (...the_args) => {
+                captured_configs.hover = the_args[4];
+                return null;
+            },
+        } as NonNullable<HandlerDependencies['hover_provider']>,
+        definition_provider: {
+            get_definition: async (...the_args) => {
+                captured_configs.definition = the_args[6];
+                return null;
+            },
+        } as NonNullable<HandlerDependencies['definition_provider']>,
+        references_provider: {
+            get_references: async (...the_args) => {
+                captured_configs.references = the_args[6];
+                return [];
+            },
+        } as NonNullable<HandlerDependencies['references_provider']>,
+        symbol_provider: null,
+        formatter_provider: null,
+        workspace_indexer: null,
+        scope_resolver: null,
+        forward_scope_resolver: null,
+        dependency_graph: null,
+        rename_handler: null,
+        get_document_settings: async () => create_test_config(),
+        connection: {
+            sendDiagnostics: () => {},
+            console: { log: () => {} },
+        },
+    };
+}
+
+async function open_test_document(
+    document_store: DocumentStore,
+    uri: string
+): Promise<void> {
+    await document_store.open(uri, 'display 1\n', 1);
+}
+
+function expect_scope_config_forwarded(
+    config: Partial<ScopeResolverConfig> | undefined
+): void {
+    expect(config).toMatchObject(TEST_SCOPE_CONFIG);
+}
+
+describe('server handler scope resolver config routing', () => {
+    it('forwards configured depth limits to cross-file-aware providers', async () => {
+        const captured_configs: CapturedScopeConfigs = {};
+        const deps = create_capture_deps(captured_configs);
+        const my_uri = 'file:///scope-config-routing.do';
+        const position = { line: 0, character: 0 };
+
+        await open_test_document(deps.document_store, my_uri);
+
+        await create_completion_handler(deps)(
+            { textDocument: { uri: my_uri }, position },
+            undefined
+        );
+        await create_hover_handler(deps)(
+            { textDocument: { uri: my_uri }, position },
+            undefined
+        );
+        await create_definition_handler(deps)(
+            { textDocument: { uri: my_uri }, position },
+            undefined
+        );
+        await create_references_handler(deps)(
+            {
+                textDocument: { uri: my_uri },
+                position,
+                context: { includeDeclaration: true },
+            },
+            undefined
+        );
+
+        expect_scope_config_forwarded(captured_configs.completion);
+        expect_scope_config_forwarded(captured_configs.hover);
+        expect_scope_config_forwarded(captured_configs.definition);
+        expect_scope_config_forwarded(captured_configs.references);
+    });
+});

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -56,6 +56,16 @@ describe('server-factory project config wiring', () => {
             },
         });
         expect(client_wins.cross_file.backward_dependencies).toBe('auto');
+
+        // init options alone must apply, including the `{ sight: {...} }`
+        // wrapper unwrap that non-VS-Code clients send; without a client or
+        // project layer there is nothing else to mask a broken init mapping.
+        const init_only = build_non_capability_settings_from_sources({
+            init_options_config: {
+                sight: { crossFile: { backwardDependencies: 'explicit' } },
+            },
+        });
+        expect(init_only.cross_file.backward_dependencies).toBe('explicit');
     });
 
     it('maps and unwraps the live per-scope getConfiguration result', () => {

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -37,4 +37,16 @@ describe('server-factory project config wiring', () => {
             /const\s+merged_partial\s*=\s*deep_merge_config\(\s*client_partial,\s*project_file_config\s*\|\|\s*\{\}\s*\)/
         );
     });
+
+    it('maps camelCase initialization options into the internal shape', () => {
+        // Regression guard: initializationOptions must be run through the
+        // public->internal mapper, otherwise crossFile/preserveAlignment from
+        // non-VS-Code clients are silently dropped by the validator.
+        const source = fs.readFileSync(server_factory_path, 'utf8');
+
+        expect(source).toContain('function map_init_options');
+        expect(source).toMatch(
+            /init_partial\s*=\s*map_init_options\(\s*\n?\s*init_record\?\.\['sight'\]\s*\?\?\s*init_options_config/
+        );
+    });
 });

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -58,8 +58,9 @@ describe('server-factory project config wiring', () => {
             /init_partial\s*=\s*map_public_settings\(\s*\n?\s*init_record\?\.\['sight'\]\s*\?\?\s*init_options_config/
         );
         // The pushed client settings (didChangeConfiguration) are mapped too.
-        expect(source).toContain(
-            'map_public_settings(\n            sources.last_client_settings,'
+        // Whitespace-tolerant so reformatting the call does not break the guard.
+        expect(source).toMatch(
+            /map_public_settings\(\s*\n?\s*sources\.last_client_settings,/
         );
         expect(source).toContain('select_pushed_client_settings');
         // The live getConfiguration result is mapped, not merged raw.

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -57,20 +57,6 @@ describe('server-factory project config wiring', () => {
         expect(client_wins.cross_file.backward_dependencies).toBe('auto');
     });
 
-    it('routes the live getConfiguration result through the shared builder', () => {
-        // Wiring guard: the per-scope getConfiguration path must delegate to
-        // build_non_capability_settings_from_sources (passing the live tree
-        // as the client layer) so it shares the mapping/precedence the
-        // behavioral tests cover, instead of re-implementing the merge inline.
-        const source = fs.readFileSync(server_factory_path, 'utf8');
-
-        expect(source).toContain('function map_public_settings');
-        expect(source).toContain('select_pushed_client_settings');
-        expect(source).toMatch(
-            /build_non_capability_settings_from_sources\(\{[\s\S]*?last_client_settings:\s*config,/
-        );
-    });
-
     it('builds merged settings for clients without configuration capability', () => {
         // Regression guard: non-capability clients cannot be queried per
         // document, so the workspace refresh and config reload must seed

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -34,14 +34,14 @@ describe('server-factory project config wiring', () => {
     it('merges client settings before project settings', () => {
         const source = fs.readFileSync(server_factory_path, 'utf8');
 
-        // The live getConfiguration result must be mapped (not merged raw)
-        // before merging, so camelCase/snake_case aliases both reach the
-        // internal shape; project config still wins as the final overlay.
+        // The shared builder maps the client layer (not merged raw) before
+        // merging, so camelCase/snake_case aliases both reach the internal
+        // shape; project config still wins as the final overlay.
         expect(source).toMatch(
-            /const\s+client_partial\s*=\s*deep_merge_config\(\s*\n?\s*init_partial,\s*\n?\s*map_public_settings\(config,\s*log_config_warning\)\s*\n?\s*\)/
+            /const\s+client_partial\s*=\s*deep_merge_config\(\s*\n?\s*init_partial,\s*\n?\s*map_public_settings\(\s*\n?\s*sources\.last_client_settings,/
         );
         expect(source).toMatch(
-            /const\s+merged_partial\s*=\s*deep_merge_config\(\s*\n?\s*client_partial,\s*\n?\s*project_file_config\s*\|\|\s*\{\}\s*\n?\s*\)/
+            /const\s+merged_partial\s*=\s*deep_merge_config\(\s*\n?\s*client_partial,\s*\n?\s*sources\.project_file_config\s*\|\|\s*\{\}\s*\n?\s*\)/
         );
     });
 
@@ -63,9 +63,12 @@ describe('server-factory project config wiring', () => {
             /map_public_settings\(\s*\n?\s*sources\.last_client_settings,/
         );
         expect(source).toContain('select_pushed_client_settings');
-        // The live getConfiguration result is mapped, not merged raw.
-        expect(source).toContain(
-            'map_public_settings(config, log_config_warning)'
+        // The live getConfiguration result flows through the shared builder
+        // as the client layer (last_client_settings), so it is mapped by the
+        // same map_public_settings(sources.last_client_settings, ...) call
+        // rather than merged raw.
+        expect(source).toMatch(
+            /build_non_capability_settings_from_sources\(\{[\s\S]*?last_client_settings:\s*config,/
         );
     });
 

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {
     build_non_capability_settings_from_sources,
+    resolve_scoped_client_settings,
     select_pushed_client_settings,
 } from '../../src/server-factory';
 
@@ -55,6 +56,30 @@ describe('server-factory project config wiring', () => {
             },
         });
         expect(client_wins.cross_file.backward_dependencies).toBe('auto');
+    });
+
+    it('maps and unwraps the live per-scope getConfiguration result', () => {
+        // Exercises the exact transformation get_document_settings applies to
+        // the live getConfiguration result: a wrapped `{ sight: {...} }`
+        // response is unwrapped and its camelCase keys are mapped to the
+        // internal shape (the regression the deleted source-regex guard
+        // covered, now behavioral).
+        const wrapped = resolve_scoped_client_settings(
+            { sight: { crossFile: { backwardDependencies: 'explicit' } } },
+            {}
+        );
+        expect(wrapped.cross_file.backward_dependencies).toBe('explicit');
+
+        // The live client layer is still overridden by project config.
+        const project_wins = resolve_scoped_client_settings(
+            { crossFile: { backwardDependencies: 'auto' } },
+            {
+                project_file_config: {
+                    cross_file: { backward_dependencies: 'explicit' },
+                },
+            }
+        );
+        expect(project_wins.cross_file.backward_dependencies).toBe('explicit');
     });
 
     it('builds merged settings for clients without configuration capability', () => {

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -135,4 +135,15 @@ describe('server-factory project config wiring', () => {
 
         expect(settings.cross_file.backward_dependencies).toBe('explicit');
     });
+
+    it('unwraps an explicitly-undefined sight section to undefined', () => {
+        // A client answering the section query with `{ sight: undefined }`
+        // must unwrap to undefined, not fall back to the whole wrapper (which
+        // would trip an unknown-top-level-key warning in the mapper).
+        expect(select_pushed_client_settings({ sight: undefined }))
+            .toBeUndefined();
+        // No `sight` key at all still returns the bare tree unchanged.
+        const bare = { crossFile: { backwardDependencies: 'auto' } };
+        expect(select_pushed_client_settings(bare)).toBe(bare);
+    });
 });

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -49,4 +49,18 @@ describe('server-factory project config wiring', () => {
             /init_partial\s*=\s*map_init_options\(\s*\n?\s*init_record\?\.\['sight'\]\s*\?\?\s*init_options_config/
         );
     });
+
+    it('builds merged settings for clients without configuration capability', () => {
+        // Regression guard: non-capability clients cannot be queried per
+        // document, so the workspace refresh and config reload must seed
+        // global_settings from the builder (init options + sight.toml), not
+        // read back the stale cached value via get_document_settings.
+        const source = fs.readFileSync(server_factory_path, 'utf8');
+
+        expect(source).toContain('function build_non_capability_settings');
+        const builder_uses = source.match(
+            /global_settings\s*=\s*build_non_capability_settings\(\)/g
+        ) || [];
+        expect(builder_uses.length).toBeGreaterThanOrEqual(2);
+    });
 });

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -66,9 +66,11 @@ describe('server-factory project config wiring', () => {
         // The live getConfiguration result flows through the shared builder
         // as the client layer (last_client_settings), so it is mapped by the
         // same map_public_settings(sources.last_client_settings, ...) call
-        // rather than merged raw.
+        // rather than merged raw. It is unwrapped via
+        // select_pushed_client_settings so a wrapped `{ sight: {...} }`
+        // response is handled the same way the push path handles it.
         expect(source).toMatch(
-            /build_non_capability_settings_from_sources\(\{[\s\S]*?last_client_settings:\s*config,/
+            /build_non_capability_settings_from_sources\(\{[\s\S]*?last_client_settings:\s*select_pushed_client_settings\(config\),/
         );
     });
 

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -31,46 +31,43 @@ describe('server-factory project config wiring', () => {
         expect(source).toMatch(/workspace_indexer\.initialize\(/);
     });
 
-    it('merges client settings before project settings', () => {
-        const source = fs.readFileSync(server_factory_path, 'utf8');
+    it('merges init, client, then project config in precedence order', () => {
+        // Behavioral guard for both the public->internal mapping and the
+        // precedence: every layer is mapped (so camelCase aliases like
+        // crossFile.* are not dropped), project config wins over client, and
+        // client wins over init options.
+        const project_wins = build_non_capability_settings_from_sources({
+            last_client_settings: {
+                crossFile: { backwardDependencies: 'auto' },
+            },
+            project_file_config: {
+                cross_file: { backward_dependencies: 'explicit' },
+            },
+        });
+        expect(project_wins.cross_file.backward_dependencies).toBe('explicit');
 
-        // The shared builder maps the client layer (not merged raw) before
-        // merging, so camelCase/snake_case aliases both reach the internal
-        // shape; project config still wins as the final overlay.
-        expect(source).toMatch(
-            /const\s+client_partial\s*=\s*deep_merge_config\(\s*\n?\s*init_partial,\s*\n?\s*map_public_settings\(\s*\n?\s*sources\.last_client_settings,/
-        );
-        expect(source).toMatch(
-            /const\s+merged_partial\s*=\s*deep_merge_config\(\s*\n?\s*client_partial,\s*\n?\s*sources\.project_file_config\s*\|\|\s*\{\}\s*\n?\s*\)/
-        );
+        const client_wins = build_non_capability_settings_from_sources({
+            init_options_config: {
+                sight: { crossFile: { backwardDependencies: 'explicit' } },
+            },
+            last_client_settings: {
+                crossFile: { backwardDependencies: 'auto' },
+            },
+        });
+        expect(client_wins.cross_file.backward_dependencies).toBe('auto');
     });
 
-    it('maps every public settings source into the internal shape', () => {
-        // Regression guard: initializationOptions, the live getConfiguration
-        // result, and pushed didChangeConfiguration settings must all run
-        // through the public->internal mapper. Otherwise camelCase keys like
-        // crossFile.* and formatting.preserveAlignment are silently dropped by
-        // the validator (which reads the hybrid internal shape).
+    it('routes the live getConfiguration result through the shared builder', () => {
+        // Wiring guard: the per-scope getConfiguration path must delegate to
+        // build_non_capability_settings_from_sources (passing the live tree
+        // as the client layer) so it shares the mapping/precedence the
+        // behavioral tests cover, instead of re-implementing the merge inline.
         const source = fs.readFileSync(server_factory_path, 'utf8');
 
         expect(source).toContain('function map_public_settings');
-        expect(source).toMatch(
-            /init_partial\s*=\s*map_public_settings\(\s*\n?\s*init_record\?\.\['sight'\]\s*\?\?\s*init_options_config/
-        );
-        // The pushed client settings (didChangeConfiguration) are mapped too.
-        // Whitespace-tolerant so reformatting the call does not break the guard.
-        expect(source).toMatch(
-            /map_public_settings\(\s*\n?\s*sources\.last_client_settings,/
-        );
         expect(source).toContain('select_pushed_client_settings');
-        // The live getConfiguration result flows through the shared builder
-        // as the client layer (last_client_settings), so it is mapped by the
-        // same map_public_settings(sources.last_client_settings, ...) call
-        // rather than merged raw. It is unwrapped via
-        // select_pushed_client_settings so a wrapped `{ sight: {...} }`
-        // response is handled the same way the push path handles it.
         expect(source).toMatch(
-            /build_non_capability_settings_from_sources\(\{[\s\S]*?last_client_settings:\s*select_pushed_client_settings\(config\),/
+            /build_non_capability_settings_from_sources\(\{[\s\S]*?last_client_settings:\s*config,/
         );
     });
 

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -30,24 +30,33 @@ describe('server-factory project config wiring', () => {
     it('merges client settings before project settings', () => {
         const source = fs.readFileSync(server_factory_path, 'utf8');
 
+        // The live getConfiguration result must be mapped (not merged raw)
+        // before merging, so camelCase/snake_case aliases both reach the
+        // internal shape; project config still wins as the final overlay.
         expect(source).toMatch(
-            /const\s+client_partial\s*=\s*deep_merge_config\(\s*init_partial\s*\|\|\s*\{\},\s*config\s*\|\|\s*\{\}\s*\)/
+            /const\s+client_partial\s*=\s*deep_merge_config\(\s*\n?\s*init_partial,\s*\n?\s*map_public_settings\(config\)\s*\n?\s*\)/
         );
         expect(source).toMatch(
-            /const\s+merged_partial\s*=\s*deep_merge_config\(\s*client_partial,\s*project_file_config\s*\|\|\s*\{\}\s*\)/
+            /const\s+merged_partial\s*=\s*deep_merge_config\(\s*\n?\s*client_partial,\s*\n?\s*project_file_config\s*\|\|\s*\{\}\s*\n?\s*\)/
         );
     });
 
-    it('maps camelCase initialization options into the internal shape', () => {
-        // Regression guard: initializationOptions must be run through the
-        // public->internal mapper, otherwise crossFile/preserveAlignment from
-        // non-VS-Code clients are silently dropped by the validator.
+    it('maps every public settings source into the internal shape', () => {
+        // Regression guard: initializationOptions, the live getConfiguration
+        // result, and pushed didChangeConfiguration settings must all run
+        // through the public->internal mapper. Otherwise camelCase keys like
+        // crossFile.* and formatting.preserveAlignment are silently dropped by
+        // the validator (which reads the hybrid internal shape).
         const source = fs.readFileSync(server_factory_path, 'utf8');
 
-        expect(source).toContain('function map_init_options');
+        expect(source).toContain('function map_public_settings');
         expect(source).toMatch(
-            /init_partial\s*=\s*map_init_options\(\s*\n?\s*init_record\?\.\['sight'\]\s*\?\?\s*init_options_config/
+            /init_partial\s*=\s*map_public_settings\(\s*\n?\s*init_record\?\.\['sight'\]\s*\?\?\s*init_options_config/
         );
+        // The pushed client settings (didChangeConfiguration) are mapped too.
+        expect(source).toContain('map_public_settings(last_client_settings)');
+        // The live getConfiguration result is mapped, not merged raw.
+        expect(source).toContain('map_public_settings(config)');
     });
 
     it('builds merged settings for clients without configuration capability', () => {

--- a/tests/unit/server-project-config-wiring.test.ts
+++ b/tests/unit/server-project-config-wiring.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
+import {
+    build_non_capability_settings_from_sources,
+    select_pushed_client_settings,
+} from '../../src/server-factory';
 
 describe('server-factory project config wiring', () => {
     const server_factory_path = path.join(
@@ -34,7 +38,7 @@ describe('server-factory project config wiring', () => {
         // before merging, so camelCase/snake_case aliases both reach the
         // internal shape; project config still wins as the final overlay.
         expect(source).toMatch(
-            /const\s+client_partial\s*=\s*deep_merge_config\(\s*\n?\s*init_partial,\s*\n?\s*map_public_settings\(config\)\s*\n?\s*\)/
+            /const\s+client_partial\s*=\s*deep_merge_config\(\s*\n?\s*init_partial,\s*\n?\s*map_public_settings\(config,\s*log_config_warning\)\s*\n?\s*\)/
         );
         expect(source).toMatch(
             /const\s+merged_partial\s*=\s*deep_merge_config\(\s*\n?\s*client_partial,\s*\n?\s*project_file_config\s*\|\|\s*\{\}\s*\n?\s*\)/
@@ -54,9 +58,14 @@ describe('server-factory project config wiring', () => {
             /init_partial\s*=\s*map_public_settings\(\s*\n?\s*init_record\?\.\['sight'\]\s*\?\?\s*init_options_config/
         );
         // The pushed client settings (didChangeConfiguration) are mapped too.
-        expect(source).toContain('map_public_settings(last_client_settings)');
+        expect(source).toContain(
+            'map_public_settings(\n            sources.last_client_settings,'
+        );
+        expect(source).toContain('select_pushed_client_settings');
         // The live getConfiguration result is mapped, not merged raw.
-        expect(source).toContain('map_public_settings(config)');
+        expect(source).toContain(
+            'map_public_settings(config, log_config_warning)'
+        );
     });
 
     it('builds merged settings for clients without configuration capability', () => {
@@ -71,5 +80,35 @@ describe('server-factory project config wiring', () => {
             /global_settings\s*=\s*build_non_capability_settings\(\)/g
         ) || [];
         expect(builder_uses.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('applies wrapped pushed settings for non-capability clients', () => {
+        const last_client_settings = select_pushed_client_settings({
+            sight: {
+                crossFile: {
+                    backwardDependencies: 'explicit',
+                },
+            },
+        });
+
+        const settings = build_non_capability_settings_from_sources({
+            last_client_settings,
+        });
+
+        expect(settings.cross_file.backward_dependencies).toBe('explicit');
+    });
+
+    it('applies unwrapped pushed settings for non-capability clients', () => {
+        const last_client_settings = select_pushed_client_settings({
+            crossFile: {
+                backwardDependencies: 'explicit',
+            },
+        });
+
+        const settings = build_non_capability_settings_from_sources({
+            last_client_settings,
+        });
+
+        expect(settings.cross_file.backward_dependencies).toBe('explicit');
     });
 });


### PR DESCRIPTION
## Summary

Adds a `sight check` CLI subcommand that runs full, workspace-aware Stata
diagnostics from the command line — intended for CI gating and pre-commit
checks. It indexes the workspace (for cross-file scope resolution), then opens
each reported file through the same analysis pipeline the LSP server uses and
emits its diagnostics.

> **Stacked on #182** (`toml` → `codex/rename-binary-to-sight`). This PR targets
> `toml`; review/merge #182 first. The diff below is only the `sight check` work.

## What it does

- `sight check [OPTIONS] [PATHS...]` — checks the given files, or the whole
  workspace when no paths are passed (paths still index the full workspace for
  scope, but only the named paths are reported).
- Options: `--workspace DIR`, `--config PATH` / `--no-config`,
  `--format text|json|sarif`, `--max-severity off|hint|info|warning|error`,
  `--quiet`, `--color auto|always|never` / `--no-color`, `-h/--help`.
- Exit codes: `0` ok, `1` diagnostics exceeded the severity threshold, `2`
  operator error (bad path/config/workspace).
- Surfaces file-level conditions as diagnostics too: oversized explicit targets,
  files skipped past `crossFile.maxIndexedFiles`, and invalid UTF-8 (with the
  offending byte offset).
- Reuses the project's `sight.toml` config (same loader/merge/validation as the
  server).

## Implementation

- `src/cli/check.ts` — arg parsing, config load, context wiring, the per-file
  diagnostics loop, and text/JSON/SARIF rendering dispatch.
- `src/cli/shared.ts` — output formats, severity gating, color resolution, and
  the renderers.
- `src/cli/source-files.ts` — source discovery, UTF-8 reading, and file-level
  diagnostics.
- Small shared-infra touch-ups: `DiagnosticsProvider` now depends on a narrowed
  `DiagnosticsConnection` (so the CLI can construct it without a full LSP
  connection); `hasStataExtension`/`VCS_METADATA_DIRS` are shared from
  `file-path-utils`.

## Quality

Ran `/simplify` to convergence — two consecutive fully-clean review passes
(reuse / simplification / efficiency / altitude) after iterating on reuse,
dead code, redundant computation, an O(n²)→O(n) UTF-8 offset scan, and an eager
index Map replaced by a cheap membership accessor. Full test suite green
(5820 pass), including new CLI unit/integration tests and UTF-8 regression tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sight check` for headless, CI-friendly batch diagnostics with workspace indexing plus file-path filtering.
  * Supports `text`, `json`, and `sarif` output, severity thresholding, quiet/color controls, standardized exit codes, and improved handling of `.mata` targets and invalid UTF-8 (byte-offset reporting).

* **Documentation**
  * Documented the CLI command, along with the related implementation plan/design specs and updated configuration guidance.

* **Bug Fixes**
  * Improved project/workspace root detection by including `.sight.json` markers for completion/project identification.

* **Tests**
  * Added integration and unit tests covering CLI parsing, config loading, output formatting, spawn behavior, and source/diagnostic edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->