### PR TITLE
Tighten vacuous negative assertions in star-comment tests (#192)

### DIFF
--- a/tests/unit/textmate-grammar-star-comments.test.ts
+++ b/tests/unit/textmate-grammar-star-comments.test.ts
@@ -52,10 +52,7 @@ describe('TextMate Grammar - Star Comment Patterns', () => {
             const my_source = 'display * expr';
             // The pattern should not match because * is not at start of line
             const my_match = my_source.match(pattern);
-            // If there's a match, it should not include the * after display
-            if (my_match) {
-                expect(my_match[0]).not.toContain('display');
-            }
+            expect(my_match).toBeNull();
         });
         
         it('should match * on new line inside braces', () => {
@@ -72,10 +69,8 @@ describe('TextMate Grammar - Star Comment Patterns', () => {
             const my_lines = my_source.split('\n');
             for (const my_line of my_lines) {
                 const my_match = my_line.match(pattern);
-                if (my_match) {
-                    // If there's a match, it should be a line that starts with *
-                    expect(my_match[0].trim().startsWith('*')).toBe(true);
-                }
+                // No line starts with * so none should match the pattern
+                expect(my_match).toBeNull();
             }
         });
     });


### PR DESCRIPTION
Closes #192.

## Problem

Two "negative" assertions in `tests/unit/textmate-grammar-star-comments.test.ts`
were written as conditional `if (my_match) { expect(...) }` blocks. Because the
star-comment pattern (`^\s*\*.*$`) correctly does **not** match the inputs, the
`if` body was skipped and the tests passed **without asserting anything** — a
vacuous green.

The test names promise "should NOT match", but neither actually verified the
non-match. A future regex edit that accidentally matched `display * expr` or
`y * z` would have stayed green, masking a re-introduction of the
comment-vs-multiplication `*` ambiguity that `CLAUDE.md` flags as a real
Stata-lexing concern.

## Fix

Replace each conditional block with a direct `expect(my_match).toBeNull()`. This
is strictly stronger than the originals (the old `gen x = y * z` assertion would
even have passed if the regex matched the `* z` substring). Stale comments
updated accordingly.

## Scope

Test-only, no production change. Verified empirically that the pattern returns
`null` for both negative inputs and matches the positive `* comment` case.

## Verification

- `bun run test` — 5944 pass, 0 fail, typecheck clean.
- The affected file now executes 11 `expect()` calls (previously the two
  negative assertions never ran).