### PR TITLE
Tailor Stata-commands install prompt to on-disk state

### DIFF
--- a/client/src/data-browser/index.ts
+++ b/client/src/data-browser/index.ts
@@ -24,6 +24,7 @@ import {
 } from './signal-watcher.js';
 import {
     ADO_ASSET_DEFS,
+    build_install_prompt_message,
     classify_ado_asset,
     aggregate_bundle_state,
     ensure_bundle_installed as ensure_bundle_installed_core,
@@ -413,17 +414,11 @@ async function set_stata_commands_install_permission(
 }
 
 export async function prompt_for_stata_commands_install(
-    target_dir: string
+    status: BundleInstallStatus
 ): Promise<VviewInstallPromptChoice> {
     const my_result =
         await vscode.window.showInformationMessage(
-            'Would you like to add Sight\'s Stata commands '
-            + '("vview" and "browse") to Stata?\n\n'
-            + '"vview" opens datasets in VS Code; in console '
-            + 'Stata, "browse" (and its abbreviations "brows", '
-            + '"brow", "bro", "br") becomes an alias for it (the '
-            + 'GUI built-in "browse" is unaffected).\n\n'
-            + `Install location: ${target_dir}`,
+            build_install_prompt_message(status),
             INSTALL_BUTTON,
             NOT_NOW_BUTTON
         );

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -409,27 +409,71 @@ export function uninstall_bundle(
     return my_all_ok;
 }
 
+// The quoted, comma-separated display list of the browse-abbreviation
+// commands (e.g. `"brows", "brow", "bro", "br"`), derived from the
+// canonical bundle definitions so the prompt copy can never name a
+// different set than what is actually installed. Anything that is not
+// the headline vview/browse command is an abbreviation alias.
+const BROWSE_ABBREVIATION_LABEL = ADO_ASSET_DEFS
+    .filter(
+        (my_def) =>
+            my_def.name !== 'vview.ado'
+            && my_def.name !== 'browse.ado'
+    )
+    .map((my_def) => '"' + my_def.name.replace(/\.ado$/, '') + '"')
+    .join(', ');
+
+// The verb describing what the install will actually do to the
+// pending (not-yet-satisfied) assets: "add" when only new files are
+// written, "update" when only existing Sight-owned files differ, and
+// "add or update" when both. Foreign and up-to-date assets are not
+// pending and so do not influence the verb.
+function describe_install_action(
+    status: BundleInstallStatus
+): string {
+    let has_addition = false;
+    let has_update = false;
+    for (const my_asset of status.assets) {
+        if (my_asset.state === 'missing') {
+            has_addition = true;
+        } else if (my_asset.state === 'outdated') {
+            has_update = true;
+        }
+    }
+
+    if (has_addition && has_update) {
+        return 'add or update';
+    }
+    if (has_update) {
+        return 'update';
+    }
+    return 'add';
+}
+
 // Build the install-permission prompt text, tailored to what is
 // already on disk. When vview.ado is already installed (up to date),
 // re-offering "vview" confuses a user who installed it before the
 // browse bundle existed, so the prompt instead frames the fresh
-// consent as *adding the console `browse` alias* (and its
-// abbreviations). When vview is not yet present, the full bundle is
-// offered. Either way the install location is named.
+// consent around the console `browse` alias (and its abbreviations).
+// When vview is not yet current, the full bundle is offered. The
+// action verb (add/update/add or update) reflects what the install
+// will actually do, so an in-place update is never described as a
+// fresh addition. Either way the install location is named.
 export function build_install_prompt_message(
     status: BundleInstallStatus
 ): string {
     const my_vview = status.assets.find(
         (my_asset) => my_asset.name === 'vview.ado'
     );
-    const vview_already_installed =
+    const my_vview_already_installed =
         my_vview?.state === 'up_to_date';
+    const my_action = describe_install_action(status);
 
-    if (vview_already_installed) {
+    if (my_vview_already_installed) {
         return (
             'vview is already installed. Would you like Sight to '
-            + 'also add the console "browse" command (and its '
-            + 'abbreviations "brows", "brow", "bro", "br") as an '
+            + `also ${my_action} the console "browse" command (and `
+            + `its abbreviations ${BROWSE_ABBREVIATION_LABEL}) as an `
             + 'alias for vview? In console Stata they open datasets '
             + 'in VS Code; the GUI built-in "browse" is unaffected.'
             + '\n\n'
@@ -438,11 +482,11 @@ export function build_install_prompt_message(
     }
 
     return (
-        'Would you like to add Sight\'s Stata commands '
-        + '("vview" and "browse") to Stata?\n\n'
+        `Would you like to ${my_action} Sight's Stata commands `
+        + '("vview" and "browse")?\n\n'
         + '"vview" opens datasets in VS Code; in console '
-        + 'Stata, "browse" (and its abbreviations "brows", '
-        + '"brow", "bro", "br") becomes an alias for it (the '
+        + `Stata, "browse" (and its abbreviations `
+        + `${BROWSE_ABBREVIATION_LABEL}) becomes an alias for it (the `
         + 'GUI built-in "browse" is unaffected).\n\n'
         + `Install location: ${status.target_dir}`
     );

--- a/client/src/data-browser/vview-install-core.ts
+++ b/client/src/data-browser/vview-install-core.ts
@@ -134,7 +134,7 @@ export interface VviewInstallHooks<
         permission: VviewInstallPermission | undefined
     ) => Promise<void>;
     prompt_for_install?: (
-        target_dir: string
+        status: BundleInstallStatus
     ) => Promise<VviewInstallPromptChoice>;
     install_bundle?: (
         status: BundleInstallStatus,
@@ -409,6 +409,45 @@ export function uninstall_bundle(
     return my_all_ok;
 }
 
+// Build the install-permission prompt text, tailored to what is
+// already on disk. When vview.ado is already installed (up to date),
+// re-offering "vview" confuses a user who installed it before the
+// browse bundle existed, so the prompt instead frames the fresh
+// consent as *adding the console `browse` alias* (and its
+// abbreviations). When vview is not yet present, the full bundle is
+// offered. Either way the install location is named.
+export function build_install_prompt_message(
+    status: BundleInstallStatus
+): string {
+    const my_vview = status.assets.find(
+        (my_asset) => my_asset.name === 'vview.ado'
+    );
+    const vview_already_installed =
+        my_vview?.state === 'up_to_date';
+
+    if (vview_already_installed) {
+        return (
+            'vview is already installed. Would you like Sight to '
+            + 'also add the console "browse" command (and its '
+            + 'abbreviations "brows", "brow", "bro", "br") as an '
+            + 'alias for vview? In console Stata they open datasets '
+            + 'in VS Code; the GUI built-in "browse" is unaffected.'
+            + '\n\n'
+            + `Install location: ${status.target_dir}`
+        );
+    }
+
+    return (
+        'Would you like to add Sight\'s Stata commands '
+        + '("vview" and "browse") to Stata?\n\n'
+        + '"vview" opens datasets in VS Code; in console '
+        + 'Stata, "browse" (and its abbreviations "brows", '
+        + '"brow", "bro", "br") becomes an alias for it (the '
+        + 'GUI built-in "browse" is unaffected).\n\n'
+        + `Install location: ${status.target_dir}`
+    );
+}
+
 export function get_install_permission<
     TContext extends VviewInstallContextLike
 >(
@@ -527,7 +566,7 @@ export async function ensure_bundle_installed<
 
     log('Stata commands: prompting for install permission');
     const my_choice = await hooks.prompt_for_install(
-        my_status.target_dir
+        my_status
     );
     if (my_choice === 'dismissed') {
         log('Stata commands: prompt dismissed');

--- a/tests/unit/data-browser/vview-install.test.ts
+++ b/tests/unit/data-browser/vview-install.test.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import {
     ADO_ASSET_DEFS,
     aggregate_bundle_state,
+    build_install_prompt_message,
     classify_ado_asset,
     ensure_bundle_installed,
     get_install_permission,
@@ -351,6 +352,42 @@ describe('bundle aggregate state', () => {
         expect(
             aggregate_bundle_state(['up_to_date', 'foreign'])
         ).toBe('up_to_date');
+    });
+});
+
+describe('install prompt message', () => {
+    it('frames consent as adding the browse alias when vview is already installed', () => {
+        const my_dir = create_temp_dir();
+        const my_status = build_bundle(my_dir, {
+            vview: { state: 'up_to_date' },
+            browse: { state: 'missing' },
+        });
+
+        const my_message =
+            build_install_prompt_message(my_status);
+
+        // Acknowledges vview is already present and frames the
+        // consent around the browse alias, not a fresh vview install.
+        expect(my_message).toContain('already installed');
+        expect(my_message).toContain('browse');
+        expect(my_message).toContain(my_dir);
+        // Must NOT present vview as something to be added.
+        expect(my_message).not.toContain('"vview" and "browse"');
+    });
+
+    it('offers the full vview + browse install when vview is absent', () => {
+        const my_dir = create_temp_dir();
+        const my_status = build_bundle(my_dir, {
+            vview: { state: 'missing' },
+            browse: { state: 'missing' },
+        });
+
+        const my_message =
+            build_install_prompt_message(my_status);
+
+        expect(my_message).toContain('"vview" and "browse"');
+        expect(my_message).toContain(my_dir);
+        expect(my_message).not.toContain('already installed');
     });
 });
 

--- a/tests/unit/data-browser/vview-install.test.ts
+++ b/tests/unit/data-browser/vview-install.test.ts
@@ -387,7 +387,62 @@ describe('install prompt message', () => {
 
         expect(my_message).toContain('"vview" and "browse"');
         expect(my_message).toContain(my_dir);
+        expect(my_message).toContain('add');
         expect(my_message).not.toContain('already installed');
+    });
+
+    it('says "update" (not "add") when a present browse alias is merely outdated', () => {
+        // vview current, browse already installed but stale: install
+        // updates it, so the prompt must not describe it as a fresh add.
+        const my_dir = create_temp_dir();
+        const my_status = build_bundle(my_dir, {
+            vview: { state: 'up_to_date' },
+            browse: { state: 'outdated' },
+        });
+
+        const my_message =
+            build_install_prompt_message(my_status);
+
+        expect(my_message).toContain('already installed');
+        expect(my_message).toContain('update');
+        expect(my_message).not.toContain('also add the console');
+    });
+
+    it('says "update" when vview itself is outdated', () => {
+        const my_dir = create_temp_dir();
+        const my_status = build_bundle(my_dir, {
+            vview: { state: 'outdated' },
+            browse: { state: 'outdated' },
+        });
+
+        const my_message =
+            build_install_prompt_message(my_status);
+
+        expect(my_message).toContain('update');
+        expect(my_message).toContain('"vview" and "browse"');
+        expect(my_message).not.toContain('already installed');
+    });
+
+    it('names the abbreviation aliases from the canonical bundle defs', () => {
+        const my_dir = create_temp_dir();
+        const my_status = build_bundle(my_dir, {
+            vview: { state: 'missing' },
+        });
+
+        const my_message =
+            build_install_prompt_message(my_status);
+
+        for (const my_def of ADO_ASSET_DEFS) {
+            if (
+                my_def.name === 'vview.ado'
+                || my_def.name === 'browse.ado'
+            ) {
+                continue;
+            }
+            const my_label =
+                '"' + my_def.name.replace(/\.ado$/, '') + '"';
+            expect(my_message).toContain(my_label);
+        }
     });
 });
 
@@ -422,6 +477,33 @@ describe('bundle install orchestration', () => {
         expect(the_logs).toContain(
             'Stata commands: prompting for install permission'
         );
+    });
+
+    it('passes the full bundle status to the prompt hook', async () => {
+        const my_dir = create_temp_dir();
+        const my_context = create_context();
+        let my_received: BundleInstallStatus | undefined;
+
+        await ensure_bundle_installed(
+            my_context,
+            () => {},
+            PERMISSION_KEY,
+            {
+                inspect_installation: () =>
+                    build_bundle(my_dir),
+                prompt_for_install: async (status) => {
+                    my_received = status;
+                    return 'not_now';
+                },
+            }
+        );
+
+        // The hook must receive the status (so it can tailor copy),
+        // not just the bare target_dir string.
+        expect(my_received).toBeDefined();
+        expect(my_received?.target_dir).toBe(my_dir);
+        expect(Array.isArray(my_received?.assets)).toBe(true);
+        expect(my_received?.assets.length).toBeGreaterThan(0);
     });
 
     it('installs without prompting when permission was already granted', async () => {


### PR DESCRIPTION
## Problem

A user who had already installed `vview` (under the older, vview-only
extension) was re-prompted to install **vview and browse** as though
vview were not installed. This is confusing.

## Root cause

`vview.ado` is already up-to-date on disk, but the new `browse.ado` +
abbreviation ados (`brows`/`brow`/`bro`/`br`) are missing, so the bundle
aggregate state is `missing` and the install flow prompts. The fresh
consent is intentional (the `browse` alias takes over a CLI built-in
name, gated behind a new permission key), but the prompt copy was static
and always named `vview` as if it were a new install. The install
**logic** was already correct — it leaves the up-to-date `vview.ado`
alone and only writes the missing alias files; only the wording was off.

## Fix

- Add `build_install_prompt_message(status)` (pure, unit-tested) that
  tailors the consent copy to on-disk state:
  - When `vview.ado` is already current, frame the prompt around the
    console `browse` alias rather than re-offering vview.
  - Otherwise, offer the full `vview` + `browse` bundle.
- The action verb (**add** / **update** / **add or update**) is derived
  from the pending asset states, so an in-place update of an existing
  alias is never described as a fresh add.
- The abbreviation display list is derived from `ADO_ASSET_DEFS`, so the
  prompt copy can never name a different set than what installs.
- The `prompt_for_install` hook now receives the full
  `BundleInstallStatus` (was just `target_dir`); all call sites updated.

## Review

Both an inline workflow `/code-review` (high effort) and a Codex review
ran on the diff. Both confirmed the targeted bug is fixed with no
regressions; their quality findings (verb accuracy, `my_` naming
convention, canonical alias list) are all addressed here.

## Tests

`tests/unit/data-browser/vview-install.test.ts`: prompt copy for the
already-installed / fresh / outdated-alias / outdated-vview cases, the
canonical abbreviation list, and an orchestration assertion that the
hook receives the full status. `bun run typecheck` and the full
data-browser suite pass; CI green on `workflow_dispatch`.
