### PR TITLE
feat(data-browser): alias browse to vview in console Stata

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The editor extension enables language server features and further provides:
 - **[Run Code](docs/send-to-stata.md)**: Execute code in the Stata application or terminal with intelligent statement detection and working directory management
 - **[Syntax Highlighting](docs/syntax-highlighting.md)**: Rich syntax highlighting with unique features like macro/string nesting depth coloring
 - **[Auto-Closing Pairs](docs/quote-auto-close.md)**: Intelligently handles Stata's unique conventions for nested macros and compound strings
-- **[Data Browser](docs/data-browser.md)**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels
+- **[Data Browser](docs/data-browser.md)**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels. In console Stata, `browse` works as an alias for `vview` (the GUI's built-in `browse` is unaffected)
 - **[Log Viewer](docs/log-viewer.md)**: Render Stata log files (`.smcl`) with formatted output directly in VS Code
 - **[Help Viewer](docs/help-viewer.md)**: Read Stata help files (`.sthlp`) directly in VS Code with clickable help-topic links
 - **[Code Formatting](docs/formatting.md)** (experimental): Format `.do` files and normalize comment styles

--- a/client/package.json
+++ b/client/package.json
@@ -503,11 +503,15 @@
       },
       {
         "command": "sight.installVviewAdo",
-        "title": "Sight: Install vview.ado"
+        "title": "Sight: Install Stata Commands (vview, browse)"
       },
       {
         "command": "sight.resetVviewInstallPermission",
-        "title": "Sight: Reset vview.ado Install Permission"
+        "title": "Sight: Reset Stata Commands Install Permission"
+      },
+      {
+        "command": "sight.uninstallStataCommands",
+        "title": "Sight: Uninstall Stata Commands (vview, browse)"
       }
     ],
     "keybindings": [
@@ -591,6 +595,9 @@
         },
         {
           "command": "sight.resetVviewInstallPermission"
+        },
+        {
+          "command": "sight.uninstallStataCommands"
         }
       ],
       "explorer/context": [
@@ -727,7 +734,7 @@
     "bundle": "bunx esbuild src/extension.ts --bundle --platform=node --format=cjs --outfile=dist/extension.js --external:vscode --minify && node -e \"require('fs').writeFileSync('dist/package.json', '{\\\"type\\\":\\\"commonjs\\\"}')\"",
     "bundle:webview": "bunx esbuild src/data-browser/webview/index.tsx --bundle --platform=browser --format=iife --outfile=dist/data-browser-webview/index.js --loader:.css=css --minify",
     "bundle:webview-test": "bunx esbuild src/data-browser/webview/test-harness/index.tsx --bundle --platform=browser --format=iife --outfile=dist-test/toolbar-wrap-harness/index.js --loader:.css=css",
-    "copy-vview-ado": "mkdir -p stata && cp ../stata/vview.ado stata/vview.ado",
+    "copy-vview-ado": "mkdir -p stata && cp ../stata/vview.ado stata/vview.ado && cp ../stata/browse.ado stata/browse.ado",
     "copy-server": "rm -rf server && mkdir -p server/command-database && bunx esbuild ../dist/server.js --bundle --platform=node --format=cjs --outfile=server/server.js --external:vscode --external:node:* --minify && cp -r ../dist/command-database/caches server/command-database/ && node -e \"require('fs').writeFileSync('server/package.json', '{\\\"type\\\":\\\"commonjs\\\"}')\"",
     "compile": "bun run copy-vview-ado && bun run bundle && bun run bundle:webview",
     "watch": "tsc -watch -p ./",

--- a/client/src/data-browser/index.ts
+++ b/client/src/data-browser/index.ts
@@ -23,21 +23,43 @@ import {
     SignalWatcher,
 } from './signal-watcher.js';
 import {
-    ensure_vview_ado_installed as ensure_vview_ado_installed_core,
-    get_vview_install_state as get_vview_install_state_core,
-    install_vview_ado as install_vview_ado_core,
-    install_vview_ado_manually as install_vview_ado_manually_core,
-    reset_vview_install_permission as reset_vview_install_permission_core,
+    classify_ado_asset,
+    aggregate_bundle_state,
+    ensure_bundle_installed as ensure_bundle_installed_core,
+    install_bundle_manually as install_bundle_manually_core,
+    reset_install_permission as reset_install_permission_core,
+    uninstall_bundle_and_reset as uninstall_bundle_and_reset_core,
+    type AdoAssetStatus,
+    type BundleInstallStatus,
     type VviewInstallHooks as CoreVviewInstallHooks,
     type VviewInstallPermission,
     type VviewInstallPromptChoice,
-    type VviewInstallState,
-    type VviewInstallStatus,
 } from './vview-install-core.js';
 import { resolve_personal_ado_dir } from './install-path.js';
 
-const VVIEW_INSTALL_PERMISSION_KEY =
-    'sight.vviewInstallPermission';
+// Versioned key: the bundle adds a command named after a Stata
+// built-in (`browse`), a broader action than the original vview-only
+// install, so existing users get one fresh consent decision rather
+// than a silently-expanded grant. The old key
+// ('sight.vviewInstallPermission') is intentionally not reused.
+const STATA_COMMANDS_INSTALL_PERMISSION_KEY =
+    'sight.stataCommandsInstallPermission';
+
+// Bundled ado files installed together into the personal ado dir.
+// `marker` is the stable leading-banner prefix used to recognize a
+// Sight-shipped copy (so we never clobber a user's own same-named
+// file). These markers MUST match the first banner line of each ado.
+const ADO_ASSETS: { name: string; marker: string }[] = [
+    {
+        name: 'vview.ado',
+        marker: '*! vview.ado — Open dataset in Sight Data Browser',
+    },
+    {
+        name: 'browse.ado',
+        marker: '*! browse.ado — CLI alias for vview',
+    },
+];
+
 const INSTALL_BUTTON = 'Install';
 const NOT_NOW_BUTTON = 'Not now';
 const VVIEW_INSTALL_PROMPT_DELAY_MS = 1500;
@@ -224,13 +246,13 @@ function register_vview_install_commands(
                     );
                 if (my_installed) {
                     void vscode.window.showInformationMessage(
-                        'vview.ado is installed and ready for Sight Data Browser.'
+                        'Sight\'s Stata commands (vview, browse) are installed and ready.'
                     );
                     return;
                 }
 
                 void vscode.window.showErrorMessage(
-                    'Failed to install vview.ado. See the Sight output channel for details.'
+                    'Failed to install Sight\'s Stata commands. See the Sight output channel for details.'
                 );
             }
         )
@@ -245,7 +267,30 @@ function register_vview_install_commands(
                     log
                 );
                 void vscode.window.showInformationMessage(
-                    'Sight vview.ado install permission has been reset.'
+                    'Sight Stata commands install permission has been reset.'
+                );
+            }
+        )
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'sight.uninstallStataCommands',
+            async () => {
+                const my_ok =
+                    await uninstall_stata_commands(
+                        context,
+                        log
+                    );
+                if (my_ok) {
+                    void vscode.window.showInformationMessage(
+                        'Sight\'s Stata commands (vview, browse) were removed (Sight-owned files only).'
+                    );
+                    return;
+                }
+
+                void vscode.window.showErrorMessage(
+                    'Some Sight Stata command files could not be removed. See the Sight output channel for details.'
                 );
             }
         )
@@ -266,23 +311,24 @@ function schedule_vview_install_check(
 }
 
 // -----------------------------------------------------------
-// vview.ado installation
+// Stata commands (vview + browse) installation
 // -----------------------------------------------------------
 
-function get_bundled_vview_path(
-    context: vscode.ExtensionContext
+function get_bundled_ado_path(
+    context: vscode.ExtensionContext,
+    name: string
 ): string {
     const the_candidate_paths = [
         vscode.Uri.joinPath(
             context.extensionUri,
             'stata',
-            'vview.ado'
+            name
         ).fsPath,
         path.resolve(
             context.extensionUri.fsPath,
             '..',
             'stata',
-            'vview.ado'
+            name
         ),
     ];
 
@@ -295,8 +341,9 @@ function get_bundled_vview_path(
     return the_candidate_paths[0];
 }
 
-export function read_bundled_vview_content(
+export function read_bundled_ado_content(
     bundled_path: string,
+    name: string,
     log: (msg: string) => void
 ): string | null {
     try {
@@ -306,80 +353,81 @@ export function read_bundled_vview_content(
         );
     } catch (my_err) {
         log(
-            'vview.ado: failed to read bundled file: '
+            name
+            + ': failed to read bundled file: '
             + String(my_err)
         );
         return null;
     }
 }
 
-export function get_vview_install_state(
-    target_path: string,
-    bundled_content: string,
-    log: (msg: string) => void
-): VviewInstallState {
-    return get_vview_install_state_core(
-        target_path,
-        bundled_content,
-        log
-    );
-}
-
-function inspect_vview_installation(
+function inspect_bundle_installation(
     context: vscode.ExtensionContext,
     log: (msg: string) => void
-): VviewInstallStatus {
+): BundleInstallStatus {
     const my_target_dir = get_personal_ado_dir();
-    const my_target_path = path.join(
-        my_target_dir,
-        'vview.ado'
-    );
-    const my_bundled_path = get_bundled_vview_path(context);
-    const my_bundled_content = read_bundled_vview_content(
-        my_bundled_path,
-        log
-    );
 
-    if (my_bundled_content === null) {
-        return {
-            state: 'error',
-            target_dir: my_target_dir,
-            target_path: my_target_path,
-            bundled_path: my_bundled_path,
-            error: 'Failed to read bundled vview.ado',
-        };
-    }
+    const the_assets: AdoAssetStatus[] = ADO_ASSETS.map(
+        (my_def) => {
+            const my_target_path = path.join(
+                my_target_dir,
+                my_def.name
+            );
+            const my_bundled_path = get_bundled_ado_path(
+                context,
+                my_def.name
+            );
+            const my_bundled_content =
+                read_bundled_ado_content(
+                    my_bundled_path,
+                    my_def.name,
+                    log
+                ) ?? undefined;
+
+            const my_asset = {
+                name: my_def.name,
+                target_path: my_target_path,
+                bundled_path: my_bundled_path,
+                bundled_content: my_bundled_content,
+                marker: my_def.marker,
+            };
+
+            return {
+                ...my_asset,
+                state: classify_ado_asset(my_asset, log),
+            };
+        }
+    );
 
     return {
-        state: get_vview_install_state(
-            my_target_path,
-            my_bundled_content,
-            log
+        state: aggregate_bundle_state(
+            the_assets.map((my_asset) => my_asset.state)
         ),
         target_dir: my_target_dir,
-        target_path: my_target_path,
-        bundled_path: my_bundled_path,
-        bundled_content: my_bundled_content,
+        assets: the_assets,
     };
 }
 
-async function set_vview_install_permission(
+async function set_stata_commands_install_permission(
     context: vscode.ExtensionContext,
     permission: VviewInstallPermission | undefined
 ): Promise<void> {
     await context.globalState.update(
-        VVIEW_INSTALL_PERMISSION_KEY,
+        STATA_COMMANDS_INSTALL_PERMISSION_KEY,
         permission
     );
 }
 
-export async function prompt_for_vview_install(
+export async function prompt_for_stata_commands_install(
     target_dir: string
 ): Promise<VviewInstallPromptChoice> {
     const my_result =
         await vscode.window.showInformationMessage(
-            'Would you like to add "vview.ado" to Stata?\n\n'
-            + 'This works like "browse", but with VS Code.\n\n'
+            'Would you like to add Sight\'s Stata commands '
+            + '("vview" and "browse") to Stata?\n\n'
+            + '"vview" opens datasets in VS Code; in console '
+            + 'Stata, "browse" becomes an alias for it (the GUI '
+            + 'built-in "browse" is unaffected).\n\n'
             + `Install location: ${target_dir}`,
             INSTALL_BUTTON,
             NOT_NOW_BUTTON
@@ -392,36 +440,27 @@ export async function prompt_for_vview_install(
         : 'dismissed';
 }
 
-export function install_vview_ado(
-    status: VviewInstallStatus,
-    log: (msg: string) => void
-): boolean {
-    return install_vview_ado_core(status, log);
-}
-
 export async function ensure_vview_ado_installed(
     context: vscode.ExtensionContext,
     log: (msg: string) => void,
     hooks: VviewInstallHooks = {}
 ): Promise<boolean> {
-    return ensure_vview_ado_installed_core(
+    return ensure_bundle_installed_core(
         context,
         log,
-        VVIEW_INSTALL_PERMISSION_KEY,
+        STATA_COMMANDS_INSTALL_PERMISSION_KEY,
         {
             inspect_installation:
                 hooks.inspect_installation
-                ?? inspect_vview_installation,
+                ?? inspect_bundle_installation,
             get_permission: hooks.get_permission,
             set_permission:
                 hooks.set_permission
-                ?? set_vview_install_permission,
-            prompt_for_vview_install:
-                hooks.prompt_for_vview_install
-                ?? prompt_for_vview_install,
-            install_vview_ado:
-                hooks.install_vview_ado
-                ?? install_vview_ado,
+                ?? set_stata_commands_install_permission,
+            prompt_for_install:
+                hooks.prompt_for_install
+                ?? prompt_for_stata_commands_install,
+            install_bundle: hooks.install_bundle,
         }
     );
 }
@@ -431,20 +470,39 @@ export async function install_vview_ado_manually(
     log: (msg: string) => void,
     hooks: VviewInstallHooks = {}
 ): Promise<boolean> {
-    return install_vview_ado_manually_core(
+    return install_bundle_manually_core(
         context,
         log,
-        VVIEW_INSTALL_PERMISSION_KEY,
+        STATA_COMMANDS_INSTALL_PERMISSION_KEY,
         {
             inspect_installation:
                 hooks.inspect_installation
-                ?? inspect_vview_installation,
+                ?? inspect_bundle_installation,
             set_permission:
                 hooks.set_permission
-                ?? set_vview_install_permission,
-            install_vview_ado:
-                hooks.install_vview_ado
-                ?? install_vview_ado,
+                ?? set_stata_commands_install_permission,
+            install_bundle: hooks.install_bundle,
+        }
+    );
+}
+
+export async function uninstall_stata_commands(
+    context: vscode.ExtensionContext,
+    log: (msg: string) => void,
+    hooks: VviewInstallHooks = {}
+): Promise<boolean> {
+    return uninstall_bundle_and_reset_core(
+        context,
+        log,
+        STATA_COMMANDS_INSTALL_PERMISSION_KEY,
+        {
+            inspect_installation:
+                hooks.inspect_installation
+                ?? inspect_bundle_installation,
+            set_permission:
+                hooks.set_permission
+                ?? set_stata_commands_install_permission,
+            uninstall_bundle: hooks.uninstall_bundle,
         }
     );
 }
@@ -454,14 +512,14 @@ export async function reset_vview_install_permission(
     log: (msg: string) => void,
     hooks: Pick<VviewInstallHooks, 'set_permission'> = {}
 ): Promise<void> {
-    await reset_vview_install_permission_core(
+    await reset_install_permission_core(
         context,
         log,
-        VVIEW_INSTALL_PERMISSION_KEY,
+        STATA_COMMANDS_INSTALL_PERMISSION_KEY,
         {
             set_permission:
                 hooks.set_permission
-                ?? set_vview_install_permission,
+                ?? set_stata_commands_install_permission,
         }
     );
 }

--- a/client/src/data-browser/index.ts
+++ b/client/src/data-browser/index.ts
@@ -23,6 +23,7 @@ import {
     SignalWatcher,
 } from './signal-watcher.js';
 import {
+    ADO_ASSET_DEFS,
     classify_ado_asset,
     aggregate_bundle_state,
     ensure_bundle_installed as ensure_bundle_installed_core,
@@ -44,21 +45,6 @@ import { resolve_personal_ado_dir } from './install-path.js';
 // ('sight.vviewInstallPermission') is intentionally not reused.
 const STATA_COMMANDS_INSTALL_PERMISSION_KEY =
     'sight.stataCommandsInstallPermission';
-
-// Bundled ado files installed together into the personal ado dir.
-// `marker` is the stable leading-banner prefix used to recognize a
-// Sight-shipped copy (so we never clobber a user's own same-named
-// file). These markers MUST match the first banner line of each ado.
-const ADO_ASSETS: { name: string; marker: string }[] = [
-    {
-        name: 'vview.ado',
-        marker: '*! vview.ado — Open dataset in Sight Data Browser',
-    },
-    {
-        name: 'browse.ado',
-        marker: '*! browse.ado — CLI alias for vview',
-    },
-];
 
 const INSTALL_BUTTON = 'Install';
 const NOT_NOW_BUTTON = 'Not now';
@@ -246,13 +232,15 @@ function register_vview_install_commands(
                     );
                 if (my_installed) {
                     void vscode.window.showInformationMessage(
-                        'Sight\'s Stata commands (vview, browse) are installed and ready.'
+                        'Sight\'s Stata commands (vview, browse) '
+                        + 'are installed and ready.'
                     );
                     return;
                 }
 
                 void vscode.window.showErrorMessage(
-                    'Failed to install Sight\'s Stata commands. See the Sight output channel for details.'
+                    'Failed to install Sight\'s Stata commands. '
+                    + 'See the Sight output channel for details.'
                 );
             }
         )
@@ -284,13 +272,16 @@ function register_vview_install_commands(
                     );
                 if (my_ok) {
                     void vscode.window.showInformationMessage(
-                        'Sight\'s Stata commands (vview, browse) were removed (Sight-owned files only).'
+                        'Sight\'s Stata commands (vview, browse) '
+                        + 'were removed (Sight-owned files only).'
                     );
                     return;
                 }
 
                 void vscode.window.showErrorMessage(
-                    'Some Sight Stata command files could not be removed. See the Sight output channel for details.'
+                    'Some Sight Stata command files could not be '
+                    + 'removed. See the Sight output channel for '
+                    + 'details.'
                 );
             }
         )
@@ -367,7 +358,7 @@ function inspect_bundle_installation(
 ): BundleInstallStatus {
     const my_target_dir = get_personal_ado_dir();
 
-    const the_assets: AdoAssetStatus[] = ADO_ASSETS.map(
+    const the_assets: AdoAssetStatus[] = ADO_ASSET_DEFS.map(
         (my_def) => {
             const my_target_path = path.join(
                 my_target_dir,

--- a/client/src/data-browser/index.ts
+++ b/client/src/data-browser/index.ts
@@ -381,6 +381,7 @@ function inspect_bundle_installation(
                 bundled_path: my_bundled_path,
                 bundled_content: my_bundled_content,
                 marker: my_def.marker,
+                protect_foreign: my_def.protect_foreign,
             };
 
             return {

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -33,13 +33,13 @@ export interface AdoAssetDef {
     // ownership detection is precise and never misclassifies a user's
     // own same-named file (e.g. a personal browse.ado).
     marker: string;
-    // When true, a differing same-named file that is NOT Sight-owned is
-    // left untouched (classified 'foreign'). When false, Sight owns the
-    // command name and installs/updates its own copy regardless. `vview`
-    // is Sight's own command, so it is always installed — otherwise a
-    // user's unrelated vview.ado could leave `browse` aliasing a
-    // non-Sight vview. `browse` is a generic Stata built-in name, so a
-    // user's own browse.ado must be protected.
+    // When true, a differing same-named file that is NOT Sight-owned
+    // is left untouched (classified 'foreign'). When false, Sight owns
+    // the command name and installs/updates its own copy regardless.
+    // `vview` is Sight's own command, so it is always installed: a
+    // user's unrelated vview.ado would otherwise leave `browse`
+    // aliasing a non-Sight vview. `browse` is a generic Stata built-in
+    // name, so a user's own browse.ado must be protected.
     protect_foreign: boolean;
 }
 
@@ -120,10 +120,10 @@ export interface VviewInstallHooks<
 
 // True when `content` is a Sight-shipped copy of an ado: its leading
 // banner line is exactly the asset's ownership marker. The match is
-// exact (not a prefix, and surrounding whitespace is NOT normalized) so
-// a foreign file that merely begins with — or pads — our banner text is
-// never misclassified as Sight-owned and clobbered. Only a trailing CR
-// is stripped, so a CRLF-saved copy of our own file is still recognized.
+// exact (not a prefix, and surrounding whitespace is NOT normalized),
+// so a foreign file that merely begins with, or pads, our banner text
+// is never misclassified as Sight-owned and clobbered. Only a trailing
+// CR is stripped, so a CRLF-saved copy of our own file still matches.
 export function is_sight_owned(
     content: string,
     marker: string

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -24,16 +24,38 @@ export type VviewInstallPromptChoice =
     | 'not_now'
     | 'dismissed';
 
-// Description of one bundled ado file.
-export interface AdoAsset {
+// Identity of one bundled ado file.
+export interface AdoAssetDef {
     name: string;
+    // The full, stable leading-banner line that identifies a
+    // Sight-shipped copy of this file. It MUST equal the first line of
+    // the corresponding stata/<name> source (a test enforces this) so
+    // ownership detection is precise and never misclassifies a user's
+    // own same-named file (e.g. a personal browse.ado).
+    marker: string;
+}
+
+// Single source of truth for the bundled ado files and their ownership
+// markers. Imported by the extension wiring and by tests, so the marker
+// strings never drift between production and test code.
+export const ADO_ASSET_DEFS: AdoAssetDef[] = [
+    {
+        name: 'vview.ado',
+        marker:
+            '*! vview.ado — Open dataset in Sight Data Browser',
+    },
+    {
+        name: 'browse.ado',
+        marker:
+            '*! browse.ado — CLI alias for vview (Sight Data Browser)',
+    },
+];
+
+// Description of one bundled ado file.
+export interface AdoAsset extends AdoAssetDef {
     target_path: string;
     bundled_path: string;
     bundled_content?: string;
-    // Stable leading-banner prefix that identifies a Sight-shipped
-    // copy of this file. Used to avoid clobbering a user's own file
-    // that happens to share the name (e.g. a personal browse.ado).
-    marker: string;
 }
 
 export interface AdoAssetStatus extends AdoAsset {
@@ -174,6 +196,37 @@ export function install_ado_asset(
             + ': failed to install: bundled content is unavailable'
         );
         return false;
+    }
+
+    // Final ownership re-check: the classification was captured during
+    // inspection, possibly before a permission prompt. Guard against a
+    // foreign file appearing at the target in that window (TOCTOU) so
+    // we never overwrite a user's own same-named file.
+    try {
+        const my_current = fs.readFileSync(
+            asset.target_path,
+            'utf-8'
+        );
+        if (!is_sight_owned(my_current, asset.marker)) {
+            log(
+                asset.name
+                + ': a non-Sight file now occupies '
+                + asset.target_path
+                + '; leaving it untouched'
+            );
+            return true;
+        }
+    } catch (my_err) {
+        const my_node_error = my_err as NodeJS.ErrnoException;
+        if (my_node_error.code !== 'ENOENT') {
+            log(
+                asset.name
+                + ': failed to re-check before install: '
+                + String(my_err)
+            );
+            return false;
+        }
+        // ENOENT: nothing at the target, safe to create.
     }
 
     try {
@@ -385,7 +438,8 @@ export async function ensure_bundle_installed<
     const my_permission = my_get_permission(context);
     if (my_permission === 'granted') {
         log(
-            'Stata commands: permission previously granted; installing without prompt'
+            'Stata commands: permission previously granted; '
+            + 'installing without prompt'
         );
         return my_install(my_status, log);
     }

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -33,6 +33,14 @@ export interface AdoAssetDef {
     // ownership detection is precise and never misclassifies a user's
     // own same-named file (e.g. a personal browse.ado).
     marker: string;
+    // When true, a differing same-named file that is NOT Sight-owned is
+    // left untouched (classified 'foreign'). When false, Sight owns the
+    // command name and installs/updates its own copy regardless. `vview`
+    // is Sight's own command, so it is always installed — otherwise a
+    // user's unrelated vview.ado could leave `browse` aliasing a
+    // non-Sight vview. `browse` is a generic Stata built-in name, so a
+    // user's own browse.ado must be protected.
+    protect_foreign: boolean;
 }
 
 // Single source of truth for the bundled ado files and their ownership
@@ -43,11 +51,13 @@ export const ADO_ASSET_DEFS: AdoAssetDef[] = [
         name: 'vview.ado',
         marker:
             '*! vview.ado — Open dataset in Sight Data Browser',
+        protect_foreign: false,
     },
     {
         name: 'browse.ado',
         marker:
             '*! browse.ado — CLI alias for vview (Sight Data Browser)',
+        protect_foreign: true,
     },
 ];
 
@@ -155,9 +165,12 @@ export function classify_ado_asset(
     if (my_existing === asset.bundled_content) {
         return 'up_to_date';
     }
-    return is_sight_owned(my_existing, asset.marker)
-        ? 'outdated'
-        : 'foreign';
+    if (is_sight_owned(my_existing, asset.marker)) {
+        return 'outdated';
+    }
+    // A differing, non-Sight file. Protect it only when the name is not
+    // Sight-owned; otherwise treat it as outdated and overwrite it.
+    return asset.protect_foreign ? 'foreign' : 'outdated';
 }
 
 export function aggregate_bundle_state(
@@ -205,45 +218,54 @@ export function install_ado_asset(
         return false;
     }
 
-    // Final ownership re-check: the classification was captured during
-    // inspection, possibly before a permission prompt. Guard against a
-    // foreign file appearing at the target in that window (TOCTOU) so
-    // we never overwrite a user's own same-named file.
-    try {
-        const my_current = fs.readFileSync(
-            asset.target_path,
-            'utf-8'
-        );
-        if (!is_sight_owned(my_current, asset.marker)) {
-            log(
-                asset.name
-                + ': a non-Sight file now occupies '
-                + asset.target_path
-                + '; leaving it untouched'
+    // For a protected (generic-named) asset, do a final ownership
+    // re-check: the classification was captured during inspection,
+    // possibly before a permission prompt. Guard against a foreign file
+    // appearing at the target in that window (TOCTOU) so we never
+    // overwrite a user's own same-named file. Sight-owned names
+    // (protect_foreign === false) are always installed, so they skip
+    // this and overwrite unconditionally.
+    if (asset.protect_foreign) {
+        try {
+            const my_current = fs.readFileSync(
+                asset.target_path,
+                'utf-8'
             );
-            return true;
+            if (!is_sight_owned(my_current, asset.marker)) {
+                log(
+                    asset.name
+                    + ': a non-Sight file now occupies '
+                    + asset.target_path
+                    + '; leaving it untouched'
+                );
+                return true;
+            }
+        } catch (my_err) {
+            const my_node_error =
+                my_err as NodeJS.ErrnoException;
+            if (my_node_error.code !== 'ENOENT') {
+                log(
+                    asset.name
+                    + ': failed to re-check before install: '
+                    + String(my_err)
+                );
+                return false;
+            }
+            // ENOENT: nothing at the target, safe to create.
         }
-    } catch (my_err) {
-        const my_node_error = my_err as NodeJS.ErrnoException;
-        if (my_node_error.code !== 'ENOENT') {
-            log(
-                asset.name
-                + ': failed to re-check before install: '
-                + String(my_err)
-            );
-            return false;
-        }
-        // ENOENT: nothing at the target, safe to create.
     }
 
     try {
         fs.mkdirSync(target_dir, { recursive: true });
-        // For a missing target, create exclusively ('wx') so that a
-        // foreign file racing in between the re-check above and this
-        // write is not clobbered (EEXIST → leave it). For an update of
-        // our own file, overwrite ('w').
+        // For a protected, missing target, create exclusively ('wx') so
+        // that a foreign file racing in between the re-check above and
+        // this write is not clobbered (EEXIST → leave it). Otherwise
+        // overwrite ('w'): updating our own file, or installing a
+        // Sight-owned name we always own.
         const my_flag =
-            asset.state === 'missing' ? 'wx' : 'w';
+            asset.protect_foreign && asset.state === 'missing'
+                ? 'wx'
+                : 'w';
         fs.writeFileSync(
             asset.target_path,
             asset.bundled_content,

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -109,14 +109,19 @@ export interface VviewInstallHooks<
 }
 
 // True when `content` is a Sight-shipped copy of an ado: its leading
-// banner line is exactly the asset's ownership marker. Exact match (not
-// a prefix) so a foreign file that merely begins with our banner text
-// is never misclassified as Sight-owned and clobbered.
+// banner line is exactly the asset's ownership marker. The match is
+// exact (not a prefix, and surrounding whitespace is NOT normalized) so
+// a foreign file that merely begins with — or pads — our banner text is
+// never misclassified as Sight-owned and clobbered. Only a trailing CR
+// is stripped, so a CRLF-saved copy of our own file is still recognized.
 export function is_sight_owned(
     content: string,
     marker: string
 ): boolean {
-    const my_first_line = content.split('\n', 1)[0].trim();
+    let my_first_line = content.split('\n', 1)[0];
+    if (my_first_line.endsWith('\r')) {
+        my_first_line = my_first_line.slice(0, -1);
+    }
     return my_first_line === marker;
 }
 
@@ -233,9 +238,16 @@ export function install_ado_asset(
 
     try {
         fs.mkdirSync(target_dir, { recursive: true });
+        // For a missing target, create exclusively ('wx') so that a
+        // foreign file racing in between the re-check above and this
+        // write is not clobbered (EEXIST → leave it). For an update of
+        // our own file, overwrite ('w').
+        const my_flag =
+            asset.state === 'missing' ? 'wx' : 'w';
         fs.writeFileSync(
             asset.target_path,
-            asset.bundled_content
+            asset.bundled_content,
+            { flag: my_flag }
         );
         log(
             asset.name
@@ -244,6 +256,16 @@ export function install_ado_asset(
         );
         return true;
     } catch (my_err) {
+        const my_node_error = my_err as NodeJS.ErrnoException;
+        if (my_node_error.code === 'EEXIST') {
+            log(
+                asset.name
+                + ': a file appeared at '
+                + asset.target_path
+                + ' during install; leaving it untouched'
+            );
+            return true;
+        }
         log(
             asset.name
             + ': failed to install: '

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -4,7 +4,16 @@ export type VviewInstallPermission =
     | 'granted'
     | 'declined';
 
-export type VviewInstallState =
+// Per-file install state for a single bundled ado.
+export type AdoAssetState =
+    | 'missing'      // no file at the target path
+    | 'up_to_date'   // target content equals bundled content
+    | 'outdated'     // a Sight-owned file differs from bundled content
+    | 'foreign'      // a non-Sight file occupies the target path
+    | 'error';       // bundled content unavailable / read failure
+
+// Aggregate state across the whole bundle.
+export type BundleInstallState =
     | 'missing'
     | 'up_to_date'
     | 'outdated'
@@ -15,13 +24,26 @@ export type VviewInstallPromptChoice =
     | 'not_now'
     | 'dismissed';
 
-export interface VviewInstallStatus {
-    state: VviewInstallState;
-    target_dir: string;
+// Description of one bundled ado file.
+export interface AdoAsset {
+    name: string;
     target_path: string;
     bundled_path: string;
     bundled_content?: string;
-    error?: string;
+    // Stable leading-banner prefix that identifies a Sight-shipped
+    // copy of this file. Used to avoid clobbering a user's own file
+    // that happens to share the name (e.g. a personal browse.ado).
+    marker: string;
+}
+
+export interface AdoAssetStatus extends AdoAsset {
+    state: AdoAssetState;
+}
+
+export interface BundleInstallStatus {
+    state: BundleInstallState;
+    target_dir: string;
+    assets: AdoAssetStatus[];
 }
 
 export interface VviewInstallContextLike {
@@ -43,7 +65,7 @@ export interface VviewInstallHooks<
     inspect_installation?: (
         context: TContext,
         log: (msg: string) => void
-    ) => VviewInstallStatus;
+    ) => BundleInstallStatus;
     get_permission?: (
         context: TContext
     ) => VviewInstallPermission | undefined;
@@ -51,74 +73,216 @@ export interface VviewInstallHooks<
         context: TContext,
         permission: VviewInstallPermission | undefined
     ) => Promise<void>;
-    prompt_for_vview_install?: (
+    prompt_for_install?: (
         target_dir: string
     ) => Promise<VviewInstallPromptChoice>;
-    install_vview_ado?: (
-        status: VviewInstallStatus,
+    install_bundle?: (
+        status: BundleInstallStatus,
+        log: (msg: string) => void
+    ) => boolean;
+    uninstall_bundle?: (
+        status: BundleInstallStatus,
         log: (msg: string) => void
     ) => boolean;
 }
 
-export function get_vview_install_state(
-    target_path: string,
-    bundled_content: string,
+// True when `content` looks like the Sight-shipped copy of an ado
+// (its leading banner begins with the asset's ownership marker).
+export function is_sight_owned(
+    content: string,
+    marker: string
+): boolean {
+    const my_first_line = content.split('\n', 1)[0].trim();
+    return my_first_line.startsWith(marker);
+}
+
+export function classify_ado_asset(
+    asset: AdoAsset,
     log: (msg: string) => void
-): VviewInstallState {
+): AdoAssetState {
+    if (asset.bundled_content === undefined) {
+        return 'error';
+    }
+
+    let my_existing: string;
     try {
-        const my_existing = fs.readFileSync(
-            target_path,
+        my_existing = fs.readFileSync(
+            asset.target_path,
             'utf-8'
         );
-        return my_existing === bundled_content
-            ? 'up_to_date'
-            : 'outdated';
     } catch (my_err) {
         const my_node_error = my_err as NodeJS.ErrnoException;
         if (my_node_error.code === 'ENOENT') {
             return 'missing';
         }
-
         log(
-            'vview.ado: failed to inspect existing install: '
+            asset.name
+            + ': failed to inspect existing install: '
             + String(my_err)
         );
         return 'error';
     }
+
+    if (my_existing === asset.bundled_content) {
+        return 'up_to_date';
+    }
+    return is_sight_owned(my_existing, asset.marker)
+        ? 'outdated'
+        : 'foreign';
 }
 
-export function install_vview_ado(
-    status: VviewInstallStatus,
+export function aggregate_bundle_state(
+    the_states: AdoAssetState[]
+): BundleInstallState {
+    if (the_states.includes('error')) {
+        return 'error';
+    }
+    if (the_states.includes('missing')) {
+        return 'missing';
+    }
+    if (the_states.includes('outdated')) {
+        return 'outdated';
+    }
+    // 'up_to_date' and 'foreign' both count as satisfied: a foreign
+    // file is intentionally left alone, so it must not re-prompt.
+    return 'up_to_date';
+}
+
+// Install a single asset, honoring its classified state. A foreign
+// file is left untouched (reported as success: blocked, not failed).
+export function install_ado_asset(
+    asset: AdoAssetStatus,
+    target_dir: string,
     log: (msg: string) => void
 ): boolean {
-    if (status.bundled_content === undefined) {
+    if (asset.state === 'foreign') {
         log(
-            'vview.ado: failed to install: bundled content is unavailable'
+            asset.name
+            + ': leaving existing non-Sight file untouched at '
+            + asset.target_path
+        );
+        return true;
+    }
+
+    if (asset.state === 'up_to_date') {
+        return true;
+    }
+
+    if (asset.bundled_content === undefined) {
+        log(
+            asset.name
+            + ': failed to install: bundled content is unavailable'
         );
         return false;
     }
 
     try {
-        fs.mkdirSync(status.target_dir, { recursive: true });
+        fs.mkdirSync(target_dir, { recursive: true });
         fs.writeFileSync(
-            status.target_path,
-            status.bundled_content
+            asset.target_path,
+            asset.bundled_content
         );
         log(
-            'vview.ado: installed to '
-            + status.target_path
+            asset.name
+            + ': installed to '
+            + asset.target_path
         );
         return true;
     } catch (my_err) {
         log(
-            'vview.ado: failed to install: '
+            asset.name
+            + ': failed to install: '
             + String(my_err)
         );
         return false;
     }
 }
 
-export function get_vview_install_permission<
+// Best-effort install of the whole bundle. A write failure for one
+// asset does not abort the others; the aggregate result is false if
+// any required write failed.
+export function install_bundle(
+    status: BundleInstallStatus,
+    log: (msg: string) => void
+): boolean {
+    if (status.state === 'error') {
+        log(
+            'Stata commands: cannot install; bundled content is unavailable'
+        );
+        return false;
+    }
+
+    let my_all_ok = true;
+    for (const my_asset of status.assets) {
+        const my_ok = install_ado_asset(
+            my_asset,
+            status.target_dir,
+            log
+        );
+        if (!my_ok) {
+            my_all_ok = false;
+        }
+    }
+    return my_all_ok;
+}
+
+// Remove each target only if it is Sight-owned; never delete a
+// foreign file that happens to share the name.
+export function uninstall_bundle(
+    status: BundleInstallStatus,
+    log: (msg: string) => void
+): boolean {
+    let my_all_ok = true;
+    for (const my_asset of status.assets) {
+        let my_existing: string;
+        try {
+            my_existing = fs.readFileSync(
+                my_asset.target_path,
+                'utf-8'
+            );
+        } catch (my_err) {
+            const my_node_error =
+                my_err as NodeJS.ErrnoException;
+            if (my_node_error.code === 'ENOENT') {
+                continue;
+            }
+            log(
+                my_asset.name
+                + ': failed to inspect before uninstall: '
+                + String(my_err)
+            );
+            my_all_ok = false;
+            continue;
+        }
+
+        if (!is_sight_owned(my_existing, my_asset.marker)) {
+            log(
+                my_asset.name
+                + ': not Sight-owned; leaving in place'
+            );
+            continue;
+        }
+
+        try {
+            fs.rmSync(my_asset.target_path, { force: true });
+            log(
+                my_asset.name
+                + ': removed '
+                + my_asset.target_path
+            );
+        } catch (my_err) {
+            log(
+                my_asset.name
+                + ': failed to remove: '
+                + String(my_err)
+            );
+            my_all_ok = false;
+        }
+    }
+    return my_all_ok;
+}
+
+export function get_install_permission<
     TContext extends VviewInstallContextLike
 >(
     context: TContext,
@@ -129,7 +293,7 @@ export function get_vview_install_permission<
     >(state_key);
 }
 
-export async function set_vview_install_permission<
+export async function set_install_permission<
     TContext extends VviewInstallContextLike
 >(
     context: TContext,
@@ -142,7 +306,36 @@ export async function set_vview_install_permission<
     );
 }
 
-export async function ensure_vview_ado_installed<
+function resolve_get_permission<
+    TContext extends VviewInstallContextLike
+>(
+    hooks: VviewInstallHooks<TContext>,
+    state_key: string
+): (context: TContext) => VviewInstallPermission | undefined {
+    return hooks.get_permission
+        ?? ((my_context) =>
+            get_install_permission(my_context, state_key));
+}
+
+function resolve_set_permission<
+    TContext extends VviewInstallContextLike
+>(
+    hooks: VviewInstallHooks<TContext>,
+    state_key: string
+): (
+    context: TContext,
+    permission: VviewInstallPermission | undefined
+) => Promise<void> {
+    return hooks.set_permission
+        ?? ((my_context, my_permission) =>
+            set_install_permission(
+                my_context,
+                state_key,
+                my_permission
+            ));
+}
+
+export async function ensure_bundle_installed<
     TContext extends VviewInstallContextLike
 >(
     context: TContext,
@@ -155,34 +348,28 @@ export async function ensure_vview_ado_installed<
             'inspect_installation hook is required'
         );
     }
-    if (!hooks.prompt_for_vview_install) {
+    if (!hooks.prompt_for_install) {
         throw new Error(
-            'prompt_for_vview_install hook is required'
+            'prompt_for_install hook is required'
         );
     }
 
-    const my_get_permission = hooks.get_permission
-        ?? ((my_context) =>
-            get_vview_install_permission(
-                my_context,
-                state_key
-            ));
-    const my_set_permission = hooks.set_permission
-        ?? ((my_context, my_permission) =>
-            set_vview_install_permission(
-                my_context,
-                state_key,
-                my_permission
-            ));
-    const my_install = hooks.install_vview_ado
-        ?? install_vview_ado;
+    const my_get_permission = resolve_get_permission(
+        hooks,
+        state_key
+    );
+    const my_set_permission = resolve_set_permission(
+        hooks,
+        state_key
+    );
+    const my_install = hooks.install_bundle ?? install_bundle;
 
     const my_status = hooks.inspect_installation(
         context,
         log
     );
     log(
-        'vview.ado: install check -> '
+        'Stata commands: install check -> '
         + my_status.state
     );
 
@@ -191,37 +378,36 @@ export async function ensure_vview_ado_installed<
     }
 
     if (my_status.state === 'up_to_date') {
-        log('vview.ado: already up to date');
+        log('Stata commands: already up to date');
         return true;
     }
 
     const my_permission = my_get_permission(context);
     if (my_permission === 'granted') {
         log(
-            'vview.ado: permission previously granted; installing without prompt'
+            'Stata commands: permission previously granted; installing without prompt'
         );
         return my_install(my_status, log);
     }
 
     if (my_permission === 'declined') {
         log(
-            'vview.ado: permission previously declined; skipping install'
+            'Stata commands: permission previously declined; skipping install'
         );
         return false;
     }
 
-    log('vview.ado: prompting for install permission');
-    const my_choice =
-        await hooks.prompt_for_vview_install(
-            my_status.target_dir
-        );
+    log('Stata commands: prompting for install permission');
+    const my_choice = await hooks.prompt_for_install(
+        my_status.target_dir
+    );
     if (my_choice === 'dismissed') {
-        log('vview.ado: prompt dismissed');
+        log('Stata commands: prompt dismissed');
         return false;
     }
 
     if (my_choice === 'not_now') {
-        log('vview.ado: install deferred by user');
+        log('Stata commands: install deferred by user');
         return false;
     }
 
@@ -235,11 +421,11 @@ export async function ensure_vview_ado_installed<
     }
 
     await my_set_permission(context, 'granted');
-    log('vview.ado: permission granted');
+    log('Stata commands: permission granted');
     return true;
 }
 
-export async function install_vview_ado_manually<
+export async function install_bundle_manually<
     TContext extends VviewInstallContextLike
 >(
     context: TContext,
@@ -253,22 +439,18 @@ export async function install_vview_ado_manually<
         );
     }
 
-    const my_set_permission = hooks.set_permission
-        ?? ((my_context, my_permission) =>
-            set_vview_install_permission(
-                my_context,
-                state_key,
-                my_permission
-            ));
-    const my_install = hooks.install_vview_ado
-        ?? install_vview_ado;
+    const my_set_permission = resolve_set_permission(
+        hooks,
+        state_key
+    );
+    const my_install = hooks.install_bundle ?? install_bundle;
+
     const my_status = hooks.inspect_installation(
         context,
         log
     );
-
     log(
-        'vview.ado: manual install check -> '
+        'Stata commands: manual install check -> '
         + my_status.state
     );
 
@@ -278,7 +460,7 @@ export async function install_vview_ado_manually<
 
     if (my_status.state === 'up_to_date') {
         await my_set_permission(context, 'granted');
-        log('vview.ado: already up to date');
+        log('Stata commands: already up to date');
         return true;
     }
 
@@ -288,11 +470,43 @@ export async function install_vview_ado_manually<
     }
 
     await my_set_permission(context, 'granted');
-    log('vview.ado: permission granted');
+    log('Stata commands: permission granted');
     return true;
 }
 
-export async function reset_vview_install_permission<
+// Remove Sight-owned ado files and clear the remembered permission.
+export async function uninstall_bundle_and_reset<
+    TContext extends VviewInstallContextLike
+>(
+    context: TContext,
+    log: (msg: string) => void,
+    state_key: string,
+    hooks: VviewInstallHooks<TContext> = {}
+): Promise<boolean> {
+    if (!hooks.inspect_installation) {
+        throw new Error(
+            'inspect_installation hook is required'
+        );
+    }
+
+    const my_set_permission = resolve_set_permission(
+        hooks,
+        state_key
+    );
+    const my_uninstall =
+        hooks.uninstall_bundle ?? uninstall_bundle;
+
+    const my_status = hooks.inspect_installation(
+        context,
+        log
+    );
+    const my_ok = my_uninstall(my_status, log);
+    await my_set_permission(context, undefined);
+    log('Stata commands: install permission reset');
+    return my_ok;
+}
+
+export async function reset_install_permission<
     TContext extends VviewInstallContextLike
 >(
     context: TContext,
@@ -303,14 +517,11 @@ export async function reset_vview_install_permission<
         'set_permission'
     > = {}
 ): Promise<void> {
-    const my_set_permission = hooks.set_permission
-        ?? ((my_context, my_permission) =>
-            set_vview_install_permission(
-                my_context,
-                state_key,
-                my_permission
-            ));
+    const my_set_permission = resolve_set_permission(
+        hooks,
+        state_key
+    );
 
     await my_set_permission(context, undefined);
-    log('vview.ado: install permission reset');
+    log('Stata commands: install permission reset');
 }

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -108,14 +108,16 @@ export interface VviewInstallHooks<
     ) => boolean;
 }
 
-// True when `content` looks like the Sight-shipped copy of an ado
-// (its leading banner begins with the asset's ownership marker).
+// True when `content` is a Sight-shipped copy of an ado: its leading
+// banner line is exactly the asset's ownership marker. Exact match (not
+// a prefix) so a foreign file that merely begins with our banner text
+// is never misclassified as Sight-owned and clobbered.
 export function is_sight_owned(
     content: string,
     marker: string
 ): boolean {
     const my_first_line = content.split('\n', 1)[0].trim();
-    return my_first_line.startsWith(marker);
+    return my_first_line === marker;
 }
 
 export function classify_ado_asset(

--- a/client/stata/browse.ado
+++ b/client/stata/browse.ado
@@ -1,0 +1,19 @@
+*! browse.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! In the Stata GUI, the built-in `browse` command shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
+
+program define browse
+    version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "browse: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
+    vview `0'
+end

--- a/docs/data-browser.md
+++ b/docs/data-browser.md
@@ -25,9 +25,32 @@ vview price mpg if foreign, replace  // Refresh existing panel
 | `name(string)` | Custom tab name (default: current filename) |
 | `rows(integer)` | Cap the number of displayed observations. Applied *after* `if`/`in` filtering — useful when you want to limit output without knowing the exact observation count (e.g., `vview, rows(500)` on a large dataset) |
 
+### `browse` in console Stata
+
+In console Stata (the CLI), the built-in `browse` command does not exist — it
+is a GUI-only feature. Sight ships a small `browse.ado` alongside `vview.ado`
+so that, **in the CLI only**, `browse` becomes an alias for `vview`:
+
+```stata
+browse                 // same as vview
+browse price mpg if foreign
+```
+
+This does **not** affect the Stata GUI. There, the built-in `browse` is
+resolved before any ado-file on your path, so the native Data Editor opens
+exactly as before; Sight's `browse.ado` never runs. The alias also guards on
+`c(console)` as a safeguard.
+
+Only the exact command `browse` is aliased — abbreviations such as `br` and
+`bro` are not (Stata does not abbreviate ado-file command names). Because the
+alias forwards to `vview`, only `vview`'s options apply; native-`browse`-only
+options such as `nolabel` are not supported in the CLI.
+
 ### Installation
 
-Sight automatically installs `vview.ado` the first time the extension activates. You'll see a one-time prompt asking for permission.
+Sight automatically installs its Stata commands (`vview.ado` and `browse.ado`)
+the first time the extension activates. You'll see a one-time prompt asking for
+permission.
 
 - **macOS**: `~/ado/`
 - **Windows**: `%USERPROFILE%\ado\personal\`
@@ -35,9 +58,12 @@ Sight automatically installs `vview.ado` the first time the extension activates.
 
 On macOS, Sight defaults to `OLDPLACE` (`~/ado/`) rather than `PERSONAL` to avoid sandbox-related writes into `~/Documents/Stata/...`.
 
-You can override the install location with the `sight.personalAdoDir` setting, or manually install with the **Sight: Install vview.ado** command from the Command Palette.
+If you already have your own `browse.ado` on the ado-path, Sight leaves it
+untouched and installs only `vview.ado`.
 
-To re-trigger the install prompt (e.g., after declining), run **Sight: Reset vview.ado Install Permission** from the Command Palette.
+You can override the install location with the `sight.personalAdoDir` setting, or manually install with the **Sight: Install Stata Commands (vview, browse)** command from the Command Palette.
+
+To re-trigger the install prompt (e.g., after declining), run **Sight: Reset Stata Commands Install Permission** from the Command Palette. To remove the installed files (Sight-owned copies only), run **Sight: Uninstall Stata Commands (vview, browse)**.
 
 ### How It Works
 

--- a/docs/superpowers/specs/2026-06-26-browse-cli-alias-design.md
+++ b/docs/superpowers/specs/2026-06-26-browse-cli-alias-design.md
@@ -1,0 +1,136 @@
+# `browse` as a CLI alias for `vview`
+
+**Date:** 2026-06-26
+**Status:** Approved (design)
+
+## Problem
+
+Sight adds a `vview` command to Stata that opens the active dataset in the
+Sight Data Browser. In the Stata GUI, users have the built-in `browse`
+command and tend to reach for it by habit. In **console Stata** (the CLI),
+`browse` does not exist — typing it returns `command browse is unrecognized
+r(199)`, because the Data Editor is a GUI-only feature.
+
+We want `browse` to act as an alias for `vview` **only in the CLI**, where
+no native `browse` exists, while leaving the GUI's built-in `browse`
+completely untouched.
+
+## Mechanism
+
+Ship a `browse.ado` on the user's ado-path that forwards to `vview`. The
+GUI/CLI split falls out of Stata's command resolution with no runtime check:
+
+- **GUI:** the built-in `browse` is resolved before any ado-file, so
+  `browse.ado` never runs. Native Data Editor behavior is unchanged.
+- **CLI:** there is no built-in `browse` (confirmed: `r(199)` unrecognized),
+  so Stata finds `browse.ado` on the ado-path and runs it, which calls
+  `vview`.
+
+Because the GUI never executes the ado, no `c(console)` guard is needed (and
+a guard could not usefully "fall through" to the built-in anyway — a
+same-named program would recurse rather than reach the built-in).
+
+### `browse.ado`
+
+```stata
+*! browse.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! In the Stata GUI, the built-in `browse` command shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+
+program define browse
+    version 16.0
+    vview `0'
+end
+```
+
+A pure forwarder via `` `0' `` (the full argument string). In the CLI,
+`vview`'s own syntax applies: `[varlist] [if] [in] [, Rows() Name()
+Replace]`. Native-`browse`-only options (e.g. `nolabel`) are not supported in
+the CLI — acceptable, because in the CLI `browse` *is* `vview`.
+
+`version 16.0` matches `vview.ado` for version-control consistency.
+
+## Bundling
+
+`stata/vview.ado` is the canonical source; `client/stata/vview.ado` is a
+generated copy produced by the `copy-vview-ado` npm script before bundling,
+and the bundled asset resolves to `<extension>/stata/vview.ado`.
+
+Changes:
+
+- Add canonical `stata/browse.ado`.
+- Extend the copy step so both ados land in `client/stata/`. Rename/extend
+  `copy-vview-ado` to copy `vview.ado` **and** `browse.ado` (keep the script
+  name or introduce a clearly-named umbrella script invoked from
+  `vscode:prepublish` and `compile`).
+
+## Installation
+
+Selected model: **treat the two files as one bundle under a single permission
+prompt.** Generalize the install core (`client/src/data-browser/vview-install-core.ts`)
+from one tracked file to a small list of bundled ado assets.
+
+### Aggregate state
+
+Per-file state is still `missing` / `up_to_date` / `outdated` / `error`
+(comparing on-disk content to bundled content). The bundle's aggregate state:
+
+- `error` if reading any bundled asset fails,
+- `missing` if any target file is absent,
+- `outdated` if every target exists but any differs from its bundled content,
+- `up_to_date` only if all target files match their bundled content.
+
+This ensures a change to **either** ado (including a browse-only change in a
+future release) re-triggers install.
+
+### Permission and flow
+
+- One permission gate in `globalState` (reuse the existing state key) covers
+  the whole bundle. The prompt copy generalizes from "vview.ado" to Sight's
+  Stata commands (still naming the install directory).
+- `ensure_*` (auto, prompt-on-first-use) and `install_*_manually` (the
+  "Sight: Install vview.ado" command) both operate on the bundle: when
+  permission is granted (or already granted), write every file whose on-disk
+  content differs from its bundled content.
+- The "Sight: Install vview.ado" / reset-permission commands and their
+  titles are updated to reflect that they manage Sight's Stata commands
+  (vview + browse), not vview alone.
+
+### Scope of refactor
+
+`VviewInstallStatus` becomes a per-file or bundle-level structure carrying a
+list of `{ name, target_path, bundled_path, bundled_content, state }` plus the
+shared `target_dir` and an aggregate `state`. Functions
+(`get_vview_install_state`, `install_vview_ado`, `ensure_vview_ado_installed`,
+`install_vview_ado_manually`, `reset_vview_install_permission`) are updated to
+iterate the list. The public hook shape (`inspect_installation`,
+`prompt_for_vview_install`, `install_vview_ado`, permission get/set) is
+preserved where practical so `index.ts` wiring stays thin.
+
+## Tests
+
+- `tests/unit/data-browser/vview-bundled-asset.test.ts`: extend to assert
+  `browse.ado` is bundled and its content matches the canonical
+  `stata/browse.ado`.
+- `tests/unit/data-browser/vview-install.test.ts`: extend / mirror for the
+  bundle — aggregate state logic (any-missing → `missing`, any-differs →
+  `outdated`, all-match → `up_to_date`, any-read-error → `error`), and that
+  install writes both files under a single granted permission.
+- Add a focused assertion that `browse.ado` is a pure `vview` forwarder
+  (content check is sufficient; we do not run Stata in tests).
+
+## Docs
+
+- `docs/data-browser.md`: document that in console Stata, `browse` is an alias
+  for `vview`, and that the GUI's built-in `browse` is unaffected.
+- `README.md`: update the Data Browser feature line to mention the CLI
+  `browse` alias.
+
+## Out of scope
+
+- No `c(console)` runtime detection in the ado (unnecessary by design).
+- No support for native-`browse`-only options in the CLI.
+- No change to `vview.ado` behavior.

--- a/docs/superpowers/specs/2026-06-26-browse-cli-alias-design.md
+++ b/docs/superpowers/specs/2026-06-26-browse-cli-alias-design.md
@@ -111,9 +111,21 @@ For each bundled asset, classify the on-disk target:
   treat it as "satisfied/blocked" for aggregate-state purposes so it does not
   re-prompt forever.
 
-`vview.ado` retains its established behavior in practice (its banner is the
-Sight marker, and the name does not collide), but it flows through the same
-ownership check for consistency.
+**Per-file policy differs by name (`protect_foreign`).** `vview` is Sight's
+own command name; `browse` is a generic Stata built-in name. A `protect_foreign`
+flag on each asset encodes this:
+
+- `vview.ado` (`protect_foreign: false`): Sight owns the name and always
+  installs/updates its own copy — a differing, non-Sight `vview.ado` is
+  classified `outdated` and overwritten (matching pre-feature behavior).
+  Otherwise a user's unrelated `vview.ado` would be left in place and the
+  installed `browse.ado` would alias *that* vview instead of Sight's,
+  breaking the feature contract.
+- `browse.ado` (`protect_foreign: true`): a differing, non-Sight `browse.ado`
+  is classified `foreign` and never overwritten or deleted.
+
+Uninstall always uses the ownership check regardless of `protect_foreign`, so
+it never deletes a non-Sight file.
 
 ### Aggregate state
 

--- a/docs/superpowers/specs/2026-06-26-browse-cli-alias-design.md
+++ b/docs/superpowers/specs/2026-06-26-browse-cli-alias-design.md
@@ -1,15 +1,15 @@
 # `browse` as a CLI alias for `vview`
 
 **Date:** 2026-06-26
-**Status:** Approved (design)
+**Status:** Approved (design, revised after adversarial review)
 
 ## Problem
 
 Sight adds a `vview` command to Stata that opens the active dataset in the
 Sight Data Browser. In the Stata GUI, users have the built-in `browse`
-command and tend to reach for it by habit. In **console Stata** (the CLI),
-`browse` does not exist — typing it returns `command browse is unrecognized
-r(199)`, because the Data Editor is a GUI-only feature.
+command and reach for it by habit. In **console Stata** (the CLI), `browse`
+does not exist — typing it returns `command browse is unrecognized r(199)`,
+because the Data Editor is a GUI-only feature (confirmed by the user).
 
 We want `browse` to act as an alias for `vview` **only in the CLI**, where
 no native `browse` exists, while leaving the GUI's built-in `browse`
@@ -18,17 +18,20 @@ completely untouched.
 ## Mechanism
 
 Ship a `browse.ado` on the user's ado-path that forwards to `vview`. The
-GUI/CLI split falls out of Stata's command resolution with no runtime check:
+GUI/CLI split is enforced by **two independent layers**:
 
-- **GUI:** the built-in `browse` is resolved before any ado-file, so
-  `browse.ado` never runs. Native Data Editor behavior is unchanged.
-- **CLI:** there is no built-in `browse` (confirmed: `r(199)` unrecognized),
-  so Stata finds `browse.ado` on the ado-path and runs it, which calls
-  `vview`.
-
-Because the GUI never executes the ado, no `c(console)` guard is needed (and
-a guard could not usefully "fall through" to the built-in anyway — a
-same-named program would recurse rather than reach the built-in).
+1. **Stata command resolution (primary).** Built-in commands resolve before
+   ado-files. In the GUI, the built-in `browse` is found first, so
+   `browse.ado` never runs and the native Data Editor is unaffected. In the
+   CLI there is no built-in `browse` (`r(199)`), so Stata finds `browse.ado`
+   on the ado-path and runs it.
+2. **`c(console)` runtime guard (defensive).** The ado refuses to run unless
+   `c(console) == "console"`. This makes the "console-only" intent explicit
+   and self-documenting, and converts a hypothetical resolution failure (the
+   ado somehow reached in the GUI) from a *silent* hijack of `browse` into a
+   *loud, debuggable* error rather than silently opening the Sight browser.
+   In normal CLI operation `c(console)` is `"console"`, so the guard never
+   blocks the feature.
 
 ### `browse.ado`
 
@@ -39,98 +42,178 @@ same-named program would recurse rather than reach the built-in).
 *! In the Stata GUI, the built-in `browse` command shadows this ado, so the
 *! native Data Editor is unaffected. In console Stata, `browse` is
 *! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
 
 program define browse
     version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "browse: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
     vview `0'
 end
 ```
 
 A pure forwarder via `` `0' `` (the full argument string). In the CLI,
 `vview`'s own syntax applies: `[varlist] [if] [in] [, Rows() Name()
-Replace]`. Native-`browse`-only options (e.g. `nolabel`) are not supported in
-the CLI — acceptable, because in the CLI `browse` *is* `vview`.
+Replace]`. The common habitual forms work: `browse`, `browse varlist`,
+`browse if exp`, `browse in range`. Native-`browse`-only options (e.g.
+`nolabel`) are not supported and surface as `vview`'s syntax error — accepted,
+because in the CLI `browse` *is* `vview` (see Out of scope).
+
+The first banner line `*! browse.ado — CLI alias for vview (Sight Data
+Browser)` is the **ownership marker** and MUST remain stable across releases;
+the installer uses it to recognize a Sight-shipped `browse.ado` (see
+Installation → Ownership).
 
 `version 16.0` matches `vview.ado` for version-control consistency.
 
 ## Bundling
 
 `stata/vview.ado` is the canonical source; `client/stata/vview.ado` is a
-generated copy produced by the `copy-vview-ado` npm script before bundling,
-and the bundled asset resolves to `<extension>/stata/vview.ado`.
+generated copy produced before bundling, and the bundled asset resolves via a
+two-candidate lookup (`<extension>/stata/<name>` then `../stata/<name>`).
 
 Changes:
 
 - Add canonical `stata/browse.ado`.
-- Extend the copy step so both ados land in `client/stata/`. Rename/extend
-  `copy-vview-ado` to copy `vview.ado` **and** `browse.ado` (keep the script
-  name or introduce a clearly-named umbrella script invoked from
-  `vscode:prepublish` and `compile`).
+- Extend the copy step so both ados land in `client/stata/` (the
+  `copy-vview-ado` script — keep the name or rename to a clear umbrella —
+  copies `vview.ado` **and** `browse.ado`; invoked from `vscode:prepublish`
+  and `compile`).
+- Generalize `get_bundled_vview_path` into a shared resolver
+  `get_bundled_ado_path(context, name)` that preserves the existing
+  two-candidate fallback **per ado file** (finding 12).
 
 ## Installation
 
-Selected model: **treat the two files as one bundle under a single permission
-prompt.** Generalize the install core (`client/src/data-browser/vview-install-core.ts`)
-from one tracked file to a small list of bundled ado assets.
+Both files install as one bundle under a **single, freshly-versioned
+permission prompt**. Generalize the install core
+(`client/src/data-browser/vview-install-core.ts`) from one tracked file to a
+small list of bundled ado assets.
+
+### Per-file install policy (finding 7 — Critical)
+
+`browse` is a generic command name; a user may already have an unrelated
+personal/community `browse.ado`. The installer MUST NOT clobber it.
+
+For each bundled asset, classify the on-disk target:
+
+- **missing** — no file at target → safe to write.
+- **sight-owned** — file exists and its leading banner matches the Sight
+  ownership marker for that file (`*! vview.ado — …` / `*! browse.ado — …`).
+  If content differs from bundled → write (update); if equal → up to date.
+- **foreign** — file exists but the banner does not match the Sight marker →
+  **never overwrite**. Skip it, log a one-time warning naming the path, and
+  treat it as "satisfied/blocked" for aggregate-state purposes so it does not
+  re-prompt forever.
+
+`vview.ado` retains its established behavior in practice (its banner is the
+Sight marker, and the name does not collide), but it flows through the same
+ownership check for consistency.
 
 ### Aggregate state
 
-Per-file state is still `missing` / `up_to_date` / `outdated` / `error`
-(comparing on-disk content to bundled content). The bundle's aggregate state:
+Per-file state feeds an aggregate used to drive prompting:
 
-- `error` if reading any bundled asset fails,
-- `missing` if any target file is absent,
-- `outdated` if every target exists but any differs from its bundled content,
-- `up_to_date` only if all target files match their bundled content.
+- `error` if reading any **bundled** asset fails,
+- `missing` if any target is missing,
+- `outdated` if all present targets exist but any sight-owned target differs
+  from its bundled content,
+- `up_to_date` if every target is either content-matched or a foreign file we
+  intentionally leave alone.
 
-This ensures a change to **either** ado (including a browse-only change in a
-future release) re-triggers install.
+A change to **either** ado in a future release re-triggers install.
 
-### Permission and flow
+### Permission (findings 5, 6)
 
-- One permission gate in `globalState` (reuse the existing state key) covers
-  the whole bundle. The prompt copy generalizes from "vview.ado" to Sight's
-  Stata commands (still naming the install directory).
+The bundle adds a command named after a Stata built-in, which is a broader
+action than the original "add vview.ado." Reusing the old permission key
+would silently expand a `vview`-only grant and would never re-prompt users
+who previously declined. Therefore:
+
+- Use a **new, versioned permission state key** (e.g.
+  `sightStataCommandsInstallPermission`) distinct from the old vview key.
+  Existing granted/declined users get exactly one fresh prompt describing the
+  bundle.
+- The prompt copy generalizes from "vview.ado" to "Sight's Stata commands
+  (`vview`, `browse`)", still naming the install directory.
+
+### Flow and atomicity (finding 9)
+
 - `ensure_*` (auto, prompt-on-first-use) and `install_*_manually` (the
-  "Sight: Install vview.ado" command) both operate on the bundle: when
-  permission is granted (or already granted), write every file whose on-disk
-  content differs from its bundled content.
-- The "Sight: Install vview.ado" / reset-permission commands and their
-  titles are updated to reflect that they manage Sight's Stata commands
-  (vview + browse), not vview alone.
+  command-palette install) operate on the bundle: when permission is granted
+  (or already granted), write every asset whose policy says "write".
+- Writes are per-file best-effort: on a write failure, log the specific file
+  and continue with the rest; report an aggregate failure. Already-written
+  files are left in place (no rollback; partial state is re-converged on the
+  next install check).
 
-### Scope of refactor
+### Uninstall (finding 8)
 
-`VviewInstallStatus` becomes a per-file or bundle-level structure carrying a
-list of `{ name, target_path, bundled_path, bundled_content, state }` plus the
-shared `target_dir` and an aggregate `state`. Functions
-(`get_vview_install_state`, `install_vview_ado`, `ensure_vview_ado_installed`,
-`install_vview_ado_manually`, `reset_vview_install_permission`) are updated to
-iterate the list. The public hook shape (`inspect_installation`,
-`prompt_for_vview_install`, `install_vview_ado`, permission get/set) is
-preserved where practical so `index.ts` wiring stays thin.
+Because the alias takes over a built-in command name in the CLI, provide a
+supported removal path. Add a command **"Sight: Uninstall Stata commands
+(vview, browse)"** that:
+
+- deletes each target **only if it is sight-owned** (ownership marker match);
+  never deletes a foreign file;
+- clears the install permission key.
+
+### Command IDs (finding 13)
+
+Keep existing command IDs (`sight.installVviewAdo`,
+`sight.resetVviewInstallPermission`, etc.) stable to avoid breaking
+keybindings/docs; update only display titles and message copy. The new
+uninstall command gets a new ID.
+
+## Verification (findings 1, 4)
+
+Tests do not run Stata, so the GUI-safety guarantee is verified out-of-band.
+Record a manual verification checklist (in PR description / docs):
+
+- **GUI:** `which browse` reports the built-in; `browse` opens the native
+  Data Editor (not Sight) with `browse.ado` installed on the ado-path.
+- **CLI:** `which browse` reports the installed ado; `browse` opens the Sight
+  Data Browser; `c(console)` is `"console"`.
+- Confirmed CLI baseline: bare `browse` is `r(199)` before install.
+
+Supported range matches `vview.ado`: Stata 16+ (uses `frames`).
 
 ## Tests
 
-- `tests/unit/data-browser/vview-bundled-asset.test.ts`: extend to assert
-  `browse.ado` is bundled and its content matches the canonical
-  `stata/browse.ado`.
-- `tests/unit/data-browser/vview-install.test.ts`: extend / mirror for the
-  bundle — aggregate state logic (any-missing → `missing`, any-differs →
-  `outdated`, all-match → `up_to_date`, any-read-error → `error`), and that
-  install writes both files under a single granted permission.
-- Add a focused assertion that `browse.ado` is a pure `vview` forwarder
-  (content check is sufficient; we do not run Stata in tests).
+- `tests/unit/data-browser/vview-bundled-asset.test.ts`: assert `browse.ado`
+  is bundled and matches canonical `stata/browse.ado`; assert it is a pure
+  `vview` forwarder carrying the `c(console)` guard and the ownership marker.
+- `tests/unit/data-browser/vview-install.test.ts`: aggregate-state logic
+  (any-missing → `missing`, any-sight-owned-differs → `outdated`, all-match →
+  `up_to_date`, any-bundled-read-error → `error`); install writes both files
+  under one granted permission; **foreign `browse.ado` is never overwritten**
+  and is reported as blocked, not perpetually outdated; uninstall removes only
+  sight-owned files and leaves foreign files intact; new permission key is
+  independent of the old one.
 
 ## Docs
 
-- `docs/data-browser.md`: document that in console Stata, `browse` is an alias
-  for `vview`, and that the GUI's built-in `browse` is unaffected.
+- `docs/data-browser.md`: document that in console Stata, `browse` aliases
+  `vview`; the GUI built-in `browse` is unaffected; only the exact `browse`
+  command is aliased (not `br`/`bro`); the new uninstall command.
 - `README.md`: update the Data Browser feature line to mention the CLI
   `browse` alias.
 
-## Out of scope
+## Out of scope (with rationale)
 
-- No `c(console)` runtime detection in the ado (unnecessary by design).
-- No support for native-`browse`-only options in the CLI.
-- No change to `vview.ado` behavior.
+- **`c(console)` is the only runtime detection.** No attempt to delegate to
+  native `browse` from the ado (a same-named program would recurse, not reach
+  the built-in).
+- **Abbreviations `br`/`bro` (finding 2).** Stata does not auto-abbreviate
+  ado-file command names, and claiming additional built-in-abbreviation names
+  is riskier and broader than the request. Documented as a limitation; only
+  exact `browse` is aliased.
+- **Native-`browse`-only options (finding 10).** `nolabel` etc. surface as
+  `vview` syntax errors; the common varlist/`if`/`in` forms work.
+- **"Opened…" printed when no extension is listening (finding 11).** This is
+  pre-existing `vview` behavior, not specific to the alias; out of scope here.
+- No change to `vview.ado`'s data-export behavior.

--- a/stata/browse.ado
+++ b/stata/browse.ado
@@ -1,0 +1,19 @@
+*! browse.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! In the Stata GUI, the built-in `browse` command shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
+
+program define browse
+    version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "browse: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
+    vview `0'
+end

--- a/tests/unit/data-browser/vview-bundled-asset.test.ts
+++ b/tests/unit/data-browser/vview-bundled-asset.test.ts
@@ -104,3 +104,55 @@ describe('bundled vview asset', () => {
         );
     });
 });
+
+describe('bundled browse alias asset', () => {
+    const BROWSE_SOURCE_PATH = path.join(
+        REPO_ROOT,
+        'stata',
+        'browse.ado'
+    );
+
+    function load_browse_source(): string {
+        return fs.readFileSync(BROWSE_SOURCE_PATH, 'utf-8');
+    }
+
+    it('matches the source browse.ado file', () => {
+        const my_client_asset_path = path.join(
+            REPO_ROOT,
+            'client',
+            'stata',
+            'browse.ado'
+        );
+
+        expect(fs.existsSync(BROWSE_SOURCE_PATH)).toBe(true);
+        expect(fs.existsSync(my_client_asset_path)).toBe(true);
+        expect(
+            fs.readFileSync(my_client_asset_path, 'utf-8')
+        ).toBe(load_browse_source());
+    });
+
+    it('is a pure vview forwarder', () => {
+        const my_source = load_browse_source();
+
+        expect(my_source).toContain('program define browse');
+        expect(my_source).toContain('vview `0\'');
+    });
+
+    it('guards on console mode so the GUI built-in is never replaced', () => {
+        const my_source = load_browse_source();
+
+        expect(my_source).toContain(
+            '`"`c(console)\'"\' != "console"'
+        );
+        expect(my_source).toContain('exit 199');
+    });
+
+    it('carries the stable Sight ownership marker on its first line', () => {
+        const my_source = load_browse_source();
+        const my_first_line = my_source.split('\n', 1)[0];
+
+        expect(my_first_line).toBe(
+            '*! browse.ado — CLI alias for vview (Sight Data Browser)'
+        );
+    });
+});

--- a/tests/unit/data-browser/vview-bundled-asset.test.ts
+++ b/tests/unit/data-browser/vview-bundled-asset.test.ts
@@ -5,6 +5,7 @@ import {
 } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
+import { ADO_ASSET_DEFS } from '../../../client/src/data-browser/vview-install-core';
 
 const REPO_ROOT = path.resolve(
     import.meta.dir,
@@ -154,5 +155,21 @@ describe('bundled browse alias asset', () => {
         expect(my_first_line).toBe(
             '*! browse.ado — CLI alias for vview (Sight Data Browser)'
         );
+    });
+});
+
+describe('ado ownership markers', () => {
+    it('each marker equals the first line of its canonical ado', () => {
+        // Ownership detection must use the FULL banner line, not a
+        // truncated prefix — otherwise a foreign same-named file
+        // could be misclassified as Sight-owned and overwritten.
+        for (const my_def of ADO_ASSET_DEFS) {
+            const my_source = fs.readFileSync(
+                path.join(REPO_ROOT, 'stata', my_def.name),
+                'utf-8'
+            );
+            const my_first_line = my_source.split('\n', 1)[0];
+            expect(my_def.marker).toBe(my_first_line);
+        }
     });
 });

--- a/tests/unit/data-browser/vview-install.test.ts
+++ b/tests/unit/data-browser/vview-install.test.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+    ADO_ASSET_DEFS,
     aggregate_bundle_state,
     classify_ado_asset,
     ensure_bundle_installed,
@@ -27,9 +28,10 @@ import {
 
 const PERMISSION_KEY =
     'sight.stataCommandsInstallPermission';
-const VVIEW_MARKER =
-    '*! vview.ado — Open dataset in Sight Data Browser';
-const BROWSE_MARKER = '*! browse.ado — CLI alias for vview';
+// Use the production markers, so tests bind to the real ownership
+// strings and catch any drift/truncation in them.
+const VVIEW_MARKER = ADO_ASSET_DEFS[0].marker;
+const BROWSE_MARKER = ADO_ASSET_DEFS[1].marker;
 
 const the_temp_dirs: string[] = [];
 
@@ -150,6 +152,18 @@ describe('ado ownership detection', () => {
                 '*! my own browse helper\nprogram define browse\nend\n',
                 BROWSE_MARKER
             )
+        ).toBe(false);
+    });
+
+    it('does not treat a mere prefix of the marker as owned', () => {
+        // Guards against a truncated marker: a banner that only
+        // starts to resemble ours must not be claimed as Sight-owned.
+        const my_prefix = BROWSE_MARKER.slice(
+            0,
+            BROWSE_MARKER.length - 12
+        );
+        expect(
+            is_sight_owned(my_prefix + '\nx\n', BROWSE_MARKER)
         ).toBe(false);
     });
 });
@@ -613,6 +627,35 @@ describe('bundle file installation', () => {
         expect(
             fs.existsSync(path.join(my_dir, 'vview.ado'))
         ).toBe(true);
+    });
+
+    it('does not overwrite a foreign file that appears after classification (TOCTOU)', () => {
+        const my_dir = create_temp_dir();
+        const my_foreign =
+            '*! my own browse\nprogram define browse\nend\n';
+        fs.writeFileSync(
+            path.join(my_dir, 'browse.ado'),
+            my_foreign
+        );
+
+        // Force a stale "missing" classification even though a
+        // foreign file now sits at the target path.
+        const my_bundle = build_bundle(my_dir, {
+            browse: { state: 'missing' },
+        });
+
+        const my_result = install_bundle(
+            my_bundle,
+            () => {}
+        );
+
+        expect(my_result).toBe(true);
+        expect(
+            fs.readFileSync(
+                path.join(my_dir, 'browse.ado'),
+                'utf-8'
+            )
+        ).toBe(my_foreign);
     });
 
     it('a lone foreign browse.ado yields up_to_date once vview is present', () => {

--- a/tests/unit/data-browser/vview-install.test.ts
+++ b/tests/unit/data-browser/vview-install.test.ts
@@ -8,20 +8,29 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
-    ensure_vview_ado_installed,
-    get_vview_install_permission,
-    get_vview_install_state,
-    install_vview_ado,
-    install_vview_ado_manually,
-    reset_vview_install_permission,
+    aggregate_bundle_state,
+    classify_ado_asset,
+    ensure_bundle_installed,
+    get_install_permission,
+    install_bundle,
+    install_bundle_manually,
+    is_sight_owned,
+    reset_install_permission,
+    uninstall_bundle,
+    uninstall_bundle_and_reset,
+    type AdoAsset,
+    type AdoAssetStatus,
+    type BundleInstallStatus,
     type VviewInstallContextLike,
-    type VviewInstallHooks,
     type VviewInstallPermission,
-    type VviewInstallStatus,
 } from '../../../client/src/data-browser/vview-install-core';
 
-const VVIEW_INSTALL_PERMISSION_KEY =
-    'sight.vviewInstallPermission';
+const PERMISSION_KEY =
+    'sight.stataCommandsInstallPermission';
+const VVIEW_MARKER =
+    '*! vview.ado — Open dataset in Sight Data Browser';
+const BROWSE_MARKER = '*! browse.ado — CLI alias for vview';
+
 const the_temp_dirs: string[] = [];
 
 function create_temp_dir(): string {
@@ -37,10 +46,7 @@ function create_context(
 ): VviewInstallContextLike {
     const my_state = new Map<string, unknown>();
     if (permission !== undefined) {
-        my_state.set(
-            VVIEW_INSTALL_PERMISSION_KEY,
-            permission
-        );
+        my_state.set(PERMISSION_KEY, permission);
     }
 
     return {
@@ -68,15 +74,57 @@ function create_context(
     };
 }
 
-function build_status(
-    state: VviewInstallStatus['state']
-): VviewInstallStatus {
+// Builds a bundle status whose assets live under a real temp dir, so
+// install/uninstall actually touch the filesystem.
+function build_bundle(
+    target_dir: string,
+    overrides: Partial<
+        Record<'vview' | 'browse', Partial<AdoAssetStatus>>
+    > = {}
+): BundleInstallStatus {
+    const make = (
+        name: string,
+        marker: string,
+        content: string,
+        extra: Partial<AdoAssetStatus>
+    ): AdoAssetStatus => {
+        const my_asset: AdoAsset = {
+            name,
+            target_path: path.join(target_dir, name),
+            bundled_path: path.join('/bundle', name),
+            bundled_content: content,
+            marker,
+        };
+        return {
+            ...my_asset,
+            ...extra,
+            state:
+                extra.state
+                ?? classify_ado_asset(my_asset, () => {}),
+        };
+    };
+
+    const the_assets = [
+        make(
+            'vview.ado',
+            VVIEW_MARKER,
+            `${VVIEW_MARKER}\nprogram define vview\nend\n`,
+            overrides.vview ?? {}
+        ),
+        make(
+            'browse.ado',
+            BROWSE_MARKER,
+            `${BROWSE_MARKER}\nprogram define browse\nvview \`0'\nend\n`,
+            overrides.browse ?? {}
+        ),
+    ];
+
     return {
-        state,
-        target_dir: '/tmp/personal',
-        target_path: '/tmp/personal/vview.ado',
-        bundled_path: '/bundle/vview.ado',
-        bundled_content: 'program define vview\nend\n',
+        state: aggregate_bundle_state(
+            the_assets.map((my_asset) => my_asset.state)
+        ),
+        target_dir,
+        assets: the_assets,
     };
 }
 
@@ -86,72 +134,163 @@ afterEach(() => {
     }
 });
 
-describe('vview install state detection', () => {
+describe('ado ownership detection', () => {
+    it('recognizes a Sight-shipped file by its banner marker', () => {
+        expect(
+            is_sight_owned(
+                `${BROWSE_MARKER} (Sight Data Browser)\n...`,
+                BROWSE_MARKER
+            )
+        ).toBe(true);
+    });
+
+    it('treats a foreign file with a different banner as not owned', () => {
+        expect(
+            is_sight_owned(
+                '*! my own browse helper\nprogram define browse\nend\n',
+                BROWSE_MARKER
+            )
+        ).toBe(false);
+    });
+});
+
+describe('ado asset classification', () => {
     it('returns missing when target file is absent', () => {
         const my_dir = create_temp_dir();
-        const my_target_path = path.join(
-            my_dir,
-            'vview.ado'
-        );
+        const my_asset: AdoAsset = {
+            name: 'browse.ado',
+            target_path: path.join(my_dir, 'browse.ado'),
+            bundled_path: '/bundle/browse.ado',
+            bundled_content: 'content',
+            marker: BROWSE_MARKER,
+        };
 
-        const my_state = get_vview_install_state(
-            my_target_path,
-            'content',
-            () => {}
+        expect(classify_ado_asset(my_asset, () => {})).toBe(
+            'missing'
         );
-
-        expect(my_state).toBe('missing');
     });
 
     it('returns up_to_date when target matches bundled content', () => {
         const my_dir = create_temp_dir();
-        const my_target_path = path.join(
-            my_dir,
-            'vview.ado'
-        );
-        fs.writeFileSync(my_target_path, 'content');
+        const my_path = path.join(my_dir, 'browse.ado');
+        fs.writeFileSync(my_path, 'content');
 
-        const my_state = get_vview_install_state(
-            my_target_path,
-            'content',
-            () => {}
-        );
-
-        expect(my_state).toBe('up_to_date');
+        expect(
+            classify_ado_asset(
+                {
+                    name: 'browse.ado',
+                    target_path: my_path,
+                    bundled_path: '/bundle/browse.ado',
+                    bundled_content: 'content',
+                    marker: BROWSE_MARKER,
+                },
+                () => {}
+            )
+        ).toBe('up_to_date');
     });
 
-    it('returns outdated when target differs from bundled content', () => {
+    it('returns outdated when a Sight-owned file differs', () => {
         const my_dir = create_temp_dir();
-        const my_target_path = path.join(
-            my_dir,
-            'vview.ado'
-        );
-        fs.writeFileSync(my_target_path, 'old');
+        const my_path = path.join(my_dir, 'browse.ado');
+        fs.writeFileSync(my_path, `${BROWSE_MARKER}\nold\n`);
 
-        const my_state = get_vview_install_state(
-            my_target_path,
-            'new',
-            () => {}
+        expect(
+            classify_ado_asset(
+                {
+                    name: 'browse.ado',
+                    target_path: my_path,
+                    bundled_path: '/bundle/browse.ado',
+                    bundled_content: `${BROWSE_MARKER}\nnew\n`,
+                    marker: BROWSE_MARKER,
+                },
+                () => {}
+            )
+        ).toBe('outdated');
+    });
+
+    it('returns foreign when a non-Sight file occupies the path', () => {
+        const my_dir = create_temp_dir();
+        const my_path = path.join(my_dir, 'browse.ado');
+        fs.writeFileSync(
+            my_path,
+            '*! someone else\nprogram define browse\nend\n'
         );
 
-        expect(my_state).toBe('outdated');
+        expect(
+            classify_ado_asset(
+                {
+                    name: 'browse.ado',
+                    target_path: my_path,
+                    bundled_path: '/bundle/browse.ado',
+                    bundled_content: `${BROWSE_MARKER}\nx\n`,
+                    marker: BROWSE_MARKER,
+                },
+                () => {}
+            )
+        ).toBe('foreign');
+    });
+
+    it('returns error when bundled content is unavailable', () => {
+        const my_dir = create_temp_dir();
+        expect(
+            classify_ado_asset(
+                {
+                    name: 'browse.ado',
+                    target_path: path.join(
+                        my_dir,
+                        'browse.ado'
+                    ),
+                    bundled_path: '/bundle/browse.ado',
+                    bundled_content: undefined,
+                    marker: BROWSE_MARKER,
+                },
+                () => {}
+            )
+        ).toBe('error');
     });
 });
 
-describe('vview install orchestration', () => {
+describe('bundle aggregate state', () => {
+    it('reports error when any asset errors', () => {
+        expect(
+            aggregate_bundle_state(['up_to_date', 'error'])
+        ).toBe('error');
+    });
+
+    it('reports missing when any asset is missing', () => {
+        expect(
+            aggregate_bundle_state(['up_to_date', 'missing'])
+        ).toBe('missing');
+    });
+
+    it('reports outdated when any Sight-owned asset differs', () => {
+        expect(
+            aggregate_bundle_state(['up_to_date', 'outdated'])
+        ).toBe('outdated');
+    });
+
+    it('reports up_to_date when a foreign file is left alone', () => {
+        expect(
+            aggregate_bundle_state(['up_to_date', 'foreign'])
+        ).toBe('up_to_date');
+    });
+});
+
+describe('bundle install orchestration', () => {
     it('prompts on startup when permission is unset and install is missing', async () => {
+        const my_dir = create_temp_dir();
         const my_context = create_context();
         const the_logs: string[] = [];
         let my_prompt_calls = 0;
 
-        await ensure_vview_ado_installed(
+        await ensure_bundle_installed(
             my_context,
             (msg) => the_logs.push(msg),
-            VVIEW_INSTALL_PERMISSION_KEY,
+            PERMISSION_KEY,
             {
                 inspect_installation: () =>
-                    build_status('missing'),
-                prompt_for_vview_install: async () => {
+                    build_bundle(my_dir),
+                prompt_for_install: async () => {
                     my_prompt_calls += 1;
                     return 'not_now';
                 },
@@ -160,242 +299,242 @@ describe('vview install orchestration', () => {
 
         expect(my_prompt_calls).toBe(1);
         expect(
-            get_vview_install_permission(
+            get_install_permission(
                 my_context,
-                VVIEW_INSTALL_PERMISSION_KEY
+                PERMISSION_KEY
             )
         ).toBeUndefined();
         expect(the_logs).toContain(
-            'vview.ado: prompting for install permission'
+            'Stata commands: prompting for install permission'
         );
     });
 
     it('installs without prompting when permission was already granted', async () => {
+        const my_dir = create_temp_dir();
         const my_context = create_context('granted');
         let my_prompt_calls = 0;
-        let my_install_calls = 0;
 
-        const my_result =
-            await ensure_vview_ado_installed(
-                my_context,
-                () => {},
-                VVIEW_INSTALL_PERMISSION_KEY,
-                {
-                    inspect_installation: () =>
-                        build_status('missing'),
-                    prompt_for_vview_install: async () => {
-                        my_prompt_calls += 1;
-                        return 'install';
-                    },
-                    install_vview_ado: () => {
-                        my_install_calls += 1;
-                        return true;
-                    },
-                }
-            );
+        const my_result = await ensure_bundle_installed(
+            my_context,
+            () => {},
+            PERMISSION_KEY,
+            {
+                inspect_installation: () =>
+                    build_bundle(my_dir),
+                prompt_for_install: async () => {
+                    my_prompt_calls += 1;
+                    return 'install';
+                },
+            }
+        );
 
         expect(my_result).toBe(true);
         expect(my_prompt_calls).toBe(0);
-        expect(my_install_calls).toBe(1);
+        expect(
+            fs.existsSync(path.join(my_dir, 'vview.ado'))
+        ).toBe(true);
+        expect(
+            fs.existsSync(path.join(my_dir, 'browse.ado'))
+        ).toBe(true);
     });
 
     it('skips prompt and install when permission was declined', async () => {
+        const my_dir = create_temp_dir();
         const my_context = create_context('declined');
         let my_prompt_calls = 0;
-        let my_install_calls = 0;
 
-        const my_result =
-            await ensure_vview_ado_installed(
-                my_context,
-                () => {},
-                VVIEW_INSTALL_PERMISSION_KEY,
-                {
-                    inspect_installation: () =>
-                        build_status('missing'),
-                    prompt_for_vview_install: async () => {
-                        my_prompt_calls += 1;
-                        return 'install';
-                    },
-                    install_vview_ado: () => {
-                        my_install_calls += 1;
-                        return true;
-                    },
-                }
-            );
+        const my_result = await ensure_bundle_installed(
+            my_context,
+            () => {},
+            PERMISSION_KEY,
+            {
+                inspect_installation: () =>
+                    build_bundle(my_dir),
+                prompt_for_install: async () => {
+                    my_prompt_calls += 1;
+                    return 'install';
+                },
+            }
+        );
 
         expect(my_result).toBe(false);
         expect(my_prompt_calls).toBe(0);
-        expect(my_install_calls).toBe(0);
+        expect(
+            fs.existsSync(path.join(my_dir, 'vview.ado'))
+        ).toBe(false);
     });
 
-    it('writes the file and stores granted permission after approval', async () => {
+    it('writes both files and stores granted permission after approval', async () => {
         const my_dir = create_temp_dir();
-        const my_status: VviewInstallStatus = {
-            state: 'missing',
-            target_dir: my_dir,
-            target_path: path.join(my_dir, 'vview.ado'),
-            bundled_path: path.join(my_dir, 'bundle', 'vview.ado'),
-            bundled_content: 'program define vview\nend\n',
-        };
         const my_context = create_context();
+        const my_bundle = build_bundle(my_dir);
 
-        const my_result =
-            await ensure_vview_ado_installed(
-                my_context,
-                () => {},
-                VVIEW_INSTALL_PERMISSION_KEY,
-                {
-                    inspect_installation: () => my_status,
-                    prompt_for_vview_install: async () =>
-                        'install',
-                }
-            );
+        const my_result = await ensure_bundle_installed(
+            my_context,
+            () => {},
+            PERMISSION_KEY,
+            {
+                inspect_installation: () => my_bundle,
+                prompt_for_install: async () => 'install',
+            }
+        );
 
         expect(my_result).toBe(true);
         expect(
             fs.readFileSync(
-                my_status.target_path,
+                path.join(my_dir, 'vview.ado'),
                 'utf-8'
             )
-        ).toBe(my_status.bundled_content);
+        ).toBe(my_bundle.assets[0].bundled_content);
         expect(
-            get_vview_install_permission(
+            fs.readFileSync(
+                path.join(my_dir, 'browse.ado'),
+                'utf-8'
+            )
+        ).toBe(my_bundle.assets[1].bundled_content);
+        expect(
+            get_install_permission(
                 my_context,
-                VVIEW_INSTALL_PERMISSION_KEY
+                PERMISSION_KEY
             )
         ).toBe('granted');
     });
 
     it('does not persist permission when the user chooses not now', async () => {
+        const my_dir = create_temp_dir();
         const my_context = create_context();
 
-        const my_result =
-            await ensure_vview_ado_installed(
-                my_context,
-                () => {},
-                VVIEW_INSTALL_PERMISSION_KEY,
-                {
-                    inspect_installation: () =>
-                        build_status('missing'),
-                    prompt_for_vview_install: async () =>
-                        'not_now',
-                }
-            );
+        const my_result = await ensure_bundle_installed(
+            my_context,
+            () => {},
+            PERMISSION_KEY,
+            {
+                inspect_installation: () =>
+                    build_bundle(my_dir),
+                prompt_for_install: async () => 'not_now',
+            }
+        );
 
         expect(my_result).toBe(false);
         expect(
-            get_vview_install_permission(
+            get_install_permission(
                 my_context,
-                VVIEW_INSTALL_PERMISSION_KEY
+                PERMISSION_KEY
             )
         ).toBeUndefined();
     });
 
     it('does not store declined permission when the prompt is dismissed', async () => {
+        const my_dir = create_temp_dir();
         const my_context = create_context();
 
-        const my_result =
-            await ensure_vview_ado_installed(
-                my_context,
-                () => {},
-                VVIEW_INSTALL_PERMISSION_KEY,
-                {
-                    inspect_installation: () =>
-                        build_status('missing'),
-                    prompt_for_vview_install: async () =>
-                        'dismissed',
-                }
-            );
+        const my_result = await ensure_bundle_installed(
+            my_context,
+            () => {},
+            PERMISSION_KEY,
+            {
+                inspect_installation: () =>
+                    build_bundle(my_dir),
+                prompt_for_install: async () => 'dismissed',
+            }
+        );
 
         expect(my_result).toBe(false);
         expect(
-            get_vview_install_permission(
+            get_install_permission(
                 my_context,
-                VVIEW_INSTALL_PERMISSION_KEY
+                PERMISSION_KEY
             )
         ).toBeUndefined();
     });
 
     it('does not store granted permission if install fails after approval', async () => {
+        const my_dir = create_temp_dir();
         const my_context = create_context();
 
-        const my_result =
-            await ensure_vview_ado_installed(
-                my_context,
-                () => {},
-                VVIEW_INSTALL_PERMISSION_KEY,
-                {
-                    inspect_installation: () =>
-                        build_status('missing'),
-                    prompt_for_vview_install: async () =>
-                        'install',
-                    install_vview_ado: () => false,
-                }
-            );
+        const my_result = await ensure_bundle_installed(
+            my_context,
+            () => {},
+            PERMISSION_KEY,
+            {
+                inspect_installation: () =>
+                    build_bundle(my_dir),
+                prompt_for_install: async () => 'install',
+                install_bundle: () => false,
+            }
+        );
 
         expect(my_result).toBe(false);
         expect(
-            get_vview_install_permission(
+            get_install_permission(
                 my_context,
-                VVIEW_INSTALL_PERMISSION_KEY
+                PERMISSION_KEY
             )
         ).toBeUndefined();
     });
 
     it('silently updates an outdated install after prior approval', async () => {
+        const my_dir = create_temp_dir();
+        // Pre-seed an outdated, Sight-owned vview.ado.
+        fs.writeFileSync(
+            path.join(my_dir, 'vview.ado'),
+            `${VVIEW_MARKER}\nstale\n`
+        );
+        fs.writeFileSync(
+            path.join(my_dir, 'browse.ado'),
+            `${BROWSE_MARKER}\nstale\n`
+        );
         const my_context = create_context('granted');
         let my_prompt_calls = 0;
-        let my_install_calls = 0;
 
-        const my_result =
-            await ensure_vview_ado_installed(
-                my_context,
-                () => {},
-                VVIEW_INSTALL_PERMISSION_KEY,
-                {
-                    inspect_installation: () =>
-                        build_status('outdated'),
-                    prompt_for_vview_install: async () => {
-                        my_prompt_calls += 1;
-                        return 'install';
-                    },
-                    install_vview_ado: () => {
-                        my_install_calls += 1;
-                        return true;
-                    },
-                }
-            );
+        const my_bundle = build_bundle(my_dir);
+        expect(my_bundle.state).toBe('outdated');
+
+        const my_result = await ensure_bundle_installed(
+            my_context,
+            () => {},
+            PERMISSION_KEY,
+            {
+                inspect_installation: () => my_bundle,
+                prompt_for_install: async () => {
+                    my_prompt_calls += 1;
+                    return 'install';
+                },
+            }
+        );
 
         expect(my_result).toBe(true);
         expect(my_prompt_calls).toBe(0);
-        expect(my_install_calls).toBe(1);
+        expect(
+            fs.readFileSync(
+                path.join(my_dir, 'vview.ado'),
+                'utf-8'
+            )
+        ).toBe(my_bundle.assets[0].bundled_content);
     });
 
     it('manual install succeeds even after a prior decline', async () => {
+        const my_dir = create_temp_dir();
         const my_context = create_context('declined');
-        let my_install_calls = 0;
 
-        const my_result =
-            await install_vview_ado_manually(
-                my_context,
-                () => {},
-                VVIEW_INSTALL_PERMISSION_KEY,
-                {
-                    inspect_installation: () =>
-                        build_status('missing'),
-                    install_vview_ado: () => {
-                        my_install_calls += 1;
-                        return true;
-                    },
-                }
-            );
+        const my_result = await install_bundle_manually(
+            my_context,
+            () => {},
+            PERMISSION_KEY,
+            {
+                inspect_installation: () =>
+                    build_bundle(my_dir),
+            }
+        );
 
         expect(my_result).toBe(true);
-        expect(my_install_calls).toBe(1);
         expect(
-            get_vview_install_permission(
+            fs.existsSync(path.join(my_dir, 'browse.ado'))
+        ).toBe(true);
+        expect(
+            get_install_permission(
                 my_context,
-                VVIEW_INSTALL_PERMISSION_KEY
+                PERMISSION_KEY
             )
         ).toBe('granted');
     });
@@ -403,48 +542,160 @@ describe('vview install orchestration', () => {
     it('reset clears remembered install permission', async () => {
         const my_context = create_context('declined');
 
-        await reset_vview_install_permission(
+        await reset_install_permission(
             my_context,
             () => {},
-            VVIEW_INSTALL_PERMISSION_KEY
+            PERMISSION_KEY
         );
 
         expect(
-            get_vview_install_permission(
+            get_install_permission(
                 my_context,
-                VVIEW_INSTALL_PERMISSION_KEY
+                PERMISSION_KEY
             )
         ).toBeUndefined();
     });
 });
 
-describe('vview file installation', () => {
-    it('writes bundled content to the target path', () => {
+describe('bundle file installation', () => {
+    it('writes bundled content for every asset', () => {
         const my_dir = create_temp_dir();
-        const my_status: VviewInstallStatus = {
-            state: 'missing',
-            target_dir: my_dir,
-            target_path: path.join(my_dir, 'vview.ado'),
-            bundled_path: path.join(my_dir, 'bundle', 'vview.ado'),
-            bundled_content: 'program define vview\nend\n',
-        };
+        const my_bundle = build_bundle(my_dir);
         const the_logs: string[] = [];
 
-        const my_result = install_vview_ado(
-            my_status,
+        const my_result = install_bundle(
+            my_bundle,
             (msg) => the_logs.push(msg)
         );
 
         expect(my_result).toBe(true);
         expect(
             fs.readFileSync(
-                my_status.target_path,
+                path.join(my_dir, 'vview.ado'),
                 'utf-8'
             )
-        ).toBe(my_status.bundled_content);
-        expect(the_logs).toContain(
-            'vview.ado: installed to '
-            + my_status.target_path
+        ).toBe(my_bundle.assets[0].bundled_content);
+        expect(
+            fs.readFileSync(
+                path.join(my_dir, 'browse.ado'),
+                'utf-8'
+            )
+        ).toBe(my_bundle.assets[1].bundled_content);
+    });
+
+    it('never overwrites a foreign browse.ado and reports it as satisfied', () => {
+        const my_dir = create_temp_dir();
+        const my_foreign =
+            '*! my own browse\nprogram define browse\nend\n';
+        fs.writeFileSync(
+            path.join(my_dir, 'browse.ado'),
+            my_foreign
         );
+
+        const my_bundle = build_bundle(my_dir);
+        // The foreign file must not drive a perpetual "outdated".
+        expect(my_bundle.assets[1].state).toBe('foreign');
+        expect(my_bundle.state).toBe('missing'); // vview still missing
+
+        const my_result = install_bundle(
+            my_bundle,
+            () => {}
+        );
+
+        expect(my_result).toBe(true);
+        // Foreign file untouched, vview installed.
+        expect(
+            fs.readFileSync(
+                path.join(my_dir, 'browse.ado'),
+                'utf-8'
+            )
+        ).toBe(my_foreign);
+        expect(
+            fs.existsSync(path.join(my_dir, 'vview.ado'))
+        ).toBe(true);
+    });
+
+    it('a lone foreign browse.ado yields up_to_date once vview is present', () => {
+        const my_dir = create_temp_dir();
+        const my_bundle_seed = build_bundle(my_dir);
+        // Install vview, leave a foreign browse.ado in place.
+        fs.writeFileSync(
+            path.join(my_dir, 'vview.ado'),
+            my_bundle_seed.assets[0].bundled_content as string
+        );
+        fs.writeFileSync(
+            path.join(my_dir, 'browse.ado'),
+            '*! foreign\nprogram define browse\nend\n'
+        );
+
+        const my_bundle = build_bundle(my_dir);
+        expect(my_bundle.assets[0].state).toBe('up_to_date');
+        expect(my_bundle.assets[1].state).toBe('foreign');
+        expect(my_bundle.state).toBe('up_to_date');
+    });
+});
+
+describe('bundle uninstall', () => {
+    it('removes only Sight-owned files and leaves foreign files intact', () => {
+        const my_dir = create_temp_dir();
+        const my_bundle = build_bundle(my_dir);
+        // Install Sight vview, but a foreign browse.ado exists.
+        install_bundle(my_bundle, () => {});
+        const my_foreign =
+            '*! my own browse\nprogram define browse\nend\n';
+        fs.writeFileSync(
+            path.join(my_dir, 'browse.ado'),
+            my_foreign
+        );
+
+        const my_after = build_bundle(my_dir);
+        const my_ok = uninstall_bundle(
+            my_after,
+            () => {}
+        );
+
+        expect(my_ok).toBe(true);
+        // Sight-owned vview removed.
+        expect(
+            fs.existsSync(path.join(my_dir, 'vview.ado'))
+        ).toBe(false);
+        // Foreign browse left in place.
+        expect(
+            fs.readFileSync(
+                path.join(my_dir, 'browse.ado'),
+                'utf-8'
+            )
+        ).toBe(my_foreign);
+    });
+
+    it('uninstall_bundle_and_reset removes files and clears permission', async () => {
+        const my_dir = create_temp_dir();
+        const my_context = create_context('granted');
+        const my_bundle = build_bundle(my_dir);
+        install_bundle(my_bundle, () => {});
+
+        const my_ok = await uninstall_bundle_and_reset(
+            my_context,
+            () => {},
+            PERMISSION_KEY,
+            {
+                inspect_installation: () =>
+                    build_bundle(my_dir),
+            }
+        );
+
+        expect(my_ok).toBe(true);
+        expect(
+            fs.existsSync(path.join(my_dir, 'vview.ado'))
+        ).toBe(false);
+        expect(
+            fs.existsSync(path.join(my_dir, 'browse.ado'))
+        ).toBe(false);
+        expect(
+            get_install_permission(
+                my_context,
+                PERMISSION_KEY
+            )
+        ).toBeUndefined();
     });
 });

--- a/tests/unit/data-browser/vview-install.test.ts
+++ b/tests/unit/data-browser/vview-install.test.ts
@@ -87,6 +87,7 @@ function build_bundle(
     const make = (
         name: string,
         marker: string,
+        protect_foreign: boolean,
         content: string,
         extra: Partial<AdoAssetStatus>
     ): AdoAssetStatus => {
@@ -96,6 +97,7 @@ function build_bundle(
             bundled_path: path.join('/bundle', name),
             bundled_content: content,
             marker,
+            protect_foreign,
         };
         return {
             ...my_asset,
@@ -110,12 +112,14 @@ function build_bundle(
         make(
             'vview.ado',
             VVIEW_MARKER,
+            ADO_ASSET_DEFS[0].protect_foreign,
             `${VVIEW_MARKER}\nprogram define vview\nend\n`,
             overrides.vview ?? {}
         ),
         make(
             'browse.ado',
             BROWSE_MARKER,
+            ADO_ASSET_DEFS[1].protect_foreign,
             `${BROWSE_MARKER}\nprogram define browse\nvview \`0'\nend\n`,
             overrides.browse ?? {}
         ),
@@ -206,6 +210,7 @@ describe('ado asset classification', () => {
             bundled_path: '/bundle/browse.ado',
             bundled_content: 'content',
             marker: BROWSE_MARKER,
+            protect_foreign: true,
         };
 
         expect(classify_ado_asset(my_asset, () => {})).toBe(
@@ -226,6 +231,7 @@ describe('ado asset classification', () => {
                     bundled_path: '/bundle/browse.ado',
                     bundled_content: 'content',
                     marker: BROWSE_MARKER,
+                    protect_foreign: true,
                 },
                 () => {}
             )
@@ -245,6 +251,7 @@ describe('ado asset classification', () => {
                     bundled_path: '/bundle/browse.ado',
                     bundled_content: `${BROWSE_MARKER}\nnew\n`,
                     marker: BROWSE_MARKER,
+                    protect_foreign: true,
                 },
                 () => {}
             )
@@ -267,6 +274,7 @@ describe('ado asset classification', () => {
                     bundled_path: '/bundle/browse.ado',
                     bundled_content: `${BROWSE_MARKER}\nx\n`,
                     marker: BROWSE_MARKER,
+                    protect_foreign: true,
                 },
                 () => {}
             )
@@ -286,10 +294,37 @@ describe('ado asset classification', () => {
                     bundled_path: '/bundle/browse.ado',
                     bundled_content: undefined,
                     marker: BROWSE_MARKER,
+                    protect_foreign: true,
                 },
                 () => {}
             )
         ).toBe('error');
+    });
+
+    it('returns outdated (not foreign) for an unowned file of a Sight-owned name', () => {
+        // vview is Sight's own command name (protect_foreign: false):
+        // a differing, non-Sight vview.ado is overwritten, never left
+        // as a foreign file — otherwise browse could alias it.
+        const my_dir = create_temp_dir();
+        const my_path = path.join(my_dir, 'vview.ado');
+        fs.writeFileSync(
+            my_path,
+            '*! someone else\nprogram define vview\nend\n'
+        );
+
+        expect(
+            classify_ado_asset(
+                {
+                    name: 'vview.ado',
+                    target_path: my_path,
+                    bundled_path: '/bundle/vview.ado',
+                    bundled_content: `${VVIEW_MARKER}\nx\n`,
+                    marker: VVIEW_MARKER,
+                    protect_foreign: false,
+                },
+                () => {}
+            )
+        ).toBe('outdated');
     });
 });
 
@@ -655,6 +690,37 @@ describe('bundle file installation', () => {
         ).toBe(my_foreign);
         expect(
             fs.existsSync(path.join(my_dir, 'vview.ado'))
+        ).toBe(true);
+    });
+
+    it('installs Sight vview over a foreign vview so browse aliases Sight (not the foreign vview)', () => {
+        const my_dir = create_temp_dir();
+        // User has their own vview.ado; browse.ado is absent.
+        fs.writeFileSync(
+            path.join(my_dir, 'vview.ado'),
+            '*! someone else\nprogram define vview\nend\n'
+        );
+
+        const my_bundle = build_bundle(my_dir);
+        // vview is a Sight-owned name → reinstalled, not protected.
+        expect(my_bundle.assets[0].state).toBe('outdated');
+        expect(my_bundle.assets[1].state).toBe('missing');
+
+        const my_result = install_bundle(
+            my_bundle,
+            () => {}
+        );
+
+        expect(my_result).toBe(true);
+        // Sight's vview now in place, and browse is installed.
+        expect(
+            fs.readFileSync(
+                path.join(my_dir, 'vview.ado'),
+                'utf-8'
+            )
+        ).toBe(my_bundle.assets[0].bundled_content);
+        expect(
+            fs.existsSync(path.join(my_dir, 'browse.ado'))
         ).toBe(true);
     });
 

--- a/tests/unit/data-browser/vview-install.test.ts
+++ b/tests/unit/data-browser/vview-install.test.ts
@@ -166,6 +166,24 @@ describe('ado ownership detection', () => {
         ).toBe(false);
     });
 
+    it('recognizes a CRLF-saved copy of our own file', () => {
+        expect(
+            is_sight_owned(
+                `${BROWSE_MARKER}\r\nprogram define browse\r\n`,
+                BROWSE_MARKER
+            )
+        ).toBe(true);
+    });
+
+    it('does not treat a whitespace-padded banner as owned', () => {
+        expect(
+            is_sight_owned(
+                `  ${BROWSE_MARKER}\nx\n`,
+                BROWSE_MARKER
+            )
+        ).toBe(false);
+    });
+
     it('does not treat a mere prefix of the marker as owned', () => {
         // Guards against a truncated marker: a banner that only
         // starts to resemble ours must not be claimed as Sight-owned.

--- a/tests/unit/data-browser/vview-install.test.ts
+++ b/tests/unit/data-browser/vview-install.test.ts
@@ -137,13 +137,24 @@ afterEach(() => {
 });
 
 describe('ado ownership detection', () => {
-    it('recognizes a Sight-shipped file by its banner marker', () => {
+    it('recognizes a Sight-shipped file by its exact banner marker', () => {
         expect(
             is_sight_owned(
-                `${BROWSE_MARKER} (Sight Data Browser)\n...`,
+                `${BROWSE_MARKER}\nprogram define browse\nend\n`,
                 BROWSE_MARKER
             )
         ).toBe(true);
+    });
+
+    it('does not treat a banner with extra trailing text as owned', () => {
+        // Exact match only: a file that merely starts with our banner
+        // text must not be claimed as Sight-owned.
+        expect(
+            is_sight_owned(
+                `${BROWSE_MARKER} (modified by user)\n...`,
+                BROWSE_MARKER
+            )
+        ).toBe(false);
     });
 
     it('treats a foreign file with a different banner as not owned', () => {


### PR DESCRIPTION
## Summary

In **console Stata** (the CLI), the built-in `browse` command doesn't exist —
it's a GUI-only feature, so typing `browse` returns `command browse is
unrecognized r(199)`. This PR ships a small `browse.ado` so that, **in the CLI
only**, `browse` becomes an alias for Sight's `vview`. The Stata **GUI is
unaffected**: the built-in `browse` is resolved before any ado-file, so the
native Data Editor opens exactly as before and `browse.ado` never runs there.

```stata
browse                      // in the CLI: same as vview
browse price mpg if foreign // varlist / if / in all forwarded
```

The GUI/CLI split is enforced by two independent layers:
1. **Stata command resolution** — built-ins win over ado-files, so the GUI
   keeps its native `browse`.
2. **`c(console)` guard** in `browse.ado` — makes the console-only intent
   explicit and, should the ado ever be reached in the GUI, errors clearly
   rather than silently replacing `browse`.

## Install machinery (generalized to a bundle)

The single-`vview.ado` installer is generalized to a small bundle of ado
assets installed under **one freshly-versioned permission prompt**
(`sight.stataCommandsInstallPermission`, distinct from the old vview-only key
so existing users get one clean re-consent rather than a silently-expanded
grant).

Per-asset policy via a `protect_foreign` flag — different files warrant
different treatment:

- **`vview.ado`** (`protect_foreign: false`): Sight's own command name. It is
  always installed/updated, overwriting a differing copy (pre-feature
  behavior). Otherwise a user's unrelated `vview.ado` would leave `browse`
  aliasing a *non-Sight* vview.
- **`browse.ado`** (`protect_foreign: true`): a generic Stata built-in name. A
  user's own `browse.ado` is **never overwritten or deleted** — recognized via
  an exact first-line ownership marker (single source of truth in
  `ADO_ASSET_DEFS`, with a test binding each marker to the canonical ado's
  first line), with a final ownership re-check + exclusive (`wx`) create to
  close the install-time TOCTOU window.

New command **"Sight: Uninstall Stata Commands (vview, browse)"** removes only
Sight-owned files. Existing command IDs are unchanged (only titles/copy
updated).

## Manual GUI verification (tests don't run Stata)

- **GUI:** `which browse` reports the built-in; `browse` opens the native Data
  Editor (not Sight) with `browse.ado` on the ado-path.
- **CLI:** `which browse` reports the installed ado; `browse` opens the Sight
  Data Browser; `c(console)` is `"console"`.

## Process

Designed via a spec (`docs/superpowers/specs/2026-06-26-browse-cli-alias-design.md`),
adversarially reviewed by Codex before implementation, then iterated through
several Codex + `/code-review` rounds until both came back clean twice
consecutively. Review-driven fixes included: exact (not prefix) ownership
markers, the TOCTOU re-check + `wx`, CRLF-tolerant exact matching, and the
`protect_foreign` policy that fixes a foreign-`vview` → wrong-alias bug.

## Test plan

- `bun run test` (typecheck + full suite): **green** (≈5989 pass, 0 fail).
- New/updated unit tests cover: ownership exactness (prefix / padded / CRLF),
  per-asset classification, aggregate state, foreign-`browse` protection,
  foreign-`vview` overwrite, install-time TOCTOU, uninstall (Sight-owned only),
  and bundled-asset parity for `browse.ado` (guard, forwarding, marker).
