### PR TITLE
feat(data-browser): alias browse abbreviations (brows/brow/bro/br) to vview

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The editor extension enables language server features and further provides:
 - **[Run Code](docs/send-to-stata.md)**: Execute code in the Stata application or terminal with intelligent statement detection and working directory management
 - **[Syntax Highlighting](docs/syntax-highlighting.md)**: Rich syntax highlighting with unique features like macro/string nesting depth coloring
 - **[Auto-Closing Pairs](docs/quote-auto-close.md)**: Intelligently handles Stata's unique conventions for nested macros and compound strings
-- **[Data Browser](docs/data-browser.md)**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels. In console Stata, `browse` works as an alias for `vview` (the GUI's built-in `browse` is unaffected)
+- **[Data Browser](docs/data-browser.md)**: Open `.dta` files directly in VS Code, or call `vview` from Stata to send the current dataset to the editor — features a virtualized grid with column resizing/hiding and value labels. In console Stata, `browse` (and its abbreviations `brows`/`brow`/`bro`/`br`) works as an alias for `vview` (the GUI's built-in `browse` is unaffected)
 - **[Log Viewer](docs/log-viewer.md)**: Render Stata log files (`.smcl`) with formatted output directly in VS Code
 - **[Help Viewer](docs/help-viewer.md)**: Read Stata help files (`.sthlp`) directly in VS Code with clickable help-topic links
 - **[Code Formatting](docs/formatting.md)** (experimental): Format `.do` files and normalize comment styles

--- a/client/package.json
+++ b/client/package.json
@@ -734,7 +734,7 @@
     "bundle": "bunx esbuild src/extension.ts --bundle --platform=node --format=cjs --outfile=dist/extension.js --external:vscode --minify && node -e \"require('fs').writeFileSync('dist/package.json', '{\\\"type\\\":\\\"commonjs\\\"}')\"",
     "bundle:webview": "bunx esbuild src/data-browser/webview/index.tsx --bundle --platform=browser --format=iife --outfile=dist/data-browser-webview/index.js --loader:.css=css --minify",
     "bundle:webview-test": "bunx esbuild src/data-browser/webview/test-harness/index.tsx --bundle --platform=browser --format=iife --outfile=dist-test/toolbar-wrap-harness/index.js --loader:.css=css",
-    "copy-vview-ado": "mkdir -p stata && cp ../stata/*.ado stata/",
+    "copy-vview-ado": "rm -rf stata && mkdir -p stata && cp ../stata/*.ado stata/",
     "copy-server": "rm -rf server && mkdir -p server/command-database && bunx esbuild ../dist/server.js --bundle --platform=node --format=cjs --outfile=server/server.js --external:vscode --external:node:* --minify && cp -r ../dist/command-database/caches server/command-database/ && node -e \"require('fs').writeFileSync('server/package.json', '{\\\"type\\\":\\\"commonjs\\\"}')\"",
     "compile": "bun run copy-vview-ado && bun run bundle && bun run bundle:webview",
     "watch": "tsc -watch -p ./",

--- a/client/package.json
+++ b/client/package.json
@@ -734,7 +734,7 @@
     "bundle": "bunx esbuild src/extension.ts --bundle --platform=node --format=cjs --outfile=dist/extension.js --external:vscode --minify && node -e \"require('fs').writeFileSync('dist/package.json', '{\\\"type\\\":\\\"commonjs\\\"}')\"",
     "bundle:webview": "bunx esbuild src/data-browser/webview/index.tsx --bundle --platform=browser --format=iife --outfile=dist/data-browser-webview/index.js --loader:.css=css --minify",
     "bundle:webview-test": "bunx esbuild src/data-browser/webview/test-harness/index.tsx --bundle --platform=browser --format=iife --outfile=dist-test/toolbar-wrap-harness/index.js --loader:.css=css",
-    "copy-vview-ado": "mkdir -p stata && cp ../stata/vview.ado stata/vview.ado && cp ../stata/browse.ado stata/browse.ado",
+    "copy-vview-ado": "mkdir -p stata && cp ../stata/*.ado stata/",
     "copy-server": "rm -rf server && mkdir -p server/command-database && bunx esbuild ../dist/server.js --bundle --platform=node --format=cjs --outfile=server/server.js --external:vscode --external:node:* --minify && cp -r ../dist/command-database/caches server/command-database/ && node -e \"require('fs').writeFileSync('server/package.json', '{\\\"type\\\":\\\"commonjs\\\"}')\"",
     "compile": "bun run copy-vview-ado && bun run bundle && bun run bundle:webview",
     "watch": "tsc -watch -p ./",

--- a/client/package.json
+++ b/client/package.json
@@ -365,7 +365,7 @@
         "sight.personalAdoDir": {
           "type": "string",
           "default": "",
-          "description": "Path where Sight installs vview.ado. Leave empty for the platform default (macOS: ~/ado/, Linux: ~/ado/personal/, Windows: %USERPROFILE%\\ado\\personal\\)."
+          "description": "Path where Sight installs its Stata commands. Leave empty for the platform default (macOS: ~/ado/, Linux: ~/ado/personal/, Windows: %USERPROFILE%\\ado\\personal\\)."
         },
         "sight.dataBrowser.maxStoredLayouts": {
           "type": "number",
@@ -503,7 +503,7 @@
       },
       {
         "command": "sight.installVviewAdo",
-        "title": "Sight: Install Stata Commands (vview, browse)"
+        "title": "Sight: Install Stata Commands"
       },
       {
         "command": "sight.resetVviewInstallPermission",
@@ -511,7 +511,7 @@
       },
       {
         "command": "sight.uninstallStataCommands",
-        "title": "Sight: Uninstall Stata Commands (vview, browse)"
+        "title": "Sight: Uninstall Stata Commands"
       }
     ],
     "keybindings": [
@@ -734,7 +734,7 @@
     "bundle": "bunx esbuild src/extension.ts --bundle --platform=node --format=cjs --outfile=dist/extension.js --external:vscode --minify && node -e \"require('fs').writeFileSync('dist/package.json', '{\\\"type\\\":\\\"commonjs\\\"}')\"",
     "bundle:webview": "bunx esbuild src/data-browser/webview/index.tsx --bundle --platform=browser --format=iife --outfile=dist/data-browser-webview/index.js --loader:.css=css --minify",
     "bundle:webview-test": "bunx esbuild src/data-browser/webview/test-harness/index.tsx --bundle --platform=browser --format=iife --outfile=dist-test/toolbar-wrap-harness/index.js --loader:.css=css",
-    "copy-vview-ado": "rm -rf stata && mkdir -p stata && cp ../stata/*.ado stata/",
+    "copy-vview-ado": "mkdir -p stata && rm -f stata/*.ado && cp ../stata/*.ado stata/",
     "copy-server": "rm -rf server && mkdir -p server/command-database && bunx esbuild ../dist/server.js --bundle --platform=node --format=cjs --outfile=server/server.js --external:vscode --external:node:* --minify && cp -r ../dist/command-database/caches server/command-database/ && node -e \"require('fs').writeFileSync('server/package.json', '{\\\"type\\\":\\\"commonjs\\\"}')\"",
     "compile": "bun run copy-vview-ado && bun run bundle && bun run bundle:webview",
     "watch": "tsc -watch -p ./",

--- a/client/src/data-browser/index.ts
+++ b/client/src/data-browser/index.ts
@@ -232,7 +232,8 @@ function register_vview_install_commands(
                     );
                 if (my_installed) {
                     void vscode.window.showInformationMessage(
-                        'Sight\'s Stata commands (vview, browse) '
+                        'Sight\'s Stata commands (vview, browse, and '
+                        + 'the browse abbreviations br/bro/brow/brows) '
                         + 'are installed and ready.'
                     );
                     return;
@@ -272,7 +273,8 @@ function register_vview_install_commands(
                     );
                 if (my_ok) {
                     void vscode.window.showInformationMessage(
-                        'Sight\'s Stata commands (vview, browse) '
+                        'Sight\'s Stata commands (vview, browse, and '
+                        + 'the browse abbreviations br/bro/brow/brows) '
                         + 'were removed (Sight-owned files only).'
                     );
                     return;

--- a/client/src/data-browser/index.ts
+++ b/client/src/data-browser/index.ts
@@ -418,8 +418,9 @@ export async function prompt_for_stata_commands_install(
             'Would you like to add Sight\'s Stata commands '
             + '("vview" and "browse") to Stata?\n\n'
             + '"vview" opens datasets in VS Code; in console '
-            + 'Stata, "browse" becomes an alias for it (the GUI '
-            + 'built-in "browse" is unaffected).\n\n'
+            + 'Stata, "browse" (and its abbreviations "brows", '
+            + '"brow", "bro", "br") becomes an alias for it (the '
+            + 'GUI built-in "browse" is unaffected).\n\n'
             + `Install location: ${target_dir}`,
             INSTALL_BUTTON,
             NOT_NOW_BUTTON

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -544,13 +544,17 @@ export async function ensure_bundle_installed<
     }
 
     const my_installed = my_install(my_status, log);
-    if (!my_installed) {
-        return false;
-    }
-
+    // Record the user's consent once they choose Install, even if a
+    // single asset write fails (e.g. a transient EACCES). 'granted'
+    // tracks the consent decision, not write success: otherwise one
+    // failed file among the bundle would re-prompt on every startup
+    // although the others installed fine. The next startup's install
+    // check retries the still-missing/outdated file without prompting
+    // (permission is granted). The boolean result still reflects the
+    // actual write outcome for the caller's success/failure message.
     await my_set_permission(context, 'granted');
-    log('Stata commands: permission granted');
-    return true;
+    log('Stata commands: permission granted (user consented to install)');
+    return my_installed;
 }
 
 export async function install_bundle_manually<
@@ -593,13 +597,13 @@ export async function install_bundle_manually<
     }
 
     const my_installed = my_install(my_status, log);
-    if (!my_installed) {
-        return false;
-    }
-
+    // As in ensure_bundle_installed: a manual install is an explicit
+    // consent, so record 'granted' even on a partial write failure so
+    // the auto-install check does not start re-prompting. The result
+    // still reflects the actual write outcome.
     await my_set_permission(context, 'granted');
-    log('Stata commands: permission granted');
-    return true;
+    log('Stata commands: permission granted (manual install)');
+    return my_installed;
 }
 
 // Remove Sight-owned ado files and clear the remembered permission.

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -59,10 +59,10 @@ export const ADO_ASSET_DEFS: AdoAssetDef[] = [
             '*! browse.ado — CLI alias for vview (Sight Data Browser)',
         protect_foreign: true,
     },
-    // Standard Stata abbreviations of `browse`. Like `browse`, each is a
-    // generic built-in name (in the GUI, the built-in command and its
-    // abbreviations shadow these ados), so a user's own same-named file
-    // must be protected.
+    // Standard Stata abbreviations of `browse`. Like `browse`, each
+    // is a generic built-in name (in the GUI, the built-in command
+    // and its abbreviations shadow these ados), so a user's own
+    // same-named file must be protected.
     {
         name: 'brows.ado',
         marker:

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -59,6 +59,34 @@ export const ADO_ASSET_DEFS: AdoAssetDef[] = [
             '*! browse.ado — CLI alias for vview (Sight Data Browser)',
         protect_foreign: true,
     },
+    // Standard Stata abbreviations of `browse`. Like `browse`, each is a
+    // generic built-in name (in the GUI, the built-in command and its
+    // abbreviations shadow these ados), so a user's own same-named file
+    // must be protected.
+    {
+        name: 'brows.ado',
+        marker:
+            '*! brows.ado — CLI alias for vview (Sight Data Browser)',
+        protect_foreign: true,
+    },
+    {
+        name: 'brow.ado',
+        marker:
+            '*! brow.ado — CLI alias for vview (Sight Data Browser)',
+        protect_foreign: true,
+    },
+    {
+        name: 'bro.ado',
+        marker:
+            '*! bro.ado — CLI alias for vview (Sight Data Browser)',
+        protect_foreign: true,
+    },
+    {
+        name: 'br.ado',
+        marker:
+            '*! br.ado — CLI alias for vview (Sight Data Browser)',
+        protect_foreign: true,
+    },
 ];
 
 // Description of one bundled ado file.

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -544,17 +544,13 @@ export async function ensure_bundle_installed<
     }
 
     const my_installed = my_install(my_status, log);
-    // Record the user's consent once they choose Install, even if a
-    // single asset write fails (e.g. a transient EACCES). 'granted'
-    // tracks the consent decision, not write success: otherwise one
-    // failed file among the bundle would re-prompt on every startup
-    // although the others installed fine. The next startup's install
-    // check retries the still-missing/outdated file without prompting
-    // (permission is granted). The boolean result still reflects the
-    // actual write outcome for the caller's success/failure message.
+    if (!my_installed) {
+        return false;
+    }
+
     await my_set_permission(context, 'granted');
-    log('Stata commands: permission granted (user consented to install)');
-    return my_installed;
+    log('Stata commands: permission granted');
+    return true;
 }
 
 export async function install_bundle_manually<
@@ -597,13 +593,13 @@ export async function install_bundle_manually<
     }
 
     const my_installed = my_install(my_status, log);
-    // As in ensure_bundle_installed: a manual install is an explicit
-    // consent, so record 'granted' even on a partial write failure so
-    // the auto-install check does not start re-prompting. The result
-    // still reflects the actual write outcome.
+    if (!my_installed) {
+        return false;
+    }
+
     await my_set_permission(context, 'granted');
-    log('Stata commands: permission granted (manual install)');
-    return my_installed;
+    log('Stata commands: permission granted');
+    return true;
 }
 
 // Remove Sight-owned ado files and clear the remembered permission.

--- a/client/stata/br.ado
+++ b/client/stata/br.ado
@@ -1,0 +1,20 @@
+*! br.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! `br` is a standard Stata abbreviation of `browse`. In the Stata GUI, the
+*! built-in `browse` command (and its abbreviations) shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
+
+program define br
+    version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "br: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
+    vview `0'
+end

--- a/client/stata/bro.ado
+++ b/client/stata/bro.ado
@@ -1,0 +1,20 @@
+*! bro.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! `bro` is a standard Stata abbreviation of `browse`. In the Stata GUI, the
+*! built-in `browse` command (and its abbreviations) shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
+
+program define bro
+    version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "bro: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
+    vview `0'
+end

--- a/client/stata/brow.ado
+++ b/client/stata/brow.ado
@@ -1,0 +1,20 @@
+*! brow.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! `brow` is a standard Stata abbreviation of `browse`. In the Stata GUI, the
+*! built-in `browse` command (and its abbreviations) shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
+
+program define brow
+    version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "brow: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
+    vview `0'
+end

--- a/client/stata/brows.ado
+++ b/client/stata/brows.ado
@@ -1,0 +1,20 @@
+*! brows.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! `brows` is a standard Stata abbreviation of `browse`. In the Stata GUI, the
+*! built-in `browse` command (and its abbreviations) shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
+
+program define brows
+    version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "brows: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
+    vview `0'
+end

--- a/docs/data-browser.md
+++ b/docs/data-browser.md
@@ -62,8 +62,10 @@ permission.
 
 On macOS, Sight defaults to `OLDPLACE` (`~/ado/`) rather than `PERSONAL` to avoid sandbox-related writes into `~/Documents/Stata/...`.
 
-If you already have your own `browse.ado` on the ado-path, Sight leaves it
-untouched and installs only `vview.ado`.
+If you already have your own copy of any of the generic command names
+(`browse`, `brows`, `brow`, `bro`, `br`) on the ado-path, Sight leaves that
+file untouched and installs only the ones it owns (`vview.ado` is always
+installed, since `vview` is Sight's own command name).
 
 You can override the install location with the `sight.personalAdoDir` setting, or manually install with the **Sight: Install Stata Commands (vview, browse)** command from the Command Palette.
 

--- a/docs/data-browser.md
+++ b/docs/data-browser.md
@@ -225,4 +225,4 @@ With the default limit of 10,000 entries and ~3-4 alias keys per dataset, this a
 | `sight.dataBrowser.persistSort` | `true` | Remember and restore the row sort per dataset (matching shape) |
 | `sight.dataBrowser.persistFilters` | `true` | Remember and restore the row filters per dataset (matching shape) |
 | `sight.dataBrowser.maxStoredLayouts` | `10000` | Maximum stored layout entries (see above) |
-| `sight.personalAdoDir` | (platform default) | Path where Sight installs `vview.ado` |
+| `sight.personalAdoDir` | (platform default) | Path where Sight installs its Stata commands |

--- a/docs/data-browser.md
+++ b/docs/data-browser.md
@@ -41,15 +41,19 @@ resolved before any ado-file on your path, so the native Data Editor opens
 exactly as before; Sight's `browse.ado` never runs. The alias also guards on
 `c(console)` as a safeguard.
 
-Only the exact command `browse` is aliased — abbreviations such as `br` and
-`bro` are not (Stata does not abbreviate ado-file command names). Because the
-alias forwards to `vview`, only `vview`'s options apply; native-`browse`-only
-options such as `nolabel` are not supported in the CLI.
+The standard abbreviations of `browse` — `brows`, `brow`, `bro`, and `br` —
+are aliased too. Stata does not auto-abbreviate ado-file command names, so
+Sight ships a small forwarder ado for each (`br.ado`, `bro.ado`, etc.). In the
+GUI, the built-in `browse` command and its abbreviations are resolved first,
+so all of these still open the native Data Editor; in the CLI they forward to
+`vview`. Because the alias forwards to `vview`, only `vview`'s options apply;
+native-`browse`-only options such as `nolabel` are not supported in the CLI.
 
 ### Installation
 
-Sight automatically installs its Stata commands (`vview.ado` and `browse.ado`)
-the first time the extension activates. You'll see a one-time prompt asking for
+Sight automatically installs its Stata commands (`vview.ado`, `browse.ado`,
+and the `browse` abbreviation forwarders `brows`/`brow`/`bro`/`br`) the first
+time the extension activates. You'll see a one-time prompt asking for
 permission.
 
 - **macOS**: `~/ado/`

--- a/docs/data-browser.md
+++ b/docs/data-browser.md
@@ -67,9 +67,9 @@ If you already have your own copy of any of the generic command names
 file untouched and installs only the ones it owns (`vview.ado` is always
 installed, since `vview` is Sight's own command name).
 
-You can override the install location with the `sight.personalAdoDir` setting, or manually install with the **Sight: Install Stata Commands (vview, browse)** command from the Command Palette.
+You can override the install location with the `sight.personalAdoDir` setting, or manually install with the **Sight: Install Stata Commands** command from the Command Palette.
 
-To re-trigger the install prompt (e.g., after declining), run **Sight: Reset Stata Commands Install Permission** from the Command Palette. To remove the installed files (Sight-owned copies only), run **Sight: Uninstall Stata Commands (vview, browse)**.
+To re-trigger the install prompt (e.g., after declining), run **Sight: Reset Stata Commands Install Permission** from the Command Palette. To remove the installed files (Sight-owned copies only), run **Sight: Uninstall Stata Commands**.
 
 ### How It Works
 

--- a/docs/superpowers/specs/2026-06-26-browse-abbreviations-design.md
+++ b/docs/superpowers/specs/2026-06-26-browse-abbreviations-design.md
@@ -1,0 +1,98 @@
+# `browse` abbreviations (`brows`/`brow`/`bro`/`br`) as CLI aliases for `vview`
+
+**Date:** 2026-06-26
+**Status:** Approved (follow-up to the browse CLI alias feature)
+
+## Problem
+
+PR #211 added `browse` as a CLI alias for `vview` in console Stata. Stata
+users habitually abbreviate `browse` to `brows`, `brow`, `bro`, or `br`. The
+original design
+([2026-06-26-browse-cli-alias-design.md](2026-06-26-browse-cli-alias-design.md))
+placed these abbreviations **out of scope** (finding 2), reasoning that Stata
+does not auto-abbreviate ado-file command names and that claiming additional
+built-in-abbreviation names was "riskier and broader than the request."
+
+This follow-up reverses that decision after empirical verification.
+
+## Empirical findings (StataMP 18, 2026-06-26)
+
+Probe ado files (`br.ado`, `bro.ado`, `brow.ado`, `brows.ado`) were placed in
+`~/ado` and `which` was run in both modes:
+
+- **GUI** (`c(console)` is empty): `which br`, `which bro`, `which brow`,
+  `which brows`, and `which browse` all report **`built-in command: browse`**.
+  The built-in command resolution — including the built-in's abbreviations —
+  shadows the same-named ado files on the path. The native Data Editor is
+  unaffected.
+- **Console** (`c(console)` is `"console"`): `which br`, `which bro`,
+  `which brow`, `which brows` each resolve to the corresponding `~/ado/*.ado`.
+  There is no built-in `browse` in the CLI, so each abbreviation ado is found
+  on the ado-path and forwards to `vview`.
+
+Conclusion: the same GUI/CLI split that makes `browse.ado` safe applies to its
+abbreviation ados. The risk cited in the original "out of scope" note does not
+materialize: the GUI built-in always wins.
+
+## Mechanism
+
+Ship four additional ados — `br.ado`, `bro.ado`, `brow.ado`, `brows.ado` —
+each a clone of `browse.ado`:
+
+- `version 16.0`,
+- the `c(console)` guard (defense-in-depth; in the GUI `c(console)` is empty,
+  so a hypothetical GUI mis-resolution errors loudly instead of hijacking),
+- a pure `vview \`0'` forwarder (forwards directly to `vview`, independent of
+  `browse.ado`),
+- a guard error message naming the **typed** command (e.g. `"br: the Sight
+  alias runs only in console Stata; …"`),
+- a stable first-line ownership marker
+  `*! <name>.ado — CLI alias for vview (Sight Data Browser)`.
+
+## Installation
+
+The install machinery in `client/src/data-browser/vview-install-core.ts` is
+already data-driven over `ADO_ASSET_DEFS`. Append four entries, all
+`protect_foreign: true` — `br`/`bro`/`brow`/`brows` are generic abbreviation
+names a user or community command might own, so a non-Sight same-named file is
+classified `foreign` and never overwritten. Uninstall removes only Sight-owned
+copies (ownership-marker match), as before.
+
+`vview`[0] and `browse`[1] stay first in the array so the index-based install
+tests remain valid; abbreviations occupy indices [2]–[5]. No install/uninstall/
+aggregate-state logic changes — only the asset list grows.
+
+## Bundling
+
+`stata/<name>.ado` are the canonical sources; `client/stata/<name>.ado` are
+generated copies. Generalize the `copy-vview-ado` script in
+`client/package.json` to copy `../stata/*.ado` (glob) rather than listing each
+file, so the set never drifts as files are added.
+
+## Tests
+
+- `tests/unit/data-browser/vview-bundled-asset.test.ts`: for each abbreviation
+  ado, assert it is bundled (the `client/stata` copy matches the canonical
+  source), is a pure `vview \`0'` forwarder, carries the `c(console)` guard,
+  and has its stable first-line marker. The existing "ado ownership markers"
+  loop already iterates `ADO_ASSET_DEFS`, so it covers the new markers.
+- `tests/unit/data-browser/vview-install.test.ts`: generalize the "writes both
+  files" test to assert every bundled file is written under one granted
+  permission.
+
+## Docs
+
+- `docs/data-browser.md`: replace the paragraph stating abbreviations are *not*
+  aliased with the new behavior — the standard abbreviations `brows`/`brow`/
+  `bro`/`br` alias `vview` in console Stata, while the GUI built-in (and its
+  abbreviations) opens the native Data Editor unchanged.
+- `README.md`: minor mention alongside the existing `browse` CLI alias line.
+
+## Out of scope / noted
+
+- **Install location.** Sight installs to `~/ado`, which Stata 18 lists as
+  `OLDPLACE` (not `PERSONAL` = `~/Documents/Stata/ado/personal/`). It is on the
+  ado-path and works; this is pre-existing and unchanged here.
+- No change to `vview.ado` or to `browse.ado`.
+- Native-`browse`-only options (e.g. `nolabel`) still surface as `vview`
+  syntax errors, as documented for the `browse` alias.

--- a/stata/br.ado
+++ b/stata/br.ado
@@ -1,0 +1,20 @@
+*! br.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! `br` is a standard Stata abbreviation of `browse`. In the Stata GUI, the
+*! built-in `browse` command (and its abbreviations) shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
+
+program define br
+    version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "br: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
+    vview `0'
+end

--- a/stata/bro.ado
+++ b/stata/bro.ado
@@ -1,0 +1,20 @@
+*! bro.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! `bro` is a standard Stata abbreviation of `browse`. In the Stata GUI, the
+*! built-in `browse` command (and its abbreviations) shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
+
+program define bro
+    version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "bro: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
+    vview `0'
+end

--- a/stata/brow.ado
+++ b/stata/brow.ado
@@ -1,0 +1,20 @@
+*! brow.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! `brow` is a standard Stata abbreviation of `browse`. In the Stata GUI, the
+*! built-in `browse` command (and its abbreviations) shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
+
+program define brow
+    version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "brow: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
+    vview `0'
+end

--- a/stata/brows.ado
+++ b/stata/brows.ado
@@ -1,0 +1,20 @@
+*! brows.ado — CLI alias for vview (Sight Data Browser)
+*! Version 0.1.0
+*!
+*! `brows` is a standard Stata abbreviation of `browse`. In the Stata GUI, the
+*! built-in `browse` command (and its abbreviations) shadows this ado, so the
+*! native Data Editor is unaffected. In console Stata, `browse` is
+*! unrecognized, so this ado is found on the ado-path and forwards to vview.
+*! The c(console) guard makes the console-only intent explicit and ensures
+*! that, should the GUI ever reach this ado, it errors clearly rather than
+*! silently replacing native browse.
+
+program define brows
+    version 16.0
+    if (`"`c(console)'"' != "console") {
+        di as err "brows: the Sight alias runs only in console Stata; " ///
+            "use the built-in Data Editor in the GUI"
+        exit 199
+    }
+    vview `0'
+end

--- a/tests/unit/data-browser/vview-bundled-asset.test.ts
+++ b/tests/unit/data-browser/vview-bundled-asset.test.ts
@@ -271,19 +271,19 @@ describe('bundled ado set reconciliation', () => {
             .filter((my_name) => my_name.endsWith('.ado'))
             .sort();
 
-    const the_def_names = ADO_ASSET_DEFS.map(
+    const expected_ado_names = ADO_ASSET_DEFS.map(
         (my_def) => my_def.name
     ).sort();
 
     it('matches the canonical stata/ directory', () => {
         expect(
             list_ados(path.join(REPO_ROOT, 'stata'))
-        ).toEqual(the_def_names);
+        ).toEqual(expected_ado_names);
     });
 
     it('matches the bundled client/stata/ directory', () => {
         expect(
             list_ados(path.join(REPO_ROOT, 'client', 'stata'))
-        ).toEqual(the_def_names);
+        ).toEqual(expected_ado_names);
     });
 });

--- a/tests/unit/data-browser/vview-bundled-asset.test.ts
+++ b/tests/unit/data-browser/vview-bundled-asset.test.ts
@@ -257,3 +257,33 @@ describe('ado ownership markers', () => {
         }
     });
 });
+
+describe('bundled ado set reconciliation', () => {
+    // The copy-vview-ado script globs `../stata/*.ado` into client/stata,
+    // and the installer is driven only by ADO_ASSET_DEFS. These must
+    // agree in both directions: an unregistered .ado dropped into stata/
+    // would ship in the extension yet never install/uninstall, and a def
+    // without a source file would abort the whole bundle install. Assert
+    // the three sets are identical so neither drift slips through.
+    const list_ados = (dir: string): string[] =>
+        fs
+            .readdirSync(dir)
+            .filter((my_name) => my_name.endsWith('.ado'))
+            .sort();
+
+    const the_def_names = ADO_ASSET_DEFS.map(
+        (my_def) => my_def.name
+    ).sort();
+
+    it('matches the canonical stata/ directory', () => {
+        expect(
+            list_ados(path.join(REPO_ROOT, 'stata'))
+        ).toEqual(the_def_names);
+    });
+
+    it('matches the bundled client/stata/ directory', () => {
+        expect(
+            list_ados(path.join(REPO_ROOT, 'client', 'stata'))
+        ).toEqual(the_def_names);
+    });
+});

--- a/tests/unit/data-browser/vview-bundled-asset.test.ts
+++ b/tests/unit/data-browser/vview-bundled-asset.test.ts
@@ -158,6 +158,90 @@ describe('bundled browse alias asset', () => {
     });
 });
 
+describe('bundled browse-abbreviation alias assets', () => {
+    // `browse` can be abbreviated to `brows`/`brow`/`bro`/`br`; each
+    // abbreviation ships its own forwarder ado, since Stata does not
+    // auto-abbreviate ado command names.
+    const THE_ABBREVIATIONS = [
+        'brows',
+        'brow',
+        'bro',
+        'br',
+    ];
+
+    for (const my_abbrev of THE_ABBREVIATIONS) {
+        const my_file_name = `${my_abbrev}.ado`;
+        const my_source_path = path.join(
+            REPO_ROOT,
+            'stata',
+            my_file_name
+        );
+
+        const load_source = (): string =>
+            fs.readFileSync(my_source_path, 'utf-8');
+
+        describe(my_file_name, () => {
+            it('matches the source file in client/stata', () => {
+                const my_client_asset_path = path.join(
+                    REPO_ROOT,
+                    'client',
+                    'stata',
+                    my_file_name
+                );
+
+                expect(fs.existsSync(my_source_path)).toBe(true);
+                expect(
+                    fs.existsSync(my_client_asset_path)
+                ).toBe(true);
+                expect(
+                    fs.readFileSync(
+                        my_client_asset_path,
+                        'utf-8'
+                    )
+                ).toBe(load_source());
+            });
+
+            it('is a pure vview forwarder', () => {
+                const my_source = load_source();
+
+                expect(my_source).toContain(
+                    `program define ${my_abbrev}`
+                );
+                expect(my_source).toContain('vview `0\'');
+            });
+
+            it('guards on console mode so the GUI built-in is never replaced', () => {
+                const my_source = load_source();
+
+                expect(my_source).toContain(
+                    '`"`c(console)\'"\' != "console"'
+                );
+                expect(my_source).toContain('exit 199');
+            });
+
+            it('names the typed command in its guard message', () => {
+                const my_source = load_source();
+
+                expect(my_source).toContain(
+                    `di as err "${my_abbrev}: the Sight alias `
+                );
+            });
+
+            it('carries the stable Sight ownership marker on its first line', () => {
+                const my_first_line = load_source().split(
+                    '\n',
+                    1
+                )[0];
+
+                expect(my_first_line).toBe(
+                    `*! ${my_file_name} — CLI alias for vview `
+                    + '(Sight Data Browser)'
+                );
+            });
+        });
+    }
+});
+
 describe('ado ownership markers', () => {
     it('each marker equals the first line of its canonical ado', () => {
         // Ownership detection must use the FULL banner line, not a

--- a/tests/unit/data-browser/vview-install.test.ts
+++ b/tests/unit/data-browser/vview-install.test.ts
@@ -837,3 +837,156 @@ describe('bundle uninstall', () => {
         ).toBeUndefined();
     });
 });
+
+// The four `browse` abbreviation forwarders share `browse`'s generic-name
+// ownership posture. build_bundle models only vview+browse, so these
+// data-driven tests exercise install-write, foreign protection, and
+// ownership-gated uninstall directly over the production abbreviation defs.
+describe('browse-abbreviation bundle assets', () => {
+    const THE_ABBREV_DEFS = ADO_ASSET_DEFS.filter((my_def) =>
+        ['brows.ado', 'brow.ado', 'bro.ado', 'br.ado'].includes(
+            my_def.name
+        )
+    );
+
+    function make_abbrev_asset(
+        def: (typeof ADO_ASSET_DEFS)[number],
+        target_dir: string,
+        extra: Partial<AdoAssetStatus> = {}
+    ): AdoAssetStatus {
+        const my_asset: AdoAsset = {
+            name: def.name,
+            target_path: path.join(target_dir, def.name),
+            bundled_path: path.join('/bundle', def.name),
+            bundled_content: `${def.marker}\nprogram define x\nend\n`,
+            marker: def.marker,
+            protect_foreign: def.protect_foreign,
+        };
+        return {
+            ...my_asset,
+            ...extra,
+            state:
+                extra.state
+                ?? classify_ado_asset(my_asset, () => {}),
+        };
+    }
+
+    it('ships all four standard abbreviations as protected assets', () => {
+        expect(THE_ABBREV_DEFS.map((my_def) => my_def.name)).toEqual([
+            'brows.ado',
+            'brow.ado',
+            'bro.ado',
+            'br.ado',
+        ]);
+        for (const my_def of THE_ABBREV_DEFS) {
+            // Generic built-in names: a user's own copy must be protected.
+            expect(my_def.protect_foreign).toBe(true);
+        }
+    });
+
+    for (const my_def of THE_ABBREV_DEFS) {
+        describe(my_def.name, () => {
+            it('writes a missing target on install', () => {
+                const my_dir = create_temp_dir();
+                const my_asset = make_abbrev_asset(my_def, my_dir);
+                expect(my_asset.state).toBe('missing');
+
+                expect(
+                    install_bundle(
+                        {
+                            state: 'missing',
+                            target_dir: my_dir,
+                            assets: [my_asset],
+                        },
+                        () => {}
+                    )
+                ).toBe(true);
+                expect(
+                    fs.readFileSync(
+                        path.join(my_dir, my_def.name),
+                        'utf-8'
+                    )
+                ).toBe(my_asset.bundled_content);
+            });
+
+            it('never overwrites a foreign file and leaves it intact', () => {
+                const my_dir = create_temp_dir();
+                const my_foreign =
+                    `*! my own ${my_def.name}\nprogram define x\nend\n`;
+                fs.writeFileSync(
+                    path.join(my_dir, my_def.name),
+                    my_foreign
+                );
+
+                const my_asset = make_abbrev_asset(my_def, my_dir);
+                expect(my_asset.state).toBe('foreign');
+
+                expect(
+                    install_bundle(
+                        {
+                            state: 'up_to_date',
+                            target_dir: my_dir,
+                            assets: [my_asset],
+                        },
+                        () => {}
+                    )
+                ).toBe(true);
+                expect(
+                    fs.readFileSync(
+                        path.join(my_dir, my_def.name),
+                        'utf-8'
+                    )
+                ).toBe(my_foreign);
+            });
+
+            it('uninstall removes a Sight-owned copy but not a foreign one', () => {
+                const my_owned_dir = create_temp_dir();
+                const my_owned = make_abbrev_asset(
+                    my_def,
+                    my_owned_dir
+                );
+                fs.writeFileSync(
+                    path.join(my_owned_dir, my_def.name),
+                    my_owned.bundled_content as string
+                );
+                uninstall_bundle(
+                    {
+                        state: 'up_to_date',
+                        target_dir: my_owned_dir,
+                        assets: [my_owned],
+                    },
+                    () => {}
+                );
+                expect(
+                    fs.existsSync(
+                        path.join(my_owned_dir, my_def.name)
+                    )
+                ).toBe(false);
+
+                const my_foreign_dir = create_temp_dir();
+                const my_foreign =
+                    `*! my own ${my_def.name}\nprogram define x\nend\n`;
+                fs.writeFileSync(
+                    path.join(my_foreign_dir, my_def.name),
+                    my_foreign
+                );
+                uninstall_bundle(
+                    {
+                        state: 'up_to_date',
+                        target_dir: my_foreign_dir,
+                        assets: [
+                            make_abbrev_asset(my_def, my_foreign_dir),
+                        ],
+                    },
+                    () => {}
+                );
+                expect(
+                    fs.readFileSync(
+                        path.join(my_foreign_dir, my_def.name),
+                        'utf-8'
+                    )
+                ).toBe(my_foreign);
+            });
+        });
+    }
+});

--- a/tests/unit/data-browser/vview-install.test.ts
+++ b/tests/unit/data-browser/vview-install.test.ts
@@ -526,12 +526,7 @@ describe('bundle install orchestration', () => {
         ).toBeUndefined();
     });
 
-    it('stores granted permission even if a write fails after approval', async () => {
-        // Consent is the user's decision to install, not whether every
-        // asset write succeeded. Recording 'granted' on a partial
-        // failure stops the auto-check from re-prompting on every
-        // startup; the next check silently retries the failed file.
-        // The boolean result still reports the write failure.
+    it('does not store granted permission if install fails after approval', async () => {
         const my_dir = create_temp_dir();
         const my_context = create_context();
 
@@ -553,7 +548,7 @@ describe('bundle install orchestration', () => {
                 my_context,
                 PERMISSION_KEY
             )
-        ).toBe('granted');
+        ).toBeUndefined();
     });
 
     it('silently updates an outdated install after prior approval', async () => {

--- a/tests/unit/data-browser/vview-install.test.ts
+++ b/tests/unit/data-browser/vview-install.test.ts
@@ -526,7 +526,12 @@ describe('bundle install orchestration', () => {
         ).toBeUndefined();
     });
 
-    it('does not store granted permission if install fails after approval', async () => {
+    it('stores granted permission even if a write fails after approval', async () => {
+        // Consent is the user's decision to install, not whether every
+        // asset write succeeded. Recording 'granted' on a partial
+        // failure stops the auto-check from re-prompting on every
+        // startup; the next check silently retries the failed file.
+        // The boolean result still reports the write failure.
         const my_dir = create_temp_dir();
         const my_context = create_context();
 
@@ -548,7 +553,7 @@ describe('bundle install orchestration', () => {
                 my_context,
                 PERMISSION_KEY
             )
-        ).toBeUndefined();
+        ).toBe('granted');
     });
 
     it('silently updates an outdated install after prior approval', async () => {


### PR DESCRIPTION
Closes #188. Follow-up to #187.

## Problem

Inside `import`/`export` statements, a filename whose **stem** is a command
name was still tinted as that command:

```stata
import delimited table.csv   // "table" tinted as a command
export delimited do.csv      // "do" tinted as the do command
```

#187 fixed the analogous bare-command case (`use table.dta`), leaving an
inconsistency: path-taking commands neutralized a command-name stem, but
`import`/`export` did not. The root cause was #187's whole-statement
`io-statement` region, whose body re-included `#statement-content` and so
re-tinted the stem.

## Fix

Replace the whole-statement `io-statement` region with single-token path rules:

- **`path-after-io-command`** (`import`/`export`): anchor on the command + a
  generic `\w+` subcommand (no enumeration of delimited/excel/…), then consume
  one path token. Two `(?!using(?=…))` guards keep the subcommand slot from
  swallowing the `using` keyword and let `import delimited using x.csv` fall
  through to the existing `#path-after-using` rule.
- **Fold `insheet`/`infile`/`outsheet`** into `path-after-data-command` with the
  same using-guard, so the standard `using file` form falls through. This also
  fixes a **latent #187 bug**: `insheet using table.csv` mis-tinted `table`
  because `#path-after-using` never ran inside the old whole-statement region.

The single-token region ends at the first whitespace/comma/comment, so options
after the filename keep highlighting.

## Behavior

| Input | Result |
|---|---|
| `import delimited table.csv` / `export delimited do.csv` | filename inert |
| `import delimited x.csv, clear` | `clear` still highlighted |
| `import delimited using i.dta` | `i.` inert, `using` highlighted |
| `import delimited i.csv` | `i.` inert (no #187 regression) |
| `insheet using table.csv` | `table` inert, `using` highlighted (latent bug fixed) |

## Review

Hardened beyond the original spec in response to an adversarial Codex review and
two consecutive clean automated review passes:

- **`using`-stem filenames** (`use using.dta`, `import delimited using.csv`,
  `using/file.csv`) — a precise standalone-`using` lookahead so these are
  treated as paths, not the keyword (fixes a regression the naive `\b` guard
  would have introduced).
- **`import using x.csv`** — leading guard so the subcommand slot never consumes
  the `using` keyword.
- Regression tests for all of the above, plus non-vacuous stem/option/quoted-path
  guards.

The **comment-before-filename** case (`import delimited /* c */ i.csv`) is a
known residual shared by *all* single-token path rules from #187 (a future
cross-cutting fix would flip them together); it's documented and tracked by an
equality test rather than fixed here.

A separate, unrelated test-quality nit surfaced during review (vacuous negative
assertions in the star-comment tests) is tracked in #192.

**Severity:** cosmetic, highlight-only. Consistency follow-up to #187.

## Verification

- New tokenizer regression tests in `tests/unit/textmate-grammar-file-paths.test.ts`
- Full unit suite: 2826 pass / 0 fail; typecheck clean
