### PR TITLE
fix(send-to-stata): explain macOS Automation permission errors (-1743)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -313,7 +313,7 @@
         "sight.sendToStata.stataApp": {
           "type": "string",
           "default": "",
-          "description": "Override Stata application name (macOS only). Leave empty for auto-detection. Options: StataMP, StataSE, StataBE, StataIC, Stata"
+          "description": "Override Stata application name (macOS only). Case-sensitive: enter the name exactly. Leave empty for auto-detection. Options: StataMP, StataSE, StataBE, StataIC, Stata"
         },
         "sight.sendToStata.focusStataWindow": {
           "type": "boolean",

--- a/client/src/send-to-stata/applescript.ts
+++ b/client/src/send-to-stata/applescript.ts
@@ -7,11 +7,14 @@ const VALID_STATA_APPS: readonly StataVariant[] = [
 const VALID_COMMANDS: readonly StataCommand[] = ['do', 'include'];
 
 /**
- * macOS Apple Events permission error code (errAEEventNotPermitted).
- * Raised when the editor has not been granted Automation access to the
- * target app under System Settings → Privacy & Security → Automation.
+ * macOS Apple Events permission error (errAEEventNotPermitted).
+ * Raised when the editor has not been granted Automation access to
+ * the target app under System Settings → Privacy & Security →
+ * Automation. We match the code in its canonical parenthesized form
+ * so a bare `-1743` elsewhere in the message (e.g. a file path) does
+ * not trigger a false positive.
  */
-const APPLE_EVENTS_NOT_PERMITTED_CODE = '-1743';
+const APPLE_EVENTS_NOT_PERMITTED_TOKEN = '(-1743)';
 
 /**
  * Translate a raw `osascript` failure message into actionable guidance.
@@ -27,7 +30,7 @@ export function friendly_applescript_error(
     raw_message: string,
     stata_app: StataVariant
 ): string {
-    if (raw_message.includes(APPLE_EVENTS_NOT_PERMITTED_CODE)) {
+    if (raw_message.includes(APPLE_EVENTS_NOT_PERMITTED_TOKEN)) {
         return (
             `macOS blocked your editor from controlling ${stata_app} ` +
             `(Automation permission). Open System Settings → Privacy & ` +
@@ -39,6 +42,28 @@ export function friendly_applescript_error(
         );
     }
     return raw_message;
+}
+
+/**
+ * Settles an `osascript` Promise from a Node child-process callback.
+ *
+ * Shared by the `exec`/`execFile` call sites so the friendly-error
+ * translation is wired in exactly one place: on failure it rejects with
+ * the translated message; on success it resolves.
+ */
+export function settle_osascript_result(
+    error: Error | null | undefined,
+    stata_app: StataVariant,
+    resolve: () => void,
+    reject: (reason: Error) => void
+): void {
+    if (error) {
+        reject(new Error(
+            friendly_applescript_error(error.message, stata_app)
+        ));
+    } else {
+        resolve();
+    }
 }
 
 /**
@@ -91,13 +116,7 @@ export function send_to_stata_app(
         // preventing any shell interpretation of special characters.
         const shell_safe_cmd = applescript_cmd.replace(/'/g, "'\\''");
         exec(`osascript -e '${shell_safe_cmd}'`, (error) => {
-            if (error) {
-                reject(new Error(
-                    friendly_applescript_error(error.message, stata_app)
-                ));
-            } else {
-                resolve();
-            }
+            settle_osascript_result(error, stata_app, resolve, reject);
         });
     });
 }

--- a/client/src/send-to-stata/applescript.ts
+++ b/client/src/send-to-stata/applescript.ts
@@ -7,6 +7,41 @@ const VALID_STATA_APPS: readonly StataVariant[] = [
 const VALID_COMMANDS: readonly StataCommand[] = ['do', 'include'];
 
 /**
+ * macOS Apple Events permission error code (errAEEventNotPermitted).
+ * Raised when the editor has not been granted Automation access to the
+ * target app under System Settings → Privacy & Security → Automation.
+ */
+const APPLE_EVENTS_NOT_PERMITTED_CODE = '-1743';
+
+/**
+ * Translate a raw `osascript` failure message into actionable guidance.
+ *
+ * The common, confusing case is errAEEventNotPermitted (-1743): macOS
+ * blocks the editor from controlling Stata until the user grants
+ * Automation permission. The raw message (e.g. `... execution error:
+ * Not authorized to send Apple events to StataSE. (-1743)`) is opaque,
+ * so we replace it with the steps to fix it. Other failures pass
+ * through unchanged.
+ */
+export function friendly_applescript_error(
+    raw_message: string,
+    stata_app: StataVariant
+): string {
+    if (raw_message.includes(APPLE_EVENTS_NOT_PERMITTED_CODE)) {
+        return (
+            `macOS blocked your editor from controlling ${stata_app} ` +
+            `(Automation permission). Open System Settings → Privacy & ` +
+            `Security → Automation, find your editor (e.g. Visual Studio ` +
+            `Code), and enable the checkbox for ${stata_app}, then try ` +
+            `again. If your editor is not listed, quit and reopen it from ` +
+            `Finder (not from a terminal) and send again to trigger the ` +
+            `permission prompt.`
+        );
+    }
+    return raw_message;
+}
+
+/**
  * Escapes a path for use in AppleScript string.
  */
 export function escape_for_applescript(path: string): string {
@@ -57,7 +92,9 @@ export function send_to_stata_app(
         const shell_safe_cmd = applescript_cmd.replace(/'/g, "'\\''");
         exec(`osascript -e '${shell_safe_cmd}'`, (error) => {
             if (error) {
-                reject(error);
+                reject(new Error(
+                    friendly_applescript_error(error.message, stata_app)
+                ));
             } else {
                 resolve();
             }

--- a/client/src/send-to-stata/applescript.ts
+++ b/client/src/send-to-stata/applescript.ts
@@ -10,11 +10,12 @@ const VALID_COMMANDS: readonly StataCommand[] = ['do', 'include'];
  * macOS Apple Events permission error (errAEEventNotPermitted).
  * Raised when the editor has not been granted Automation access to
  * the target app under System Settings → Privacy & Security →
- * Automation. We match the code in its canonical parenthesized form
- * so a bare `-1743` elsewhere in the message (e.g. a file path) does
+ * Automation. osascript appends the code in parentheses at the end of
+ * the message, so we anchor the match there: a `(-1743)` mid-message
+ * (e.g. inside a file path) when the real code is something else does
  * not trigger a false positive.
  */
-const APPLE_EVENTS_NOT_PERMITTED_TOKEN = '(-1743)';
+const APPLE_EVENTS_NOT_PERMITTED_RE = /\(-1743\)\s*$/;
 
 /**
  * Translate a raw `osascript` failure message into actionable guidance.
@@ -30,7 +31,7 @@ export function friendly_applescript_error(
     raw_message: string,
     stata_app: StataVariant
 ): string {
-    if (raw_message.includes(APPLE_EVENTS_NOT_PERMITTED_TOKEN)) {
+    if (APPLE_EVENTS_NOT_PERMITTED_RE.test(raw_message)) {
         return (
             `macOS blocked your editor from controlling ${stata_app} ` +
             `(Automation permission). Open System Settings → Privacy & ` +

--- a/client/src/send-to-stata/open-in-stata.ts
+++ b/client/src/send-to-stata/open-in-stata.ts
@@ -3,7 +3,7 @@ import { execFile } from 'child_process';
 import { detect_stata_app } from './stata-detector.js';
 import {
     escape_for_applescript,
-    friendly_applescript_error,
+    settle_osascript_result,
 } from './applescript.js';
 import { StataVariant } from './index.js';
 
@@ -23,13 +23,7 @@ function open_in_stata_app(
             `\ntell application "${stata_app}" to activate`;
 
         execFile('osascript', ['-e', applescript_cmd], (error) => {
-            if (error) {
-                reject(new Error(
-                    friendly_applescript_error(error.message, stata_app)
-                ));
-            } else {
-                resolve();
-            }
+            settle_osascript_result(error, stata_app, resolve, reject);
         });
     });
 }

--- a/client/src/send-to-stata/open-in-stata.ts
+++ b/client/src/send-to-stata/open-in-stata.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode';
 import { execFile } from 'child_process';
 import { detect_stata_app } from './stata-detector.js';
-import { escape_for_applescript } from './applescript.js';
+import {
+    escape_for_applescript,
+    friendly_applescript_error,
+} from './applescript.js';
 import { StataVariant } from './index.js';
 
 /**
@@ -21,7 +24,9 @@ function open_in_stata_app(
 
         execFile('osascript', ['-e', applescript_cmd], (error) => {
             if (error) {
-                reject(error);
+                reject(new Error(
+                    friendly_applescript_error(error.message, stata_app)
+                ));
             } else {
                 resolve();
             }

--- a/tests/unit/send-to-stata/applescript-error.test.ts
+++ b/tests/unit/send-to-stata/applescript-error.test.ts
@@ -1,0 +1,49 @@
+/// <reference types="bun-types" />
+/**
+ * Unit tests for friendly translation of `osascript` failures.
+ *
+ * The high-value case is errAEEventNotPermitted (-1743): macOS blocks
+ * the editor from controlling Stata until the user grants Automation
+ * permission. The raw osascript message is opaque, so we surface
+ * actionable guidance instead.
+ *
+ * Feature: send-to-stata — AppleScript Automation permission errors
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { friendly_applescript_error } from '../../../client/src/send-to-stata/applescript';
+
+describe('friendly_applescript_error', () => {
+    const not_permitted =
+        '30:149: execution error: Not authorized to send Apple events ' +
+        'to StataSE. (-1743)';
+
+    it('translates the -1743 permission error into guidance', () => {
+        const my_message = friendly_applescript_error(not_permitted, 'StataSE');
+        expect(my_message).toContain('Automation permission');
+        expect(my_message).toContain('Privacy & Security');
+        // Names the actual variant so the user knows what to enable.
+        expect(my_message).toContain('StataSE');
+        // Does not leak the raw error code at the user.
+        expect(my_message).not.toContain('-1743');
+    });
+
+    it('uses the provided variant name in the message', () => {
+        const my_message = friendly_applescript_error(
+            'Not authorized to send Apple events to StataMP. (-1743)',
+            'StataMP'
+        );
+        expect(my_message).toContain('StataMP');
+        expect(my_message).not.toContain('StataSE');
+    });
+
+    it('passes unrelated errors through unchanged', () => {
+        const my_other = '0:0: execution error: Application isn’t ' +
+            'running. (-600)';
+        expect(friendly_applescript_error(my_other, 'StataSE')).toBe(my_other);
+    });
+
+    it('passes an empty message through unchanged', () => {
+        expect(friendly_applescript_error('', 'Stata')).toBe('');
+    });
+});

--- a/tests/unit/send-to-stata/applescript-error.test.ts
+++ b/tests/unit/send-to-stata/applescript-error.test.ts
@@ -11,7 +11,10 @@
  */
 
 import { describe, expect, it } from 'bun:test';
-import { friendly_applescript_error } from '../../../client/src/send-to-stata/applescript';
+import {
+    friendly_applescript_error,
+    settle_osascript_result,
+} from '../../../client/src/send-to-stata/applescript';
 
 describe('friendly_applescript_error', () => {
     const not_permitted =
@@ -43,7 +46,58 @@ describe('friendly_applescript_error', () => {
         expect(friendly_applescript_error(my_other, 'StataSE')).toBe(my_other);
     });
 
+    it('does not fire on a bare -1743 substring outside the code', () => {
+        // A path or value containing "-1743" must not be mistaken for the
+        // canonical "(-1743)" Apple Events permission code.
+        const my_unrelated =
+            '0:0: execution error: cannot read ' +
+            '/Users/me/project-1743/data.dta. (-43)';
+        expect(friendly_applescript_error(my_unrelated, 'StataSE'))
+            .toBe(my_unrelated);
+    });
+
     it('passes an empty message through unchanged', () => {
         expect(friendly_applescript_error('', 'Stata')).toBe('');
+    });
+});
+
+describe('settle_osascript_result', () => {
+    // Guards the wiring shared by the exec/execFile call sites: the
+    // friendly translation must be applied on the reject path, so the
+    // helper cannot be silently unwired without failing a test.
+    it('resolves when there is no error', () => {
+        let resolved = false;
+        settle_osascript_result(
+            null,
+            'StataSE',
+            () => { resolved = true; },
+            () => { throw new Error('should not reject on success'); }
+        );
+        expect(resolved).toBe(true);
+    });
+
+    it('rejects with friendly guidance on a -1743 failure', () => {
+        let my_reason: Error | undefined;
+        settle_osascript_result(
+            new Error('execution error: Not authorized ... (-1743)'),
+            'StataMP',
+            () => { throw new Error('should not resolve on failure'); },
+            (reason) => { my_reason = reason; }
+        );
+        expect(my_reason?.message).toContain('Automation permission');
+        expect(my_reason?.message).toContain('StataMP');
+        expect(my_reason?.message).not.toContain('-1743');
+    });
+
+    it('rejects with the raw message on unrelated failures', () => {
+        const raw_message = 'execution error: not running. (-600)';
+        let my_reason: Error | undefined;
+        settle_osascript_result(
+            new Error(raw_message),
+            'StataSE',
+            () => { throw new Error('should not resolve on failure'); },
+            (reason) => { my_reason = reason; }
+        );
+        expect(my_reason?.message).toBe(raw_message);
     });
 });

--- a/tests/unit/send-to-stata/applescript-error.test.ts
+++ b/tests/unit/send-to-stata/applescript-error.test.ts
@@ -47,11 +47,20 @@ describe('friendly_applescript_error', () => {
     });
 
     it('does not fire on a bare -1743 substring outside the code', () => {
-        // A path or value containing "-1743" must not be mistaken for the
-        // canonical "(-1743)" Apple Events permission code.
+        // A path or value containing "-1743" must not be mistaken
+        // for the canonical "(-1743)" Apple Events permission code.
         const my_unrelated =
             '0:0: execution error: cannot read ' +
             '/Users/me/project-1743/data.dta. (-43)';
+        expect(friendly_applescript_error(my_unrelated, 'StataSE'))
+            .toBe(my_unrelated);
+    });
+
+    it('does not fire when (-1743) is mid-message but not the code', () => {
+        // The real code is (-43); the anchored match must ignore a
+        // "(-1743)" that appears earlier in the message (e.g. a path).
+        const my_unrelated =
+            'cannot read /Users/me/project(-1743)/data.dta. (-43)';
         expect(friendly_applescript_error(my_unrelated, 'StataSE'))
             .toBe(my_unrelated);
     });


### PR DESCRIPTION
## Problem

When the editor hasn't been granted Automation access to Stata, macOS rejects the Apple Event with `errAEEventNotPermitted` (`-1743`). The raw `osascript` failure was surfaced verbatim:

> Error: Command failed: osascript -e 'tell application "StataSE" to DoCommandAsync ...' 30:149: execution error: Not authorized to send Apple events to StataSE. (-1743)

That gives the user no idea that the fix is a one-time Automation permission grant in System Settings.

## Fix

- Add `friendly_applescript_error(raw_message, stata_app)` in `applescript.ts`: when the message contains `-1743`, return actionable guidance (System Settings → Privacy & Security → Automation → enable your editor for the named Stata variant, and how to re-trigger the prompt if the editor isn't listed). All other osascript errors pass through unchanged.
- Wire it into both AppleScript paths: `send_to_stata_app` (send to Stata) and `open_in_stata_app` (Open in Stata viewer).

## Tests

- New `tests/unit/send-to-stata/applescript-error.test.ts`: verifies the -1743 message is translated, names the correct variant, doesn't leak the raw code, and that unrelated/empty messages pass through unchanged.
- `bun run typecheck` (server + client) and the full `bun test` suite pass (5963 pass / 0 fail).

## Note

This is independent of #201 (StataNow detection) and branched off `main`. Together they cover the two failure modes a macOS user hits when sending to Stata: the install dir not being found (#201) and the OS blocking Apple Events (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macOS launch messaging for Stata actions, with clearer guidance when Automation permission is blocked.
  * Updated the Stata app selection hint to emphasize entering the app name exactly.

* **Bug Fixes**
  * Replaced raw AppleScript permission errors with a friendlier message that explains how to grant access.
  * Preserved normal error handling for unrelated failures while keeping successful launches unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->