### PR TITLE
fix(neovim): detect StataNow installs in stata-send.lua reference

### DIFF
--- a/docs/neovim/stata-send.lua
+++ b/docs/neovim/stata-send.lua
@@ -11,8 +11,11 @@ local stata_apps = { "StataMP", "StataSE", "StataBE", "StataIC", "Stata" }
 -- install to different roots: perpetual-license editions under
 -- /Applications/Stata/ and the StataNow subscription channel under
 -- /Applications/StataNow/. The .app bundle inside each is named by
--- edition (e.g. StataSE.app), so only the root differs. The perpetual
--- root is listed first so it wins when an edition exists in both.
+-- edition (e.g. StataSE.app), so only the root differs; we probe both
+-- so detection works regardless of channel. The perpetual root is
+-- listed first only so it is the one we detect first -- the launch is
+-- by edition name (see send_to_stata), so the root a match came from
+-- does not change which app AppleScript opens.
 local stata_app_roots = { "/Applications/Stata/", "/Applications/StataNow/" }
 
 -- Shown when no Stata GUI app can be located. Kept in one place so the
@@ -20,9 +23,11 @@ local stata_app_roots = { "/Applications/Stata/", "/Applications/StataNow/" }
 local STATA_NOT_FOUND_MESSAGE =
   "Stata not found in /Applications/Stata/ or /Applications/StataNow/"
 
--- Find the first available Stata application. Variants are tried in
--- order (outer loop) and, for each, the roots are tried in order (inner
--- loop), so the result reflects edition priority first, then channel.
+-- Find the first available Stata application and return its edition
+-- name. Variants are tried in order (outer loop) and, for each, both
+-- roots are probed (inner loop), so a more capable edition wins
+-- regardless of channel. The return value is the edition name because
+-- AppleScript launches Stata by name, not by bundle path.
 local function find_stata_app()
   for _, app in ipairs(stata_apps) do
     for _, root in ipairs(stata_app_roots) do

--- a/docs/neovim/stata-send.lua
+++ b/docs/neovim/stata-send.lua
@@ -5,14 +5,31 @@
 local M = {}
 
 -- Stata application variants in order of preference
-local stata_apps = { "StataMP", "StataSE", "StataBE", "Stata" }
+local stata_apps = { "StataMP", "StataSE", "StataBE", "StataIC", "Stata" }
 
--- Find the first available Stata application
+-- macOS install roots to probe. Stata ships through two channels that
+-- install to different roots: perpetual-license editions under
+-- /Applications/Stata/ and the StataNow subscription channel under
+-- /Applications/StataNow/. The .app bundle inside each is named by
+-- edition (e.g. StataSE.app), so only the root differs. The perpetual
+-- root is listed first so it wins when an edition exists in both.
+local stata_app_roots = { "/Applications/Stata/", "/Applications/StataNow/" }
+
+-- Shown when no Stata GUI app can be located. Kept in one place so the
+-- wording lives in a single source of truth.
+local STATA_NOT_FOUND_MESSAGE =
+  "Stata not found in /Applications/Stata/ or /Applications/StataNow/"
+
+-- Find the first available Stata application. Variants are tried in
+-- order (outer loop) and, for each, the roots are tried in order (inner
+-- loop), so the result reflects edition priority first, then channel.
 local function find_stata_app()
   for _, app in ipairs(stata_apps) do
-    local path = "/Applications/Stata/" .. app .. ".app"
-    if vim.fn.isdirectory(path) == 1 then
-      return app
+    for _, root in ipairs(stata_app_roots) do
+      local path = root .. app .. ".app"
+      if vim.fn.isdirectory(path) == 1 then
+        return app
+      end
     end
   end
   return nil
@@ -221,7 +238,7 @@ function M.send(command)
   command = command or "do"
   local stata_app = find_stata_app()
   if not stata_app then
-    vim.notify("Stata not found in /Applications/Stata/", vim.log.levels.ERROR)
+    vim.notify(STATA_NOT_FOUND_MESSAGE, vim.log.levels.ERROR)
     return
   end
 
@@ -244,7 +261,7 @@ function M.send_range(command, line1, line2)
   command = command or "do"
   local stata_app = find_stata_app()
   if not stata_app then
-    vim.notify("Stata not found in /Applications/Stata/", vim.log.levels.ERROR)
+    vim.notify(STATA_NOT_FOUND_MESSAGE, vim.log.levels.ERROR)
     return
   end
 
@@ -267,7 +284,7 @@ function M.send_upward(command)
   command = command or "do"
   local stata_app = find_stata_app()
   if not stata_app then
-    vim.notify("Stata not found in /Applications/Stata/", vim.log.levels.ERROR)
+    vim.notify(STATA_NOT_FOUND_MESSAGE, vim.log.levels.ERROR)
     return
   end
 
@@ -285,7 +302,7 @@ function M.send_downward(command)
   command = command or "do"
   local stata_app = find_stata_app()
   if not stata_app then
-    vim.notify("Stata not found in /Applications/Stata/", vim.log.levels.ERROR)
+    vim.notify(STATA_NOT_FOUND_MESSAGE, vim.log.levels.ERROR)
     return
   end
 
@@ -303,7 +320,7 @@ function M.send_file(command)
   command = command or "do"
   local stata_app = find_stata_app()
   if not stata_app then
-    vim.notify("Stata not found in /Applications/Stata/", vim.log.levels.ERROR)
+    vim.notify(STATA_NOT_FOUND_MESSAGE, vim.log.levels.ERROR)
     return
   end
 
@@ -327,7 +344,7 @@ end
 function M.cd_file()
   local stata_app = find_stata_app()
   if not stata_app then
-    vim.notify("Stata not found in /Applications/Stata/", vim.log.levels.ERROR)
+    vim.notify(STATA_NOT_FOUND_MESSAGE, vim.log.levels.ERROR)
     return
   end
 
@@ -345,7 +362,7 @@ end
 function M.cd_workspace()
   local stata_app = find_stata_app()
   if not stata_app then
-    vim.notify("Stata not found in /Applications/Stata/", vim.log.levels.ERROR)
+    vim.notify(STATA_NOT_FOUND_MESSAGE, vim.log.levels.ERROR)
     return
   end
 


### PR DESCRIPTION
## Summary

Fixes #204. The reference Neovim integration `docs/neovim/stata-send.lua` only probed `/Applications/Stata/`, so a user who installed Stata via the **StataNow** subscription channel (`/Applications/StataNow/`) got "Stata not found" even though Stata was installed. This is the same gap #200 reported for the VS Code extension, fixed in #203 — this PR mirrors that fix in the Lua reference snippet.

## Changes

- **`find_stata_app()` probes both roots.** It now checks `/Applications/Stata/` and `/Applications/StataNow/` via a nested loop (variants outer, roots inner), so edition priority outranks channel priority — the same semantics as `find_installed_variant` in `client/src/send-to-stata/stata-install-roots.ts`. The perpetual root is listed first, so it wins when an edition exists in both.
- **Add `StataIC`** to the variant list, matching the `VALID_VARIANTS` order from #203 (`stata-detector.ts`).
- **Single not-found message.** The seven duplicate `"Stata not found in /Applications/Stata/"` notifications are consolidated into one `STATA_NOT_FOUND_MESSAGE` constant that names both directories.

## Verification

- File parses cleanly (`luac -p`).
- Spec adversarially reviewed by Codex before implementation (APPROVE).
- Implementation reviewed by both Codex and `/code-review` — clean twice consecutively.

## Context

- Original issue: #200
- VS Code extension fix: #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stata app detection on macOS by checking more common install locations and Stata editions.
  * Updated error messages shown when Stata can’t be found to be clearer and consistent across Stata-related actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->