### PR TITLE
fix(send-to-stata): detect Stata installed under /Applications/StataNow

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -313,7 +313,7 @@
         "sight.sendToStata.stataApp": {
           "type": "string",
           "default": "",
-          "description": "Override Stata application name (macOS only). Leave empty for auto-detection. Options: StataMP, StataSE, StataBE, StataIC, Stata"
+          "description": "Override Stata application name (macOS only). Leave empty for auto-detection, which scans /Applications/Stata and /Applications/StataNow. Options: StataMP, StataSE, StataBE, StataIC, Stata"
         },
         "sight.sendToStata.focusStataWindow": {
           "type": "boolean",

--- a/client/src/send-to-stata/cd-context.ts
+++ b/client/src/send-to-stata/cd-context.ts
@@ -137,8 +137,8 @@ export async function execute_cd_command(
                 if (!stata_app) {
                     vscode.window.showErrorMessage(
                         'Stata not found. Install Stata in ' +
-                        '/Applications/Stata/ or configure ' +
-                        'sight.sendToStata.stataApp setting.'
+                        '/Applications/Stata/ or /Applications/StataNow/, ' +
+                        'or configure the sight.sendToStata.stataApp setting.'
                     );
                     return;
                 }

--- a/client/src/send-to-stata/commands.ts
+++ b/client/src/send-to-stata/commands.ts
@@ -272,8 +272,9 @@ async function handle_send_command(
                     if (!my_stata_app) {
                         vscode.window.showErrorMessage(
                             'Stata not found. Install Stata in ' +
-                            '/Applications/Stata/ or configure ' +
-                            'sight.sendToStata.stataApp setting.');
+                            '/Applications/Stata/ or /Applications/StataNow/, ' +
+                            'or configure the sight.sendToStata.stataApp ' +
+                            'setting.');
                         return;
                     }
 

--- a/client/src/send-to-stata/stata-cli-detector.ts
+++ b/client/src/send-to-stata/stata-cli-detector.ts
@@ -3,6 +3,7 @@ import { execFile } from 'child_process';
 import * as fs from 'fs/promises';
 import { constants as fs_constants } from 'fs';
 import { StataVariant } from './index.js';
+import { macos_cli_paths } from './stata-paths.js';
 
 /**
  * CLI binary names in priority order, per platform.
@@ -44,18 +45,6 @@ function get_variant_to_cli(): Record<StataVariant, string> {
         ? WIN_VARIANT_TO_CLI
         : UNIX_VARIANT_TO_CLI;
 }
-
-/**
- * Maps CLI binary names to macOS .app bundle paths.
- * Fallback when the binary is not on PATH.
- */
-const CLI_TO_MACOS_PATH: Record<string, string> = {
-    'stata-mp': '/Applications/Stata/StataMP.app/Contents/MacOS/stata-mp',
-    'stata-se': '/Applications/Stata/StataSE.app/Contents/MacOS/stata-se',
-    'stata-ic': '/Applications/Stata/StataIC.app/Contents/MacOS/stata-ic',
-    'stata-be': '/Applications/Stata/StataBE.app/Contents/MacOS/stata-be',
-    'stata': '/Applications/Stata/Stata.app/Contents/MacOS/stata',
-};
 
 let cached_stata_cli: string | null | undefined = undefined;
 
@@ -118,11 +107,11 @@ export async function detect_stata_cli(): Promise<string | null> {
         }
     }
 
-    // macOS .app fallback
+    // macOS .app fallback. Probe each binary across every known install
+    // directory (/Applications/Stata and /Applications/StataNow).
     if (process.platform === 'darwin') {
         for (const my_binary of the_binaries) {
-            const my_path = CLI_TO_MACOS_PATH[my_binary];
-            if (my_path) {
+            for (const my_path of macos_cli_paths(my_binary)) {
                 try {
                     await fs.access(my_path, fs_constants.X_OK);
                     cached_stata_cli = my_path;

--- a/client/src/send-to-stata/stata-detector.ts
+++ b/client/src/send-to-stata/stata-detector.ts
@@ -1,44 +1,45 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import { StataVariant } from './index.js';
-
-const VALID_VARIANTS: readonly StataVariant[] = [
-    'StataMP', 'StataSE', 'StataIC', 'Stata'
-];
+import {
+    MACOS_VARIANT_PRIORITY,
+    find_installed_stata_app,
+} from './stata-paths.js';
 
 let cached_stata_app: StataVariant | null | undefined = undefined;
+
+async function bundle_exists(bundle_path: string): Promise<boolean> {
+    try {
+        await fs.access(bundle_path);
+        return true;
+    } catch {
+        return false;
+    }
+}
 
 export async function detect_stata_app(): Promise<StataVariant | null> {
     // Early return for non-macOS platforms since the hardcoded path is macOS-specific
     if (process.platform !== 'darwin') {
         return null;
     }
-    
+
     const config = vscode.workspace.getConfiguration('sight.sendToStata');
     const setting_value = config.get<string>('stataApp');
-    
+
     // Validate setting_value against allowed variants before using it
-    if (setting_value && VALID_VARIANTS.includes(setting_value as StataVariant)) {
+    if (setting_value && MACOS_VARIANT_PRIORITY.includes(setting_value as StataVariant)) {
         return setting_value as StataVariant;
     }
     // If setting_value is invalid, fall through to auto-detection
-    
+
     if (cached_stata_app !== undefined) {
         return cached_stata_app;
     }
-    
-    for (const my_variant of VALID_VARIANTS) {
-        try {
-            await fs.access(`/Applications/Stata/${my_variant}.app`);
-            cached_stata_app = my_variant;
-            return my_variant;
-        } catch {
-            continue;
-        }
-    }
-    
-    cached_stata_app = null;
-    return null;
+
+    // Probe each variant across every known install directory
+    // (/Applications/Stata and /Applications/StataNow).
+    cached_stata_app = await find_installed_stata_app(bundle_exists);
+    return cached_stata_app;
 }
 
 export function clear_stata_cache(): void {

--- a/client/src/send-to-stata/stata-paths.ts
+++ b/client/src/send-to-stata/stata-paths.ts
@@ -1,0 +1,99 @@
+/**
+ * Pure helpers for locating Stata installs on macOS.
+ *
+ * Kept free of `vscode` / `fs` imports so the path logic can be unit
+ * tested directly (the surrounding detectors inject the real
+ * filesystem checks). See `stata-detector.ts` (GUI app, AppleScript)
+ * and `stata-cli-detector.ts` (terminal binary).
+ */
+
+import type { StataVariant } from './index.js';
+
+/**
+ * Parent directories under /Applications that may contain Stata .app
+ * bundles on macOS, in probe-priority order.
+ *
+ * `/Applications/Stata` is the long-standing location for perpetual-
+ * license installs. `/Applications/StataNow` is where StataNow (the
+ * subscription edition) installs by default. Both directories hold the
+ * same variant bundles (e.g. `StataSE.app`), and the AppleScript
+ * application name is the bundle name (`StataSE`) regardless of which
+ * directory it lives in — so the only thing that differs is where we
+ * look on disk.
+ */
+export const MACOS_APP_DIRS: readonly string[] = [
+    '/Applications/Stata',
+    '/Applications/StataNow',
+];
+
+/**
+ * GUI variant bundle names, in detection priority order
+ * (StataMP > StataSE > StataIC > Stata).
+ */
+export const MACOS_VARIANT_PRIORITY: readonly StataVariant[] = [
+    'StataMP', 'StataSE', 'StataIC', 'Stata',
+];
+
+/**
+ * Candidate `.app` bundle paths for a GUI variant, across every known
+ * /Applications install directory, in directory-priority order.
+ */
+export function macos_app_bundle_paths(
+    variant: StataVariant,
+    app_dirs: readonly string[] = MACOS_APP_DIRS
+): string[] {
+    return app_dirs.map(my_app_dir => `${my_app_dir}/${variant}.app`);
+}
+
+/**
+ * Find the first installed GUI variant by probing each variant (in
+ * priority order) across each install directory. `exists` must resolve
+ * to true when the given `.app` bundle path is present on disk.
+ *
+ * Variant priority is the outer loop, so e.g. StataMP in
+ * /Applications/StataNow is preferred over StataSE in
+ * /Applications/Stata, preserving the historical variant precedence.
+ */
+export async function find_installed_stata_app(
+    exists: (bundle_path: string) => Promise<boolean>,
+    variants: readonly StataVariant[] = MACOS_VARIANT_PRIORITY,
+    app_dirs: readonly string[] = MACOS_APP_DIRS
+): Promise<StataVariant | null> {
+    for (const my_variant of variants) {
+        for (const my_bundle_path of macos_app_bundle_paths(my_variant, app_dirs)) {
+            if (await exists(my_bundle_path)) {
+                return my_variant;
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Maps CLI binary names to the bundle-relative path of the executable
+ * inside a macOS Stata `.app`. Combined with `MACOS_APP_DIRS` to build
+ * the full fallback paths probed when the binary is not on PATH.
+ */
+const CLI_TO_MACOS_BUNDLE_SUFFIX: Record<string, string> = {
+    'stata-mp': 'StataMP.app/Contents/MacOS/stata-mp',
+    'stata-se': 'StataSE.app/Contents/MacOS/stata-se',
+    'stata-ic': 'StataIC.app/Contents/MacOS/stata-ic',
+    'stata-be': 'StataBE.app/Contents/MacOS/stata-be',
+    'stata': 'Stata.app/Contents/MacOS/stata',
+};
+
+/**
+ * macOS `.app` fallback paths for a CLI binary name, across every known
+ * /Applications install directory, in directory-priority order. Returns
+ * an empty list for binaries with no known bundle mapping.
+ */
+export function macos_cli_paths(
+    binary: string,
+    app_dirs: readonly string[] = MACOS_APP_DIRS
+): string[] {
+    const my_suffix = CLI_TO_MACOS_BUNDLE_SUFFIX[binary];
+    if (!my_suffix) {
+        return [];
+    }
+    return app_dirs.map(my_app_dir => `${my_app_dir}/${my_suffix}`);
+}

--- a/src/utils/stata-install-paths.ts
+++ b/src/utils/stata-install-paths.ts
@@ -31,7 +31,12 @@ import * as path from 'path';
 const STATA_MAJOR_VERSIONS = [20, 19, 18, 17, 16, 15, 14, 13];
 
 const WINDOWS_VARIANT_DIRS = ['Stata'];
-const MAC_VARIANT_DIRS = ['Stata', 'StataMP', 'StataSE', 'StataBE', 'StataIC'];
+// "StataNow" is the directory the subscription edition installs into
+// (alongside the classic "/Applications/Stata"); its ado tree lives at
+// "/Applications/StataNow/ado/...".
+const MAC_VARIANT_DIRS = [
+    'Stata', 'StataNow', 'StataMP', 'StataSE', 'StataBE', 'StataIC',
+];
 
 // Drive letters to probe for drive-root installs like `C:\Stata18` or
 // `D:\Stata18`. Many institutional and lab-image Windows machines put

--- a/tests/unit/send-to-stata/stata-paths.test.ts
+++ b/tests/unit/send-to-stata/stata-paths.test.ts
@@ -1,0 +1,105 @@
+/// <reference types="bun-types" />
+/**
+ * Unit tests for the pure Stata install-path helpers.
+ *
+ * These verify that both the classic `/Applications/Stata` location and
+ * the StataNow `/Applications/StataNow` location are probed, which is
+ * what lets auto-detection find StataNow installs (the subscription
+ * edition installs into a differently named directory).
+ *
+ * Feature: send-to-stata — StataNow install support
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+    MACOS_APP_DIRS,
+    macos_app_bundle_paths,
+    macos_cli_paths,
+    find_installed_stata_app,
+} from '../../../client/src/send-to-stata/stata-paths';
+
+/**
+ * Build an async `exists` predicate that resolves true only for the
+ * given set of present paths.
+ */
+function make_exists(
+    the_present_paths: readonly string[]
+): (p: string) => Promise<boolean> {
+    const the_present = new Set(the_present_paths);
+    return (candidate: string) => Promise.resolve(the_present.has(candidate));
+}
+
+describe('MACOS_APP_DIRS', () => {
+    it('includes both the classic and StataNow directories', () => {
+        expect(MACOS_APP_DIRS).toContain('/Applications/Stata');
+        expect(MACOS_APP_DIRS).toContain('/Applications/StataNow');
+    });
+
+    it('probes the classic directory before StataNow', () => {
+        const classic_idx = MACOS_APP_DIRS.indexOf('/Applications/Stata');
+        const now_idx = MACOS_APP_DIRS.indexOf('/Applications/StataNow');
+        expect(classic_idx).toBeLessThan(now_idx);
+    });
+});
+
+describe('macos_app_bundle_paths', () => {
+    it('produces a bundle path per install directory', () => {
+        expect(macos_app_bundle_paths('StataSE')).toEqual([
+            '/Applications/Stata/StataSE.app',
+            '/Applications/StataNow/StataSE.app',
+        ]);
+    });
+});
+
+describe('find_installed_stata_app', () => {
+    it('finds a StataNow-only install (the reported bug)', async () => {
+        const exists = make_exists([
+            '/Applications/StataNow/StataSE.app',
+        ]);
+        expect(await find_installed_stata_app(exists)).toBe('StataSE');
+    });
+
+    it('still finds a classic /Applications/Stata install', async () => {
+        const exists = make_exists([
+            '/Applications/Stata/StataMP.app',
+        ]);
+        expect(await find_installed_stata_app(exists)).toBe('StataMP');
+    });
+
+    it('returns null when nothing is installed', async () => {
+        expect(await find_installed_stata_app(make_exists([]))).toBeNull();
+    });
+
+    it('prefers variant priority over install directory', async () => {
+        // StataMP under StataNow should beat StataSE under the classic
+        // directory, preserving historical variant precedence.
+        const exists = make_exists([
+            '/Applications/Stata/StataSE.app',
+            '/Applications/StataNow/StataMP.app',
+        ]);
+        expect(await find_installed_stata_app(exists)).toBe('StataMP');
+    });
+
+    it('prefers the classic directory for the same variant', async () => {
+        const exists = make_exists([
+            '/Applications/Stata/StataSE.app',
+            '/Applications/StataNow/StataSE.app',
+        ]);
+        // Both resolve to the "StataSE" variant; the returned name is
+        // the same, but the classic directory is probed first.
+        expect(await find_installed_stata_app(exists)).toBe('StataSE');
+    });
+});
+
+describe('macos_cli_paths', () => {
+    it('returns a path under each install directory for a known binary', () => {
+        expect(macos_cli_paths('stata-se')).toEqual([
+            '/Applications/Stata/StataSE.app/Contents/MacOS/stata-se',
+            '/Applications/StataNow/StataSE.app/Contents/MacOS/stata-se',
+        ]);
+    });
+
+    it('returns an empty list for an unknown binary', () => {
+        expect(macos_cli_paths('not-a-real-binary')).toEqual([]);
+    });
+});

--- a/tests/unit/stata-install-paths.test.ts
+++ b/tests/unit/stata-install-paths.test.ts
@@ -74,6 +74,20 @@ describe('discover_stata_ado_paths', () => {
             expect(the_paths).toEqual(the_present);
         });
 
+        it('picks up the StataNow install dir', () => {
+            const the_present = [
+                '/Applications/StataNow/ado/base',
+                '/Applications/StataNow/ado/updates',
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: '/Users/me',
+                platform: 'darwin',
+                exists: make_exists(the_present),
+                env: {},
+            });
+            expect(the_paths).toEqual(the_present);
+        });
+
         it('considers Stata variants like StataMP and StataSE', () => {
             const the_present = [
                 '/Applications/StataMP/ado/base',


### PR DESCRIPTION
## Problem

StataNow (Stata's subscription edition) installs into `/Applications/StataNow/` instead of the classic `/Applications/Stata/`. The macOS detectors in `send-to-stata` only probed `/Applications/Stata/`, so users with a StataNow install (e.g. `/Applications/StataNow/StataSE.app`) get:

> Stata not found. Install Stata in /Applications/Stata/ or configure sight.sendToStata.stataApp setting.

…even though Stata is installed. The AppleScript application name is the bundle name (`StataSE`) regardless of which directory it lives in, so the only thing that was wrong was *where we looked on disk*.

## Fix

- Add a small pure helper module `client/src/send-to-stata/stata-paths.ts` that lists both install directories (`/Applications/Stata`, `/Applications/StataNow`) and provides the path logic. It is free of `vscode`/`fs` imports so it can be unit tested directly (matching the repo's "test pure functions" convention).
- Wire both detectors to use it:
  - `stata-detector.ts` (GUI app / AppleScript) — the source of the reported error.
  - `stata-cli-detector.ts` (integrated-terminal binary fallback).
- Add `StataNow` to `MAC_VARIANT_DIRS` in `src/utils/stata-install-paths.ts` so help-file ado-path discovery also picks up `/Applications/StataNow/ado/...`.
- Update the "Stata not found" messages (`commands.ts`, `cd-context.ts`) and the `sight.sendToStata.stataApp` setting description to mention StataNow.

### Behavior preserved
- Variant priority is unchanged: `StataMP > StataSE > StataIC > Stata`.
- The classic `/Applications/Stata` directory is still probed **first**; StataNow is a fallback.
- Same-variant matches return the same variant name as before.

## Tests
- New `tests/unit/send-to-stata/stata-paths.test.ts` covering: StataNow-only install (the reported bug), classic-only install regression, variant-priority-over-directory, directory ordering, and CLI path generation.
- Extended `tests/unit/stata-install-paths.test.ts` with a StataNow ado-dir case.
- `bun run typecheck` (server + client) and the full `bun test` suite pass (5970 pass / 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macOS detection for Stata installations, including support for StataNow and more reliable auto-detection across common install locations.
  * Added broader fallback support for locating Stata command-line executables on macOS.

* **Bug Fixes**
  * Updated “Stata not found” messages to better guide users when automatic detection is unavailable.
  * Expanded install-path discovery so StataNow-related directories are recognized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->