### PR TITLE
Fix hover non-hoverable position generator

### DIFF
--- a/tests/property/generators/documents.ts
+++ b/tests/property/generators/documents.ts
@@ -425,12 +425,15 @@ export function arbitrary_non_hoverable_position(): fc.Arbitrary<{
   document: string;
   position: { line: number; character: number };
 }> {
-  return fc
-    .tuple(arbitrary_command_name(), fc.integer({ min: 0, max: 5 }))
-    .map(([my_cmd, my_offset]) => ({
-      document: `  ${my_cmd}  `,
-      position: { line: 0, character: my_offset },
-    }));
+  return arbitrary_command_name().chain((my_cmd) => {
+    const my_document = `  ${my_cmd}  `;
+    return fc
+      .constantFrom(0, 1, my_cmd.length + 3)
+      .map((my_character) => ({
+        document: my_document,
+        position: { line: 0, character: my_character },
+      }));
+  });
 }
 
 /**
@@ -489,6 +492,4 @@ export function arbitrary_document_with_mixed_symbols(): fc.Arbitrary<{
       return { document: my_document, expected_symbols: my_symbols };
     });
 }
-
-
 

--- a/tests/property/hover-completeness.prop.test.ts
+++ b/tests/property/hover-completeness.prop.test.ts
@@ -8,7 +8,7 @@
  * - Non-hoverable positions: returns null
  */
 
-import { describe, it, beforeEach } from 'bun:test';
+import { describe, it, beforeEach, expect } from 'bun:test';
 import * as fc from 'fast-check';
 import { HoverProvider } from '../../src/providers/hover';
 import { CommandDatabase } from '../../src/commands';
@@ -166,6 +166,23 @@ describe('Hover Completeness Property Tests', () => {
    * Feature: comprehensive-property-tests, Property 23: Non-Hoverable Positions
    * Validates: Requirement 7.4
    */
+  it('should generate non-hoverable positions on whitespace', () => {
+    fc.assert(
+      fc.property(
+        arbitrary_non_hoverable_position(),
+        ({ document, position }) => {
+          const my_previous_char = document[position.character - 1] ?? ' ';
+          const my_current_char = document[position.character] ?? ' ';
+
+          expect(my_previous_char).not.toMatch(/[a-zA-Z0-9_]/);
+          expect(document[position.character]).toMatch(/\s/);
+          expect(my_current_char).not.toMatch(/[a-zA-Z0-9_]/);
+        }
+      ),
+      { numRuns: 100, seed: 191 }
+    );
+  });
+
   it('should return null for non-hoverable positions', () => {
     fc.assert(
       fc.asyncProperty(
@@ -179,7 +196,7 @@ describe('Hover Completeness Property Tests', () => {
           return my_hover === null;
         }
       ),
-      { numRuns: 100 }
+      { numRuns: 100, seed: 191 }
     );
   });
 


### PR DESCRIPTION
## Summary
- Tighten `arbitrary_non_hoverable_position` so generated cursor positions are not inside or adjacent to generated command words.
- Add a deterministic generator invariant covering cursor-boundary semantics.
- Pin the affected non-hoverable hover property to seed 191 for reproducibility.

Closes #191

## Test Plan
- `bun test tests/property/hover-completeness.prop.test.ts`
- `bun run test`