### PR TITLE
test: pin color off in max-severity gating assertion

### DIFF
--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -63,7 +63,10 @@ describe('sight check integration', () => {
         );
         fs.writeFileSync(path.join(root, 'main.do'), "display \"`missing'\"\n");
 
-        const result = await run_capture(['--workspace', root, '--max-severity', 'info'], root);
+        const result = await run_capture(
+            ['--workspace', root, '--max-severity', 'info', '--no-color'],
+            root
+        );
 
         expect(result.code).toBe(EXIT_OK);
         expect(result.stdout).toContain('info:');


### PR DESCRIPTION
## Problem

`sight check integration > uses strict max severity gating` fails when `bun test` is run directly in a terminal, but passes when piped (e.g. CI). Not truly flaky — environment-dependent.

## Root cause

The test asserts `stdout.toContain('info:')` but invokes `sight check` with no color flag. Color then resolves via `resolve_color_from_env`, which reads process-global state (`process.stdout.isTTY`, `FORCE_COLOR`, `NO_COLOR`). In a TTY, color auto-enables and wraps the severity word in ANSI escapes, splitting `info` from `:`, so `toContain('info:')` fails. Piped runs leave color off, hiding the dependence on ambient TTY state.

## Not a tool bug

The production behavior is correct: severity gating returns `EXIT_OK` for an `information`-level diagnostic under `--max-severity info` (that assertion always passed), the diagnostic is correctly labeled `info`, and auto-color-on-TTY / off-when-piped is standard CLI convention. Only the test's assertion was fragile.

## Fix

Pin `--no-color` in this test's invocation so output is deterministic regardless of TTY. The test targets severity gating, not color rendering (covered in `tests/unit/cli/shared.test.ts`).

## Verification

- Gating test passes under both `FORCE_COLOR=1` (previously failing) and piped/no-color.
- Full `tests/integration/cli-check.test.ts` (19 tests) passes under `FORCE_COLOR=1`.