### PR TITLE
Neutralize command-name filename stems in import/export (#188)

### DIFF
--- a/client/syntaxes/stata.tmLanguage.json
+++ b/client/syntaxes/stata.tmLanguage.json
@@ -7,7 +7,7 @@
         { "include": "#macros" },
         { "include": "#mata-inline" },
         { "include": "#mata-block" },
-        { "include": "#io-statement" },
+        { "include": "#path-after-io-command" },
         { "include": "#path-after-control-command" },
         { "include": "#path-after-data-command" },
         { "include": "#path-after-using" },
@@ -34,17 +34,15 @@
                 { "include": "#numbers" }
             ]
         },
-        "io-statement": {
-            "begin": "(?:^|;)\\s*(?:(?:quietly|qui|noisily|noi|capture|cap)\\s+)*(import|export|insheet|infile|outsheet)\\b",
+        "path-after-io-command": {
+            "begin": "(?:^|;)\\s*(?:(?:quietly|qui|noisily|noi|capture|cap)\\s+)*(import|export)\\b\\s+(?!using(?=\\s|[,;]|/[/*]|$))\\w+\\s+(?!using(?=\\s|[,;]|/[/*]|$))",
             "beginCaptures": {
                 "1": { "name": "keyword.functions.data.stata" }
             },
-            "end": "(?=[;]|$)",
+            "end": "(?=\\s|[,;]|/[/*]|$)",
             "patterns": [
-                { "include": "#comments" },
                 { "include": "#strings" },
-                { "include": "#macros" },
-                { "include": "#statement-content" }
+                { "include": "#macros" }
             ]
         },
         "path-after-control-command": {
@@ -59,7 +57,7 @@
             ]
         },
         "path-after-data-command": {
-            "begin": "(?:^|;)\\s*(?:(?:quietly|qui|noisily|noi|capture|cap)\\s+)*(u(s(e)?)?|sa(v(e)?)?|saveold)\\b\\s+",
+            "begin": "(?:^|;)\\s*(?:(?:quietly|qui|noisily|noi|capture|cap)\\s+)*(u(s(e)?)?|sa(v(e)?)?|saveold|insheet|infile|outsheet)\\b\\s+(?!using(?=\\s|[,;]|/[/*]|$))",
             "beginCaptures": {
                 "1": { "name": "keyword.functions.data.stata" }
             },

--- a/tests/unit/textmate-grammar-file-paths.test.ts
+++ b/tests/unit/textmate-grammar-file-paths.test.ts
@@ -356,3 +356,197 @@ describe('TextMate Grammar - filename arguments (#187)', () => {
         });
     });
 });
+
+describe('TextMate Grammar - import/export filename stems (#188)', () => {
+    describe('a command-name stem in the filename is inert', () => {
+        it('import/export <subcommand> <stem-named-as-command>', async () => {
+            // [line, stem-word]. The stem matches a command name; on the
+            // pre-#188 grammar it is split out and command-scoped, so this is
+            // a non-vacuous check.
+            for (const [my_line, my_stem] of [
+                ['import delimited table.csv', 'table'],
+                ['export delimited do.csv', 'do'],
+                ['import excel list.xlsx', 'list'],
+            ] as const) {
+                const tokens = await tokenize_stata(my_line);
+                expect(
+                    exact_token_has_command_scope(tokens, my_stem),
+                    `${my_line}: stem "${my_stem}" should be inert`
+                ).toBe(false);
+                expect(
+                    any_command_scope_on(
+                        tokens,
+                        my_line.split(' ').at(-1) as string
+                    ),
+                    `${my_line}: whole filename should be inert`
+                ).toBe(false);
+            }
+        });
+    });
+
+    describe('options after the filename still highlight', () => {
+        it('import delimited x.csv, clear → clear kept', async () => {
+            const tokens = await tokenize_stata('import delimited x.csv, clear');
+            expect(has_scope(find_token(tokens, 'clear'), DATA_CMD)).toBe(true);
+        });
+    });
+
+    describe('filename shapes the single-token region must consume whole', () => {
+        it('no-extension command-name stem is inert', async () => {
+            const tokens = await tokenize_stata('import delimited table');
+            expect(
+                exact_token_has_command_scope(tokens, 'table'),
+                'bare "table" filename should be inert'
+            ).toBe(false);
+        });
+
+        it('multi-dot filename is not split into a command stem', async () => {
+            const tokens = await tokenize_stata('import delimited list.tar.gz');
+            expect(
+                exact_token_has_command_scope(tokens, 'list'),
+                'list.tar.gz stem should be inert'
+            ).toBe(false);
+        });
+
+        it('quoted path keeps string scope (region includes #strings)', async () => {
+            const tokens = await tokenize_stata(
+                'import delimited "my save.csv"'
+            );
+            expect(
+                tokens.some((t) => t.scopes.some((s) => s.startsWith('string'))),
+                'quoted import path should be a string'
+            ).toBe(true);
+        });
+    });
+
+    describe('regression guards', () => {
+        it('import delimited using i.dta → i. inert, using kept', async () => {
+            const tokens = await tokenize_stata('import delimited using i.dta');
+            expect(factor_texts(tokens)).toEqual([]);
+            expect(has_scope(find_token(tokens, 'using'), OTHER_KW)).toBe(true);
+        });
+
+        it('import delimited i.csv → i. inert (no #187 regression)', async () => {
+            const tokens = await tokenize_stata('import delimited i.csv');
+            expect(factor_texts(tokens)).toEqual([]);
+        });
+
+        it('import command word still carries its data-command scope', async () => {
+            for (const my_line of [
+                'import delimited table.csv',
+                'import delimited using i.dta',
+            ]) {
+                const tokens = await tokenize_stata(my_line);
+                expect(
+                    has_scope(find_token(tokens, 'import'), DATA_CMD),
+                    `${my_line}: import kept`
+                ).toBe(true);
+            }
+        });
+    });
+
+    describe('insheet/infile/outsheet (full handling)', () => {
+        it('post-using filename stem is inert, using kept', async () => {
+            for (const [my_line, my_stem] of [
+                ['insheet using table.csv', 'table'],
+                ['outsheet using list.csv', 'list'],
+            ] as const) {
+                const tokens = await tokenize_stata(my_line);
+                expect(
+                    exact_token_has_command_scope(tokens, my_stem),
+                    `${my_line}: stem "${my_stem}" should be inert`
+                ).toBe(false);
+                expect(
+                    has_scope(find_token(tokens, 'using'), OTHER_KW),
+                    `${my_line}: using kept`
+                ).toBe(true);
+            }
+        });
+
+        it('a varlist before using keeps the post-using filename inert', async () => {
+            // Non-vacuous: `list` is a command name, so the post-`using`
+            // filename stem would be command-tinted if the fall-through to
+            // #path-after-using did not fire.
+            const tokens = await tokenize_stata(
+                'infile var1 var2 using list.csv'
+            );
+            expect(
+                exact_token_has_command_scope(tokens, 'list'),
+                'list.csv stem should be inert'
+            ).toBe(false);
+            expect(has_scope(find_token(tokens, 'using'), OTHER_KW)).toBe(true);
+        });
+    });
+
+    describe('filenames whose stem is the literal word "using"', () => {
+        // A real file can be named `using.dta`. The standalone-`using` guard
+        // must fire ONLY for `using` as a separate token (`... using file`),
+        // not for a path whose first component happens to be `using`. (Codex
+        // adversarial review, #188.)
+        // These assert OTHER_KW is absent ENTIRELY rather than probing for a
+        // `using` token by exact text: a broken guard splits `using` into its
+        // own keyword token, making OTHER_KW non-empty, so the check is
+        // non-vacuous regardless of how the filename is tokenized.
+        it('use/save using.dta → no spurious using keyword', async () => {
+            for (const my_line of ['use using.dta', 'save using.dta']) {
+                const tokens = await tokenize_stata(my_line);
+                expect(
+                    texts_with_scope(tokens, OTHER_KW),
+                    `${my_line}: "using" stem must not be the using keyword`
+                ).toEqual([]);
+            }
+        });
+
+        it('import delimited using.csv / using/file.csv → inert path', async () => {
+            for (const my_line of [
+                'import delimited using.csv',
+                'import delimited using/file.csv',
+            ]) {
+                const tokens = await tokenize_stata(my_line);
+                expect(
+                    texts_with_scope(tokens, OTHER_KW),
+                    `${my_line}: "using" stem must not be the using keyword`
+                ).toEqual([]);
+            }
+        });
+
+        it('using/file.csv keeps its command-named component inert', async () => {
+            // `file` is itself a command name; if the path were split on `/`
+            // the `file` component would be command-tinted. (Non-vacuous.)
+            const tokens = await tokenize_stata(
+                'import delimited using/file.csv'
+            );
+            expect(exact_token_has_command_scope(tokens, 'file')).toBe(false);
+        });
+
+        it('`using` is never swallowed as the import subcommand', async () => {
+            // `import using x` is not valid Stata, but the subcommand slot
+            // must not consume `using` — it stays the keyword. (Finder C, #188.)
+            const tokens = await tokenize_stata('import using x.csv');
+            expect(has_scope(find_token(tokens, 'using'), OTHER_KW)).toBe(true);
+        });
+
+        it('standalone `using` is still highlighted (guard is precise)', async () => {
+            const tokens = await tokenize_stata('import delimited using x.csv');
+            expect(has_scope(find_token(tokens, 'using'), OTHER_KW)).toBe(true);
+            expect(factor_texts(tokens)).toEqual([]);
+        });
+    });
+
+    describe('documented residual: a comment before the filename', () => {
+        it('import/export behaves identically to use/save', async () => {
+            // A `/* */` comment between the command and the filename ends the
+            // single-token path region early, so the filename is re-scanned by
+            // the top-level rules and a factor-letter stem re-tints. This is a
+            // shared limitation of ALL single-token path rules (introduced in
+            // #187, not by #188). #188 makes import/export CONSISTENT with
+            // use/save here rather than fixing it (the fix is a cross-cutting
+            // change to every path rule, out of scope). Asserting equality —
+            // not a specific scope — tracks the residual and ensures a future
+            // fix flips both together. (Codex adversarial review, #188.)
+            const io = await tokenize_stata('import delimited /* c */ i.csv');
+            const data = await tokenize_stata('use /* c */ i.dta');
+            expect(factor_texts(io)).toEqual(factor_texts(data));
+        });
+    });
+});

--- a/tests/unit/textmate-grammar-star-comments.test.ts
+++ b/tests/unit/textmate-grammar-star-comments.test.ts
@@ -89,14 +89,13 @@ describe('TextMate Grammar - Star Comment Patterns', () => {
             // Find the first command-consuming pattern. Command rules may be
             // included directly (#commands-*), via the #statement-content group
             // that houses them after the #187 file-path refactor, or via the
-            // file-path/io rules (#io-statement, #path-after-*) that consume
-            // command keywords and their arguments. Comments must precede ALL
-            // of these so a `* ...` / `// ...` line is never mis-tokenized.
+            // file-path/io rules (#path-after-*) that consume command keywords
+            // and their arguments. Comments must precede ALL of these so a
+            // `* ...` / `// ...` line is never mis-tokenized.
             const command_index = top_patterns.findIndex(
                 (p: { include?: string }) =>
                     p.include?.startsWith('#commands') ||
                     p.include?.startsWith('#path-after') ||
-                    p.include === '#io-statement' ||
                     p.include === '#statement-content'
             );
 


### PR DESCRIPTION
Closes #188. Follow-up to #187.

## Problem

Inside `import`/`export` statements, a filename whose **stem** is a command
name was still tinted as that command:

```stata
import delimited table.csv   // "table" tinted as a command
export delimited do.csv      // "do" tinted as the do command
```

#187 fixed the analogous bare-command case (`use table.dta`), leaving an
inconsistency: path-taking commands neutralized a command-name stem, but
`import`/`export` did not. The root cause was #187's whole-statement
`io-statement` region, whose body re-included `#statement-content` and so
re-tinted the stem.

## Fix

Replace the whole-statement `io-statement` region with single-token path rules:

- **`path-after-io-command`** (`import`/`export`): anchor on the command + a
  generic `\w+` subcommand (no enumeration of delimited/excel/…), then consume
  one path token. Two `(?!using(?=…))` guards keep the subcommand slot from
  swallowing the `using` keyword and let `import delimited using x.csv` fall
  through to the existing `#path-after-using` rule.
- **Fold `insheet`/`infile`/`outsheet`** into `path-after-data-command` with the
  same using-guard, so the standard `using file` form falls through. This also
  fixes a **latent #187 bug**: `insheet using table.csv` mis-tinted `table`
  because `#path-after-using` never ran inside the old whole-statement region.

The single-token region ends at the first whitespace/comma/comment, so options
after the filename keep highlighting.

## Behavior

| Input | Result |
|---|---|
| `import delimited table.csv` / `export delimited do.csv` | filename inert |
| `import delimited x.csv, clear` | `clear` still highlighted |
| `import delimited using i.dta` | `i.` inert, `using` highlighted |
| `import delimited i.csv` | `i.` inert (no #187 regression) |
| `insheet using table.csv` | `table` inert, `using` highlighted (latent bug fixed) |

## Review

Hardened beyond the original spec in response to an adversarial Codex review and
two consecutive clean automated review passes:

- **`using`-stem filenames** (`use using.dta`, `import delimited using.csv`,
  `using/file.csv`) — a precise standalone-`using` lookahead so these are
  treated as paths, not the keyword (fixes a regression the naive `\b` guard
  would have introduced).
- **`import using x.csv`** — leading guard so the subcommand slot never consumes
  the `using` keyword.
- Regression tests for all of the above, plus non-vacuous stem/option/quoted-path
  guards.

The **comment-before-filename** case (`import delimited /* c */ i.csv`) is a
known residual shared by *all* single-token path rules from #187 (a future
cross-cutting fix would flip them together); it's documented and tracked by an
equality test rather than fixed here.

A separate, unrelated test-quality nit surfaced during review (vacuous negative
assertions in the star-comment tests) is tracked in #192.

**Severity:** cosmetic, highlight-only. Consistency follow-up to #187.

## Verification

- New tokenizer regression tests in `tests/unit/textmate-grammar-file-paths.test.ts`
- Full unit suite: 2826 pass / 0 fail; typecheck clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syntax highlighting for Stata file paths in import/export and data loading commands.
  * Fixed cases where filenames that look like command names, include multiple dots, or use `using`-like stems were incorrectly highlighted.
  * Better handles quoted paths, options after filenames, and related command forms such as `insheet`, `infile`, and `outsheet`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->