### PR TITLE
Detect StataNow installs (#200)

### DIFF
--- a/client/src/send-to-stata/cd-context.ts
+++ b/client/src/send-to-stata/cd-context.ts
@@ -137,8 +137,9 @@ export async function execute_cd_command(
                 if (!stata_app) {
                     vscode.window.showErrorMessage(
                         'Stata not found. Install Stata in ' +
-                        '/Applications/Stata/ or configure ' +
-                        'sight.sendToStata.stataApp setting.'
+                        '/Applications/Stata/ or /Applications/StataNow/, ' +
+                        'or set sight.sendToStata.stataApp to a variant ' +
+                        'name (StataMP, StataSE, StataBE, StataIC, or Stata).'
                     );
                     return;
                 }

--- a/client/src/send-to-stata/cd-context.ts
+++ b/client/src/send-to-stata/cd-context.ts
@@ -9,7 +9,10 @@ import {
     create_temp_file,
     schedule_temp_file_cleanup,
 } from './temp-file.js';
-import { detect_stata_app } from './stata-detector.js';
+import {
+    detect_stata_app,
+    STATA_APP_NOT_FOUND_MESSAGE
+} from './stata-detector.js';
 import { send_to_stata_app } from './applescript.js';
 import { send_to_terminal } from './terminal.js';
 import {
@@ -136,10 +139,7 @@ export async function execute_cd_command(
                 const stata_app = await detect_stata_app();
                 if (!stata_app) {
                     vscode.window.showErrorMessage(
-                        'Stata not found. Install Stata in ' +
-                        '/Applications/Stata/ or /Applications/StataNow/, ' +
-                        'or set sight.sendToStata.stataApp to a variant ' +
-                        'name (StataMP, StataSE, StataBE, StataIC, or Stata).'
+                        STATA_APP_NOT_FOUND_MESSAGE
                     );
                     return;
                 }

--- a/client/src/send-to-stata/commands.ts
+++ b/client/src/send-to-stata/commands.ts
@@ -11,7 +11,10 @@ import {
     create_temp_file,
     schedule_temp_file_cleanup
 } from './temp-file.js';
-import { detect_stata_app } from './stata-detector.js';
+import {
+    detect_stata_app,
+    STATA_APP_NOT_FOUND_MESSAGE
+} from './stata-detector.js';
 import { send_to_stata_app } from './applescript.js';
 import { send_to_terminal } from './terminal.js';
 import {
@@ -271,12 +274,7 @@ async function handle_send_command(
                     const my_stata_app = await detect_stata_app();
                     if (!my_stata_app) {
                         vscode.window.showErrorMessage(
-                            'Stata not found. Install Stata in ' +
-                            '/Applications/Stata/ or ' +
-                            '/Applications/StataNow/, or set ' +
-                            'sight.sendToStata.stataApp to a variant ' +
-                            'name (StataMP, StataSE, StataBE, StataIC, ' +
-                            'or Stata).');
+                            STATA_APP_NOT_FOUND_MESSAGE);
                         return;
                     }
 

--- a/client/src/send-to-stata/commands.ts
+++ b/client/src/send-to-stata/commands.ts
@@ -272,8 +272,9 @@ async function handle_send_command(
                     if (!my_stata_app) {
                         vscode.window.showErrorMessage(
                             'Stata not found. Install Stata in ' +
-                            '/Applications/Stata/ or configure ' +
-                            'sight.sendToStata.stataApp setting.');
+                            '/Applications/Stata/ or /Applications/StataNow/, ' +
+                            'or set sight.sendToStata.stataApp to a variant ' +
+                            'name (StataMP, StataSE, StataBE, StataIC, or Stata).');
                         return;
                     }
 

--- a/client/src/send-to-stata/commands.ts
+++ b/client/src/send-to-stata/commands.ts
@@ -272,9 +272,11 @@ async function handle_send_command(
                     if (!my_stata_app) {
                         vscode.window.showErrorMessage(
                             'Stata not found. Install Stata in ' +
-                            '/Applications/Stata/ or /Applications/StataNow/, ' +
-                            'or set sight.sendToStata.stataApp to a variant ' +
-                            'name (StataMP, StataSE, StataBE, StataIC, or Stata).');
+                            '/Applications/Stata/ or ' +
+                            '/Applications/StataNow/, or set ' +
+                            'sight.sendToStata.stataApp to a variant ' +
+                            'name (StataMP, StataSE, StataBE, StataIC, ' +
+                            'or Stata).');
                         return;
                     }
 

--- a/client/src/send-to-stata/stata-cli-detector.ts
+++ b/client/src/send-to-stata/stata-cli-detector.ts
@@ -3,6 +3,7 @@ import { execFile } from 'child_process';
 import * as fs from 'fs/promises';
 import { constants as fs_constants } from 'fs';
 import { StataVariant } from './index.js';
+import { macos_cli_candidate_paths } from './stata-install-roots.js';
 
 /**
  * CLI binary names in priority order, per platform.
@@ -44,18 +45,6 @@ function get_variant_to_cli(): Record<StataVariant, string> {
         ? WIN_VARIANT_TO_CLI
         : UNIX_VARIANT_TO_CLI;
 }
-
-/**
- * Maps CLI binary names to macOS .app bundle paths.
- * Fallback when the binary is not on PATH.
- */
-const CLI_TO_MACOS_PATH: Record<string, string> = {
-    'stata-mp': '/Applications/Stata/StataMP.app/Contents/MacOS/stata-mp',
-    'stata-se': '/Applications/Stata/StataSE.app/Contents/MacOS/stata-se',
-    'stata-ic': '/Applications/Stata/StataIC.app/Contents/MacOS/stata-ic',
-    'stata-be': '/Applications/Stata/StataBE.app/Contents/MacOS/stata-be',
-    'stata': '/Applications/Stata/Stata.app/Contents/MacOS/stata',
-};
 
 let cached_stata_cli: string | null | undefined = undefined;
 
@@ -118,11 +107,12 @@ export async function detect_stata_cli(): Promise<string | null> {
         }
     }
 
-    // macOS .app fallback
+    // macOS .app fallback. Each binary may live under either the
+    // perpetual `/Applications/Stata/` root or the StataNow root, so we
+    // probe every candidate path the install-roots helper produces.
     if (process.platform === 'darwin') {
         for (const my_binary of the_binaries) {
-            const my_path = CLI_TO_MACOS_PATH[my_binary];
-            if (my_path) {
+            for (const my_path of macos_cli_candidate_paths(my_binary)) {
                 try {
                     await fs.access(my_path, fs_constants.X_OK);
                     cached_stata_cli = my_path;

--- a/client/src/send-to-stata/stata-cli-detector.ts
+++ b/client/src/send-to-stata/stata-cli-detector.ts
@@ -9,10 +9,13 @@ import { macos_cli_candidate_paths } from './stata-install-roots.js';
  * CLI binary names in priority order, per platform.
  * Windows uses PascalCase names; Unix uses lowercase with hyphens.
  */
+// Edition priority order (most capable first), matching the GUI
+// detector's VALID_VARIANTS so app sends and terminal sends pick the
+// same edition when several are installed.
 const UNIX_CLI_BINARIES: readonly string[] =
-    ['stata-mp', 'stata-se', 'stata-ic', 'stata-be', 'stata'];
+    ['stata-mp', 'stata-se', 'stata-be', 'stata-ic', 'stata'];
 const WIN_CLI_BINARIES: readonly string[] =
-    ['StataMP', 'StataSE', 'StataIC', 'StataBE', 'Stata'];
+    ['StataMP', 'StataSE', 'StataBE', 'StataIC', 'Stata'];
 
 function get_cli_binaries(): readonly string[] {
     return process.platform === 'win32'

--- a/client/src/send-to-stata/stata-detector.ts
+++ b/client/src/send-to-stata/stata-detector.ts
@@ -22,8 +22,9 @@ export async function detect_stata_app(): Promise<StataVariant | null> {
     const setting_value = config.get<string>('stataApp');
     
     // Validate setting_value against allowed variants before using it
-    if (setting_value && VALID_VARIANTS.includes(setting_value as StataVariant)) {
-        return setting_value as StataVariant;
+    const my_setting = setting_value as StataVariant;
+    if (setting_value && VALID_VARIANTS.includes(my_setting)) {
+        return my_setting;
     }
     // If setting_value is invalid, fall through to auto-detection
     

--- a/client/src/send-to-stata/stata-detector.ts
+++ b/client/src/send-to-stata/stata-detector.ts
@@ -10,6 +10,16 @@ const VALID_VARIANTS: readonly StataVariant[] = [
     'StataMP', 'StataSE', 'StataBE', 'StataIC', 'Stata'
 ];
 
+/**
+ * User-facing message shown when no Stata GUI app can be located on
+ * macOS. Shared by the send and cd command handlers so the wording and
+ * install-path guidance live in one place.
+ */
+export const STATA_APP_NOT_FOUND_MESSAGE =
+    'Stata not found. Install Stata in /Applications/Stata/ or ' +
+    '/Applications/StataNow/, or set sight.sendToStata.stataApp to a ' +
+    'variant name (StataMP, StataSE, StataBE, StataIC, or Stata).';
+
 let cached_stata_app: StataVariant | null | undefined = undefined;
 
 export async function detect_stata_app(): Promise<StataVariant | null> {

--- a/client/src/send-to-stata/stata-detector.ts
+++ b/client/src/send-to-stata/stata-detector.ts
@@ -1,9 +1,13 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import { StataVariant } from './index.js';
+import {
+    MAC_APP_INSTALL_ROOTS,
+    find_installed_variant
+} from './stata-install-roots.js';
 
 const VALID_VARIANTS: readonly StataVariant[] = [
-    'StataMP', 'StataSE', 'StataIC', 'Stata'
+    'StataMP', 'StataSE', 'StataBE', 'StataIC', 'Stata'
 ];
 
 let cached_stata_app: StataVariant | null | undefined = undefined;
@@ -27,18 +31,21 @@ export async function detect_stata_app(): Promise<StataVariant | null> {
         return cached_stata_app;
     }
     
-    for (const my_variant of VALID_VARIANTS) {
-        try {
-            await fs.access(`/Applications/Stata/${my_variant}.app`);
-            cached_stata_app = my_variant;
-            return my_variant;
-        } catch {
-            continue;
+    const my_variant = await find_installed_variant(
+        MAC_APP_INSTALL_ROOTS,
+        VALID_VARIANTS,
+        async (app_path: string) => {
+            try {
+                await fs.access(app_path);
+                return true;
+            } catch {
+                return false;
+            }
         }
-    }
-    
-    cached_stata_app = null;
-    return null;
+    );
+
+    cached_stata_app = my_variant;
+    return my_variant;
 }
 
 export function clear_stata_cache(): void {

--- a/client/src/send-to-stata/stata-install-roots.ts
+++ b/client/src/send-to-stata/stata-install-roots.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared, vscode-free logic for locating a Stata install on macOS.
+ *
+ * Stata ships through two channels that install to different roots:
+ *   - perpetual-license editions install under `/Applications/Stata/`
+ *   - StataNow (the subscription channel) installs under
+ *     `/Applications/StataNow/`
+ * In both cases the `.app` bundle inside is named by edition (e.g.
+ * `StataSE.app`, `StataMP.app`), so only the install root differs. We
+ * probe both roots so detection works regardless of channel (#200).
+ */
+import type { StataVariant } from './index.js';
+
+/**
+ * macOS install roots to probe, in priority order. A perpetual install
+ * is preferred over StataNow when both are present; within each root,
+ * the caller's variant priority applies.
+ */
+export const MAC_APP_INSTALL_ROOTS: readonly string[] = [
+    '/Applications/Stata',
+    '/Applications/StataNow',
+];
+
+/**
+ * Find the first installed Stata GUI variant by probing
+ * `<root>/<variant>.app` across the given roots. Roots are tried in
+ * order, and within each root the variants are tried in order, so the
+ * result reflects root priority first, then variant priority.
+ *
+ * `exists` must resolve true when the candidate `.app` bundle is present.
+ */
+export async function find_installed_variant(
+    roots: readonly string[],
+    variants: readonly StataVariant[],
+    exists: (app_path: string) => Promise<boolean>
+): Promise<StataVariant | null> {
+    for (const my_root of roots) {
+        for (const my_variant of variants) {
+            if (await exists(`${my_root}/${my_variant}.app`)) {
+                return my_variant;
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * The macOS `.app` bundle subpath (relative to an install root) for each
+ * Unix CLI binary name. Combined with `MAC_APP_INSTALL_ROOTS` to build
+ * full candidate paths.
+ */
+const CLI_TO_APP_SUBPATH: Record<string, string> = {
+    'stata-mp': 'StataMP.app/Contents/MacOS/stata-mp',
+    'stata-se': 'StataSE.app/Contents/MacOS/stata-se',
+    'stata-ic': 'StataIC.app/Contents/MacOS/stata-ic',
+    'stata-be': 'StataBE.app/Contents/MacOS/stata-be',
+    'stata': 'Stata.app/Contents/MacOS/stata',
+};
+
+/**
+ * Build the list of candidate macOS CLI binary paths for a Unix CLI
+ * binary name, one per install root (perpetual first, then StataNow).
+ * Returns an empty list for an unrecognized binary name.
+ */
+export function macos_cli_candidate_paths(binary: string): string[] {
+    const my_subpath = CLI_TO_APP_SUBPATH[binary];
+    if (!my_subpath) {
+        return [];
+    }
+    return MAC_APP_INSTALL_ROOTS.map(my_root => `${my_root}/${my_subpath}`);
+}

--- a/client/src/send-to-stata/stata-install-roots.ts
+++ b/client/src/send-to-stata/stata-install-roots.ts
@@ -8,13 +8,21 @@
  * In both cases the `.app` bundle inside is named by edition (e.g.
  * `StataSE.app`, `StataMP.app`), so only the install root differs. We
  * probe both roots so detection works regardless of channel (#200).
+ *
+ * NOTE: the server (`src/utils/stata-install-paths.ts`) keeps its own
+ * macOS root list for ado/help discovery. That is deliberate: the server
+ * is a separate build unit (CommonJS LSP bundle) with no import path to
+ * `client/src`, and it works in terms of variant *directories* under
+ * `/Applications` rather than full `.app` roots. Keep the StataNow entry
+ * in both in sync.
  */
 import type { StataVariant } from './index.js';
 
 /**
- * macOS install roots to probe, in priority order. A perpetual install
- * is preferred over StataNow when both are present; within each root,
- * the caller's variant priority applies.
+ * macOS install roots to probe. When the same edition exists under both
+ * roots, the perpetual `/Applications/Stata/` install is preferred over
+ * StataNow (it appears first). Edition priority outranks channel — see
+ * `find_installed_variant`.
  */
 export const MAC_APP_INSTALL_ROOTS: readonly string[] = [
     '/Applications/Stata',
@@ -22,20 +30,22 @@ export const MAC_APP_INSTALL_ROOTS: readonly string[] = [
 ];
 
 /**
- * Find the first installed Stata GUI variant by probing
- * `<root>/<variant>.app` across the given roots. Roots are tried in
- * order, and within each root the variants are tried in order, so the
- * result reflects root priority first, then variant priority.
+ * Find the best installed Stata GUI variant by probing
+ * `<root>/<variant>.app`. Variants are tried in order (outer loop) and,
+ * for each, the roots are tried in order (inner loop), so the result
+ * reflects edition priority first, then channel/root priority. This
+ * matches the CLI detector's edition-first fallback: a user who has a
+ * more capable edition installed gets it regardless of channel.
  *
  * `exists` must resolve true when the candidate `.app` bundle is present.
  */
 export async function find_installed_variant(
-    roots: readonly string[],
-    variants: readonly StataVariant[],
+    the_roots: readonly string[],
+    the_variants: readonly StataVariant[],
     exists: (app_path: string) => Promise<boolean>
 ): Promise<StataVariant | null> {
-    for (const my_root of roots) {
-        for (const my_variant of variants) {
+    for (const my_variant of the_variants) {
+        for (const my_root of the_roots) {
             if (await exists(`${my_root}/${my_variant}.app`)) {
                 return my_variant;
             }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,7 +158,7 @@ Example:
 
 In addition to the paths you configure, Sight automatically consults the standard Stata install and user ado directories when resolving help topics for the SMCL help viewer:
 
-- **macOS:** `/Applications/Stata/ado/{base,site,updates}`, its `StataMP` / `StataSE` / `StataBE` / `StataIC` variants, and `~/Library/Application Support/Stata/ado/{personal,plus}`.
+- **macOS:** `/Applications/Stata/ado/{base,site,updates}`, its `StataMP` / `StataSE` / `StataBE` / `StataIC` variants, the StataNow channel directory `/Applications/StataNow/ado/{base,site,updates}`, and `~/Library/Application Support/Stata/ado/{personal,plus}`.
 - **Linux:** `/usr/local/stata<version>/ado/{base,site,updates}` and `/opt/stata<version>/…` for versions 13–20, plus unversioned `stata` directories.
 - **Windows:** `Stata<version>\ado\{base,site,updates}` under each `Program Files` / `Program Files (x86)` directory that Windows reports via its environment variables.
 - All platforms: the legacy `~/ado`, `~/ado/personal`, and `~/ado/plus` conventions.

--- a/docs/send-to-stata.md
+++ b/docs/send-to-stata.md
@@ -31,7 +31,7 @@ When the integrated terminal is selected (directly or via auto-detection), the e
 The extension adds a "Stata" terminal profile to VS Code's terminal dropdown (not shown on native Windows, where Stata has no interactive CLI). You can open a Stata terminal manually from the terminal profile picker at any time. The Stata CLI binary is detected automatically:
 
 1. Checks your PATH for `stata-mp`, `stata-se`, `stata-ic`, `stata-be`, or `stata` (in priority order)
-2. On macOS, falls back to checking inside `/Applications/Stata/*.app/Contents/MacOS/`
+2. On macOS, falls back to checking inside `/Applications/Stata/*.app/Contents/MacOS/` and `/Applications/StataNow/*.app/Contents/MacOS/` (StataNow installs under `/Applications/StataNow/`)
 3. If `sight.sendToStata.stataApp` is set, that variant is checked first
 
 ## Keyboard Shortcuts

--- a/docs/send-to-stata.md
+++ b/docs/send-to-stata.md
@@ -30,7 +30,7 @@ When the integrated terminal is selected (directly or via auto-detection), the e
 
 The extension adds a "Stata" terminal profile to VS Code's terminal dropdown (not shown on native Windows, where Stata has no interactive CLI). You can open a Stata terminal manually from the terminal profile picker at any time. The Stata CLI binary is detected automatically:
 
-1. Checks your PATH for `stata-mp`, `stata-se`, `stata-ic`, `stata-be`, or `stata` (in priority order)
+1. Checks your PATH for `stata-mp`, `stata-se`, `stata-be`, `stata-ic`, or `stata` (in priority order)
 2. On macOS, falls back to checking inside `/Applications/Stata/*.app/Contents/MacOS/` and `/Applications/StataNow/*.app/Contents/MacOS/` (StataNow installs under `/Applications/StataNow/`)
 3. If `sight.sendToStata.stataApp` is set, that variant is checked first
 

--- a/src/utils/stata-install-paths.ts
+++ b/src/utils/stata-install-paths.ts
@@ -35,6 +35,9 @@ const WINDOWS_VARIANT_DIRS = ['Stata'];
 // `/Applications/StataNow/` rather than `/Applications/Stata/` (the .app
 // bundle inside is still named by flavour, e.g. `StataSE.app`). We probe
 // both roots so ado/help discovery works regardless of channel.
+// NOTE: the VS Code extension keeps a parallel macOS root list in
+// `client/src/send-to-stata/stata-install-roots.ts`; the two are separate
+// build units, so keep the StataNow entry in sync across both.
 const MAC_VARIANT_DIRS = [
     'Stata', 'StataMP', 'StataSE', 'StataBE', 'StataIC', 'StataNow',
 ];

--- a/src/utils/stata-install-paths.ts
+++ b/src/utils/stata-install-paths.ts
@@ -31,7 +31,13 @@ import * as path from 'path';
 const STATA_MAJOR_VERSIONS = [20, 19, 18, 17, 16, 15, 14, 13];
 
 const WINDOWS_VARIANT_DIRS = ['Stata'];
-const MAC_VARIANT_DIRS = ['Stata', 'StataMP', 'StataSE', 'StataBE', 'StataIC'];
+// StataNow is Stata's subscription release channel; it installs under
+// `/Applications/StataNow/` rather than `/Applications/Stata/` (the .app
+// bundle inside is still named by flavour, e.g. `StataSE.app`). We probe
+// both roots so ado/help discovery works regardless of channel.
+const MAC_VARIANT_DIRS = [
+    'Stata', 'StataMP', 'StataSE', 'StataBE', 'StataIC', 'StataNow',
+];
 
 // Drive letters to probe for drive-root installs like `C:\Stata18` or
 // `D:\Stata18`. Many institutional and lab-image Windows machines put

--- a/tests/integration/send-to-stata-app-temp-file-lifecycle.test.ts
+++ b/tests/integration/send-to-stata-app-temp-file-lifecycle.test.ts
@@ -370,6 +370,7 @@ describe.serial('Feature: send-to-stata app temp file lifecycle', () => {
         mock.module(STATA_DETECTOR_MODULE_URL, () => ({
             detect_stata_app: async () => 'StataMP',
             clear_stata_cache: () => {},
+            STATA_APP_NOT_FOUND_MESSAGE: 'Stata not found.',
         }));
 
         mock.module(STATA_CLI_DETECTOR_MODULE_URL, () => ({

--- a/tests/property/send-to-stata-detection.prop.test.ts
+++ b/tests/property/send-to-stata-detection.prop.test.ts
@@ -14,8 +14,10 @@ import { StataVariant } from '../../client/src/send-to-stata/index';
  * function is tested via integration tests.
  */
 
-// Simulate the detection order logic
-const DETECTION_ORDER: StataVariant[] = ['StataMP', 'StataSE', 'StataIC', 'Stata'];
+// Simulate the detection order logic. Mirrors VALID_VARIANTS in
+// stata-detector.ts (edition priority, most capable first); keep in sync.
+const DETECTION_ORDER: StataVariant[] =
+    ['StataMP', 'StataSE', 'StataBE', 'StataIC', 'Stata'];
 
 function simulate_detection(
     installed_variants: Set<StataVariant>,
@@ -39,11 +41,11 @@ function simulate_detection(
 describe('Feature: send-to-stata - Stata Detection Properties', () => {
     // Generator for Stata variants
     const variant_gen = fc.constantFrom<StataVariant>(
-        'StataMP', 'StataSE', 'StataIC', 'Stata'
+        'StataMP', 'StataSE', 'StataBE', 'StataIC', 'Stata'
     );
 
     // Generator for set of installed variants
-    const installed_variants_gen = fc.array(variant_gen, { minLength: 0, maxLength: 4 })
+    const installed_variants_gen = fc.array(variant_gen, { minLength: 0, maxLength: 5 })
         .map(arr => new Set(arr));
 
     test('Property 7: Setting always takes precedence over detection', () => {
@@ -57,7 +59,7 @@ describe('Feature: send-to-stata - Stata Detection Properties', () => {
         ), { numRuns: 100 });
     });
 
-    test('Property 7: Detection order is StataMP > StataSE > StataIC > Stata', () => {
+    test('Property 7: Detection order is StataMP > StataSE > StataBE > StataIC > Stata', () => {
         fc.assert(fc.property(
             installed_variants_gen,
             (installed) => {
@@ -86,10 +88,16 @@ describe('Feature: send-to-stata - Stata Detection Properties', () => {
 
     test('Property 7: StataMP is preferred when all variants installed', () => {
         const all_installed = new Set<StataVariant>([
-            'StataMP', 'StataSE', 'StataIC', 'Stata'
+            'StataMP', 'StataSE', 'StataBE', 'StataIC', 'Stata'
         ]);
         const result = simulate_detection(all_installed);
         expect(result).toBe('StataMP');
+    });
+
+    test('Property 7: StataBE is preferred over StataIC when both installed', () => {
+        const installed = new Set<StataVariant>(['StataBE', 'StataIC']);
+        const result = simulate_detection(installed);
+        expect(result).toBe('StataBE');
     });
 
     test('Property 7: StataSE is returned when only SE and IC installed', () => {

--- a/tests/unit/send-to-stata/stata-install-roots.test.ts
+++ b/tests/unit/send-to-stata/stata-install-roots.test.ts
@@ -1,0 +1,97 @@
+/// <reference types="bun-types" />
+/**
+ * Tests for the vscode-free Stata install-root probing logic shared by
+ * the GUI and CLI detectors.
+ *
+ * Feature: send-to-stata — StataNow directory compatibility (#200)
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+    MAC_APP_INSTALL_ROOTS,
+    find_installed_variant,
+    macos_cli_candidate_paths,
+} from '../../../client/src/send-to-stata/stata-install-roots';
+import type { StataVariant } from '../../../client/src/send-to-stata/index';
+
+const VARIANTS: readonly StataVariant[] = [
+    'StataMP', 'StataSE', 'StataBE', 'StataIC', 'Stata',
+];
+
+function make_exists(the_present: string[]): (p: string) => Promise<boolean> {
+    const the_set = new Set(the_present);
+    return (p: string) => Promise.resolve(the_set.has(p));
+}
+
+describe('MAC_APP_INSTALL_ROOTS', () => {
+    it('probes both the perpetual Stata and StataNow directories', () => {
+        expect(MAC_APP_INSTALL_ROOTS).toContain('/Applications/Stata');
+        expect(MAC_APP_INSTALL_ROOTS).toContain('/Applications/StataNow');
+    });
+});
+
+describe('find_installed_variant', () => {
+    it('finds a variant under the canonical /Applications/Stata root', async () => {
+        const the_result = await find_installed_variant(
+            MAC_APP_INSTALL_ROOTS,
+            VARIANTS,
+            make_exists(['/Applications/Stata/StataMP.app'])
+        );
+        expect(the_result).toBe('StataMP');
+    });
+
+    it('finds a StataSE install under /Applications/StataNow (#200)', async () => {
+        const the_result = await find_installed_variant(
+            MAC_APP_INSTALL_ROOTS,
+            VARIANTS,
+            make_exists(['/Applications/StataNow/StataSE.app'])
+        );
+        expect(the_result).toBe('StataSE');
+    });
+
+    it('finds a StataBE install (variant omitted from the old detector)', async () => {
+        const the_result = await find_installed_variant(
+            MAC_APP_INSTALL_ROOTS,
+            VARIANTS,
+            make_exists(['/Applications/StataNow/StataBE.app'])
+        );
+        expect(the_result).toBe('StataBE');
+    });
+
+    it('returns null when nothing is installed', async () => {
+        const the_result = await find_installed_variant(
+            MAC_APP_INSTALL_ROOTS,
+            VARIANTS,
+            make_exists([])
+        );
+        expect(the_result).toBeNull();
+    });
+
+    it('applies variant priority within a root', async () => {
+        const the_result = await find_installed_variant(
+            MAC_APP_INSTALL_ROOTS,
+            VARIANTS,
+            make_exists([
+                '/Applications/Stata/StataSE.app',
+                '/Applications/Stata/Stata.app',
+            ])
+        );
+        expect(the_result).toBe('StataSE');
+    });
+});
+
+describe('macos_cli_candidate_paths', () => {
+    it('includes a StataNow .app/Contents/MacOS path for the binary (#200)', () => {
+        const the_paths = macos_cli_candidate_paths('stata-se');
+        expect(the_paths).toContain(
+            '/Applications/Stata/StataSE.app/Contents/MacOS/stata-se'
+        );
+        expect(the_paths).toContain(
+            '/Applications/StataNow/StataSE.app/Contents/MacOS/stata-se'
+        );
+    });
+
+    it('returns an empty list for an unknown binary name', () => {
+        expect(macos_cli_candidate_paths('not-a-stata-binary')).toEqual([]);
+    });
+});

--- a/tests/unit/send-to-stata/stata-install-roots.test.ts
+++ b/tests/unit/send-to-stata/stata-install-roots.test.ts
@@ -18,8 +18,10 @@ const VARIANTS: readonly StataVariant[] = [
     'StataMP', 'StataSE', 'StataBE', 'StataIC', 'Stata',
 ];
 
-function make_exists(the_present: string[]): (p: string) => Promise<boolean> {
-    const the_set = new Set(the_present);
+function make_exists(
+    the_present_paths: string[]
+): (p: string) => Promise<boolean> {
+    const the_set = new Set(the_present_paths);
     return (p: string) => Promise.resolve(the_set.has(p));
 }
 
@@ -77,6 +79,20 @@ describe('find_installed_variant', () => {
             ])
         );
         expect(the_result).toBe('StataSE');
+    });
+
+    it('prefers the higher edition across channels (edition before channel)', async () => {
+        // Perpetual SE vs StataNow MP: the more capable edition (MP)
+        // wins regardless of which channel it lives in.
+        const the_result = await find_installed_variant(
+            MAC_APP_INSTALL_ROOTS,
+            VARIANTS,
+            make_exists([
+                '/Applications/Stata/StataSE.app',
+                '/Applications/StataNow/StataMP.app',
+            ])
+        );
+        expect(the_result).toBe('StataMP');
     });
 });
 

--- a/tests/unit/stata-install-paths.test.ts
+++ b/tests/unit/stata-install-paths.test.ts
@@ -88,6 +88,21 @@ describe('discover_stata_ado_paths', () => {
             expect(the_paths).toContain('/Applications/StataMP/ado/base');
             expect(the_paths).toContain('/Applications/StataSE/ado/base');
         });
+
+        it('discovers StataNow installs under /Applications/StataNow', () => {
+            const the_present = [
+                '/Applications/StataNow/ado/base',
+                '/Applications/StataNow/ado/site',
+                '/Applications/StataNow/ado/updates',
+            ];
+            const the_paths = discover_stata_ado_paths({
+                home: '/Users/me',
+                platform: 'darwin',
+                exists: make_exists(the_present),
+                env: {},
+            });
+            expect(the_paths).toEqual(the_present);
+        });
     });
 
     describe('Linux', () => {


### PR DESCRIPTION
## Summary

Fixes #200. The Send-to-Stata feature reported **"Stata not found"** for users on the StataNow subscription channel, which installs under `/Applications/StataNow/` instead of `/Applications/Stata/`. Three macOS subsystems hardcoded `/Applications/Stata/` and never probed `StataNow`, so the install was invisible. The reporter's setting attempts also failed because `sight.sendToStata.stataApp` only accepts an edition name (`StataMP`/`StataSE`/`StataBE`/`StataIC`/`Stata`), not a path.

## Changes

- **New shared module** `client/src/send-to-stata/stata-install-roots.ts` (vscode-free, unit-tested): `MAC_APP_INSTALL_ROOTS = ['/Applications/Stata', '/Applications/StataNow']`, plus `find_installed_variant()` and `macos_cli_candidate_paths()`.
- **GUI detector** (`stata-detector.ts`): probes both roots; also fixes a latent bug where `StataBE` was missing from `VALID_VARIANTS`.
- **CLI detector** (`stata-cli-detector.ts`): the macOS `.app` fallback now tries both roots per binary.
- **ado/help discovery** (`src/utils/stata-install-paths.ts`): adds `StataNow` to the macOS install roots.
- **Consistency:** detection is now *edition-first* everywhere (a more capable edition wins regardless of channel); CLI binary priority arrays reordered (`BE` before `IC`) to match the GUI variant order.
- **Error message:** clarified (mentions `/Applications/StataNow/` and that the setting takes a variant name) and de-duplicated into a shared `STATA_APP_NOT_FOUND_MESSAGE` constant.
- **Docs:** `send-to-stata.md` and `configuration.md` updated.

## Why the reporter's workarounds failed

`sight.sendToStata.stataApp` is validated against the `StataVariant` enum, so `/applications/statanow/statase.app`, `statase`, and `statanow` were all rejected and fell through to the (broken) auto-detection.

## Testing

- New unit tests: `tests/unit/send-to-stata/stata-install-roots.test.ts` (StataNow + StataBE detection, edition-first cross-channel priority) and a StataNow case in `tests/unit/stata-install-paths.test.ts`.
- Property test `send-to-stata-detection.prop.test.ts` synced to the new variant order.
- Full suite: **5973 pass / 0 fail**; `bun run typecheck` clean (incl. client `tsc`).

## Notes

- AppleScript GUI sends target the app by name via LaunchServices, so the install root is irrelevant once detection returns a variant — only detection needed fixing for the GUI path.
- The server (`src/`) and client (`client/src/`) keep separate macOS root lists by necessity (separate build units, no import path); cross-reference comments document the deliberate duplication and the need to keep the `StataNow` entry in sync.

https://claude.ai/code/session_01YPvE35JToBaGsCiDc6gi1B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded macOS Stata detection to recognize the StataNow channel alongside the standard installation location.
  * Improved app and CLI discovery so more installed Stata variants can be found automatically.

* **Bug Fixes**
  * Standardized “Stata not found” messaging for a clearer, consistent error experience.
  * Updated search priorities to better match installed edition order across platforms.

* **Documentation**
  * Refreshed setup docs to reflect the new install paths and detection behavior.

* **Tests**
  * Added and updated coverage for the new detection paths and variant priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->