### PR TITLE
Fix TextMate grammar parity gaps from tree-sitter-stata (#185)

### DIFF
--- a/client/syntaxes/stata.tmLanguage.json
+++ b/client/syntaxes/stata.tmLanguage.json
@@ -7,6 +7,7 @@
         { "include": "#macros" },
         { "include": "#mata-inline" },
         { "include": "#mata-block" },
+        { "include": "#factor-variables" },
         { "include": "#program-definition" },
         { "include": "#keywords" },
         { "include": "#commands-file-execution" },
@@ -25,11 +26,7 @@
     "repository": {
         "comments": {
             "patterns": [
-                {
-                    "begin": "/\\*",
-                    "end": "\\*/",
-                    "name": "comment.block.stata"
-                },
+                { "include": "#block-comment" },
                 {
                     "match": "^\\s*\\*.*$",
                     "name": "comment.line.star.stata"
@@ -43,6 +40,18 @@
                     "name": "comment.line.double-slash.stata"
                 }
             ]
+        },
+        "block-comment": {
+            "begin": "/\\*",
+            "end": "\\*/",
+            "name": "comment.block.stata",
+            "patterns": [
+                { "include": "#block-comment" }
+            ]
+        },
+        "factor-variables": {
+            "match": "(?<![A-Za-z0-9_.])(ibn|ib|bn|i|c|o|b)(\\d+|\\((?:[0-9 ,/]+|first|last|freq|#\\d+)\\))?\\.(?=[A-Za-z_(])",
+            "name": "keyword.operator.factor.stata"
         },
         "strings": {
             "patterns": [

--- a/docs/syntax-highlighting.md
+++ b/docs/syntax-highlighting.md
@@ -47,6 +47,8 @@ The LSP provides comprehensive syntax highlighting through TextMate grammar scop
 |               | `keyword.operator.comparison.stata` | `==`, `!=`, `<`, `>` |
 |               | `keyword.operator.logical.stata`    | `&`, `\|`, `!`       |
 |               | `keyword.operator.assignment.stata` | `=`                  |
+|               | `keyword.operator.interaction.stata` | `#`                 |
+|               | `keyword.operator.factor.stata`     | `i.`, `c.`, `o.`, `b2.`, `ibn.`, `i(1/3).` |
 | **Programs**  | `storage.type.function.stata`       | `program` keyword    |
 |               | `entity.name.function.stata`        | Program names        |
 

--- a/tests/unit/helpers/textmate-tokenizer.ts
+++ b/tests/unit/helpers/textmate-tokenizer.ts
@@ -1,0 +1,141 @@
+/**
+ * Real TextMate tokenizer harness for grammar tests.
+ *
+ * The other grammar tests (textmate-grammar.test.ts,
+ * textmate-grammar-star-comments.test.ts) only run individual patterns through
+ * `new RegExp(...)`. That cannot validate begin/end region behavior such as
+ * nested block comments, which is inherently multiline and stateful. This
+ * helper drives the grammar through the same engine VS Code uses
+ * (vscode-textmate + vscode-oniguruma) so tests can assert the real scope
+ * stack produced for a snippet.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { Registry, parseRawGrammar, INITIAL } from 'vscode-textmate';
+import type { IGrammar } from 'vscode-textmate';
+import {
+    loadWASM,
+    createOnigScanner,
+    createOnigString,
+} from 'vscode-oniguruma';
+
+const GRAMMAR_PATH = path.join(
+    __dirname,
+    '../../../client/syntaxes/stata.tmLanguage.json'
+);
+const WASM_PATH = path.join(
+    __dirname,
+    '../../../node_modules/vscode-oniguruma/release/onig.wasm'
+);
+
+// A single token of source text and the full scope stack that applies to it.
+export interface ScopedToken {
+    text: string;
+    line: number; // 0-indexed
+    start_column: number; // 0-indexed, inclusive
+    end_column: number; // 0-indexed, exclusive
+    scopes: string[];
+}
+
+let grammar_promise: Promise<IGrammar> | null = null;
+
+function load_grammar(): Promise<IGrammar> {
+    if (grammar_promise) {
+        return grammar_promise;
+    }
+
+    const wasm_bin = fs.readFileSync(WASM_PATH);
+    const onig_lib = loadWASM(wasm_bin).then(() => ({
+        createOnigScanner,
+        createOnigString,
+    }));
+
+    const registry = new Registry({
+        onigLib: onig_lib,
+        loadGrammar: async (scope_name: string) => {
+            if (scope_name !== 'source.stata') {
+                return null;
+            }
+            const content = fs.readFileSync(GRAMMAR_PATH, 'utf-8');
+            return parseRawGrammar(content, GRAMMAR_PATH);
+        },
+    });
+
+    grammar_promise = registry.loadGrammar('source.stata').then((my_grammar) => {
+        if (!my_grammar) {
+            throw new Error('Failed to load source.stata grammar');
+        }
+        return my_grammar;
+    });
+    return grammar_promise;
+}
+
+/**
+ * Tokenize a multiline Stata snippet, returning every token with its scope
+ * stack. The rule stack is carried from one line to the next so that
+ * multiline state (block comments, mata blocks) is honored.
+ */
+export async function tokenize_stata(source: string): Promise<ScopedToken[]> {
+    const grammar = await load_grammar();
+    const the_lines = source.split('\n');
+    const the_tokens: ScopedToken[] = [];
+
+    let rule_stack = INITIAL;
+    for (let i = 0; i < the_lines.length; i++) {
+        const my_line = the_lines[i];
+        const result = grammar.tokenizeLine(my_line, rule_stack);
+        for (const my_token of result.tokens) {
+            the_tokens.push({
+                text: my_line.substring(my_token.startIndex, my_token.endIndex),
+                line: i,
+                start_column: my_token.startIndex,
+                end_column: my_token.endIndex,
+                scopes: my_token.scopes,
+            });
+        }
+        rule_stack = result.ruleStack;
+    }
+
+    return the_tokens;
+}
+
+/**
+ * Convenience: return the scope stack that applies at a given line/column.
+ */
+export function scopes_at(
+    the_tokens: ScopedToken[],
+    line: number,
+    column: number
+): string[] {
+    for (const my_token of the_tokens) {
+        if (
+            my_token.line === line &&
+            column >= my_token.start_column &&
+            column < my_token.end_column
+        ) {
+            return my_token.scopes;
+        }
+    }
+    return [];
+}
+
+/**
+ * Convenience: find the first token whose text exactly equals `text`.
+ */
+export function find_token(
+    the_tokens: ScopedToken[],
+    text: string
+): ScopedToken | undefined {
+    return the_tokens.find((my_token) => my_token.text === text);
+}
+
+/**
+ * Convenience: does any scope in the token's stack equal `scope`?
+ */
+export function has_scope(
+    token: ScopedToken | undefined,
+    scope: string
+): boolean {
+    return !!token && token.scopes.includes(scope);
+}

--- a/tests/unit/textmate-grammar-block-comments.test.ts
+++ b/tests/unit/textmate-grammar-block-comments.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tokenizer tests for nested / inline block comments.
+ *
+ * Mirrors the tree-sitter-stata v0.1.2 comment-parsing corpus (issue #185).
+ * The flat begin/end block-comment region exited at the first inner `*​/`,
+ * leaking the rest of an outer comment back into code scope. These tests use
+ * the real vscode-textmate engine (see helpers/textmate-tokenizer.ts) so the
+ * stateful, multiline begin/end behavior is actually exercised.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+    tokenize_stata,
+    scopes_at,
+    find_token,
+    has_scope,
+} from './helpers/textmate-tokenizer';
+
+const BLOCK = 'comment.block.stata';
+const STAR_LINE = 'comment.line.star.stata';
+
+describe('TextMate Grammar - Block Comments (tokenizer)', () => {
+    it('keeps the outer comment active across a nested /* */', async () => {
+        const source = [
+            '/*',
+            'reg y x /* nested comment */',
+            'sum x',
+            '*/',
+            'display 1',
+        ].join('\n');
+        const tokens = await tokenize_stata(source);
+
+        // Line 2 ("sum x") is between the inner close and the outer close:
+        // it MUST still be inside the block comment, not code.
+        const sum_scopes = scopes_at(tokens, 2, 0);
+        expect(sum_scopes).toContain(BLOCK);
+
+        // The text after the inner close on line 1 is also still comment.
+        const nested_close_line_scopes = scopes_at(tokens, 1, 20);
+        expect(nested_close_line_scopes).toContain(BLOCK);
+
+        // The outer close line must NOT be re-grabbed by the star-line rule.
+        const outer_close_scopes = scopes_at(tokens, 3, 0);
+        expect(outer_close_scopes).toContain(BLOCK);
+        expect(outer_close_scopes).not.toContain(STAR_LINE);
+
+        // After the outer close, code is code again.
+        const display_token = find_token(tokens, 'display');
+        expect(display_token).toBeDefined();
+        expect(display_token!.line).toBe(4);
+        expect(has_scope(display_token, BLOCK)).toBe(false);
+    });
+
+    it('treats /***/ as a single block comment', async () => {
+        const source = '/***/\ndisplay 1';
+        const tokens = await tokenize_stata(source);
+
+        // Every token on line 0 is comment.
+        const line0 = tokens.filter((my_token) => my_token.line === 0);
+        expect(line0.length).toBeGreaterThan(0);
+        for (const my_token of line0) {
+            expect(my_token.scopes).toContain(BLOCK);
+        }
+        // Line 1 is code again.
+        expect(has_scope(find_token(tokens, 'display'), BLOCK)).toBe(false);
+    });
+
+    it('treats /** text **/ as a single block comment', async () => {
+        const source = '/** text **/\ndisplay 1';
+        const tokens = await tokenize_stata(source);
+        const line0 = tokens.filter((my_token) => my_token.line === 0);
+        for (const my_token of line0) {
+            expect(my_token.scopes).toContain(BLOCK);
+        }
+        expect(has_scope(find_token(tokens, 'display'), BLOCK)).toBe(false);
+    });
+
+    it('handles an inline block comment followed by code', async () => {
+        const source = 'reg y x /* note */ , robust';
+        const tokens = await tokenize_stata(source);
+
+        // The comment span is block-scoped.
+        const comment_open_scopes = scopes_at(tokens, 0, 8);
+        expect(comment_open_scopes).toContain(BLOCK);
+
+        // Code after the inline close is NOT comment.
+        expect(scopes_at(tokens, 0, 20)).not.toContain(BLOCK);
+    });
+
+    it('handles a deeply nested block comment', async () => {
+        const source = [
+            '/* a /* b /* c */ b */ a */',
+            'display 1',
+        ].join('\n');
+        const tokens = await tokenize_stata(source);
+
+        // Whole first line is comment, all the way to the last `*/`.
+        const line0 = tokens.filter((my_token) => my_token.line === 0);
+        for (const my_token of line0) {
+            expect(my_token.scopes).toContain(BLOCK);
+        }
+        // Code resumes on line 1.
+        expect(has_scope(find_token(tokens, 'display'), BLOCK)).toBe(false);
+    });
+
+    it('still treats an unterminated /* as comment to end of input', async () => {
+        const source = '/* open\ndisplay 1\nsum y';
+        const tokens = await tokenize_stata(source);
+        for (const my_token of tokens) {
+            expect(my_token.scopes).toContain(BLOCK);
+        }
+    });
+});

--- a/tests/unit/textmate-grammar-factor-variables.test.ts
+++ b/tests/unit/textmate-grammar-factor-variables.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tokenizer tests for factor-variable operator highlighting.
+ *
+ * Mirrors the tree-sitter-stata v0.1.1 factor-variable corpus (issue #185).
+ * Before this change, factor operators (`i.`, `c.`, ...) had no TextMate scope.
+ * We scope only the OPERATOR PREFIX (e.g. `i.`); the following variable keeps
+ * its ordinary scope. Test variable names deliberately avoid Stata
+ * command/function words so assertions about the variable token are stable.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+    tokenize_stata,
+    find_token,
+    has_scope,
+    type ScopedToken,
+} from './helpers/textmate-tokenizer';
+
+const FACTOR = 'keyword.operator.factor.stata';
+const INTERACTION = 'keyword.operator.interaction.stata';
+
+// Assert a token with exactly this text exists AND carries the factor scope.
+// (find_token returning undefined makes has_scope false, so a positive
+// assertion is self-guarding; this helper just gives a clearer message.)
+function expect_factor(the_tokens: ScopedToken[], text: string): void {
+    const my_token = find_token(the_tokens, text);
+    expect(my_token, `expected a token "${text}"`).toBeDefined();
+    expect(has_scope(my_token, FACTOR), `"${text}" should be factor`).toBe(true);
+}
+
+// All token texts that carry the factor scope, in source order.
+function factor_token_texts(the_tokens: ScopedToken[]): string[] {
+    return the_tokens
+        .filter((my_token) => has_scope(my_token, FACTOR))
+        .map((my_token) => my_token.text);
+}
+
+describe('TextMate Grammar - Factor Variables (tokenizer)', () => {
+    it('scopes ONLY the i./c. operators, not the variables', async () => {
+        const tokens = await tokenize_stata('regress depvar i.treatment c.income');
+        expect_factor(tokens, 'i.');
+        expect_factor(tokens, 'c.');
+        // The complete factor set is exactly the two operators — the variable
+        // names (treatment/income) are NOT scoped. Asserting the whole set
+        // guards against a vacuous pass if token splitting changes.
+        expect(factor_token_texts(tokens)).toEqual(['i.', 'c.']);
+    });
+
+    it('scopes factor operators and interaction together', async () => {
+        const tokens = await tokenize_stata(
+            'xtreg outcome c.popgrowth#i.shrink i.year, fe robust'
+        );
+        // Two factor operators present.
+        const factor_tokens = tokens.filter((my_token) => has_scope(my_token, FACTOR));
+        expect(factor_tokens.map((my_token) => my_token.text).sort()).toEqual(['c.', 'i.', 'i.']);
+        // The interaction operator keeps its own scope.
+        expect(has_scope(find_token(tokens, '#'), INTERACTION)).toBe(true);
+    });
+
+    it('scopes o. (omit), b. and bn. (base), and numbered base b2.', async () => {
+        const tokens = await tokenize_stata('regress depvar o.treatment b.region bn.arm b2.grp');
+        expect_factor(tokens, 'o.');
+        expect_factor(tokens, 'b.');
+        expect_factor(tokens, 'bn.');
+        expect_factor(tokens, 'b2.');
+    });
+
+    it('scopes ibn. and numbered base ib2.', async () => {
+        const tokens = await tokenize_stata('regress depvar ibn.region ib2.group');
+        expect_factor(tokens, 'ibn.');
+        expect_factor(tokens, 'ib2.');
+    });
+
+    it('scopes parenthesized level lists and named base selectors', async () => {
+        const tokens = await tokenize_stata(
+            'regress depvar i(1/3).group ib(first).region i(last).arm ib(#2).cat'
+        );
+        expect_factor(tokens, 'i(1/3).');
+        expect_factor(tokens, 'ib(first).');
+        expect_factor(tokens, 'i(last).');
+        expect_factor(tokens, 'ib(#2).');
+    });
+
+    it('scopes the operator on a grouped variable list i.(...) / c.(...)', async () => {
+        // This is why the trailing lookahead admits `(`.
+        const tokens = await tokenize_stata('regress depvar i.(group sex) c.(age weight)');
+        expect_factor(tokens, 'i.');
+        expect_factor(tokens, 'c.');
+    });
+
+    // --- negative cases: these must NOT be scoped as factor operators ---
+
+    it('does not scope multiplication mid-expression', async () => {
+        const tokens = await tokenize_stata('gen z = myx*myy');
+        expect(tokens.some((my_token) => has_scope(my_token, FACTOR))).toBe(false);
+    });
+
+    it('does not scope numeric literals or missing values', async () => {
+        const tokens = await tokenize_stata('gen z = 2.5\nreplace z = .a if myv');
+        expect(tokens.some((my_token) => has_scope(my_token, FACTOR))).toBe(false);
+    });
+
+    it('does not scope a dotted name embedded in a word', async () => {
+        // `version 18.0` and a function result like e(b) must stay non-factor.
+        const tokens = await tokenize_stata('version 18.0\ndisplay e(b)');
+        expect(tokens.some((my_token) => has_scope(my_token, FACTOR))).toBe(false);
+    });
+
+    it('does not scope factor-looking text inside a string', async () => {
+        const tokens = await tokenize_stata('display "i.treatment c.income"');
+        expect(tokens.some((my_token) => has_scope(my_token, FACTOR))).toBe(false);
+    });
+
+    it('does not scope factor-looking text inside line comments', async () => {
+        const tokens = await tokenize_stata('// i.treatment\n* c.income');
+        expect(tokens.some((my_token) => has_scope(my_token, FACTOR))).toBe(false);
+    });
+
+    it('does not scope ordinary (multi-character stem) file names', async () => {
+        // The realistic filename case: a normal stem like `mydata` is never a
+        // factor letter, so `use mydata.dta` is not mis-scoped. (A bare
+        // single-letter stem like `use i.dta` IS a known, accepted false
+        // positive — a context-free grammar cannot tell a factor operator from
+        // a one-letter filename; this is rare and cosmetic-only.)
+        const tokens = await tokenize_stata(
+            'use mydata.dta\nsave myresults.csv\ndo analysis.do'
+        );
+        expect(tokens.some((my_token) => has_scope(my_token, FACTOR))).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #185. Brings the VS Code TextMate grammar (`client/syntaxes/stata.tmLanguage.json`) in line with language-bug fixes shipped in `tree-sitter-stata` v0.1.1 (factor variables) and v0.1.2 (comments).

### 1. Nested block comments — confirmed bug
The flat `begin:/\* end:\*/` region exited at the **first** inner `*/`, so code after a nested comment was mis-highlighted and the final `*/` was wrongly matched by the star-line comment rule. Replaced with a recursive `#block-comment` rule that self-includes:

```json
"block-comment": {
  "begin": "/\\*", "end": "\\*/", "name": "comment.block.stata",
  "patterns": [ { "include": "#block-comment" } ]
}
```

Nested `/* ... /* ... */ ... */`, `/***/`, comments ending in asterisks, inline comments, and unterminated `/*` all behave correctly.

### 2. Factor-variable operators — highlighting parity
`i.`, `c.`, `o.`, `b2.`, `bn.`, `ibn.`, `i(1/3).`, named base selectors (`ib(first).`), and grouped lists `i.(group sex)` had no TextMate scope. Added a `factor-variables` rule that scopes only the operator prefix as `keyword.operator.factor.stata`, placed after the mata rules so it never fires inside embedded blocks/strings/comments. The interaction `#` keeps its existing scope.

### 3. Mid-command `*` — already correct
`disp 2*3`, `gen z = x*y`, `summarize inc*` were already handled by the `^\s*\*` anchor. No change; covered by regression tests.

## Testing
Adds a real **vscode-textmate + vscode-oniguruma** tokenizer harness (`tests/unit/helpers/textmate-tokenizer.ts`). The pre-existing grammar tests only run individual patterns through `new RegExp`, which cannot exercise stateful begin/end nesting. New tests mirror the upstream corpus for both fixes plus negative cases (strings, comments, numerics, missing values, ordinary filenames). Full suite: 5905 pass, 0 fail, typecheck clean.

## Known accepted limitation
A context-free grammar cannot distinguish a factor operator from a bare **single-letter** filename stem (e.g. unquoted `use i.dta`), which may get a cosmetic factor tint. Realistic multi-character filenames (`use mydata.dta`) are unaffected. An earlier extension-denylist approach was removed in review as a band-aid that would rot; accepting the rare, cosmetic edge is the simpler, higher-altitude choice.

## Review process
Plan adversarially reviewed by Codex and an independent subagent before implementation; implementation reviewed by Codex; two consecutive clean `/code-review` passes.

https://claude.ai/code/session_01NtFd7w6u99RHXmvatwNncy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced syntax highlighting for Stata factor-variable operators (e.g., `i.`, `c.`, `o.`, `b.`, numbered variants).
  * Improved block comment syntax highlighting and parsing.

* **Documentation**
  * Updated syntax-highlighting scope table with entries for factor-variable and interaction operators.

* **Tests**
  * Added comprehensive test suite for block comment handling.
  * Added comprehensive test suite for factor-variable operator highlighting.
  * Added TextMate tokenizer test helper utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->