### PR TITLE
ci: upgrade GitHub Actions to node24 runtimes

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,15 +22,15 @@ runs:
   steps:
     - name: Setup Bun
       # Pinned action SHA for supply-chain safety.
-      # Tag v2.0.2 -> commit 735343b667d3e6f658f44d0eca948eb6282f2b76
-      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+      # Tag v2.2.0 -> commit 0c5077e51419868618aeaa5fe8019c62421857d6
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version: ${{ inputs.bun-version }}
 
     - name: Setup Node.js
       # Pinned action SHA for supply-chain safety.
-      # Tag v4 -> commit 49933ea5288caeca8642d1e84afbd3f7d6820020
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      # Tag v5 -> commit a0853c24544627f65ddf259abe73b1d18a591444
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
@@ -39,8 +39,8 @@ runs:
     # We key off both root + client lockfiles because this repo is a workspace.
     - name: Cache dependencies
       # Pinned action SHA for supply-chain safety.
-      # Tag v4 -> commit 5a3ec84eff668545956fd18022155c47e93e2684
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      # Tag v6 -> commit 2c8a9bd7457de244a408f35966fab2fb45fda9c8
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
       with:
         path: |
           node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,9 @@ jobs:
       #       # if object.type == "tag":
       #       gh api repos/<OWNER>/<REPO>/git/tags/<SHA_FROM_REF>
       #  3) Replace the SHA in uses: lines; keep the trailing "# vX" comments.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         with:
           filters: |
             # "server" is the base set that should run tests/typecheck.
@@ -101,7 +101,7 @@ jobs:
       needs.changes.outputs.client == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -120,7 +120,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -148,7 +148,7 @@ jobs:
     if: needs.changes.outputs.client == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -205,7 +205,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -244,7 +244,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
         with:
           fetch-depth: 1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -37,7 +37,7 @@ jobs:
       #       # if object.type == "tag":
       #       gh api repos/actions/checkout/git/tags/<SHA_FROM_REF>
       #  3) Replace the SHA below; keep the trailing comment with the major tag (e.g. "# v4").
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload package artifacts
         # Pinned action SHA for supply-chain safety (see note above).
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-package
           if-no-files-found: error
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload Linux binaries
         # Pinned action SHA for supply-chain safety (see note above).
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-linux
           if-no-files-found: error
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload Windows ARM64 binary
         # Pinned action SHA for supply-chain safety (see note above).
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-windows-arm64
           if-no-files-found: error
@@ -145,7 +145,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
@@ -164,7 +164,7 @@ jobs:
 
       - name: Upload macOS binary
         # Pinned action SHA for supply-chain safety (see note above).
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-darwin
           if-no-files-found: error
@@ -181,7 +181,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload Windows x64 binary
         # Pinned action SHA for supply-chain safety (see note above).
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-windows-x64
           if-no-files-found: error
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 
@@ -286,7 +286,7 @@ jobs:
 
       - name: Upload release artifacts
         # Pinned action SHA for supply-chain safety (see note above).
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-${{ inputs.tag || github.ref_name }}
           if-no-files-found: error

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -51,7 +51,7 @@ jobs:
         #       # if object.type == "tag":
         #       gh api repos/<OWNER>/<REPO>/git/tags/<SHA_FROM_REF>
         #  3) Replace the SHA in the uses: line; keep the trailing "# vX" comment.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag }}
 
@@ -141,8 +141,8 @@ jobs:
 
       - name: Create GitHub Release
         # Pinned action SHA for supply-chain safety.
-        # Tag v2.5.0 -> commit a06a81a03ee405af7f2048a818ed3f03bbf83c7b
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        # Tag v3.0.1 -> commit 2bb465e97f322d3cb2a965294d483e0d26a67aa9
+        uses: softprops/action-gh-release@2bb465e97f322d3cb2a965294d483e0d26a67aa9 # v3.0.1
         with:
           tag_name: ${{ inputs.tag }}
           name: Release ${{ inputs.tag }}

--- a/.github/workflows/update-send-to-stata.yml
+++ b/.github/workflows/update-send-to-stata.yml
@@ -13,7 +13,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Check for updates
         id: check


### PR DESCRIPTION
## Why

CI emits this on every run:

> Node 20 is being deprecated. This workflow is running with Node 24 by default...

The warning is **not** about the Node our build uses — `setup-node` already installs Node 24 for our `run:` steps. It's about the Node runtime each JavaScript action declares via `runs.using` in its own `action.yml`. GitHub is deprecating the `node20` runtime, and several of our pinned actions still ship on it.

## What

Bump the pinned actions to their `node24` majors (kept SHA-pinned for supply-chain safety):

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/cache` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `oven-sh/setup-bun` | v2.0.2 | v2.2.0 |
| `dorny/paths-filter` | v3 | v4 |
| `softprops/action-gh-release` | v2.5.0 | v3.0.1 |

(`anthropics/claude-code-action` is a composite action — no node runtime, no warning.)

## Notes

- All bumps are pure Node-24 runtime moves; release notes show no functional breaking changes.
- `cache` v5+ and `upload-artifact` v6+ require Actions Runner ≥ 2.327.1. All our jobs run on GitHub-hosted runners (`ubuntu`/`macos`/`windows-latest`), which satisfy this automatically.