### PR TITLE
fix(send-to-stata): run the first command on the integrated terminal's first launch

### DIFF
--- a/client/src/send-to-stata/stata-terminal-manager.ts
+++ b/client/src/send-to-stata/stata-terminal-manager.ts
@@ -160,26 +160,62 @@ export function register_stata_terminal(
 }
 
 /**
+ * A command to run as the terminal's very first action, baked into the
+ * Stata CLI launch arguments instead of typed into the REPL.
+ */
+interface InitialCommand {
+    command: StataCommand;
+    temp_file_path: string;
+}
+
+/**
+ * Result of resolving the Stata terminal for a send.
+ * `created_with_initial_command` is true only for the call that created
+ * a brand-new terminal carrying `initial_command` in its launch args;
+ * such a send must NOT also type the command (Stata runs it itself).
+ */
+interface ResolvedStataTerminal {
+    terminal: vscode.Terminal;
+    created_with_initial_command: boolean;
+}
+
+/**
  * Get an existing Stata profile terminal, or create a new one.
  * Returns the last-activated profile terminal if one exists.
  * Serializes concurrent calls so only one terminal is created.
+ *
+ * When a new terminal is created and `initial_command` is provided, the
+ * command is baked into the CLI launch args so Stata runs it itself
+ * after initialization. Only that initiating call reports
+ * `created_with_initial_command: true`; reused terminals and calls that
+ * merely join an in-flight creation report false and must type their
+ * command via sendText.
  */
-export async function get_or_create_stata_terminal():
-    Promise<vscode.Terminal> {
+export async function get_or_create_stata_terminal(
+    initial_command?: InitialCommand
+): Promise<ResolvedStataTerminal> {
     if (last_active_profile_terminal) {
-        return last_active_profile_terminal;
+        return {
+            terminal: last_active_profile_terminal,
+            created_with_initial_command: false,
+        };
     }
     if (creation_in_flight) {
-        return creation_in_flight;
+        const terminal = await creation_in_flight;
+        return { terminal, created_with_initial_command: false };
     }
 
-    creation_in_flight = create_stata_terminal().finally(() => {
+    const baked = initial_command !== undefined;
+    creation_in_flight = create_stata_terminal(initial_command).finally(() => {
         creation_in_flight = null;
     });
-    return creation_in_flight;
+    const terminal = await creation_in_flight;
+    return { terminal, created_with_initial_command: baked };
 }
 
-async function create_stata_terminal(): Promise<vscode.Terminal> {
+async function create_stata_terminal(
+    initial_command?: InitialCommand
+): Promise<vscode.Terminal> {
     const stata_cli = await detect_stata_cli();
     if (!stata_cli) {
         throw new Error(
@@ -189,10 +225,23 @@ async function create_stata_terminal(): Promise<vscode.Terminal> {
         );
     }
 
+    // Bake the first command into the launch args so Stata executes it
+    // itself once fully initialized. Typing it into the just-spawned
+    // REPL would race Stata's startup stdin flush and be discarded (the
+    // "first console launch" bug). The path is wrapped in Stata's
+    // compound-quote form because Stata joins launch argv with spaces
+    // and re-parses them as a single command line.
+    const shell_args = initial_command
+        ? [
+            initial_command.command,
+            wrap_path_for_stata_terminal(initial_command.temp_file_path),
+        ]
+        : [];
+
     const terminal = vscode.window.createTerminal({
         name: TERMINAL_NAME,
         shellPath: stata_cli,
-        shellArgs: [],
+        shellArgs: shell_args,
         isTransient: false,
         iconPath: create_terminal_icon(),
     });
@@ -281,15 +330,23 @@ export async function send_to_stata_terminal(
         );
     }
 
-    const terminal = await get_or_create_stata_terminal();
-    const escaped_path = wrap_path_for_stata_terminal(temp_file_path);
-    const command_string = `${command} ${escaped_path}`;
+    const { terminal, created_with_initial_command } =
+        await get_or_create_stata_terminal({ command, temp_file_path });
     terminal.show(true);  // Reveal without stealing focus
+    // Always await readiness: even a baked first command relies on the
+    // process actually launching, and this surfaces a terminal that
+    // closes before it is ready. It also serializes a rapid follow-up
+    // send so it does not type into a still-starting Stata.
     const ready_promise = the_terminal_ready_promises.get(terminal);
     if (ready_promise) {
         await ready_promise;
     }
-    terminal.sendText(command_string);
+    // A freshly-created terminal already runs this command via its launch
+    // args; typing it again would run it twice.
+    if (!created_with_initial_command) {
+        const escaped_path = wrap_path_for_stata_terminal(temp_file_path);
+        terminal.sendText(`${command} ${escaped_path}`);
+    }
 }
 
 export function reset_stata_terminal_manager_for_tests(): void {

--- a/client/src/send-to-stata/stata-terminal-manager.ts
+++ b/client/src/send-to-stata/stata-terminal-manager.ts
@@ -72,15 +72,28 @@ function handle_terminal_opened(terminal: vscode.Terminal): void {
         last_active_profile_terminal = terminal;
         // A profile terminal the user opened from the dropdown carries no
         // command we can bake into launch args, so its first send must be
-        // typed. Install a readiness promise so that send waits out
-        // Stata's startup stdin flush instead of racing it.
-        the_terminal_ready_promises.set(
-            terminal,
-            wait_for_terminal_ready(terminal).finally(() => {
-                the_terminal_ready_promises.delete(terminal);
-            })
-        );
+        // typed. Track readiness so that send waits out Stata's startup
+        // stdin flush instead of racing it.
+        track_terminal_ready(terminal);
     }
+}
+
+/**
+ * Begin tracking when `terminal` is ready to receive typed input, storing
+ * the promise so the next send can await it.
+ *
+ * The profile-opened path installs this eagerly, before any send, so the
+ * promise may have no awaiter when it settles. wait_for_terminal_ready
+ * rejects if the terminal closes or times out before it is ready, so we
+ * attach a no-op catch to avoid an unhandled rejection in that case; an
+ * actual send still awaits the stored promise and observes the rejection.
+ */
+function track_terminal_ready(terminal: vscode.Terminal): void {
+    const ready_promise = wait_for_terminal_ready(terminal).finally(() => {
+        the_terminal_ready_promises.delete(terminal);
+    });
+    ready_promise.catch(() => {});
+    the_terminal_ready_promises.set(terminal, ready_promise);
 }
 
 function handle_terminal_closed(terminal: vscode.Terminal): void {
@@ -262,12 +275,7 @@ async function create_stata_terminal(
     the_profile_terminals.add(terminal);
     track_activation(terminal);
     last_active_profile_terminal = terminal;
-    the_terminal_ready_promises.set(
-        terminal,
-        wait_for_terminal_ready(terminal).finally(() => {
-            the_terminal_ready_promises.delete(terminal);
-        })
-    );
+    track_terminal_ready(terminal);
 
     return terminal;
 }

--- a/client/src/send-to-stata/stata-terminal-manager.ts
+++ b/client/src/send-to-stata/stata-terminal-manager.ts
@@ -6,6 +6,13 @@ import { wrap_path_for_stata_terminal } from './terminal.js';
 const PROFILE_ID = 'sight.stataTerminal';
 const TERMINAL_NAME = 'Stata';
 const TERMINAL_READY_TIMEOUT_MS = 5000;
+// Best-effort readiness heuristic for commands that must be TYPED into the
+// terminal (a reused terminal, a rapid second send, or a user-opened
+// profile terminal). VS Code exposes no signal for when an arbitrary REPL
+// has finished initializing its tty, so we wait for the process to exist
+// plus a short grace. The primary first-send path avoids this race
+// entirely by baking the command into the launch args (see
+// create_stata_terminal), where Stata runs it itself after init.
 const TERMINAL_STARTUP_GRACE_MS = 150;
 
 /**
@@ -228,12 +235,14 @@ export async function get_or_create_stata_terminal(
         return { terminal, created_with_initial_command: false };
     }
 
-    const baked = initial_command !== undefined;
     creation_in_flight = create_stata_terminal(initial_command).finally(() => {
         creation_in_flight = null;
     });
     const terminal = await creation_in_flight;
-    return { terminal, created_with_initial_command: baked };
+    return {
+        terminal,
+        created_with_initial_command: initial_command !== undefined,
+    };
 }
 
 async function create_stata_terminal(

--- a/client/src/send-to-stata/stata-terminal-manager.ts
+++ b/client/src/send-to-stata/stata-terminal-manager.ts
@@ -70,6 +70,16 @@ function handle_terminal_opened(terminal: vscode.Terminal): void {
         the_profile_terminals.add(terminal);
         track_activation(terminal);
         last_active_profile_terminal = terminal;
+        // A profile terminal the user opened from the dropdown carries no
+        // command we can bake into launch args, so its first send must be
+        // typed. Install a readiness promise so that send waits out
+        // Stata's startup stdin flush instead of racing it.
+        the_terminal_ready_promises.set(
+            terminal,
+            wait_for_terminal_ready(terminal).finally(() => {
+                the_terminal_ready_promises.delete(terminal);
+            })
+        );
     }
 }
 
@@ -347,6 +357,20 @@ export async function send_to_stata_terminal(
         const escaped_path = wrap_path_for_stata_terminal(temp_file_path);
         terminal.sendText(`${command} ${escaped_path}`);
     }
+}
+
+/**
+ * Test seam: simulate the user opening a Stata profile terminal from the
+ * dropdown. In production VS Code calls provideTerminalProfile (which
+ * increments the pending-creation counter) and then fires
+ * onDidOpenTerminal; this drives the same handle_terminal_opened path,
+ * including its readiness tracking, without a full VS Code mock.
+ */
+export function simulate_profile_terminal_opened_for_tests(
+    terminal: vscode.Terminal
+): void {
+    pending_profile_creation_count++;
+    handle_terminal_opened(terminal);
 }
 
 export function reset_stata_terminal_manager_for_tests(): void {

--- a/client/src/send-to-stata/temp-file.ts
+++ b/client/src/send-to-stata/temp-file.ts
@@ -3,7 +3,13 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as crypto from 'crypto';
 
-export const DEFAULT_TEMP_FILE_CLEANUP_DELAY_MS = 5000;
+// Stata reads the temp do-file asynchronously after we hand it off, so
+// the file must outlive that read. For the integrated terminal the file
+// is now handed to Stata as a launch argument, and a cold first console
+// launch (license check, init) can take many seconds before Stata reads
+// it. Delete late enough to clear a slow cold start; the file is tiny so
+// a longer lifetime is cheap.
+export const DEFAULT_TEMP_FILE_CLEANUP_DELAY_MS = 30000;
 
 export function get_temp_dir(): string {
     return os.tmpdir();

--- a/tests/integration/send-to-stata-app-temp-file-lifecycle.test.ts
+++ b/tests/integration/send-to-stata-app-temp-file-lifecycle.test.ts
@@ -279,21 +279,44 @@ describe.serial('Feature: send-to-stata app temp file lifecycle', () => {
                     return Promise.resolve(undefined);
                 },
                 showWarningMessage: () => Promise.resolve(undefined),
-                createTerminal: () => ({
-                    name: 'Stata',
-                    processId: Promise.resolve(1234),
-                    show: () => {},
-                    sendText: (text: string) => {
-                        const temp_file_path = text.replace(
-                            /^[^ ]+\s+/,
-                            ''
-                        );
+                createTerminal: (
+                    options?: { shellArgs?: string[] }
+                ) => {
+                    // The integrated first command is delivered via launch
+                    // args (shellArgs: [command, `"<path>"']), not typed,
+                    // so simulate Stata reading that baked file. The path
+                    // is the last arg wrapped in Stata compound quotes.
+                    const the_shell_args = options?.shellArgs;
+                    if (
+                        Array.isArray(the_shell_args)
+                        && the_shell_args.length >= 2
+                    ) {
+                        const wrapped =
+                            the_shell_args[the_shell_args.length - 1];
+                        const temp_file_path = wrapped
+                            .replace(/^`"/, '')
+                            .replace(/"'$/, '');
                         simulate_stata_read(
                             temp_file_path,
                             current_read_attempt_state
                         );
-                    },
-                }),
+                    }
+                    return {
+                        name: 'Stata',
+                        processId: Promise.resolve(1234),
+                        show: () => {},
+                        sendText: (text: string) => {
+                            const temp_file_path = text.replace(
+                                /^[^ ]+\s+/,
+                                ''
+                            );
+                            simulate_stata_read(
+                                temp_file_path,
+                                current_read_attempt_state
+                            );
+                        },
+                    };
+                },
                 onDidCloseTerminal: () => ({
                     dispose: () => {},
                 }),

--- a/tests/integration/send-to-stata-integrated-terminal.test.ts
+++ b/tests/integration/send-to-stata-integrated-terminal.test.ts
@@ -429,4 +429,43 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
         );
         expect(vscode_state.the_send_calls).toEqual([]);
     });
+
+    test('waits for readiness before the first send to a profile-opened terminal', async () => {
+        const process_id_deferred = create_deferred<number | undefined>();
+        const vscode_state = create_vscode_mock_state(
+            process_id_deferred.promise
+        );
+        const terminal_manager = await import_terminal_manager_module(
+            vscode_state
+        );
+
+        // Simulate the user opening a "Stata" terminal from the dropdown:
+        // VS Code creates it and fires onDidOpenTerminal, which makes it
+        // the active managed terminal. We did NOT create it, so its first
+        // command cannot be baked into launch args -- it must be typed.
+        terminal_manager.simulate_profile_terminal_opened_for_tests(
+            vscode_state.terminal
+        );
+
+        // Send while Stata is still starting (processId unresolved).
+        const send_promise = terminal_manager.send_to_stata_terminal(
+            'do',
+            '/tmp/first.do'
+        );
+        await wait_for_condition(() => {
+            return vscode_state.the_show_calls.length === 1;
+        });
+
+        // Must NOT type into the still-starting Stata yet.
+        expect(vscode_state.the_send_calls).toEqual([]);
+
+        process_id_deferred.resolve(1234);
+        await send_promise;
+
+        expect(vscode_state.the_send_calls).toEqual([
+            "do `\"/tmp/first.do\"'",
+        ]);
+        // No new terminal was created; we reused the profile terminal.
+        expect(vscode_state.create_terminal_calls).toBe(0);
+    });
 });

--- a/tests/integration/send-to-stata-integrated-terminal.test.ts
+++ b/tests/integration/send-to-stata-integrated-terminal.test.ts
@@ -468,4 +468,33 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
         // No new terminal was created; we reused the profile terminal.
         expect(vscode_state.create_terminal_calls).toBe(0);
     });
+
+    test('rejects a send to a profile terminal that closes before ready', async () => {
+        const process_id_deferred = create_deferred<number | undefined>();
+        const vscode_state = create_vscode_mock_state(
+            process_id_deferred.promise
+        );
+        const terminal_manager = await import_terminal_manager_module(
+            vscode_state
+        );
+
+        terminal_manager.simulate_profile_terminal_opened_for_tests(
+            vscode_state.terminal
+        );
+
+        const send_promise = terminal_manager.send_to_stata_terminal(
+            'do',
+            '/tmp/first.do'
+        );
+
+        // Terminal dies during startup, before processId resolves.
+        for (const my_listener of vscode_state.the_close_listeners) {
+            my_listener(vscode_state.terminal);
+        }
+
+        await expect(send_promise).rejects.toThrow(
+            'closed before it was ready'
+        );
+        expect(vscode_state.the_send_calls).toEqual([]);
+    });
 });

--- a/tests/integration/send-to-stata-integrated-terminal.test.ts
+++ b/tests/integration/send-to-stata-integrated-terminal.test.ts
@@ -52,8 +52,15 @@ interface MockTerminal {
     sendText: (text: string) => void;
 }
 
+interface CreateTerminalOptions {
+    name?: string;
+    shellPath?: string;
+    shellArgs?: string[];
+}
+
 interface VscodeMockState {
     create_terminal_calls: number;
+    the_create_options: CreateTerminalOptions[];
     the_close_listeners: Array<(terminal: MockTerminal) => void>;
     the_send_calls: string[];
     the_show_calls: boolean[];
@@ -108,6 +115,7 @@ function create_vscode_mock_state(
 
     return {
         create_terminal_calls: 0,
+        the_create_options: [],
         the_close_listeners,
         the_send_calls,
         the_show_calls,
@@ -162,9 +170,12 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
                 getWorkspaceFolder: () => null,
             },
             window: {
-                createTerminal: () => {
+                createTerminal: (options?: CreateTerminalOptions) => {
                     if (current_vscode_state) {
                         current_vscode_state.create_terminal_calls += 1;
+                        current_vscode_state.the_create_options.push(
+                            options ?? {}
+                        );
                         return current_vscode_state.terminal;
                     }
                     const shared_state = get_shared_vscode_test_state();
@@ -280,7 +291,7 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
         mock.restore();
     });
 
-    test('waits for a new terminal to become ready before sending', async () => {
+    test('bakes the first command into shellArgs and does not type it', async () => {
         const process_id_deferred = create_deferred<number | undefined>();
         const vscode_state = create_vscode_mock_state(
             process_id_deferred.promise
@@ -300,14 +311,19 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
 
         expect(vscode_state.create_terminal_calls).toBe(1);
         expect(vscode_state.the_show_calls).toEqual([true]);
+        // The first command runs via launch args, so Stata executes it
+        // itself after init -- it is never typed into the racing REPL.
+        expect(vscode_state.the_create_options[0].shellArgs).toEqual([
+            'do',
+            "`\"/tmp/first.do\"'",
+        ]);
         expect(vscode_state.the_send_calls).toEqual([]);
 
         process_id_deferred.resolve(1234);
         await send_promise;
 
-        expect(vscode_state.the_send_calls).toEqual([
-            "do `\"/tmp/first.do\"'",
-        ]);
+        // Still no sendText for the baked first command.
+        expect(vscode_state.the_send_calls).toEqual([]);
     });
 
     test('reuses an existing managed terminal without another readiness wait', async () => {
@@ -326,15 +342,22 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
         process_id_deferred.resolve(1234);
         await first_send;
 
+        // First command was baked into shellArgs, not typed.
+        expect(vscode_state.the_send_calls).toEqual([]);
+
         const second_send = terminal_manager.send_to_stata_terminal(
             'include',
             '/tmp/second.do'
         );
         await second_send;
 
+        // Reused terminal: subsequent command IS typed (Stata is ready).
         expect(vscode_state.create_terminal_calls).toBe(1);
+        expect(vscode_state.the_create_options[0].shellArgs).toEqual([
+            'do',
+            "`\"/tmp/first.do\"'",
+        ]);
         expect(vscode_state.the_send_calls).toEqual([
-            "do `\"/tmp/first.do\"'",
             "include `\"/tmp/second.do\"'",
         ]);
     });
@@ -367,8 +390,14 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
         process_id_deferred.resolve(1234);
         await Promise.all([first_send, second_send]);
 
+        // One terminal: the initiating send is baked into shellArgs; the
+        // send that joins the in-flight creation is typed after readiness.
+        expect(vscode_state.create_terminal_calls).toBe(1);
+        expect(vscode_state.the_create_options[0].shellArgs).toEqual([
+            'do',
+            "`\"/tmp/first.do\"'",
+        ]);
         expect(vscode_state.the_send_calls).toEqual([
-            "do `\"/tmp/first.do\"'",
             "include `\"/tmp/second.do\"'",
         ]);
     });

--- a/tests/integration/send-to-stata-real-cli-launch.test.ts
+++ b/tests/integration/send-to-stata-real-cli-launch.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Opt-in regression test for the integrated-terminal "first console
+ * launch" fix.
+ *
+ * The fix bakes the first command into the Stata CLI launch arguments
+ * (`shellArgs: [command, `"<path>"']`) so Stata runs it itself after
+ * initialization, instead of typing it into the freshly-spawned REPL
+ * where it races Stata's startup stdin flush and gets discarded.
+ *
+ * This test exercises the real external contract that the fix depends
+ * on: that launching the actual Stata CLI with the command as launch
+ * arguments actually runs the file (including when the path contains
+ * spaces, which requires Stata's compound-quote form because Stata
+ * joins launch argv with spaces and re-parses them as one command
+ * line).
+ *
+ * It is SKIPPED unless SIGHT_REAL_STATA_CLI points at a Stata console
+ * binary (e.g. /Applications/Stata/StataMP.app/Contents/MacOS/stata-mp
+ * or `stata-mp` on PATH), so CI without Stata stays green. Run with:
+ *
+ *   SIGHT_REAL_STATA_CLI=/path/to/stata-mp bun test \
+ *     tests/integration/send-to-stata-real-cli-launch.test.ts
+ */
+import { afterAll, describe, expect, test } from 'bun:test';
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const STATA_CLI = process.env.SIGHT_REAL_STATA_CLI;
+
+/**
+ * Mirrors wrap_path_for_stata_terminal in the terminal module. Kept
+ * inline so this test does not import the manager (which imports the
+ * 'vscode' module, unavailable outside the extension host).
+ */
+function wrap_path_for_stata(my_path: string): string {
+    return '`"' + my_path + '"' + "'";
+}
+
+const the_temp_dirs: string[] = [];
+
+function make_work_dir(): string {
+    // Include a space to exercise the compound-quote launch-arg path.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sight real cli '));
+    the_temp_dirs.push(dir);
+    return dir;
+}
+
+interface LaunchResult {
+    exit_code: number | null;
+}
+
+function launch_stata_with_command(
+    cli: string,
+    command: string,
+    runner_path: string,
+    cwd: string
+): Promise<LaunchResult> {
+    return new Promise((resolve, reject) => {
+        // Exactly the argv the terminal manager builds for shellArgs.
+        const the_args = [command, wrap_path_for_stata(runner_path)];
+        const child = spawn(cli, the_args, {
+            cwd,
+            // stdin closed: no REPL interaction, so the only way the
+            // marker appears is the launch-arg command running.
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        const timeout = setTimeout(() => {
+            child.kill('SIGKILL');
+            reject(new Error('Stata launch timed out.'));
+        }, 30000);
+        child.on('error', my_error => {
+            clearTimeout(timeout);
+            reject(my_error);
+        });
+        child.on('exit', my_code => {
+            clearTimeout(timeout);
+            resolve({ exit_code: my_code });
+        });
+    });
+}
+
+async function run_first_command(command: string): Promise<boolean> {
+    const work_dir = make_work_dir();
+    const marker_path = path.join(work_dir, 'marker.txt');
+    // Space in the runner filename too, to stress quoting.
+    const runner_path = path.join(work_dir, 'first command.do');
+    const runner_source =
+        `file open f using "${marker_path}", write replace\n` +
+        `file write f "ran" _n\n` +
+        `file close f\n`;
+    fs.writeFileSync(runner_path, runner_source);
+
+    await launch_stata_with_command(
+        STATA_CLI as string,
+        command,
+        runner_path,
+        work_dir
+    );
+    return fs.existsSync(marker_path);
+}
+
+const describe_real_cli = STATA_CLI ? describe : describe.skip;
+
+describe_real_cli(
+    'Feature: real Stata CLI runs the baked first command (opt-in)',
+    () => {
+        afterAll(() => {
+            for (const my_dir of the_temp_dirs) {
+                fs.rmSync(my_dir, { recursive: true, force: true });
+            }
+        });
+
+        test('`do` as a launch argument runs the file', async () => {
+            expect(await run_first_command('do')).toBe(true);
+        });
+
+        test('`include` as a launch argument runs the file', async () => {
+            expect(await run_first_command('include')).toBe(true);
+        });
+    }
+);

--- a/tests/integration/send-to-stata-real-cli-launch.test.ts
+++ b/tests/integration/send-to-stata-real-cli-launch.test.ts
@@ -63,8 +63,10 @@ function launch_stata_with_command(
         const child = spawn(cli, the_args, {
             cwd,
             // stdin closed: no REPL interaction, so the only way the
-            // marker appears is the launch-arg command running.
-            stdio: ['ignore', 'pipe', 'pipe'],
+            // marker appears is the launch-arg command running. stdout/
+            // stderr are ignored (not piped) -- we assert via the marker
+            // file, and unread pipes could fill and block a chatty Stata.
+            stdio: ['ignore', 'ignore', 'ignore'],
         });
         const timeout = setTimeout(() => {
             child.kill('SIGKILL');


### PR DESCRIPTION
## Problem

When sending to the integrated Stata terminal and no Stata terminal is open yet, Sight launches one — but on the **first** send the command was frequently lost: the terminal opened and Stata started, yet the `do`/`include` never ran. Subsequent sends worked.

## Root cause (proven, not guessed)

Stata's console **discards stdin written while it initializes its tty** (a startup flush). I reproduced this against the real `stata-mp` under a pty with a marker-file as ground truth:

| delay after spawn | command ran |
|---|---|
| 0ms, 25ms | 0/6 — always discarded |
| 50ms | 5/6 — flaky edge |
| ≥75ms | 6/6 (warm) |

The previous fix waited only `processId` + a fixed 150ms grace. That cleared the window on a *warm* Stata but not reliably on a *cold first launch* (slower init), so the bug was an intermittent race. The old unit tests mocked `processId` to resolve instantly, so they validated await-ordering but never real startup timing.

## Fix

Bake the first command into the **CLI launch arguments** (`shellArgs: [command, ` + "`" + `"<path>"'` + "`" + `]`) so Stata runs it *itself* after initialization, instead of typing it into the racing REPL. This eliminates the race for the common path rather than widening a timing window. Verified for `do` and `include`, including paths with spaces (Stata joins launch argv with spaces and re-parses as one command line, so the path uses Stata's compound-quote form).

- `get_or_create_stata_terminal` now returns `{ terminal, created_with_initial_command }` so only the creating call skips `sendText`; reused terminals and concurrent joiners type their command after awaiting readiness.
- Profile-opened terminals (user opens "Stata" from the dropdown) can't carry a baked command, so a shared `track_terminal_ready` helper installs a readiness promise when one opens — its first send waits out startup instead of racing it.
- `DEFAULT_TEMP_FILE_CLEANUP_DELAY_MS` raised 5s → 30s: the command is now handed to Stata at launch, so on a slow cold start Stata may read the temp do-file after the old 5s cleanup deleted it.

### Known limitation
VS Code exposes no API for when an arbitrary REPL has finished initializing (shell integration doesn't apply to a raw REPL; terminal-output reading is proposed-API only). So **typed** sends (reused terminal, rapid second send, profile-opened terminal) remain a best-effort `processId` + grace heuristic — documented in code. The common first-send path is fully deterministic.

## Tests
- Updated the integrated-terminal tests for the baked-shellArgs behavior; added profile-opened readiness + close-before-ready coverage.
- New **opt-in** real-CLI regression test (`SIGHT_REAL_STATA_CLI=…`) that exercises actual Stata startup timing (skipped in CI). Passes locally against `stata-mp` for `do` and `include` with spaced paths.
- Full suite: 6004 pass, 0 fail; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stata commands launched from the integrated terminal now start more reliably, including when using the Stata profile terminal.
  * Temporary Stata files are kept available longer during startup to better support slower or first-time launches.

* **Bug Fixes**
  * Fixed cases where the first command could be sent too early or duplicated.
  * Improved handling when a Stata terminal is opened before it is fully ready, reducing failed sends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->