### PR TITLE
fix: symlink-aware directory walks (#219)

### DIFF
--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -114,26 +114,27 @@ The indexer is *best-effort* and intentionally bounded:
 
 #### Symlinks
 
-A **symlinked source file** is indexed when the symlink's **own name** has a
-Stata source extension (`.do`, `.ado`, `.doh`, `.mata`) and its target is a
-regular file (the target may live anywhere). Detection is by the link name —
-the same rule used for regular files — so `analysis.do -> …/analysis.do` is
-indexed, but a link whose name lacks a Stata extension is not, even if its
-target is a `.do` file. It is indexed under the symlink's own path; if the
-symlink and its target are both inside the workspace, the same content is
-indexed under two separate URIs, and each counts toward
-`crossFile.maxIndexedFiles` — so near that cap a duplicate symlink can crowd
-out another file.
+The **persistent workspace index** follows neither symlinked directories nor
+symlinked files. It keys entries by path and the file watcher invalidates by
+the changed file's path, so an alias entry could not be kept in sync when its
+real target changes — rather than serve stale duplicates, the index simply
+holds the real files. If a symlink's target is inside your workspace, its
+content is already indexed via the real path, so cross-file go-to-definition
+and workspace-symbol search still work. If the target is *outside* your
+workspace (for example a symlink to a shared library elsewhere on disk), add
+that location as a workspace folder (or, for `.ado` help/programs, an ado-path)
+to have it indexed directly. This also keeps a stray symlinked directory from
+making the indexer crawl an arbitrary external tree.
 
-A **symlinked directory** is *not* recursively scanned. If its target is
-inside your workspace, those files are already indexed via the directory's
-real location, so nothing is lost. If its target is *outside* your workspace
-(for example a symlink to a shared library elsewhere on disk), its contents
-are **not** indexed — add that location as a workspace folder (or, for `.ado`
-help/programs, an ado-path) to have it scanned directly. This keeps a stray
-symlink from making the indexer crawl an arbitrary external tree. The same
-applies to `sight check` source discovery. Path completion still *offers*
-symlinked directories for navigation (listing one level is not recursion).
+Symlink-following *is* applied where there is no long-lived, path-keyed state
+to keep fresh:
+
+- **Path completion** offers symlinked directories (as navigable folders) and
+  symlinked source files, so you can complete and open them.
+- **`sight check`** discovers symlinked source files (a symlink whose own name
+  has a Stata source extension and whose target is a regular file) during its
+  one-shot scan; symlinked directories are still not descended.
+- **Help (`.sthlp`) lookup** follows a symlinked help file.
 
 ### Cross-file scope resolution
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -112,6 +112,21 @@ The indexer is *best-effort* and intentionally bounded:
 - It stops after `crossFile.maxIndexedFiles` (default 1000)
 - It updates the index when files change on disk (via the VS Code file watcher)
 
+#### Symlinks
+
+A **symlinked source file** (a symlink that resolves to a `.do`, `.ado`,
+`.doh`, or `.mata` file) is indexed normally — its target may live anywhere.
+
+A **symlinked directory** is *not* recursively scanned. If its target is
+inside your workspace, those files are already indexed via the directory's
+real location, so nothing is lost. If its target is *outside* your workspace
+(for example a symlink to a shared library elsewhere on disk), its contents
+are **not** indexed — add that location as a workspace folder (or, for `.ado`
+help/programs, an ado-path) to have it scanned directly. This keeps a stray
+symlink from making the indexer crawl an arbitrary external tree. The same
+applies to `sight check` source discovery. Path completion still *offers*
+symlinked directories for navigation (listing one level is not recursion).
+
 ### Cross-file scope resolution
 
 Cross-file *scope* (which symbols are considered "in scope" at a particular

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -133,7 +133,10 @@ to keep fresh:
   symlinked source files, so you can complete and open them.
 - **`sight check`** discovers symlinked source files (a symlink whose own name
   has a Stata source extension and whose target is a regular file) during its
-  one-shot scan; symlinked directories are still not descended.
+  one-shot scan; symlinked directories are still not descended. Discovered
+  files are de-duplicated by physical identity (realpath), so a symlink and its
+  in-tree target are checked once (no duplicate diagnostics), reported under
+  the lexically-smallest of their names.
 - **Help (`.sthlp`) lookup** follows a symlinked help file.
 
 ### Cross-file scope resolution

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -116,17 +116,20 @@ The indexer is *best-effort* and intentionally bounded:
 
 Features that **analyze** files — the persistent workspace index and
 `sight check` — follow neither symlinked directories nor symlinked files; they
-process **real files only**. Both are keyed by path: the index/file-watcher key
-entries by the changed file's path, and the dependency graph keys cross-file
-edges by the resolved real path. Analyzing a symlink-alias path would therefore
-mismatch that state (stale entries, missing parents, false "not indexed"), so
-the alias is not analyzed. If a symlink's target is inside your workspace its
-content is already analyzed via the real path, so cross-file go-to-definition,
-workspace-symbol search, and diagnostics still work. If the target is *outside*
-your workspace (for example a shared library elsewhere on disk), add that
-location as a workspace folder (or, for `.ado` help/programs, an ado-path) to
-have it analyzed directly. This also keeps a stray symlinked directory from
-making a walk crawl an arbitrary external tree.
+process **real files only**. The index holds entries keyed by file path (the
+file watcher invalidates by the changed path), so a symlinked-file alias the
+index never indexed would be a stranger to the cross-file graph: analyzing it
+gives unreliable scope and (in `sight check`, past the index cap) a spurious
+"file not indexed". So the alias is not analyzed. If a symlink's target is
+inside your workspace its content is already analyzed via the real path, so
+cross-file go-to-definition, workspace-symbol search, and diagnostics still
+work. If the target is *outside* your workspace (for example a shared library
+elsewhere on disk), add that location as a workspace folder (or, for `.ado`
+help/programs, an ado-path) to have it analyzed directly. This also keeps a
+stray symlinked directory from making a walk crawl an arbitrary external tree.
+
+(A `do`/`include` that references a file *through* a symlink path is a separate,
+pre-existing matter handled by path resolution, not by these directory walks.)
 
 Symlink-following *is* applied in the features that only **list or look up**
 paths (no path-keyed analysis state to keep consistent):

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -114,29 +114,25 @@ The indexer is *best-effort* and intentionally bounded:
 
 #### Symlinks
 
-The **persistent workspace index** follows neither symlinked directories nor
-symlinked files. It keys entries by path and the file watcher invalidates by
-the changed file's path, so an alias entry could not be kept in sync when its
-real target changes — rather than serve stale duplicates, the index simply
-holds the real files. If a symlink's target is inside your workspace, its
-content is already indexed via the real path, so cross-file go-to-definition
-and workspace-symbol search still work. If the target is *outside* your
-workspace (for example a symlink to a shared library elsewhere on disk), add
-that location as a workspace folder (or, for `.ado` help/programs, an ado-path)
-to have it indexed directly. This also keeps a stray symlinked directory from
-making the indexer crawl an arbitrary external tree.
+Features that **analyze** files — the persistent workspace index and
+`sight check` — follow neither symlinked directories nor symlinked files; they
+process **real files only**. Both are keyed by path: the index/file-watcher key
+entries by the changed file's path, and the dependency graph keys cross-file
+edges by the resolved real path. Analyzing a symlink-alias path would therefore
+mismatch that state (stale entries, missing parents, false "not indexed"), so
+the alias is not analyzed. If a symlink's target is inside your workspace its
+content is already analyzed via the real path, so cross-file go-to-definition,
+workspace-symbol search, and diagnostics still work. If the target is *outside*
+your workspace (for example a shared library elsewhere on disk), add that
+location as a workspace folder (or, for `.ado` help/programs, an ado-path) to
+have it analyzed directly. This also keeps a stray symlinked directory from
+making a walk crawl an arbitrary external tree.
 
-Symlink-following *is* applied where there is no long-lived, path-keyed state
-to keep fresh:
+Symlink-following *is* applied in the features that only **list or look up**
+paths (no path-keyed analysis state to keep consistent):
 
 - **Path completion** offers symlinked directories (as navigable folders) and
-  symlinked source files, so you can complete and open them.
-- **`sight check`** discovers symlinked source files (a symlink whose own name
-  has a Stata source extension and whose target is a regular file) during its
-  one-shot scan; symlinked directories are still not descended. Discovered
-  files are de-duplicated by physical identity (realpath), so a symlink and its
-  in-tree target are checked once (no duplicate diagnostics), reported under
-  the lexically-smallest of their names.
+  symlinked files, so you can complete and open them.
 - **Help (`.sthlp`) lookup** follows a symlinked help file.
 
 ### Cross-file scope resolution

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -114,11 +114,16 @@ The indexer is *best-effort* and intentionally bounded:
 
 #### Symlinks
 
-A **symlinked source file** (a symlink that resolves to a `.do`, `.ado`,
-`.doh`, or `.mata` file) is indexed normally — its target may live anywhere.
-It is indexed under the symlink's own path; if the symlink and its target are
-both inside the workspace, the file is indexed under both paths (a harmless
-over-count — both paths resolve to the same content).
+A **symlinked source file** is indexed when the symlink's **own name** has a
+Stata source extension (`.do`, `.ado`, `.doh`, `.mata`) and its target is a
+regular file (the target may live anywhere). Detection is by the link name —
+the same rule used for regular files — so `analysis.do -> …/analysis.do` is
+indexed, but a link whose name lacks a Stata extension is not, even if its
+target is a `.do` file. It is indexed under the symlink's own path; if the
+symlink and its target are both inside the workspace, the same content is
+indexed under two separate URIs, and each counts toward
+`crossFile.maxIndexedFiles` — so near that cap a duplicate symlink can crowd
+out another file.
 
 A **symlinked directory** is *not* recursively scanned. If its target is
 inside your workspace, those files are already indexed via the directory's

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -116,6 +116,9 @@ The indexer is *best-effort* and intentionally bounded:
 
 A **symlinked source file** (a symlink that resolves to a `.do`, `.ado`,
 `.doh`, or `.mata` file) is indexed normally — its target may live anywhere.
+It is indexed under the symlink's own path; if the symlink and its target are
+both inside the workspace, the file is indexed under both paths (a harmless
+over-count — both paths resolve to the same content).
 
 A **symlinked directory** is *not* recursively scanned. If its target is
 inside your workspace, those files are already indexed via the directory's

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -47,9 +47,9 @@ We reuse exactly this logic.
 ### 1. Shared symlink-aware classification helper
 
 `resolve_path_rich` already contains the canonical sync implementation as the
-private `entry_is_dir` / `entry_is_file`. To avoid a fourth and fifth copy of
-the same try/catch, extract the logic into a new focused module and have all
-consumers (including `file-path-utils.ts`) call it.
+private `entry_is_dir` / `entry_is_file`. Rather than copy that try/catch into
+each new walk site, extract it into a focused module and have all consumers
+(including `file-path-utils.ts`) call it.
 
 New file `src/utils/symlink-aware-entry.ts`:
 
@@ -72,134 +72,115 @@ export function entry_is_directory_sync(
     entry: DirentLike, full_path: string, fs: StatSyncFs): boolean;
 export function entry_is_file_sync(
     entry: DirentLike, full_path: string, fs: StatSyncFs): boolean;
-export async function entry_is_directory_async(
-    entry: DirentLike, full_path: string, fs: StatAsyncFs): Promise<boolean>;
 export async function entry_is_file_async(
     entry: DirentLike, full_path: string, fs: StatAsyncFs): Promise<boolean>;
 
-// Single-syscall classifier for walker call sites that test dir-then-file
-// on the same entry (the boolean pair would stat a symlink twice).
+// Single-syscall classifier for path completion, which lists one directory
+// level and offers BOTH symlinked dirs and symlinked files (dir-then-file on
+// the same entry — the boolean pair would stat a symlink twice).
 export type EntryKind = 'directory' | 'file' | 'other';
 export function classify_entry_sync(
     entry: DirentLike, full_path: string, fs: StatSyncFs): EntryKind;
-export async function classify_entry_async(
-    entry: DirentLike, full_path: string, fs: StatAsyncFs): Promise<EntryKind>;
 ```
 
 Each is the PR #216 shape: fast path on the `Dirent` predicate; on
 `isSymbolicLink()`, stat the full path and classify by the target; `try/catch`
-→ `false`/`'other'` on a dangling/erroring link. The sync and async pairs share
-identical logic, differing only in `await`.
+→ `false`/`'other'` on a dangling/erroring link.
 
-The boolean pair stays for `resolve_path_rich`, which tests *either* dir
-(non-final component) *or* file (final component) on a given entry, never both.
-The four recursive/listing walk sites test **directory-then-file** on the same
-entry, so they use `classify_entry_*` to avoid stat-ing a symlinked entry twice
-(Codex review, minor #4).
+`entry_is_directory_sync` / `entry_is_file_sync` serve `resolve_path_rich`,
+which tests *either* dir (non-final component) *or* file (final component) on a
+given entry, never both. `entry_is_file_async` serves the async indexer walks
+(see §2). `classify_entry_sync` serves path completion. There is deliberately
+**no** async directory variant or async classifier: the recursive walks descend
+only real subdirectories (`Dirent.isDirectory()`), so they never async-classify
+a directory.
 
 `file-path-utils.ts`'s private `entry_is_dir` / `entry_is_file` delegate to
 `entry_is_directory_sync` / `entry_is_file_sync` (one source of truth).
 `RichResolveFs.statSync` already satisfies `StatSyncFs`, so the resolver and its
 tests are unaffected behaviorally — verified green by the existing
-`path-resolve-rich.test.ts` symlink suite. *(Already implemented.)*
+`path-resolve-rich.test.ts` symlink suite.
 
-### 2. Traversal policy for recursive walks (separate from classification)
+### 2. Traversal policy: follow symlinked files, do NOT descend symlinked dirs
 
-Classification (§1) tells a walk *what* an entry is. It does **not** decide
-*whether to descend* — and `resolve_path_rich` never had to, because it walks a
-**fixed component list** from a request path and cannot loop or escape. The
-three recursive walks (`scan_directory`, `walk_sources`,
-`find_sthlp_file_recursive`) enumerate arbitrary trees, so following symlinked
-directories introduces two distinct hazards that classification alone does not
-address (Codex review, major #1/#2/#3):
+Classification (§1) tells a walk *what* an entry is. It does **not** by itself
+decide *whether to descend* — and `resolve_path_rich` never had to, because it
+walks a **fixed component list** from a request path and cannot loop or escape.
+The three recursive walks (`scan_directory`, `walk_sources`,
+`find_sthlp_file_recursive`) enumerate arbitrary trees, where recursively
+following symlinked **directories** introduces a cluster of hazards (raised by
+Codex's adversarial reviews of both the spec and the implementation):
 
-1. **Cycles** — a directory symlink pointing at an ancestor
-   (`/ws/sub/link -> /ws`) is an infinite descent.
-2. **Escape** — a directory symlink pointing outside the declared scan roots
-   (`/ws/link -> /Users/me`) makes the walk crawl an arbitrary external tree.
-   The indexer's `maxIndexedFiles` cap does **not** bound this: it gates
-   *indexing* inside `index_file` (`should_skip_for_max_indexed_files`,
-   `src/indexer/index.ts:421`), while `scan_directory` keeps recursing
-   regardless, so the directory walk itself is unbounded.
-3. **Duplicate traversal/indexing** — the same physical dir reached via two
-   paths (`/ws/a` and `/ws/link_to_a`) is walked and indexed twice under
-   distinct URIs (symbols are keyed by traversal path, `src/indexer/index.ts:450`).
+1. **Cycles** — a dir symlink pointing at an ancestor (`/ws/sub/link -> /ws`).
+2. **Escape** — a dir symlink to outside the workspace (`/ws/link -> /Users/me`)
+   crawls an arbitrary external tree. The indexer's `maxIndexedFiles` cap does
+   **not** bound this: it gates *indexing* inside `index_file`
+   (`should_skip_for_max_indexed_files`, `src/indexer/index.ts:421`), while the
+   directory walk keeps recursing regardless.
+3. **Aliasing / duplicate indexing** — the same physical dir reached via a
+   symlink and via its real path is walked/indexed twice under distinct URIs
+   (symbols are keyed by traversal path, `src/indexer/index.ts:450`); a symlink
+   to a *declared root* can even claim that root before its own scan.
+4. **TOCTOU + exclusion bypass** — a parent-side boundary check is racy, and a
+   symlink named innocuously but pointing at `.git`/`node_modules` bypasses the
+   name-based exclusion.
 
-**Policy — canonical visited set + scan-root boundary, threaded per walk:**
+The key realization: descending symlinked directories adds essentially **no
+coverage** anyway. If a symlinked dir's target is *inside* the workspace, the
+direct scan of its real location already indexes those files; if the target is
+*outside*, that is precisely the escape hazard. So the policy is simply:
 
-Each top-level walk owns a `visited_real_dirs: Set<string>` and a set of
-**canonical boundary roots** (the canonical form of the directories the walk was
-explicitly told to scan). On entering *any* directory `dir` to scan (root and
-every subdirectory, symlinked or not):
+- **Recurse into real subdirectories only** (`entry.isDirectory()`, the
+  pre-existing check — symlinked dirs excluded, as before). A real directory
+  tree is finite and acyclic, so **no** visited set, realpath, or boundary
+  machinery is needed; cycles, escape, aliasing, TOCTOU, and exclusion-bypass
+  are all structurally impossible.
+- **Follow symlinked source FILES.** A `readdir` entry for a symlinked file is
+  neither `isFile()` nor `isDirectory()`, so the old code dropped it — this is
+  the actual #219 bug. Replace the file test with the symlink-aware
+  `entry_is_file_*` so a symlinked `.do`/`.ado`/`.sthlp` (target anywhere) is
+  recognized.
 
-1. `canonical = realpath(dir)`; on throw (dangling/raced) → skip the directory.
-2. If `visited_real_dirs.has(canonical)` → return (handles cycles **and**
-   duplicate traversal/indexing for free). Else add it.
-3. Recurse into child directories. For a child that **is a symlink**, first
-   check its canonical target is within some canonical boundary root; if not,
-   skip it (do not follow the escape). Non-symlink children are within the root
-   by construction and need no boundary check.
-
-Why `realpath` on every directory rather than only on symlinked entries: the
-visited set must be keyed by physical identity to dedupe a plain subtree reached
-*through* a symlink (`/ws/link/sub` vs `/ws/real/sub`). `realpath` is one
-syscall per **directory** (not per file); directories are far fewer than files,
-and the indexer already `stat`s every file it indexes (`src/indexer/index.ts:463`),
-so the added cost is negligible against total scan work. The non-symlinked
-common case gains one `realpath` per directory and no behavior change.
-
-The boundary deliberately does **not** follow symlinks that escape the declared
-roots. A user who wants an external shared library indexed adds it as a
-workspace folder or ado-path (the indexer already accepts both) rather than
-relying on an escaping symlink — a conservative, predictable default that avoids
-silently crawling `$HOME`. This is an explicit, reviewed scope decision.
-
-`find_sthlp_file_recursive` gets the **same** visited-set + boundary guard. Its
-`MAX_STHLP_SEARCH_DEPTH = 8` cap bounds depth but **not** repeated traversal of
-the same physical dirs within that depth, so the depth cap alone is not
-sufficient (Codex review, major #3). Boundary root = the canonical `root_dir`
-it was invoked with.
+This is the conscious scope decision: **symlinked source files are followed
+everywhere; symlinked directories are not recursively crawled.** A user who
+wants an external directory indexed declares it as a workspace folder or
+ado-path (the indexer already accepts both) rather than reaching it through a
+symlink. Path completion is the one exception — it *lists* a symlinked dir as a
+navigable folder (see §3) because listing is not recursion.
 
 ### 3. Per-site changes
 
-**`scan_directory` (async):** signature gains a threaded
-`visited_real_dirs: Set<string>` and `boundary_roots: string[]` (canonical).
-`initialize` seeds `boundary_roots` once from the canonical form of
-`workspace_folders ∪ ado_paths` and passes a fresh `visited_real_dirs` per
-top-level `scan_directory` call (shared across its recursion). Per directory:
-realpath + visited check (step 1–2). Per entry: `classify_entry_async(entry,
-entry_path, fs.promises)`; `'directory'` → VCS skip, then symlink-boundary check
-(step 3) before recursing; `'file'` + `hasStataExtension` → collect. VCS skip
-(`VCS_METADATA_DIRS.has(entry.name)`) unchanged.
+**`scan_directory` (async):** signature unchanged. Directory branch stays
+`entry.isDirectory()` (real subdirs only) with the existing `VCS_METADATA_DIRS`
+skip. File branch becomes `await entry_is_file_async(entry, entry_path,
+fs.promises) && hasStataExtension(entry.name)` so a symlinked source file is
+collected.
 
-**`find_sthlp_file_recursive` (async):** add `classify_entry_async`; seed a
-`visited_real_dirs` set and a single boundary root (canonical `root_dir`) at the
-top; realpath + visited check before processing each popped dir; symlink
-children get the boundary check before being pushed. `EXCLUDED_DIRS` unchanged;
-depth cap retained as an additional bound.
+**`find_sthlp_file_recursive` (async):** directory branch stays
+`my_dirent.isDirectory()` with the `EXCLUDED_DIRS` skip and the depth cap. File
+branch becomes `my_dirent.name === basename && await entry_is_file_async(...)`
+so a symlinked `.sthlp` is matched.
 
-**`walk_sources` (sync):** thread `visited_real_dirs` and a `boundary_root`
-(canonical of the top dir passed by `collect_report_targets`). Use
-`classify_entry_sync` with `{ statSync: fs.statSync }` and `fs.realpathSync` for
-the visited/boundary logic. `VCS_METADATA_DIRS` skip unchanged. (Explicit
-top-level input paths in `collect_report_targets` already `statSync` and
-`canonicalize_existing_path`, so they are unaffected.)
+**`walk_sources` (sync):** signature unchanged. Directory branch stays
+`entry.isDirectory()` with the `VCS_METADATA_DIRS` skip. File branch becomes
+`entry_is_file_sync(entry, entry_path, fs) && hasStataExtension(entry.name)`.
+(Explicit top-level input paths in `collect_report_targets` already `statSync`
++ `canonicalize_existing_path`, so a directly-named symlink already works.)
 
-**path completion (sync):** swap the dir/file predicates to
-`classify_entry_sync` with `{ statSync: fs.statSync }`. **No recursion** → no
-visited set, no boundary: the provider lists one directory level; navigating
-into a symlinked dir re-lists that one level on the next request. Hidden-file
-skip (`entry.name.startsWith('.')`) and prefix filter unchanged. A symlinked dir
-is offered with the trailing `/`; a symlinked Stata file like a regular file.
+**path completion (sync):** uses `classify_entry_sync(entry, full_path, fs)` and
+offers `'directory'` (incl. symlinked dirs) with a trailing `/` and `'file'`
+(incl. symlinked files) as files. **No recursion** → listing a symlinked dir is
+safe; navigating into it re-lists that one level on the next request. Hidden-file
+skip (`entry.name.startsWith('.')`) and prefix filter unchanged.
 
 ### 4. Out of scope / explicitly preserved
 
-- **Output paths stay as written (symlink paths), not canonicalized.** Indexed
-  URIs and completion labels remain the traversal/symlink path, matching how
-  non-symlink entries are reported today. Canonical paths are used *only*
-  internally for the visited set and boundary check.
-- **Escaping symlinks are not followed** (see §2). Declared roots are the
-  boundary; external targets must be declared explicitly.
+- **Symlinked directories are not recursively descended** by the indexer or
+  `sight check` (see §2). In-workspace targets are covered by the direct scan;
+  external targets must be declared as a workspace folder / ado-path. Path
+  completion still *offers* symlinked dirs (listing, not recursion).
+- **Output paths stay as written.** Indexed URIs / completion labels remain the
+  path as encountered, matching non-symlink entries.
 - `resolve_path_rich`'s external behavior is unchanged; the helper extraction is
   mechanical de-duplication covered by existing tests.
 
@@ -211,35 +192,38 @@ and platform-independent (no real symlinks on disk, which are awkward on CI /
 Windows). For sites whose seams are not injectable, use a temp dir with real
 symlinks, guarded so the test skips where the platform cannot create symlinks.
 
-New unit tests for `symlink-aware-entry.ts` *(already implemented, 9 passing)*:
+New unit tests for `symlink-aware-entry.ts`:
 - symlinked-dir / symlinked-file / dangling / plain-dir / plain-file across the
-  boolean pair and the `classify_entry_*` pair
+  boolean helpers and `classify_entry_sync`
 - fast path asserts the stat seam is **never called** for plain entries
-- sync and async variants each covered
+- `entry_is_file_async` covered (sync + async parity)
 
-Per-site tests:
-- **indexer `scan_directory`:** symlinked `.do` is indexed; files under a
-  symlinked subdir are indexed; an ancestor-pointing dir symlink **terminates**;
-  the same physical file reached via a symlink is **not double-indexed**; a dir
-  symlink whose target is **outside** all declared roots is **not followed**.
-- **indexer `find_sthlp_file_recursive`:** a symlinked `.sthlp` (or symlinked
-  dir containing it) is found; a cycle terminates within the depth cap.
-- **`walk_sources` / `collect_report_targets`:** symlinked source file and
-  symlinked subtree are discovered; a cycle terminates; an escaping symlink is
-  not followed.
-- **path completion:** symlinked dir and symlinked `.do` appear as completions.
+Per-site tests (real temp-dir symlinks, skipped where the platform can't make
+them):
+- **indexer `scan_directory`:** a symlinked `.do` is indexed; a symlinked dir's
+  in-workspace target is indexed once via its real path; an ancestor-pointing
+  dir symlink does not hang (not descended) and nothing is double-indexed; a dir
+  symlink whose target is **outside** the workspace is **not descended**.
+- **indexer `find_sthlp_file_recursive`:** a symlinked `.sthlp` under a real
+  subdir is found; a dir symlink is not recursed through.
+- **`walk_sources` / `collect_report_targets`:** symlinked source file
+  discovered; symlinked-dir target discovered via its real path; dir symlink not
+  recursed; external dir symlink not descended.
+- **path completion:** a symlinked dir and a symlinked `.do` appear as
+  completions.
 
 Existing `path-resolve-rich.test.ts` symlink suite must stay green after the
 delegation refactor (regression guard for §1) — confirmed.
 
 ## Risks
 
-- **Performance:** one `realpath` per directory entered (not per file) plus
-  `stat` only on symlinked entries. Negligible against per-file indexing work;
-  the non-symlinked common case is otherwise unchanged.
-- **Boundary too strict:** a symlink to an undeclared external tree is silently
-  not indexed. Mitigation: documented behavior; the fix is to declare the target
-  as a workspace folder / ado-path. Chosen over the alternative (crawl anywhere)
-  because unbounded external traversal is the worse failure.
+- **Performance:** `stat` only on symlinked entries (one syscall, only when the
+  `Dirent` fast path doesn't resolve it). The non-symlinked common case is
+  unchanged — same `isDirectory()` recursion as before.
+- **Symlinked-dir targets not indexed when external:** a symlinked directory
+  pointing outside the workspace has its contents un-indexed. Mitigation:
+  documented; declare the target as a workspace folder / ado-path. Chosen over
+  recursively crawling symlinked dirs, which reintroduces cycle / escape /
+  aliasing / TOCTOU hazards for no coverage gain on in-workspace layouts.
 - **Refactor regression in the resolver:** bounded — delegation preserves
   semantics and is covered by the existing symlink test suite (confirmed green).

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -140,17 +140,20 @@ Two realizations shape the policy:
    real location already covers those files; if *outside*, that is precisely
    the escape hazard. So no walk descends symlinked directories.
 2. **Anything that ANALYZES files cannot safely follow symlinked files,
-   because analysis is keyed by path.** The persistent index keys entries by
-   `URI.file(file_path)` and `onDidChangeWatchedFiles` re-indexes/removes only
-   the *changed event path*, so an `alias.do -> real.do` entry would go stale
-   when `real.do` is edited (watcher fires for `real.do`, not the alias —
-   Codex round-7). `sight check` opens each target under `URI.file(target.path)`
-   and resolves backward scope via `dependency_graph.get_parents(uri)`, whose
-   callee edges are keyed by the **resolved real path**; it also gates on
-   `has_indexed_file(uri)` (real files only). Analyzing a symlink-alias URI
-   would therefore miss its parents (false undefined-symbol diagnostics) and,
-   past the index cap, be reported `SIGHT_FILE_NOT_INDEXED` (Codex round-9). So
-   the analyzing consumers process **real files only**.
+   because the index holds real files only and is keyed by path.** The
+   persistent index keys entries by `URI.file(file_path)` and
+   `onDidChangeWatchedFiles` re-indexes/removes only the *changed event path*,
+   so an `alias.do -> real.do` entry would go stale when `real.do` is edited
+   (watcher fires for `real.do`, not the alias — Codex round-7). `sight check`
+   opens each target under `URI.file(target.path)` and gates on
+   `has_indexed_file(uri)` (real files only); analyzing a symlink-alias URI the
+   index never indexed yields unreliable cross-file scope and, past the index
+   cap, a spurious `SIGHT_FILE_NOT_INDEXED` (Codex round-9). So the analyzing
+   consumers process **real files only**. (Separately and pre-existing: a
+   `do`/`include` that names a child *through* a symlink path keys its
+   dependency-graph edge by the alias path that `resolve_forward_call_rich`
+   returns, not the realpath — a cross-file-resolution matter independent of
+   these directory walks and out of scope for #219.)
 
 So:
 

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -28,6 +28,13 @@ Note: `collect_report_targets` (the caller of `walk_sources`) already
 symlinked file/dir already works; only the recursive `walk_sources` descent
 misses symlinks. No change needed there.
 
+These are the sites the original bug touches. The fix's reach differs by site
+(see §2): the **persistent indexer** `scan_directory` is intentionally left
+real-files-only (it cannot keep a symlink-alias entry fresh — Codex round-7),
+no walk descends symlinked directories, and the **one-shot** consumers
+(`walk_sources`, `find_sthlp_file_recursive`, path completion) follow symlinked
+files.
+
 ## Reference behavior (PR #216)
 
 `resolve_path_rich` added a `statSync` to its injected fs seam and two private
@@ -87,13 +94,13 @@ Each is the PR #216 shape: fast path on the `Dirent` predicate; on
 `isSymbolicLink()`, stat the full path and classify by the target; `try/catch`
 → `false`/`'other'` on a dangling/erroring link.
 
-`entry_is_directory_sync` / `entry_is_file_sync` serve `resolve_path_rich`,
-which tests *either* dir (non-final component) *or* file (final component) on a
-given entry, never both. `entry_is_file_async` serves the async indexer walks
-(see §2). `classify_entry_sync` serves path completion. There is deliberately
-**no** async directory variant or async classifier: the recursive walks descend
-only real subdirectories (`Dirent.isDirectory()`), so they never async-classify
-a directory.
+`entry_is_directory_sync` / `entry_is_file_sync` serve `resolve_path_rich`
+(which tests *either* dir or file on a given entry, never both) and
+`walk_sources` (`entry_is_file_sync`). `entry_is_file_async` serves the
+on-demand async `.sthlp` lookup. `classify_entry_sync` serves path completion.
+There is deliberately **no** async directory variant or async classifier: the
+recursive walks descend only real subdirectories (`Dirent.isDirectory()`), so
+they never async-classify a directory.
 
 `file-path-utils.ts`'s private `entry_is_dir` / `entry_is_file` delegate to
 `entry_is_directory_sync` / `entry_is_file_sync` (one source of truth).
@@ -125,58 +132,65 @@ Codex's adversarial reviews of both the spec and the implementation):
    symlink named innocuously but pointing at `.git`/`node_modules` bypasses the
    name-based exclusion.
 
-The key realization: descending symlinked directories adds essentially **no
-coverage** anyway. If a symlinked dir's target is *inside* the workspace, the
-direct scan of its real location already indexes those files; if the target is
-*outside*, that is precisely the escape hazard. So the policy is simply:
+Two realizations shape the policy:
 
-- **Recurse into real subdirectories only** (`entry.isDirectory()`, the
-  pre-existing check — symlinked dirs excluded, as before). Because recursion
-  follows only real subdirectories (exactly as it did before this fix), the
-  change introduces **no** new symlink cycle/escape risk, so **no** visited
-  set, realpath, or boundary machinery is added; the TOCTOU / aliasing /
-  exclusion-bypass classes that a symlinked-dir descent would create simply do
-  not arise. (OS-level Windows junctions and bind mounts report as real
-  directories via `isDirectory()` and are therefore descended just as the
-  pre-existing code descended them — that is unchanged by this fix and out of
-  scope here.)
-- **Follow symlinked source FILES.** A `readdir` entry for a symlinked file is
-  neither `isFile()` nor `isDirectory()`, so the old code dropped it — this is
-  the actual #219 bug. Each walk keeps its existing **name-based** match
-  (`hasStataExtension(entry.name)`, or `name === basename` for `.sthlp`) and
-  adds the symlink-aware `entry_is_file_*` to confirm the target is a regular
-  file. Detection is therefore by the link's own name (matching how regular
-  files are matched): a link named `analysis.do` is followed (target may live
-  anywhere), while a link whose name lacks a Stata extension is not, even if
-  its target is a `.do`.
+1. **Descending symlinked directories adds essentially no coverage.** If a
+   symlinked dir's target is *inside* the workspace, the direct scan of its
+   real location already covers those files; if *outside*, that is precisely
+   the escape hazard. So no walk descends symlinked directories.
+2. **The persistent workspace index cannot safely follow symlinked files
+   either.** It keys entries by path (`URI.file(file_path)`) and the file
+   watcher (`onDidChangeWatchedFiles`) re-indexes/removes only the *changed
+   event path*. An `alias.do -> real.do` entry indexed alongside `real.do`
+   would go stale the moment `real.do` is edited (the watcher fires for
+   `real.do`, not `alias.do`), leaving duplicate/stale symbols in
+   completions, go-to-definition, and the dependency graph. (Codex round-7
+   finding.) Rather than add a realpath→aliases invalidation map, the
+   long-lived index holds **real files only**.
 
-This is the conscious scope decision: **symlinked source files are followed
-everywhere; symlinked directories are not recursively crawled.** A user who
-wants an external directory indexed declares it as a workspace folder or
-ado-path (the indexer already accepts both) rather than reaching it through a
-symlink. Path completion is the one exception — it *lists* a symlinked dir as a
-navigable folder (see §3) because listing is not recursion.
+So:
 
-A symlinked source file is indexed under the path at which it is encountered
-(the symlink path), matching how every other entry is indexed by traversal
-path. If such a symlink and its real target are *both* inside the workspace,
-the same content is indexed under two separate URIs. Each URI counts toward
-`crossFile.maxIndexedFiles`, so the duplicate consumes a slot and could, near
-the cap, crowd out another file — it is a best-effort-index over-count, not a
-correctness bug, but not strictly free. De-duplicating by canonical path would
-reintroduce the realpath machinery this design deliberately removes, so it is
-left as-is and documented (see `docs/cross-file.md`).
+- **Recursive walks recurse into real subdirectories only**
+  (`entry.isDirectory()`, the pre-existing check). Recursion follows only real
+  subdirectories exactly as before, so the change adds **no** new symlink
+  cycle/escape risk and needs **no** visited set, realpath, or boundary
+  machinery; the TOCTOU / aliasing / exclusion-bypass classes a symlinked-dir
+  descent would create do not arise. (OS-level Windows junctions and bind
+  mounts report as real directories via `isDirectory()` and are descended just
+  as the pre-existing code descended them — unchanged by this fix, out of
+  scope.)
+- **The persistent indexer (`scan_directory`) follows real files only** — its
+  file branch is unchanged (`entry.isFile() && hasStataExtension(name)`), for
+  the staleness reason above. In-workspace symlink targets are covered via
+  their real path; external targets are declared as a workspace folder /
+  ado-path.
+- **One-shot consumers follow symlinked source FILES**, where there is no
+  long-lived path-keyed state to keep fresh, so no staleness can arise:
+  - **path completion** offers symlinked dirs (navigable folders) and files;
+  - **`sight check`** (`walk_sources`) discovers symlinked source files in its
+    single scan;
+  - the on-demand **`.sthlp` lookup** (`find_sthlp_file_recursive`, a fresh
+    per-request walk that returns a path and never caches into the index)
+    matches a symlinked help file.
+  Each keeps its existing **name-based** match (`hasStataExtension(entry.name)`,
+  or `name === basename` for `.sthlp`) and adds `entry_is_file_*` to confirm
+  the target is a regular file. Detection is by the link's own name (matching
+  how regular files are matched): a link named `analysis.do` is followed
+  (target anywhere), a link without a Stata-extension name is not.
+
+This is the conscious scope decision: **the persistent index follows neither
+symlinked directories nor symlinked files; one-shot consumers follow symlinked
+files; no walk descends symlinked directories.**
 
 ### 3. Per-site changes
 
-**`scan_directory` (async):** signature unchanged. Directory branch stays
-`entry.isDirectory()` (real subdirs only) with the existing `VCS_METADATA_DIRS`
-skip. File branch becomes `hasStataExtension(entry.name) && await
-entry_is_file_async(entry, entry_path, fs.promises)` so a symlinked source file
-is collected — the cheap name check is left of the `&&` so the (possibly
-stat-ing) helper runs only for Stata-named entries.
+**`scan_directory` (async, persistent index):** **unchanged from `main`** —
+directory branch `entry.isDirectory()` (real subdirs only) with the
+`VCS_METADATA_DIRS` skip, file branch `entry.isFile() &&
+hasStataExtension(entry.name)`. The persistent index follows neither symlinked
+dirs nor symlinked files (staleness reason in §2). A brief comment records why.
 
-**`find_sthlp_file_recursive` (async):** directory branch stays
+**`find_sthlp_file_recursive` (async, on-demand lookup):** directory branch stays
 `my_dirent.isDirectory()` with the `EXCLUDED_DIRS` skip and the depth cap. File
 branch becomes `my_dirent.name === basename && await entry_is_file_async(...)`
 so a symlinked `.sthlp` is matched.
@@ -196,10 +210,14 @@ skip (`entry.name.startsWith('.')`) and prefix filter unchanged.
 
 ### 4. Out of scope / explicitly preserved
 
-- **Symlinked directories are not recursively descended** by the indexer or
-  `sight check` (see §2). In-workspace targets are covered by the direct scan;
-  external targets must be declared as a workspace folder / ado-path. Path
-  completion still *offers* symlinked dirs (listing, not recursion).
+- **Symlinked directories are not recursively descended** by any walk (see §2).
+  In-workspace targets are covered by the direct scan; external targets must be
+  declared as a workspace folder / ado-path. Path completion still *offers*
+  symlinked dirs (listing, not recursion).
+- **The persistent workspace index follows real files only** (see §2) — it does
+  not add symlinked-file aliases it could not keep fresh. Symlinked files are
+  followed by the one-shot consumers (completion, `sight check`, `.sthlp`
+  lookup) only.
 - **Output paths stay as written.** Indexed URIs / completion labels remain the
   path as encountered, matching non-symlink entries.
 - `resolve_path_rich`'s external behavior is unchanged; the helper extraction is
@@ -221,30 +239,35 @@ New unit tests for `symlink-aware-entry.ts`:
 
 Per-site tests (real temp-dir symlinks, skipped where the platform can't make
 them):
-- **indexer `scan_directory`:** a symlinked `.do` is indexed; a symlinked dir's
-  in-workspace target is indexed once via its real path; an ancestor-pointing
-  dir symlink does not hang (not descended) and nothing is double-indexed; a dir
-  symlink whose target is **outside** the workspace is **not descended**.
-- **indexer `find_sthlp_file_recursive`:** a symlinked `.sthlp` under a real
-  subdir is found; a dir symlink is not recursed through.
+- **indexer `scan_directory`:** a symlinked `.do` is **not** added to the index
+  (real files only); a symlinked dir's in-workspace target is indexed via its
+  real path; an ancestor-pointing dir symlink does not hang (not descended); a
+  dir symlink whose target is **outside** the workspace is **not descended**; a
+  dangling symlink does not break the scan.
+- **`.sthlp` lookup `find_sthlp_file_recursive`:** a symlinked `.sthlp` under a
+  real subdir is found; a dangling symlinked `.sthlp` is not returned; a dir
+  symlink is not recursed through.
 - **`walk_sources` / `collect_report_targets`:** symlinked source file
-  discovered; symlinked-dir target discovered via its real path; dir symlink not
-  recursed; external dir symlink not descended.
+  discovered; non-source symlink not discovered; symlinked-dir target discovered
+  via its real path; dir symlink not recursed; external dir symlink not
+  descended.
 - **path completion:** a symlinked dir and a symlinked `.do` appear as
-  completions.
+  completions; an external-target symlinked dir is offered; a dangling symlink
+  is not.
 
 Existing `path-resolve-rich.test.ts` symlink suite must stay green after the
 delegation refactor (regression guard for §1) — confirmed.
 
 ## Risks
 
-- **Performance:** `stat` only on symlinked entries (one syscall, only when the
-  `Dirent` fast path doesn't resolve it). The non-symlinked common case is
-  unchanged — same `isDirectory()` recursion as before.
-- **Symlinked-dir targets not indexed when external:** a symlinked directory
-  pointing outside the workspace has its contents un-indexed. Mitigation:
+- **Performance:** in the one-shot consumers, `stat` only on symlinked entries
+  (one syscall, only when the `Dirent` fast path doesn't resolve it). The
+  indexer (the hot startup path) is unchanged.
+- **External symlink targets not indexed:** a symlinked directory or file whose
+  target is outside the workspace is not in the persistent index. Mitigation:
   documented; declare the target as a workspace folder / ado-path. Chosen over
-  recursively crawling symlinked dirs, which reintroduces cycle / escape /
-  aliasing / TOCTOU hazards for no coverage gain on in-workspace layouts.
+  crawling symlinked dirs (cycle/escape/aliasing/TOCTOU hazards) and over
+  indexing symlinked-file aliases (path-keyed staleness, Codex round-7) — both
+  for little gain on in-workspace layouts.
 - **Refactor regression in the resolver:** bounded — delegation preserves
   semantics and is covered by the existing symlink test suite (confirmed green).

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -131,10 +131,15 @@ direct scan of its real location already indexes those files; if the target is
 *outside*, that is precisely the escape hazard. So the policy is simply:
 
 - **Recurse into real subdirectories only** (`entry.isDirectory()`, the
-  pre-existing check — symlinked dirs excluded, as before). A real directory
-  tree is finite and acyclic, so **no** visited set, realpath, or boundary
-  machinery is needed; cycles, escape, aliasing, TOCTOU, and exclusion-bypass
-  are all structurally impossible.
+  pre-existing check — symlinked dirs excluded, as before). Because recursion
+  follows only real subdirectories (exactly as it did before this fix), the
+  change introduces **no** new symlink cycle/escape risk, so **no** visited
+  set, realpath, or boundary machinery is added; the TOCTOU / aliasing /
+  exclusion-bypass classes that a symlinked-dir descent would create simply do
+  not arise. (OS-level Windows junctions and bind mounts report as real
+  directories via `isDirectory()` and are therefore descended just as the
+  pre-existing code descended them — that is unchanged by this fix and out of
+  scope here.)
 - **Follow symlinked source FILES.** A `readdir` entry for a symlinked file is
   neither `isFile()` nor `isDirectory()`, so the old code dropped it — this is
   the actual #219 bug. Replace the file test with the symlink-aware
@@ -147,6 +152,14 @@ wants an external directory indexed declares it as a workspace folder or
 ado-path (the indexer already accepts both) rather than reaching it through a
 symlink. Path completion is the one exception — it *lists* a symlinked dir as a
 navigable folder (see §3) because listing is not recursion.
+
+A symlinked source file is indexed under the path at which it is encountered
+(the symlink path), matching how every other entry is indexed by traversal
+path. If such a symlink and its real target are *both* inside the workspace,
+the same physical file is indexed under both URIs — a benign best-effort-index
+over-count (both paths are valid and resolve to the same content), not a
+correctness issue. De-duplicating by canonical path would reintroduce the
+realpath machinery this design deliberately removes, so it is left as-is.
 
 ### 3. Per-site changes
 

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -29,11 +29,11 @@ symlinked file/dir already works; only the recursive `walk_sources` descent
 misses symlinks. No change needed there.
 
 These are the sites the original bug touches. The fix's reach differs by site
-(see §2): the **persistent indexer** `scan_directory` is intentionally left
-real-files-only (it cannot keep a symlink-alias entry fresh — Codex round-7),
-no walk descends symlinked directories, and the **one-shot** consumers
-(`walk_sources`, `find_sthlp_file_recursive`, path completion) follow symlinked
-files.
+(see §2): no walk descends symlinked directories; the **analyzing** consumers
+(`scan_directory` and `sight check`'s `walk_sources`) are intentionally left
+real-files-only (they cannot safely analyze a symlink-alias URI the index does
+not hold — Codex rounds 7/9); and only the **listing/lookup** consumers
+(`find_sthlp_file_recursive`, path completion) follow symlinked files.
 
 ## Reference behavior (PR #216)
 
@@ -109,7 +109,7 @@ async-classify a directory.
 tests are unaffected behaviorally — verified green by the existing
 `path-resolve-rich.test.ts` symlink suite.
 
-### 2. Traversal policy: follow symlinked files, do NOT descend symlinked dirs
+### 2. Traversal policy: who follows symlinks (and who must not)
 
 Classification (§1) tells a walk *what* an entry is. It does **not** by itself
 decide *whether to descend* — and `resolve_path_rich` never had to, because it

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -1,0 +1,198 @@
+# Symlink-aware directory walks (issue #219)
+
+## Problem
+
+Several directory-walk sites classify `readdir` entries with only
+`Dirent.isDirectory()` / `Dirent.isFile()`. For a symlink entry **both** return
+`false` (the true predicate is `isSymbolicLink()`), so symlinked directories and
+symlinked `.do`/source files are silently invisible to these walks. A Stata
+project laid out with symlinked directories or symlinked source files is not
+fully indexed, checked, or completed.
+
+This is the same class of bug fixed in PR #216 for `resolve_path_rich`
+(`src/utils/file-path-utils.ts`). Those sites are **pre-existing** (they never
+followed symlinks — not regressions), so #216 left them out of scope and #219
+tracks them.
+
+## Affected sites
+
+| Site | Function | I/O | Recursive? |
+|------|----------|-----|------------|
+| `src/indexer/index.ts:308` | `scan_directory` | async (`fs.promises.readdir`) | yes, **unbounded** |
+| `src/indexer/index.ts:1298` | `find_sthlp_file_recursive` | async | yes, depth-capped (8) |
+| `src/cli/source-files.ts:67` | `walk_sources` | sync (`fs.readdirSync`) | yes, **unbounded** |
+| `src/providers/completion.ts:~1426` | path completion | sync | no (single dir listing) |
+
+Note: `collect_report_targets` (the caller of `walk_sources`) already
+`fs.statSync`s each **explicit** top-level input path, so an explicitly named
+symlinked file/dir already works; only the recursive `walk_sources` descent
+misses symlinks. No change needed there.
+
+## Reference behavior (PR #216)
+
+`resolve_path_rich` added a `statSync` to its injected fs seam and two private
+helpers, `entry_is_dir` / `entry_is_file`:
+
+- Fast path: `entry.isDirectory()` / `entry.isFile()` — no extra syscall for the
+  common non-symlink entry.
+- Symlink path: only when `entry.isSymbolicLink()`, `statSync(full_path)` (which
+  follows the link) and classify by the **target's** `isDirectory()`/`isFile()`.
+- A dangling symlink makes `statSync` throw; caught → treated as non-matching
+  (skipped, not crashed).
+
+We reuse exactly this logic.
+
+## Design
+
+### 1. Shared symlink-aware classification helper
+
+`resolve_path_rich` already contains the canonical sync implementation as the
+private `entry_is_dir` / `entry_is_file`. To avoid a fourth and fifth copy of
+the same try/catch, extract the logic into a new focused module and have all
+consumers (including `file-path-utils.ts`) call it.
+
+New file `src/utils/symlink-aware-entry.ts`:
+
+```typescript
+/** Minimal fs seam: a stat that FOLLOWS symlinks (throws on dangling). */
+export interface StatSyncFs {
+    statSync(p: string): { isFile(): boolean; isDirectory(): boolean };
+}
+export interface StatAsyncFs {
+    stat(p: string): Promise<{ isFile(): boolean; isDirectory(): boolean }>;
+}
+
+interface DirentLike {
+    isFile(): boolean;
+    isDirectory(): boolean;
+    isSymbolicLink(): boolean;
+}
+
+export function entry_is_directory_sync(
+    entry: DirentLike, full_path: string, fs: StatSyncFs): boolean;
+export function entry_is_file_sync(
+    entry: DirentLike, full_path: string, fs: StatSyncFs): boolean;
+export async function entry_is_directory_async(
+    entry: DirentLike, full_path: string, fs: StatAsyncFs): Promise<boolean>;
+export async function entry_is_file_async(
+    entry: DirentLike, full_path: string, fs: StatAsyncFs): Promise<boolean>;
+```
+
+Each is the PR #216 shape: fast path on the `Dirent` predicate; on
+`isSymbolicLink()`, stat the full path and classify by the target; `try/catch`
+→ `false` on a dangling/erroring link. The sync and async pairs share identical
+logic, differing only in `await`.
+
+`file-path-utils.ts`'s private `entry_is_dir` / `entry_is_file` are rewritten to
+delegate to `entry_is_directory_sync` / `entry_is_file_sync` (one source of
+truth). `RichResolveFs.statSync` already satisfies `StatSyncFs`, so the resolver
+and its tests are unaffected behaviorally — verified by the existing
+`path-resolve-rich.test.ts` symlink suite.
+
+### 2. Cycle protection for unbounded recursive walks
+
+`resolve_path_rich` walks a **fixed component list** from a request path, so it
+cannot loop. The two unbounded recursive discovery walks (`scan_directory`,
+`walk_sources`) *can*: a directory symlink pointing at an ancestor
+(`/ws/sub/link -> /ws`) becomes an infinite descent the moment we start
+following symlinked directories. We must add a guard **as part of this fix**, or
+we trade an invisible-files bug for a hang.
+
+`find_sthlp_file_recursive` is already bounded by `MAX_STHLP_SEARCH_DEPTH = 8`,
+so it cannot hang; it gets the classification fix but no cycle set. (Worst case:
+a symlink cycle is re-walked up to depth 8 — bounded and cheap. Adding the set
+there too is harmless but not required; we add it for consistency only if it
+costs nothing — decision: **do not** add it there, to keep the depth-capped path
+unchanged.)
+
+**Guard strategy — canonical-path visited set, symlinked-dirs only:**
+
+- A non-symlink subdirectory of a tree can never create a cycle, so the common
+  case stays exactly as today (no extra syscall, no set membership cost worth
+  mentioning).
+- Only when we are about to descend into an entry that is a **symlinked
+  directory** do we resolve its real path (`fs.realpathSync` / `fs.promises.realpath`)
+  and check a `Set<string>` of already-entered canonical dirs. If present →
+  skip. Otherwise add and recurse.
+- `realpath` on the symlink target also collapses two different symlinks to the
+  same physical dir, avoiding duplicate indexing.
+- If `realpath` throws (dangling/raced), skip that entry.
+
+This keeps cycle-detection cost proportional to the number of symlinked
+directories, not the (far larger) number of plain directories.
+
+`scan_directory` currently takes `(dir_path, generation)`. Thread an optional
+`visited_real_dirs: Set<string>` (created at the scan root, default a fresh
+empty set) through the recursion. `walk_sources` similarly threads a
+`Set<string>`.
+
+### 3. Per-site changes
+
+**`scan_directory` (async):** for each entry, replace
+`entry.isDirectory()` → `await entry_is_directory_async(entry, entry_path, fs.promises)`
+and `entry.isFile() && hasStataExtension(...)` →
+`(await entry_is_file_async(entry, entry_path, fs.promises)) && hasStataExtension(...)`.
+Before recursing into a directory that is a symlink, apply the cycle guard from
+§2. The VCS-metadata skip (`VCS_METADATA_DIRS.has(entry.name)`) is unchanged and
+still keyed on the entry name.
+
+**`find_sthlp_file_recursive` (async):** same async classification swap; no
+cycle set (depth-capped). `EXCLUDED_DIRS` check unchanged.
+
+**`walk_sources` (sync):** swap to `entry_is_directory_sync` / `entry_is_file_sync`
+with the real `fs` (`{ statSync: fs.statSync }`). Apply the §2 cycle guard
+(sync `realpath`) before descending symlinked dirs. `VCS_METADATA_DIRS` check
+unchanged.
+
+**path completion (sync):** swap the two predicates to the sync helpers. No
+recursion → no cycle set. The hidden-file skip (`entry.name.startsWith('.')`)
+and prefix filter are unchanged. A symlinked dir is offered with the trailing
+`/`; a symlinked Stata file is offered like a regular file.
+
+### 4. Out of scope / explicitly preserved
+
+- **No new symlink-following anywhere except classification + guarded descent.**
+  We do not resolve/canonicalize output paths reported to users — indexed and
+  completed paths remain the symlink path as written (matching how non-symlink
+  entries are reported today). Only the internal cycle set uses canonical paths.
+- `resolve_path_rich`'s external behavior is unchanged; the refactor is
+  mechanical de-duplication covered by existing tests.
+- `find_sthlp_file_recursive` keeps its depth cap as its loop bound.
+
+## Testing
+
+Mirror `path-resolve-rich.test.ts`'s injected-fs approach (a fake fs mapping
+paths → `link-dir` / `link-file` / `link-dead` kinds) so tests are deterministic
+and platform-independent (no real symlinks on disk, which are awkward on CI /
+Windows).
+
+New unit tests for `symlink-aware-entry.ts`:
+- symlinked-dir entry → `entry_is_directory_*` true, `entry_is_file_*` false
+- symlinked-file entry → file true, dir false
+- dangling symlink → both false, no throw
+- plain dir / plain file → fast path, stat never called (spy asserts 0 calls)
+- sync and async variants each covered
+
+Per-site tests (injected fs where the site supports it; otherwise a temp dir
+with real symlinks guarded for the platform):
+- **indexer `scan_directory`:** a symlinked `.do` file is indexed; a symlinked
+  subdirectory's files are indexed; a directory symlink cycle terminates and
+  does not double-index.
+- **indexer `find_sthlp_file_recursive`:** a symlinked `.sthlp` (or symlinked
+  dir containing it) is found.
+- **`walk_sources` / `collect_report_targets`:** symlinked source file and
+  symlinked subtree are discovered; a cycle terminates.
+- **path completion:** symlinked dir and symlinked `.do` appear as completions.
+
+Existing `path-resolve-rich.test.ts` symlink suite must stay green after the
+delegation refactor (regression guard for §1).
+
+## Risks
+
+- **Performance:** stat/realpath only on symlink entries; non-symlink fast path
+  unchanged. Negligible for non-symlinked projects (the common case).
+- **Cycle guard correctness:** canonical-path set is the standard, robust
+  approach; the main subtlety (only guard symlinked-dir descent) is called out
+  so reviewers can confirm a plain deep tree pays nothing.
+- **Refactor regression in the resolver:** bounded — delegation preserves
+  semantics and is covered by the existing symlink test suite.

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -171,9 +171,10 @@ left as-is and documented (see `docs/cross-file.md`).
 
 **`scan_directory` (async):** signature unchanged. Directory branch stays
 `entry.isDirectory()` (real subdirs only) with the existing `VCS_METADATA_DIRS`
-skip. File branch becomes `await entry_is_file_async(entry, entry_path,
-fs.promises) && hasStataExtension(entry.name)` so a symlinked source file is
-collected.
+skip. File branch becomes `hasStataExtension(entry.name) && await
+entry_is_file_async(entry, entry_path, fs.promises)` so a symlinked source file
+is collected — the cheap name check is left of the `&&` so the (possibly
+stat-ing) helper runs only for Stata-named entries.
 
 **`find_sthlp_file_recursive` (async):** directory branch stays
 `my_dirent.isDirectory()` with the `EXCLUDED_DIRS` skip and the depth cap. File
@@ -182,9 +183,10 @@ so a symlinked `.sthlp` is matched.
 
 **`walk_sources` (sync):** signature unchanged. Directory branch stays
 `entry.isDirectory()` with the `VCS_METADATA_DIRS` skip. File branch becomes
-`entry_is_file_sync(entry, entry_path, fs) && hasStataExtension(entry.name)`.
-(Explicit top-level input paths in `collect_report_targets` already `statSync`
-+ `canonicalize_existing_path`, so a directly-named symlink already works.)
+`hasStataExtension(entry.name) && entry_is_file_sync(entry, entry_path, fs)`
+(cheap name check first, same gating as the other walks). (Explicit top-level
+input paths in `collect_report_targets` already `statSync` +
+`canonicalize_existing_path`, so a directly-named symlink already works.)
 
 **path completion (sync):** uses `classify_entry_sync(entry, full_path, fs)` and
 offers `'directory'` (incl. symlinked dirs) with a trailing `/` and `'file'`

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -18,10 +18,10 @@ tracks them.
 
 | Site | Function | I/O | Recursive? |
 |------|----------|-----|------------|
-| `src/indexer/index.ts:308` | `scan_directory` | async (`fs.promises.readdir`) | yes, **unbounded** |
-| `src/indexer/index.ts:1298` | `find_sthlp_file_recursive` | async | yes, depth-capped (8) |
-| `src/cli/source-files.ts:67` | `walk_sources` | sync (`fs.readdirSync`) | yes, **unbounded** |
-| `src/providers/completion.ts:~1426` | path completion | sync | no (single dir listing) |
+| `src/indexer/index.ts` | `scan_directory` | async (`fs.promises.readdir`) | yes, **unbounded** |
+| `src/indexer/index.ts` | `find_sthlp_file_recursive` | async | yes, depth-capped (8) |
+| `src/cli/source-files.ts` | `walk_sources` | sync (`fs.readdirSync`) | yes, **unbounded** |
+| `src/providers/completion.ts` | path completion | sync | no (single dir listing) |
 
 Note: `collect_report_targets` (the caller of `walk_sources`) already
 `fs.statSync`s each **explicit** top-level input path, so an explicitly named
@@ -122,12 +122,12 @@ Codex's adversarial reviews of both the spec and the implementation):
 2. **Escape** — a dir symlink to outside the workspace (`/ws/link -> /Users/me`)
    crawls an arbitrary external tree. The indexer's `maxIndexedFiles` cap does
    **not** bound this: it gates *indexing* inside `index_file`
-   (`should_skip_for_max_indexed_files`, `src/indexer/index.ts:421`), while the
-   directory walk keeps recursing regardless.
+   (`should_skip_for_max_indexed_files`), while the directory walk keeps
+   recursing regardless.
 3. **Aliasing / duplicate indexing** — the same physical dir reached via a
    symlink and via its real path is walked/indexed twice under distinct URIs
-   (symbols are keyed by traversal path, `src/indexer/index.ts:450`); a symlink
-   to a *declared root* can even claim that root before its own scan.
+   (`index_file` keys by traversal path, not realpath); a symlink to a
+   *declared root* can even claim that root before its own scan.
 4. **TOCTOU + exclusion bypass** — a parent-side boundary check is racy, and a
    symlink named innocuously but pointing at `.git`/`node_modules` bypasses the
    name-based exclusion.
@@ -198,9 +198,12 @@ so a symlinked `.sthlp` is matched.
 **`walk_sources` (sync):** signature unchanged. Directory branch stays
 `entry.isDirectory()` with the `VCS_METADATA_DIRS` skip. File branch becomes
 `hasStataExtension(entry.name) && entry_is_file_sync(entry, entry_path, fs)`
-(cheap name check first, same gating as the other walks). (Explicit top-level
-input paths in `collect_report_targets` already `statSync` +
-`canonicalize_existing_path`, so a directly-named symlink already works.)
+(cheap name check first, same gating as the other walks). `collect_report_targets`
+then de-duplicates the discovered files by **realpath** (keeping the
+lexically-smallest name) instead of by raw path string, so a symlink and its
+in-tree target are checked once — no duplicate diagnostics. (Explicit top-level
+input paths already `statSync` + `canonicalize_existing_path`, so a
+directly-named symlink already works.)
 
 **path completion (sync):** uses `classify_entry_sync(entry, full_path, fs)` and
 offers `'directory'` (incl. symlinked dirs) with a trailing `/` and `'file'`
@@ -247,10 +250,11 @@ them):
 - **`.sthlp` lookup `find_sthlp_file_recursive`:** a symlinked `.sthlp` under a
   real subdir is found; a dangling symlinked `.sthlp` is not returned; a dir
   symlink is not recursed through.
-- **`walk_sources` / `collect_report_targets`:** symlinked source file
-  discovered; non-source symlink not discovered; symlinked-dir target discovered
-  via its real path; dir symlink not recursed; external dir symlink not
-  descended.
+- **`walk_sources` / `collect_report_targets`:** external-target symlinked
+  source file discovered; a symlink + its in-tree target reported once
+  (realpath dedup); non-source symlink not discovered; symlinked-dir target
+  discovered via its real path; dir symlink not recursed; external dir symlink
+  not descended.
 - **path completion:** a symlinked dir and a symlinked `.do` appear as
   completions; an external-target symlinked dir is offered; a dangling symlink
   is not.

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -76,123 +76,170 @@ export async function entry_is_directory_async(
     entry: DirentLike, full_path: string, fs: StatAsyncFs): Promise<boolean>;
 export async function entry_is_file_async(
     entry: DirentLike, full_path: string, fs: StatAsyncFs): Promise<boolean>;
+
+// Single-syscall classifier for walker call sites that test dir-then-file
+// on the same entry (the boolean pair would stat a symlink twice).
+export type EntryKind = 'directory' | 'file' | 'other';
+export function classify_entry_sync(
+    entry: DirentLike, full_path: string, fs: StatSyncFs): EntryKind;
+export async function classify_entry_async(
+    entry: DirentLike, full_path: string, fs: StatAsyncFs): Promise<EntryKind>;
 ```
 
 Each is the PR #216 shape: fast path on the `Dirent` predicate; on
 `isSymbolicLink()`, stat the full path and classify by the target; `try/catch`
-→ `false` on a dangling/erroring link. The sync and async pairs share identical
-logic, differing only in `await`.
+→ `false`/`'other'` on a dangling/erroring link. The sync and async pairs share
+identical logic, differing only in `await`.
 
-`file-path-utils.ts`'s private `entry_is_dir` / `entry_is_file` are rewritten to
-delegate to `entry_is_directory_sync` / `entry_is_file_sync` (one source of
-truth). `RichResolveFs.statSync` already satisfies `StatSyncFs`, so the resolver
-and its tests are unaffected behaviorally — verified by the existing
-`path-resolve-rich.test.ts` symlink suite.
+The boolean pair stays for `resolve_path_rich`, which tests *either* dir
+(non-final component) *or* file (final component) on a given entry, never both.
+The four recursive/listing walk sites test **directory-then-file** on the same
+entry, so they use `classify_entry_*` to avoid stat-ing a symlinked entry twice
+(Codex review, minor #4).
 
-### 2. Cycle protection for unbounded recursive walks
+`file-path-utils.ts`'s private `entry_is_dir` / `entry_is_file` delegate to
+`entry_is_directory_sync` / `entry_is_file_sync` (one source of truth).
+`RichResolveFs.statSync` already satisfies `StatSyncFs`, so the resolver and its
+tests are unaffected behaviorally — verified green by the existing
+`path-resolve-rich.test.ts` symlink suite. *(Already implemented.)*
 
-`resolve_path_rich` walks a **fixed component list** from a request path, so it
-cannot loop. The two unbounded recursive discovery walks (`scan_directory`,
-`walk_sources`) *can*: a directory symlink pointing at an ancestor
-(`/ws/sub/link -> /ws`) becomes an infinite descent the moment we start
-following symlinked directories. We must add a guard **as part of this fix**, or
-we trade an invisible-files bug for a hang.
+### 2. Traversal policy for recursive walks (separate from classification)
 
-`find_sthlp_file_recursive` is already bounded by `MAX_STHLP_SEARCH_DEPTH = 8`,
-so it cannot hang; it gets the classification fix but no cycle set. (Worst case:
-a symlink cycle is re-walked up to depth 8 — bounded and cheap. Adding the set
-there too is harmless but not required; we add it for consistency only if it
-costs nothing — decision: **do not** add it there, to keep the depth-capped path
-unchanged.)
+Classification (§1) tells a walk *what* an entry is. It does **not** decide
+*whether to descend* — and `resolve_path_rich` never had to, because it walks a
+**fixed component list** from a request path and cannot loop or escape. The
+three recursive walks (`scan_directory`, `walk_sources`,
+`find_sthlp_file_recursive`) enumerate arbitrary trees, so following symlinked
+directories introduces two distinct hazards that classification alone does not
+address (Codex review, major #1/#2/#3):
 
-**Guard strategy — canonical-path visited set, symlinked-dirs only:**
+1. **Cycles** — a directory symlink pointing at an ancestor
+   (`/ws/sub/link -> /ws`) is an infinite descent.
+2. **Escape** — a directory symlink pointing outside the declared scan roots
+   (`/ws/link -> /Users/me`) makes the walk crawl an arbitrary external tree.
+   The indexer's `maxIndexedFiles` cap does **not** bound this: it gates
+   *indexing* inside `index_file` (`should_skip_for_max_indexed_files`,
+   `src/indexer/index.ts:421`), while `scan_directory` keeps recursing
+   regardless, so the directory walk itself is unbounded.
+3. **Duplicate traversal/indexing** — the same physical dir reached via two
+   paths (`/ws/a` and `/ws/link_to_a`) is walked and indexed twice under
+   distinct URIs (symbols are keyed by traversal path, `src/indexer/index.ts:450`).
 
-- A non-symlink subdirectory of a tree can never create a cycle, so the common
-  case stays exactly as today (no extra syscall, no set membership cost worth
-  mentioning).
-- Only when we are about to descend into an entry that is a **symlinked
-  directory** do we resolve its real path (`fs.realpathSync` / `fs.promises.realpath`)
-  and check a `Set<string>` of already-entered canonical dirs. If present →
-  skip. Otherwise add and recurse.
-- `realpath` on the symlink target also collapses two different symlinks to the
-  same physical dir, avoiding duplicate indexing.
-- If `realpath` throws (dangling/raced), skip that entry.
+**Policy — canonical visited set + scan-root boundary, threaded per walk:**
 
-This keeps cycle-detection cost proportional to the number of symlinked
-directories, not the (far larger) number of plain directories.
+Each top-level walk owns a `visited_real_dirs: Set<string>` and a set of
+**canonical boundary roots** (the canonical form of the directories the walk was
+explicitly told to scan). On entering *any* directory `dir` to scan (root and
+every subdirectory, symlinked or not):
 
-`scan_directory` currently takes `(dir_path, generation)`. Thread an optional
-`visited_real_dirs: Set<string>` (created at the scan root, default a fresh
-empty set) through the recursion. `walk_sources` similarly threads a
-`Set<string>`.
+1. `canonical = realpath(dir)`; on throw (dangling/raced) → skip the directory.
+2. If `visited_real_dirs.has(canonical)` → return (handles cycles **and**
+   duplicate traversal/indexing for free). Else add it.
+3. Recurse into child directories. For a child that **is a symlink**, first
+   check its canonical target is within some canonical boundary root; if not,
+   skip it (do not follow the escape). Non-symlink children are within the root
+   by construction and need no boundary check.
+
+Why `realpath` on every directory rather than only on symlinked entries: the
+visited set must be keyed by physical identity to dedupe a plain subtree reached
+*through* a symlink (`/ws/link/sub` vs `/ws/real/sub`). `realpath` is one
+syscall per **directory** (not per file); directories are far fewer than files,
+and the indexer already `stat`s every file it indexes (`src/indexer/index.ts:463`),
+so the added cost is negligible against total scan work. The non-symlinked
+common case gains one `realpath` per directory and no behavior change.
+
+The boundary deliberately does **not** follow symlinks that escape the declared
+roots. A user who wants an external shared library indexed adds it as a
+workspace folder or ado-path (the indexer already accepts both) rather than
+relying on an escaping symlink — a conservative, predictable default that avoids
+silently crawling `$HOME`. This is an explicit, reviewed scope decision.
+
+`find_sthlp_file_recursive` gets the **same** visited-set + boundary guard. Its
+`MAX_STHLP_SEARCH_DEPTH = 8` cap bounds depth but **not** repeated traversal of
+the same physical dirs within that depth, so the depth cap alone is not
+sufficient (Codex review, major #3). Boundary root = the canonical `root_dir`
+it was invoked with.
 
 ### 3. Per-site changes
 
-**`scan_directory` (async):** for each entry, replace
-`entry.isDirectory()` → `await entry_is_directory_async(entry, entry_path, fs.promises)`
-and `entry.isFile() && hasStataExtension(...)` →
-`(await entry_is_file_async(entry, entry_path, fs.promises)) && hasStataExtension(...)`.
-Before recursing into a directory that is a symlink, apply the cycle guard from
-§2. The VCS-metadata skip (`VCS_METADATA_DIRS.has(entry.name)`) is unchanged and
-still keyed on the entry name.
+**`scan_directory` (async):** signature gains a threaded
+`visited_real_dirs: Set<string>` and `boundary_roots: string[]` (canonical).
+`initialize` seeds `boundary_roots` once from the canonical form of
+`workspace_folders ∪ ado_paths` and passes a fresh `visited_real_dirs` per
+top-level `scan_directory` call (shared across its recursion). Per directory:
+realpath + visited check (step 1–2). Per entry: `classify_entry_async(entry,
+entry_path, fs.promises)`; `'directory'` → VCS skip, then symlink-boundary check
+(step 3) before recursing; `'file'` + `hasStataExtension` → collect. VCS skip
+(`VCS_METADATA_DIRS.has(entry.name)`) unchanged.
 
-**`find_sthlp_file_recursive` (async):** same async classification swap; no
-cycle set (depth-capped). `EXCLUDED_DIRS` check unchanged.
+**`find_sthlp_file_recursive` (async):** add `classify_entry_async`; seed a
+`visited_real_dirs` set and a single boundary root (canonical `root_dir`) at the
+top; realpath + visited check before processing each popped dir; symlink
+children get the boundary check before being pushed. `EXCLUDED_DIRS` unchanged;
+depth cap retained as an additional bound.
 
-**`walk_sources` (sync):** swap to `entry_is_directory_sync` / `entry_is_file_sync`
-with the real `fs` (`{ statSync: fs.statSync }`). Apply the §2 cycle guard
-(sync `realpath`) before descending symlinked dirs. `VCS_METADATA_DIRS` check
-unchanged.
+**`walk_sources` (sync):** thread `visited_real_dirs` and a `boundary_root`
+(canonical of the top dir passed by `collect_report_targets`). Use
+`classify_entry_sync` with `{ statSync: fs.statSync }` and `fs.realpathSync` for
+the visited/boundary logic. `VCS_METADATA_DIRS` skip unchanged. (Explicit
+top-level input paths in `collect_report_targets` already `statSync` and
+`canonicalize_existing_path`, so they are unaffected.)
 
-**path completion (sync):** swap the two predicates to the sync helpers. No
-recursion → no cycle set. The hidden-file skip (`entry.name.startsWith('.')`)
-and prefix filter are unchanged. A symlinked dir is offered with the trailing
-`/`; a symlinked Stata file is offered like a regular file.
+**path completion (sync):** swap the dir/file predicates to
+`classify_entry_sync` with `{ statSync: fs.statSync }`. **No recursion** → no
+visited set, no boundary: the provider lists one directory level; navigating
+into a symlinked dir re-lists that one level on the next request. Hidden-file
+skip (`entry.name.startsWith('.')`) and prefix filter unchanged. A symlinked dir
+is offered with the trailing `/`; a symlinked Stata file like a regular file.
 
 ### 4. Out of scope / explicitly preserved
 
-- **No new symlink-following anywhere except classification + guarded descent.**
-  We do not resolve/canonicalize output paths reported to users — indexed and
-  completed paths remain the symlink path as written (matching how non-symlink
-  entries are reported today). Only the internal cycle set uses canonical paths.
-- `resolve_path_rich`'s external behavior is unchanged; the refactor is
+- **Output paths stay as written (symlink paths), not canonicalized.** Indexed
+  URIs and completion labels remain the traversal/symlink path, matching how
+  non-symlink entries are reported today. Canonical paths are used *only*
+  internally for the visited set and boundary check.
+- **Escaping symlinks are not followed** (see §2). Declared roots are the
+  boundary; external targets must be declared explicitly.
+- `resolve_path_rich`'s external behavior is unchanged; the helper extraction is
   mechanical de-duplication covered by existing tests.
-- `find_sthlp_file_recursive` keeps its depth cap as its loop bound.
 
 ## Testing
 
 Mirror `path-resolve-rich.test.ts`'s injected-fs approach (a fake fs mapping
 paths → `link-dir` / `link-file` / `link-dead` kinds) so tests are deterministic
 and platform-independent (no real symlinks on disk, which are awkward on CI /
-Windows).
+Windows). For sites whose seams are not injectable, use a temp dir with real
+symlinks, guarded so the test skips where the platform cannot create symlinks.
 
-New unit tests for `symlink-aware-entry.ts`:
-- symlinked-dir entry → `entry_is_directory_*` true, `entry_is_file_*` false
-- symlinked-file entry → file true, dir false
-- dangling symlink → both false, no throw
-- plain dir / plain file → fast path, stat never called (spy asserts 0 calls)
+New unit tests for `symlink-aware-entry.ts` *(already implemented, 9 passing)*:
+- symlinked-dir / symlinked-file / dangling / plain-dir / plain-file across the
+  boolean pair and the `classify_entry_*` pair
+- fast path asserts the stat seam is **never called** for plain entries
 - sync and async variants each covered
 
-Per-site tests (injected fs where the site supports it; otherwise a temp dir
-with real symlinks guarded for the platform):
-- **indexer `scan_directory`:** a symlinked `.do` file is indexed; a symlinked
-  subdirectory's files are indexed; a directory symlink cycle terminates and
-  does not double-index.
+Per-site tests:
+- **indexer `scan_directory`:** symlinked `.do` is indexed; files under a
+  symlinked subdir are indexed; an ancestor-pointing dir symlink **terminates**;
+  the same physical file reached via a symlink is **not double-indexed**; a dir
+  symlink whose target is **outside** all declared roots is **not followed**.
 - **indexer `find_sthlp_file_recursive`:** a symlinked `.sthlp` (or symlinked
-  dir containing it) is found.
+  dir containing it) is found; a cycle terminates within the depth cap.
 - **`walk_sources` / `collect_report_targets`:** symlinked source file and
-  symlinked subtree are discovered; a cycle terminates.
+  symlinked subtree are discovered; a cycle terminates; an escaping symlink is
+  not followed.
 - **path completion:** symlinked dir and symlinked `.do` appear as completions.
 
 Existing `path-resolve-rich.test.ts` symlink suite must stay green after the
-delegation refactor (regression guard for §1).
+delegation refactor (regression guard for §1) — confirmed.
 
 ## Risks
 
-- **Performance:** stat/realpath only on symlink entries; non-symlink fast path
-  unchanged. Negligible for non-symlinked projects (the common case).
-- **Cycle guard correctness:** canonical-path set is the standard, robust
-  approach; the main subtlety (only guard symlinked-dir descent) is called out
-  so reviewers can confirm a plain deep tree pays nothing.
+- **Performance:** one `realpath` per directory entered (not per file) plus
+  `stat` only on symlinked entries. Negligible against per-file indexing work;
+  the non-symlinked common case is otherwise unchanged.
+- **Boundary too strict:** a symlink to an undeclared external tree is silently
+  not indexed. Mitigation: documented behavior; the fix is to declare the target
+  as a workspace folder / ado-path. Chosen over the alternative (crawl anywhere)
+  because unbounded external traversal is the worse failure.
 - **Refactor regression in the resolver:** bounded — delegation preserves
-  semantics and is covered by the existing symlink test suite.
+  semantics and is covered by the existing symlink test suite (confirmed green).

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -142,9 +142,13 @@ direct scan of its real location already indexes those files; if the target is
   scope here.)
 - **Follow symlinked source FILES.** A `readdir` entry for a symlinked file is
   neither `isFile()` nor `isDirectory()`, so the old code dropped it — this is
-  the actual #219 bug. Replace the file test with the symlink-aware
-  `entry_is_file_*` so a symlinked `.do`/`.ado`/`.sthlp` (target anywhere) is
-  recognized.
+  the actual #219 bug. Each walk keeps its existing **name-based** match
+  (`hasStataExtension(entry.name)`, or `name === basename` for `.sthlp`) and
+  adds the symlink-aware `entry_is_file_*` to confirm the target is a regular
+  file. Detection is therefore by the link's own name (matching how regular
+  files are matched): a link named `analysis.do` is followed (target may live
+  anywhere), while a link whose name lacks a Stata extension is not, even if
+  its target is a `.do`.
 
 This is the conscious scope decision: **symlinked source files are followed
 everywhere; symlinked directories are not recursively crawled.** A user who
@@ -156,10 +160,12 @@ navigable folder (see §3) because listing is not recursion.
 A symlinked source file is indexed under the path at which it is encountered
 (the symlink path), matching how every other entry is indexed by traversal
 path. If such a symlink and its real target are *both* inside the workspace,
-the same physical file is indexed under both URIs — a benign best-effort-index
-over-count (both paths are valid and resolve to the same content), not a
-correctness issue. De-duplicating by canonical path would reintroduce the
-realpath machinery this design deliberately removes, so it is left as-is.
+the same content is indexed under two separate URIs. Each URI counts toward
+`crossFile.maxIndexedFiles`, so the duplicate consumes a slot and could, near
+the cap, crowd out another file — it is a best-effort-index over-count, not a
+correctness bug, but not strictly free. De-duplicating by canonical path would
+reintroduce the realpath machinery this design deliberately removes, so it is
+left as-is and documented (see `docs/cross-file.md`).
 
 ### 3. Per-site changes
 

--- a/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
+++ b/docs/superpowers/specs/2026-06-26-symlink-aware-directory-walks-design.md
@@ -95,12 +95,13 @@ Each is the PR #216 shape: fast path on the `Dirent` predicate; on
 → `false`/`'other'` on a dangling/erroring link.
 
 `entry_is_directory_sync` / `entry_is_file_sync` serve `resolve_path_rich`
-(which tests *either* dir or file on a given entry, never both) and
-`walk_sources` (`entry_is_file_sync`). `entry_is_file_async` serves the
-on-demand async `.sthlp` lookup. `classify_entry_sync` serves path completion.
-There is deliberately **no** async directory variant or async classifier: the
-recursive walks descend only real subdirectories (`Dirent.isDirectory()`), so
-they never async-classify a directory.
+(which tests *either* dir or file on a given entry, never both — this is the
+PR #216 resolver, which resolves a specific requested path and legitimately
+follows symlinked components). `entry_is_file_async` serves the on-demand async
+`.sthlp` lookup. `classify_entry_sync` serves path completion. There is
+deliberately **no** async directory variant or async classifier: the recursive
+walks descend only real subdirectories (`Dirent.isDirectory()`), so they never
+async-classify a directory.
 
 `file-path-utils.ts`'s private `entry_is_dir` / `entry_is_file` delegate to
 `entry_is_directory_sync` / `entry_is_file_sync` (one source of truth).
@@ -138,15 +139,18 @@ Two realizations shape the policy:
    symlinked dir's target is *inside* the workspace, the direct scan of its
    real location already covers those files; if *outside*, that is precisely
    the escape hazard. So no walk descends symlinked directories.
-2. **The persistent workspace index cannot safely follow symlinked files
-   either.** It keys entries by path (`URI.file(file_path)`) and the file
-   watcher (`onDidChangeWatchedFiles`) re-indexes/removes only the *changed
-   event path*. An `alias.do -> real.do` entry indexed alongside `real.do`
-   would go stale the moment `real.do` is edited (the watcher fires for
-   `real.do`, not `alias.do`), leaving duplicate/stale symbols in
-   completions, go-to-definition, and the dependency graph. (Codex round-7
-   finding.) Rather than add a realpath→aliases invalidation map, the
-   long-lived index holds **real files only**.
+2. **Anything that ANALYZES files cannot safely follow symlinked files,
+   because analysis is keyed by path.** The persistent index keys entries by
+   `URI.file(file_path)` and `onDidChangeWatchedFiles` re-indexes/removes only
+   the *changed event path*, so an `alias.do -> real.do` entry would go stale
+   when `real.do` is edited (watcher fires for `real.do`, not the alias —
+   Codex round-7). `sight check` opens each target under `URI.file(target.path)`
+   and resolves backward scope via `dependency_graph.get_parents(uri)`, whose
+   callee edges are keyed by the **resolved real path**; it also gates on
+   `has_indexed_file(uri)` (real files only). Analyzing a symlink-alias URI
+   would therefore miss its parents (false undefined-symbol diagnostics) and,
+   past the index cap, be reported `SIGHT_FILE_NOT_INDEXED` (Codex round-9). So
+   the analyzing consumers process **real files only**.
 
 So:
 
@@ -159,28 +163,28 @@ So:
   mounts report as real directories via `isDirectory()` and are descended just
   as the pre-existing code descended them — unchanged by this fix, out of
   scope.)
-- **The persistent indexer (`scan_directory`) follows real files only** — its
-  file branch is unchanged (`entry.isFile() && hasStataExtension(name)`), for
-  the staleness reason above. In-workspace symlink targets are covered via
-  their real path; external targets are declared as a workspace folder /
-  ado-path.
-- **One-shot consumers follow symlinked source FILES**, where there is no
-  long-lived path-keyed state to keep fresh, so no staleness can arise:
-  - **path completion** offers symlinked dirs (navigable folders) and files;
-  - **`sight check`** (`walk_sources`) discovers symlinked source files in its
-    single scan;
+- **The analyzing consumers follow real files only** — the persistent indexer
+  (`scan_directory`) and `sight check` (`walk_sources`) keep their file branch
+  unchanged (`entry.isFile() && hasStataExtension(name)`), for the path-keyed
+  reasons above. In-workspace symlink targets are analyzed via their real path;
+  external targets are declared as a workspace folder / ado-path.
+- **The non-analyzing consumers follow symlinked source FILES**, because they
+  only list or look up paths — no path-keyed analysis state to keep consistent:
+  - **path completion** offers symlinked dirs (navigable folders) and files
+    via `classify_entry_sync`;
   - the on-demand **`.sthlp` lookup** (`find_sthlp_file_recursive`, a fresh
     per-request walk that returns a path and never caches into the index)
-    matches a symlinked help file.
+    matches a symlinked help file via `entry_is_file_async`.
   Each keeps its existing **name-based** match (`hasStataExtension(entry.name)`,
-  or `name === basename` for `.sthlp`) and adds `entry_is_file_*` to confirm
-  the target is a regular file. Detection is by the link's own name (matching
-  how regular files are matched): a link named `analysis.do` is followed
-  (target anywhere), a link without a Stata-extension name is not.
+  or `name === basename` for `.sthlp`) plus the symlink-aware classifier to
+  confirm the target is a regular file. Detection is by the link's own name
+  (matching how regular files are matched): a link named `analysis.do` is
+  followed (target anywhere), a link without a Stata-extension name is not.
 
-This is the conscious scope decision: **the persistent index follows neither
-symlinked directories nor symlinked files; one-shot consumers follow symlinked
-files; no walk descends symlinked directories.**
+This is the conscious scope decision: **the analyzing consumers (index,
+`sight check`) follow real files only; the listing/lookup consumers (path
+completion, `.sthlp` lookup) follow symlinked files; no walk descends symlinked
+directories.**
 
 ### 3. Per-site changes
 
@@ -195,15 +199,13 @@ dirs nor symlinked files (staleness reason in §2). A brief comment records why.
 branch becomes `my_dirent.name === basename && await entry_is_file_async(...)`
 so a symlinked `.sthlp` is matched.
 
-**`walk_sources` (sync):** signature unchanged. Directory branch stays
-`entry.isDirectory()` with the `VCS_METADATA_DIRS` skip. File branch becomes
-`hasStataExtension(entry.name) && entry_is_file_sync(entry, entry_path, fs)`
-(cheap name check first, same gating as the other walks). `collect_report_targets`
-then de-duplicates the discovered files by **realpath** (keeping the
-lexically-smallest name) instead of by raw path string, so a symlink and its
-in-tree target are checked once — no duplicate diagnostics. (Explicit top-level
-input paths already `statSync` + `canonicalize_existing_path`, so a
-directly-named symlink already works.)
+**`walk_sources` (sync, `sight check`):** **unchanged from `main`** — directory
+branch `entry.isDirectory()` (real subdirs only) with the `VCS_METADATA_DIRS`
+skip, file branch `entry.isFile() && hasStataExtension(entry.name)`. `sight
+check` analyzes each discovered target by path, so it follows real files only
+for the same path-keyed reason as the indexer (§2); a comment records why.
+(Explicit top-level input paths already `statSync` + `canonicalize_existing_path`,
+so a directly-named symlink given as an argument still works.)
 
 **path completion (sync):** uses `classify_entry_sync(entry, full_path, fs)` and
 offers `'directory'` (incl. symlinked dirs) with a trailing `/` and `'file'`
@@ -217,10 +219,10 @@ skip (`entry.name.startsWith('.')`) and prefix filter unchanged.
   In-workspace targets are covered by the direct scan; external targets must be
   declared as a workspace folder / ado-path. Path completion still *offers*
   symlinked dirs (listing, not recursion).
-- **The persistent workspace index follows real files only** (see §2) — it does
-  not add symlinked-file aliases it could not keep fresh. Symlinked files are
-  followed by the one-shot consumers (completion, `sight check`, `.sthlp`
-  lookup) only.
+- **The analyzing consumers (index, `sight check`) follow real files only**
+  (see §2) — they do not analyze symlinked-file aliases that the path-keyed
+  index/dep-graph could not match. Symlinked files are followed by the
+  listing/lookup consumers (path completion, `.sthlp` lookup) only.
 - **Output paths stay as written.** Indexed URIs / completion labels remain the
   path as encountered, matching non-symlink entries.
 - `resolve_path_rich`'s external behavior is unchanged; the helper extraction is
@@ -250,11 +252,11 @@ them):
 - **`.sthlp` lookup `find_sthlp_file_recursive`:** a symlinked `.sthlp` under a
   real subdir is found; a dangling symlinked `.sthlp` is not returned; a dir
   symlink is not recursed through.
-- **`walk_sources` / `collect_report_targets`:** external-target symlinked
-  source file discovered; a symlink + its in-tree target reported once
-  (realpath dedup); non-source symlink not discovered; symlinked-dir target
-  discovered via its real path; dir symlink not recursed; external dir symlink
-  not descended.
+- **`walk_sources` / `collect_report_targets`:** a symlinked source file is
+  **not** discovered (real files only — the real file is checked, the alias is
+  not a target); an external-target symlinked source file is not discovered;
+  non-source symlink not discovered; symlinked-dir target discovered via its
+  real path; dir symlink not recursed.
 - **path completion:** a symlinked dir and a symlinked `.do` appear as
   completions; an external-target symlinked dir is offered; a dangling symlink
   is not.
@@ -264,14 +266,15 @@ delegation refactor (regression guard for §1) — confirmed.
 
 ## Risks
 
-- **Performance:** in the one-shot consumers, `stat` only on symlinked entries
-  (one syscall, only when the `Dirent` fast path doesn't resolve it). The
-  indexer (the hot startup path) is unchanged.
-- **External symlink targets not indexed:** a symlinked directory or file whose
-  target is outside the workspace is not in the persistent index. Mitigation:
+- **Performance:** in the listing/lookup consumers, `stat` only on symlinked
+  entries (one syscall, only when the `Dirent` fast path doesn't resolve it).
+  The indexer and `sight check` (the bulk-scan paths) are unchanged.
+- **External symlink targets not analyzed:** a symlinked directory or file
+  whose target is outside the workspace is not indexed or checked. Mitigation:
   documented; declare the target as a workspace folder / ado-path. Chosen over
-  crawling symlinked dirs (cycle/escape/aliasing/TOCTOU hazards) and over
-  indexing symlinked-file aliases (path-keyed staleness, Codex round-7) — both
+  crawling symlinked dirs (cycle/escape/aliasing/TOCTOU) and over analyzing
+  symlinked-file aliases (path-keyed staleness in the index, Codex round-7;
+  dep-graph/`has_indexed_file` mismatch in `sight check`, Codex round-9) — both
   for little gain on in-workspace layouts.
 - **Refactor regression in the resolver:** bounded — delegation preserves
   semantics and is covered by the existing symlink test suite (confirmed green).

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -82,11 +82,12 @@ function walk_sources(
 
     for (const entry of entries) {
         const entry_path = path.join(dir_path, entry.name);
-        // Recurse into real subdirectories only. Symlinked dirs are not
-        // descended: an in-workspace target is already covered by the
-        // direct scan of its real location, and an external target
-        // would crawl an arbitrary tree (issue #219). The walk stays a
-        // finite real tree, so no cycle/boundary guard is needed.
+        // Recurse into real subdirectories only (unchanged). Symlinked
+        // dirs are not descended: an in-workspace target is already
+        // covered by the direct scan of its real location, and an
+        // external target would crawl an arbitrary tree (issue #219).
+        // Recursing only real subdirs adds no symlink cycle/escape
+        // risk, so no new guard is needed.
         if (entry.isDirectory()) {
             if (VCS_METADATA_DIRS.has(entry.name)) continue;
             walk_sources(entry_path, out, operator_errors);

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -2,7 +2,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { TextDecoder } from 'util';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
-import { hasStataExtension, VCS_METADATA_DIRS } from '../utils/file-path-utils';
+import {
+    hasStataExtension,
+    VCS_METADATA_DIRS,
+    is_within_any_root,
+} from '../utils/file-path-utils';
+import { classify_entry_sync } from '../utils/symlink-aware-entry';
 import { compare_strings, error_message } from './shared';
 
 export interface ReportTarget {
@@ -67,8 +72,23 @@ export function is_within_workspace(
 function walk_sources(
     dir_path: string,
     out: string[],
-    operator_errors: string[]
+    operator_errors: string[],
+    boundary_root: string,
+    visited_real_dirs: Set<string>
 ): void {
+    // Canonicalize the directory and dedupe by physical identity. This makes a
+    // symlink cycle terminate and prevents walking the same physical dir twice
+    // when it is reachable through a symlink (issue #219). realpath is one
+    // syscall per directory entered (not per file).
+    let canonical_dir: string;
+    try {
+        canonical_dir = fs.realpathSync.native(dir_path);
+    } catch {
+        return; // dangling/raced directory — skip
+    }
+    if (visited_real_dirs.has(canonical_dir)) return;
+    visited_real_dirs.add(canonical_dir);
+
     let entries: fs.Dirent[];
     try {
         entries = fs.readdirSync(dir_path, { withFileTypes: true });
@@ -81,10 +101,29 @@ function walk_sources(
 
     for (const entry of entries) {
         const entry_path = path.join(dir_path, entry.name);
-        if (entry.isDirectory()) {
+        const entry_kind = classify_entry_sync(entry, entry_path, fs);
+        if (entry_kind === 'directory') {
             if (VCS_METADATA_DIRS.has(entry.name)) continue;
-            walk_sources(entry_path, out, operator_errors);
-        } else if (entry.isFile() && hasStataExtension(entry.name)) {
+            // A symlinked directory may point outside the scan root; follow it
+            // only when its physical target stays within the boundary, so a
+            // symlink cannot make the walk escape into an arbitrary tree.
+            if (entry.isSymbolicLink()) {
+                let target: string;
+                try {
+                    target = fs.realpathSync.native(entry_path);
+                } catch {
+                    continue; // dangling symlink — skip
+                }
+                if (!is_within_any_root(target, [boundary_root])) continue;
+            }
+            walk_sources(
+                entry_path,
+                out,
+                operator_errors,
+                boundary_root,
+                visited_real_dirs
+            );
+        } else if (entry_kind === 'file' && hasStataExtension(entry.name)) {
             out.push(entry_path);
         }
     }
@@ -135,7 +174,15 @@ export function collect_report_targets(
             continue;
         }
         if (stat.isDirectory()) {
-            walk_sources(absolute_path, source_paths, operator_errors);
+            // `absolute_path` is already canonical (canonicalize_existing_path),
+            // so it is both the boundary root and the first visited entry.
+            walk_sources(
+                absolute_path,
+                source_paths,
+                operator_errors,
+                absolute_path,
+                new Set<string>()
+            );
         } else if (stat.isFile() && hasStataExtension(absolute_path)) {
             source_paths.push(absolute_path);
         }

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -2,12 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { TextDecoder } from 'util';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
-import {
-    hasStataExtension,
-    VCS_METADATA_DIRS,
-    is_within_any_root,
-} from '../utils/file-path-utils';
-import { classify_entry_sync } from '../utils/symlink-aware-entry';
+import { hasStataExtension, VCS_METADATA_DIRS } from '../utils/file-path-utils';
+import { entry_is_file_sync } from '../utils/symlink-aware-entry';
 import { compare_strings, error_message } from './shared';
 
 export interface ReportTarget {
@@ -72,23 +68,8 @@ export function is_within_workspace(
 function walk_sources(
     dir_path: string,
     out: string[],
-    operator_errors: string[],
-    boundary_root: string,
-    visited_real_dirs: Set<string>
+    operator_errors: string[]
 ): void {
-    // Canonicalize the directory and dedupe by physical identity. This makes a
-    // symlink cycle terminate and prevents walking the same physical dir twice
-    // when it is reachable through a symlink (issue #219). realpath is one
-    // syscall per directory entered (not per file).
-    let canonical_dir: string;
-    try {
-        canonical_dir = fs.realpathSync.native(dir_path);
-    } catch {
-        return; // dangling/raced directory — skip
-    }
-    if (visited_real_dirs.has(canonical_dir)) return;
-    visited_real_dirs.add(canonical_dir);
-
     let entries: fs.Dirent[];
     try {
         entries = fs.readdirSync(dir_path, { withFileTypes: true });
@@ -101,29 +82,21 @@ function walk_sources(
 
     for (const entry of entries) {
         const entry_path = path.join(dir_path, entry.name);
-        const entry_kind = classify_entry_sync(entry, entry_path, fs);
-        if (entry_kind === 'directory') {
+        // Recurse into real subdirectories only. Symlinked directories are not
+        // descended: an in-workspace target is already covered by the direct
+        // scan of its real location, and an out-of-workspace target would crawl
+        // an arbitrary external tree (issue #219). This keeps the walk a finite
+        // real tree, so no cycle/boundary guard is needed.
+        if (entry.isDirectory()) {
             if (VCS_METADATA_DIRS.has(entry.name)) continue;
-            // A symlinked directory may point outside the scan root; follow it
-            // only when its physical target stays within the boundary, so a
-            // symlink cannot make the walk escape into an arbitrary tree.
-            if (entry.isSymbolicLink()) {
-                let target: string;
-                try {
-                    target = fs.realpathSync.native(entry_path);
-                } catch {
-                    continue; // dangling symlink — skip
-                }
-                if (!is_within_any_root(target, [boundary_root])) continue;
-            }
-            walk_sources(
-                entry_path,
-                out,
-                operator_errors,
-                boundary_root,
-                visited_real_dirs
-            );
-        } else if (entry_kind === 'file' && hasStataExtension(entry.name)) {
+            walk_sources(entry_path, out, operator_errors);
+        } else if (
+            // A symlinked source FILE is followed (its target may live
+            // anywhere): without this it is neither isFile() nor isDirectory()
+            // and was silently skipped (#219).
+            entry_is_file_sync(entry, entry_path, fs) &&
+            hasStataExtension(entry.name)
+        ) {
             out.push(entry_path);
         }
     }
@@ -174,15 +147,7 @@ export function collect_report_targets(
             continue;
         }
         if (stat.isDirectory()) {
-            // `absolute_path` is already canonical (canonicalize_existing_path),
-            // so it is both the boundary root and the first visited entry.
-            walk_sources(
-                absolute_path,
-                source_paths,
-                operator_errors,
-                absolute_path,
-                new Set<string>()
-            );
+            walk_sources(absolute_path, source_paths, operator_errors);
         } else if (stat.isFile() && hasStataExtension(absolute_path)) {
             source_paths.push(absolute_path);
         }

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -157,7 +157,31 @@ export function collect_report_targets(
         }
     }
 
-    const targets: ReportTarget[] = Array.from(new Set(source_paths))
+    // Dedupe by physical identity, not by path string. Following
+    // symlinked source files (#219) means one physical file can be
+    // reached by several names (a symlink and its target, or two
+    // symlinks to it); report it ONCE so `sight check` does not emit
+    // duplicate diagnostics for the same content. Keep the lexically
+    // smallest name for a deterministic report. A path that cannot be
+    // canonicalized (race) is keyed by itself, never silently dropped.
+    const canonical_to_path = new Map<string, string>();
+    for (const my_path of source_paths) {
+        let my_canonical: string;
+        try {
+            my_canonical = canonicalize_existing_path(my_path);
+        } catch {
+            my_canonical = my_path;
+        }
+        const my_existing = canonical_to_path.get(my_canonical);
+        if (
+            my_existing === undefined ||
+            compare_strings(my_path, my_existing) < 0
+        ) {
+            canonical_to_path.set(my_canonical, my_path);
+        }
+    }
+
+    const targets: ReportTarget[] = Array.from(canonical_to_path.values())
         .map((file_path) => ({
             path: file_path,
             relative_path: relative_path(normalized_root, file_path),

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -82,20 +82,23 @@ function walk_sources(
 
     for (const entry of entries) {
         const entry_path = path.join(dir_path, entry.name);
-        // Recurse into real subdirectories only. Symlinked directories are not
-        // descended: an in-workspace target is already covered by the direct
-        // scan of its real location, and an out-of-workspace target would crawl
-        // an arbitrary external tree (issue #219). This keeps the walk a finite
-        // real tree, so no cycle/boundary guard is needed.
+        // Recurse into real subdirectories only. Symlinked dirs are not
+        // descended: an in-workspace target is already covered by the
+        // direct scan of its real location, and an external target
+        // would crawl an arbitrary tree (issue #219). The walk stays a
+        // finite real tree, so no cycle/boundary guard is needed.
         if (entry.isDirectory()) {
             if (VCS_METADATA_DIRS.has(entry.name)) continue;
             walk_sources(entry_path, out, operator_errors);
         } else if (
-            // A symlinked source FILE is followed (its target may live
-            // anywhere): without this it is neither isFile() nor isDirectory()
-            // and was silently skipped (#219).
-            entry_is_file_sync(entry, entry_path, fs) &&
-            hasStataExtension(entry.name)
+            // A symlinked source FILE is followed (target may live
+            // anywhere): without this it is neither isFile() nor
+            // isDirectory() and was silently skipped (#219). The cheap
+            // extension check gates the (possibly stat-ing) helper so
+            // irrelevant symlinks (e.g. to a slow/blocked target) are
+            // never followed.
+            hasStataExtension(entry.name) &&
+            entry_is_file_sync(entry, entry_path, fs)
         ) {
             out.push(entry_path);
         }

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -81,15 +81,15 @@ function walk_sources(
 
     for (const entry of entries) {
         const entry_path = path.join(dir_path, entry.name);
-        // `sight check` analyzes each discovered file, and analysis is
-        // keyed by path: the dependency graph keys callee edges by the
-        // resolved (real) path and the workspace index holds real files
-        // only, so analyzing a symlink-alias URI would miss its parents
-        // and could be reported as un-indexed. So this walk, like the
-        // persistent indexer, follows neither symlinked directories nor
-        // symlinked files — real files only (issue #219). In-workspace
-        // symlink targets are covered via their real path; symlink
-        // following lives in the non-analyzing consumers (path
+        // `sight check` analyzes each discovered file under its own
+        // URI, and the workspace index holds real files only. Opening a
+        // symlink-alias URI the index never indexed gives unreliable
+        // cross-file scope and a spurious SIGHT_FILE_NOT_INDEXED past
+        // the index cap (`has_indexed_file` is keyed by URI). So this
+        // walk, like the persistent indexer, follows neither symlinked
+        // dirs nor symlinked files — real files only (issue #219).
+        // In-workspace symlink targets are covered via their real path;
+        // symlink following lives in the non-analyzing consumers (path
         // completion, the `.sthlp` lookup).
         if (entry.isDirectory()) {
             if (VCS_METADATA_DIRS.has(entry.name)) continue;

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import { TextDecoder } from 'util';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { hasStataExtension, VCS_METADATA_DIRS } from '../utils/file-path-utils';
-import { entry_is_file_sync } from '../utils/symlink-aware-entry';
 import { compare_strings, error_message } from './shared';
 
 export interface ReportTarget {
@@ -82,25 +81,20 @@ function walk_sources(
 
     for (const entry of entries) {
         const entry_path = path.join(dir_path, entry.name);
-        // Recurse into real subdirectories only (unchanged). Symlinked
-        // dirs are not descended: an in-workspace target is already
-        // covered by the direct scan of its real location, and an
-        // external target would crawl an arbitrary tree (issue #219).
-        // Recursing only real subdirs adds no symlink cycle/escape
-        // risk, so no new guard is needed.
+        // `sight check` analyzes each discovered file, and analysis is
+        // keyed by path: the dependency graph keys callee edges by the
+        // resolved (real) path and the workspace index holds real files
+        // only, so analyzing a symlink-alias URI would miss its parents
+        // and could be reported as un-indexed. So this walk, like the
+        // persistent indexer, follows neither symlinked directories nor
+        // symlinked files — real files only (issue #219). In-workspace
+        // symlink targets are covered via their real path; symlink
+        // following lives in the non-analyzing consumers (path
+        // completion, the `.sthlp` lookup).
         if (entry.isDirectory()) {
             if (VCS_METADATA_DIRS.has(entry.name)) continue;
             walk_sources(entry_path, out, operator_errors);
-        } else if (
-            // A symlinked source FILE is followed (target may live
-            // anywhere): without this it is neither isFile() nor
-            // isDirectory() and was silently skipped (#219). The cheap
-            // extension check gates the (possibly stat-ing) helper so
-            // irrelevant symlinks (e.g. to a slow/blocked target) are
-            // never followed.
-            hasStataExtension(entry.name) &&
-            entry_is_file_sync(entry, entry_path, fs)
-        ) {
+        } else if (entry.isFile() && hasStataExtension(entry.name)) {
             out.push(entry_path);
         }
     }
@@ -157,31 +151,7 @@ export function collect_report_targets(
         }
     }
 
-    // Dedupe by physical identity, not by path string. Following
-    // symlinked source files (#219) means one physical file can be
-    // reached by several names (a symlink and its target, or two
-    // symlinks to it); report it ONCE so `sight check` does not emit
-    // duplicate diagnostics for the same content. Keep the lexically
-    // smallest name for a deterministic report. A path that cannot be
-    // canonicalized (race) is keyed by itself, never silently dropped.
-    const canonical_to_path = new Map<string, string>();
-    for (const my_path of source_paths) {
-        let my_canonical: string;
-        try {
-            my_canonical = canonicalize_existing_path(my_path);
-        } catch {
-            my_canonical = my_path;
-        }
-        const my_existing = canonical_to_path.get(my_canonical);
-        if (
-            my_existing === undefined ||
-            compare_strings(my_path, my_existing) < 0
-        ) {
-            canonical_to_path.set(my_canonical, my_path);
-        }
-    }
-
-    const targets: ReportTarget[] = Array.from(canonical_to_path.values())
+    const targets: ReportTarget[] = Array.from(new Set(source_paths))
         .map((file_path) => ({
             path: file_path,
             relative_path: relative_path(normalized_root, file_path),

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -48,7 +48,9 @@ import {
 import {
     hasStataExtension,
     VCS_METADATA_DIRS,
+    is_within_any_root,
 } from '../utils/file-path-utils';
+import { classify_entry_async } from '../utils/symlink-aware-entry';
 
 const MAX_PARALLEL = 4;
 const YIELD_INTERVAL_MS = 100;
@@ -278,9 +280,32 @@ export class WorkspaceIndexer {
         this.help_search_paths = discover_stata_ado_paths();
         const start_time = Date.now();
 
-        for (const folder of [...workspace_folders, ...this.ado_paths]) {
+        // Scan-root boundary for symlinked-directory traversal: a symlinked
+        // dir is followed only when its physical target stays within one of
+        // the declared roots, so a symlink cannot escape into an arbitrary
+        // external tree (issue #219). Canonicalize each declared root once;
+        // fall back to the resolved path if it cannot be canonicalized.
+        const the_declared_roots = [...workspace_folders, ...this.ado_paths];
+        const boundary_roots: string[] = [];
+        for (const my_root of the_declared_roots) {
+            try {
+                boundary_roots.push(await fs.promises.realpath(my_root));
+            } catch {
+                boundary_roots.push(path.resolve(my_root));
+            }
+        }
+        // One visited set shared across all declared roots so a physical dir
+        // reachable from two roots (or via a symlink) is walked once.
+        const visited_real_dirs = new Set<string>();
+
+        for (const folder of the_declared_roots) {
             if (!this.is_active_generation(generation)) break;
-            await this.scan_directory(folder, generation);
+            await this.scan_directory(
+                folder,
+                generation,
+                boundary_roots,
+                visited_real_dirs
+            );
         }
 
         if (!this.is_active_generation(generation)) {
@@ -307,9 +332,26 @@ export class WorkspaceIndexer {
      */
     private async scan_directory(
         dir_path: string,
-        generation: number
+        generation: number,
+        boundary_roots: string[],
+        visited_real_dirs: Set<string>
     ): Promise<void> {
         if (!this.is_active_generation(generation)) return;
+
+        // Canonicalize the directory and dedupe by physical identity. This
+        // terminates symlink cycles and avoids walking/indexing the same
+        // physical dir twice when it is reachable through a symlink (#219).
+        // realpath is one syscall per directory entered, not per file. On
+        // failure, fall back to the lexical path so readdir below still
+        // surfaces the real error (preserving the prior error-log behavior).
+        let canonical_dir: string;
+        try {
+            canonical_dir = await fs.promises.realpath(dir_path);
+        } catch {
+            canonical_dir = dir_path;
+        }
+        if (visited_real_dirs.has(canonical_dir)) return;
+        visited_real_dirs.add(canonical_dir);
 
         try {
             const entries = await fs.promises.readdir(dir_path, {
@@ -323,8 +365,16 @@ export class WorkspaceIndexer {
                 if (!this.is_active_generation(generation)) break;
 
                 const entry_path = path.join(dir_path, entry.name);
+                // Symlink-aware, single stat: a symlinked dir/file would
+                // otherwise be neither isDirectory() nor isFile() and be
+                // silently skipped (#219).
+                const entry_kind = await classify_entry_async(
+                    entry,
+                    entry_path,
+                    fs.promises
+                );
 
-                if (entry.isDirectory()) {
+                if (entry_kind === 'directory') {
                     // Skip version-control metadata directories. They hold no
                     // Stata source, can be very large, and recursing them is
                     // pure scan overhead — the standard convention for code
@@ -332,9 +382,28 @@ export class WorkspaceIndexer {
                     if (VCS_METADATA_DIRS.has(entry.name)) {
                         continue;
                     }
-                    await this.scan_directory(entry_path, generation);
+                    // Follow a symlinked directory only when its physical
+                    // target stays within a declared scan root, so a symlink
+                    // cannot make the indexer crawl an arbitrary external tree.
+                    if (entry.isSymbolicLink()) {
+                        let target: string;
+                        try {
+                            target = await fs.promises.realpath(entry_path);
+                        } catch {
+                            continue; // dangling symlink — skip
+                        }
+                        if (!is_within_any_root(target, boundary_roots)) {
+                            continue;
+                        }
+                    }
+                    await this.scan_directory(
+                        entry_path,
+                        generation,
+                        boundary_roots,
+                        visited_real_dirs
+                    );
                 } else if (
-                    entry.isFile() &&
+                    entry_kind === 'file' &&
                     hasStataExtension(entry.name)
                 ) {
                     file_paths.push(entry_path);
@@ -1299,6 +1368,17 @@ export class WorkspaceIndexer {
         root_dir: string,
         basename: string
     ): Promise<string | null> {
+        // Boundary for symlinked-dir traversal + a canonical visited set so a
+        // symlink cycle cannot re-walk the same physical dirs within the depth
+        // cap (the depth cap alone bounds depth, not repeated traversal) (#219).
+        let boundary_root: string;
+        try {
+            boundary_root = await fs.promises.realpath(root_dir);
+        } catch {
+            boundary_root = root_dir;
+        }
+        const visited_real_dirs = new Set<string>();
+
         const the_dirs: Array<{ path: string; depth: number }> = [
             { path: root_dir, depth: 0 },
         ];
@@ -1308,6 +1388,15 @@ export class WorkspaceIndexer {
             if (my_entry.depth >= WorkspaceIndexer.MAX_STHLP_SEARCH_DEPTH) {
                 continue;
             }
+
+            let canonical_dir: string;
+            try {
+                canonical_dir = await fs.promises.realpath(my_entry.path);
+            } catch {
+                canonical_dir = my_entry.path;
+            }
+            if (visited_real_dirs.has(canonical_dir)) continue;
+            visited_real_dirs.add(canonical_dir);
 
             let the_entries: fs.Dirent[];
             try {
@@ -1320,19 +1409,37 @@ export class WorkspaceIndexer {
 
             for (const my_dirent of the_entries) {
                 const my_path = path.join(my_entry.path, my_dirent.name);
-                if (my_dirent.isDirectory()) {
-                    if (!WorkspaceIndexer.EXCLUDED_DIRS.has(my_dirent.name)) {
-                        the_dirs.push({
-                            path: my_path,
-                            depth: my_entry.depth + 1,
-                        });
+                // Symlink-aware classification so a symlinked subdir is
+                // descended and a symlinked `.sthlp` is matched (#219).
+                const my_kind = await classify_entry_async(
+                    my_dirent,
+                    my_path,
+                    fs.promises
+                );
+                if (my_kind === 'directory') {
+                    if (WorkspaceIndexer.EXCLUDED_DIRS.has(my_dirent.name)) {
+                        continue;
                     }
+                    // Follow a symlinked dir only if its target stays within
+                    // the search root.
+                    if (my_dirent.isSymbolicLink()) {
+                        let target: string;
+                        try {
+                            target = await fs.promises.realpath(my_path);
+                        } catch {
+                            continue; // dangling symlink — skip
+                        }
+                        if (!is_within_any_root(target, [boundary_root])) {
+                            continue;
+                        }
+                    }
+                    the_dirs.push({
+                        path: my_path,
+                        depth: my_entry.depth + 1,
+                    });
                     continue;
                 }
-                if (
-                    my_dirent.isFile() &&
-                    my_dirent.name === basename
-                ) {
+                if (my_kind === 'file' && my_dirent.name === basename) {
                     return my_path;
                 }
             }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -330,9 +330,9 @@ export class WorkspaceIndexer {
                 // and the watcher invalidates by the changed path, so
                 // an alias entry could not be kept fresh when its
                 // target changes. In-workspace targets are covered via
-                // the real path; one-shot consumers follow symlinked
-                // files (completion, `sight check`, .sthlp lookup),
-                // where no staleness can arise.
+                // the real path; symlink-following lives in the
+                // listing/lookup consumers (path completion, the .sthlp
+                // lookup), which keep no path-keyed analysis state.
                 if (entry.isDirectory()) {
                     // Skip version-control metadata directories. They hold no
                     // Stata source, can be very large, and recursing them is

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -325,12 +325,12 @@ export class WorkspaceIndexer {
 
                 const entry_path = path.join(dir_path, entry.name);
 
-                // Recurse into real subdirectories only. Symlinked directories
-                // are deliberately NOT descended: an in-workspace target is
-                // already covered by the direct scan of its real location, and
-                // following an out-of-workspace target would crawl an arbitrary
-                // external tree (issue #219). This keeps the walk a finite real
-                // tree, so no cycle/boundary guard is needed.
+                // Recurse into real subdirectories only. Symlinked dirs
+                // are NOT descended: an in-workspace target is already
+                // covered by the direct scan of its real location, and
+                // an external target would crawl an arbitrary tree
+                // (#219). The walk stays a finite real tree, so no
+                // cycle/boundary guard is needed.
                 if (entry.isDirectory()) {
                     // Skip version-control metadata directories. They hold no
                     // Stata source, can be very large, and recursing them is
@@ -341,15 +341,17 @@ export class WorkspaceIndexer {
                     }
                     await this.scan_directory(entry_path, generation);
                 } else if (
-                    // A symlinked source FILE is followed (its target may live
-                    // anywhere): without this it is neither isFile() nor
-                    // isDirectory() and was silently skipped (#219).
+                    // A symlinked source FILE is followed (target may
+                    // live anywhere): without this it is neither
+                    // isFile() nor isDirectory() and was silently
+                    // skipped (#219). The cheap extension check gates
+                    // the (possibly stat-ing) helper.
+                    hasStataExtension(entry.name) &&
                     (await entry_is_file_async(
                         entry,
                         entry_path,
                         fs.promises
-                    )) &&
-                    hasStataExtension(entry.name)
+                    ))
                 ) {
                     file_paths.push(entry_path);
                 }
@@ -1334,8 +1336,9 @@ export class WorkspaceIndexer {
 
             for (const my_dirent of the_entries) {
                 const my_path = path.join(my_entry.path, my_dirent.name);
-                // Recurse into real subdirectories only; symlinked directories
-                // are not descended (avoids cycles / external crawl, #219).
+                // Recurse into real subdirectories only; symlinked
+                // dirs are not descended (avoids cycles / external
+                // crawl, #219).
                 if (my_dirent.isDirectory()) {
                     if (!WorkspaceIndexer.EXCLUDED_DIRS.has(my_dirent.name)) {
                         the_dirs.push({
@@ -1345,7 +1348,7 @@ export class WorkspaceIndexer {
                     }
                     continue;
                 }
-                // A symlinked `.sthlp` file IS matched (its target may live
+                // A symlinked `.sthlp` file IS matched (target may live
                 // anywhere): without this it is neither isFile() nor
                 // isDirectory() and was silently skipped (#219).
                 if (

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -325,14 +325,14 @@ export class WorkspaceIndexer {
 
                 const entry_path = path.join(dir_path, entry.name);
 
-                // Recurse into real subdirectories only (unchanged).
-                // Symlinked dirs are NOT descended: an in-workspace
-                // target is already covered by the direct scan of its
-                // real location, and an external target would crawl an
-                // arbitrary tree (#219). Recursing only real subdirs
-                // adds no symlink cycle/escape risk, so no new guard is
-                // needed. (OS junctions/bind mounts present as real
-                // dirs and are descended as before — pre-existing.)
+                // The persistent index follows neither symlinked dirs
+                // nor symlinked files (#219): it keys entries by path
+                // and the watcher invalidates by the changed path, so
+                // an alias entry could not be kept fresh when its
+                // target changes. In-workspace targets are covered via
+                // the real path; one-shot consumers follow symlinked
+                // files (completion, `sight check`, .sthlp lookup),
+                // where no staleness can arise.
                 if (entry.isDirectory()) {
                     // Skip version-control metadata directories. They hold no
                     // Stata source, can be very large, and recursing them is
@@ -343,17 +343,8 @@ export class WorkspaceIndexer {
                     }
                     await this.scan_directory(entry_path, generation);
                 } else if (
-                    // A symlinked source FILE is followed (target may
-                    // live anywhere): without this it is neither
-                    // isFile() nor isDirectory() and was silently
-                    // skipped (#219). The cheap extension check gates
-                    // the (possibly stat-ing) helper.
-                    hasStataExtension(entry.name) &&
-                    (await entry_is_file_async(
-                        entry,
-                        entry_path,
-                        fs.promises
-                    ))
+                    entry.isFile() &&
+                    hasStataExtension(entry.name)
                 ) {
                     file_paths.push(entry_path);
                 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -48,9 +48,8 @@ import {
 import {
     hasStataExtension,
     VCS_METADATA_DIRS,
-    is_within_any_root,
 } from '../utils/file-path-utils';
-import { classify_entry_async } from '../utils/symlink-aware-entry';
+import { entry_is_file_async } from '../utils/symlink-aware-entry';
 
 const MAX_PARALLEL = 4;
 const YIELD_INTERVAL_MS = 100;
@@ -280,32 +279,9 @@ export class WorkspaceIndexer {
         this.help_search_paths = discover_stata_ado_paths();
         const start_time = Date.now();
 
-        // Scan-root boundary for symlinked-directory traversal: a symlinked
-        // dir is followed only when its physical target stays within one of
-        // the declared roots, so a symlink cannot escape into an arbitrary
-        // external tree (issue #219). Canonicalize each declared root once;
-        // fall back to the resolved path if it cannot be canonicalized.
-        const the_declared_roots = [...workspace_folders, ...this.ado_paths];
-        const boundary_roots: string[] = [];
-        for (const my_root of the_declared_roots) {
-            try {
-                boundary_roots.push(await fs.promises.realpath(my_root));
-            } catch {
-                boundary_roots.push(path.resolve(my_root));
-            }
-        }
-        // One visited set shared across all declared roots so a physical dir
-        // reachable from two roots (or via a symlink) is walked once.
-        const visited_real_dirs = new Set<string>();
-
-        for (const folder of the_declared_roots) {
+        for (const folder of [...workspace_folders, ...this.ado_paths]) {
             if (!this.is_active_generation(generation)) break;
-            await this.scan_directory(
-                folder,
-                generation,
-                boundary_roots,
-                visited_real_dirs
-            );
+            await this.scan_directory(folder, generation);
         }
 
         if (!this.is_active_generation(generation)) {
@@ -332,26 +308,9 @@ export class WorkspaceIndexer {
      */
     private async scan_directory(
         dir_path: string,
-        generation: number,
-        boundary_roots: string[],
-        visited_real_dirs: Set<string>
+        generation: number
     ): Promise<void> {
         if (!this.is_active_generation(generation)) return;
-
-        // Canonicalize the directory and dedupe by physical identity. This
-        // terminates symlink cycles and avoids walking/indexing the same
-        // physical dir twice when it is reachable through a symlink (#219).
-        // realpath is one syscall per directory entered, not per file. On
-        // failure, fall back to the lexical path so readdir below still
-        // surfaces the real error (preserving the prior error-log behavior).
-        let canonical_dir: string;
-        try {
-            canonical_dir = await fs.promises.realpath(dir_path);
-        } catch {
-            canonical_dir = dir_path;
-        }
-        if (visited_real_dirs.has(canonical_dir)) return;
-        visited_real_dirs.add(canonical_dir);
 
         try {
             const entries = await fs.promises.readdir(dir_path, {
@@ -365,16 +324,14 @@ export class WorkspaceIndexer {
                 if (!this.is_active_generation(generation)) break;
 
                 const entry_path = path.join(dir_path, entry.name);
-                // Symlink-aware, single stat: a symlinked dir/file would
-                // otherwise be neither isDirectory() nor isFile() and be
-                // silently skipped (#219).
-                const entry_kind = await classify_entry_async(
-                    entry,
-                    entry_path,
-                    fs.promises
-                );
 
-                if (entry_kind === 'directory') {
+                // Recurse into real subdirectories only. Symlinked directories
+                // are deliberately NOT descended: an in-workspace target is
+                // already covered by the direct scan of its real location, and
+                // following an out-of-workspace target would crawl an arbitrary
+                // external tree (issue #219). This keeps the walk a finite real
+                // tree, so no cycle/boundary guard is needed.
+                if (entry.isDirectory()) {
                     // Skip version-control metadata directories. They hold no
                     // Stata source, can be very large, and recursing them is
                     // pure scan overhead — the standard convention for code
@@ -382,28 +339,16 @@ export class WorkspaceIndexer {
                     if (VCS_METADATA_DIRS.has(entry.name)) {
                         continue;
                     }
-                    // Follow a symlinked directory only when its physical
-                    // target stays within a declared scan root, so a symlink
-                    // cannot make the indexer crawl an arbitrary external tree.
-                    if (entry.isSymbolicLink()) {
-                        let target: string;
-                        try {
-                            target = await fs.promises.realpath(entry_path);
-                        } catch {
-                            continue; // dangling symlink — skip
-                        }
-                        if (!is_within_any_root(target, boundary_roots)) {
-                            continue;
-                        }
-                    }
-                    await this.scan_directory(
-                        entry_path,
-                        generation,
-                        boundary_roots,
-                        visited_real_dirs
-                    );
+                    await this.scan_directory(entry_path, generation);
                 } else if (
-                    entry_kind === 'file' &&
+                    // A symlinked source FILE is followed (its target may live
+                    // anywhere): without this it is neither isFile() nor
+                    // isDirectory() and was silently skipped (#219).
+                    (await entry_is_file_async(
+                        entry,
+                        entry_path,
+                        fs.promises
+                    )) &&
                     hasStataExtension(entry.name)
                 ) {
                     file_paths.push(entry_path);
@@ -1368,17 +1313,6 @@ export class WorkspaceIndexer {
         root_dir: string,
         basename: string
     ): Promise<string | null> {
-        // Boundary for symlinked-dir traversal + a canonical visited set so a
-        // symlink cycle cannot re-walk the same physical dirs within the depth
-        // cap (the depth cap alone bounds depth, not repeated traversal) (#219).
-        let boundary_root: string;
-        try {
-            boundary_root = await fs.promises.realpath(root_dir);
-        } catch {
-            boundary_root = root_dir;
-        }
-        const visited_real_dirs = new Set<string>();
-
         const the_dirs: Array<{ path: string; depth: number }> = [
             { path: root_dir, depth: 0 },
         ];
@@ -1388,15 +1322,6 @@ export class WorkspaceIndexer {
             if (my_entry.depth >= WorkspaceIndexer.MAX_STHLP_SEARCH_DEPTH) {
                 continue;
             }
-
-            let canonical_dir: string;
-            try {
-                canonical_dir = await fs.promises.realpath(my_entry.path);
-            } catch {
-                canonical_dir = my_entry.path;
-            }
-            if (visited_real_dirs.has(canonical_dir)) continue;
-            visited_real_dirs.add(canonical_dir);
 
             let the_entries: fs.Dirent[];
             try {
@@ -1409,37 +1334,28 @@ export class WorkspaceIndexer {
 
             for (const my_dirent of the_entries) {
                 const my_path = path.join(my_entry.path, my_dirent.name);
-                // Symlink-aware classification so a symlinked subdir is
-                // descended and a symlinked `.sthlp` is matched (#219).
-                const my_kind = await classify_entry_async(
-                    my_dirent,
-                    my_path,
-                    fs.promises
-                );
-                if (my_kind === 'directory') {
-                    if (WorkspaceIndexer.EXCLUDED_DIRS.has(my_dirent.name)) {
-                        continue;
+                // Recurse into real subdirectories only; symlinked directories
+                // are not descended (avoids cycles / external crawl, #219).
+                if (my_dirent.isDirectory()) {
+                    if (!WorkspaceIndexer.EXCLUDED_DIRS.has(my_dirent.name)) {
+                        the_dirs.push({
+                            path: my_path,
+                            depth: my_entry.depth + 1,
+                        });
                     }
-                    // Follow a symlinked dir only if its target stays within
-                    // the search root.
-                    if (my_dirent.isSymbolicLink()) {
-                        let target: string;
-                        try {
-                            target = await fs.promises.realpath(my_path);
-                        } catch {
-                            continue; // dangling symlink — skip
-                        }
-                        if (!is_within_any_root(target, [boundary_root])) {
-                            continue;
-                        }
-                    }
-                    the_dirs.push({
-                        path: my_path,
-                        depth: my_entry.depth + 1,
-                    });
                     continue;
                 }
-                if (my_kind === 'file' && my_dirent.name === basename) {
+                // A symlinked `.sthlp` file IS matched (its target may live
+                // anywhere): without this it is neither isFile() nor
+                // isDirectory() and was silently skipped (#219).
+                if (
+                    my_dirent.name === basename &&
+                    (await entry_is_file_async(
+                        my_dirent,
+                        my_path,
+                        fs.promises
+                    ))
+                ) {
                     return my_path;
                 }
             }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -325,12 +325,14 @@ export class WorkspaceIndexer {
 
                 const entry_path = path.join(dir_path, entry.name);
 
-                // Recurse into real subdirectories only. Symlinked dirs
-                // are NOT descended: an in-workspace target is already
-                // covered by the direct scan of its real location, and
-                // an external target would crawl an arbitrary tree
-                // (#219). The walk stays a finite real tree, so no
-                // cycle/boundary guard is needed.
+                // Recurse into real subdirectories only (unchanged).
+                // Symlinked dirs are NOT descended: an in-workspace
+                // target is already covered by the direct scan of its
+                // real location, and an external target would crawl an
+                // arbitrary tree (#219). Recursing only real subdirs
+                // adds no symlink cycle/escape risk, so no new guard is
+                // needed. (OS junctions/bind mounts present as real
+                // dirs and are descended as before — pre-existing.)
                 if (entry.isDirectory()) {
                     // Skip version-control metadata directories. They hold no
                     // Stata source, can be very large, and recursing them is

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -46,6 +46,7 @@ import {
 } from '../scope-resolver';
 import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 import { isPathDirective, isFileCommand, hasStataExtension } from '../utils/file-path-utils';
+import { classify_entry_sync } from '../utils/symlink-aware-entry';
 import { logger } from '../utils/logger';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -1436,7 +1437,19 @@ export class CompletionProvider {
                     continue;
                 }
 
-                if (entry.isDirectory()) {
+                // Classify symlink-aware: a symlinked directory/file would
+                // otherwise be `other` (isDirectory()/isFile() both false) and
+                // silently dropped from completions (issue #219). One stat,
+                // and only for symlink entries. No recursion here, so no
+                // cycle/boundary guard is needed — listing a symlinked dir the
+                // user navigates into re-lists that one level next request.
+                const entry_kind = classify_entry_sync(
+                    entry,
+                    path.join(base_dir, entry.name),
+                    fs,
+                );
+
+                if (entry_kind === 'directory') {
                     // Always include directories
                     completions.push({
                         label: entry.name + '/',
@@ -1445,7 +1458,7 @@ export class CompletionProvider {
                         insertText: entry.name + '/',
                         sortText: `0_${entry.name}` // Directories first
                     });
-                } else if (!directories_only && entry.isFile()) {
+                } else if (!directories_only && entry_kind === 'file') {
                     // Include files only if not directories_only
                     const is_stata_file = hasStataExtension(entry.name);
                     

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -1437,12 +1437,12 @@ export class CompletionProvider {
                     continue;
                 }
 
-                // Classify symlink-aware: a symlinked directory/file would
-                // otherwise be `other` (isDirectory()/isFile() both false) and
-                // silently dropped from completions (issue #219). One stat,
-                // and only for symlink entries. No recursion here, so no
-                // cycle/boundary guard is needed — listing a symlinked dir the
-                // user navigates into re-lists that one level next request.
+                // Classify symlink-aware: a symlinked directory/file
+                // would otherwise be `other` (isDirectory()/isFile()
+                // both false) and silently dropped from completions
+                // (issue #219). One stat, only for symlink entries. No
+                // recursion here, so no cycle/boundary guard is needed:
+                // navigating into a symlinked dir re-lists one level.
                 const entry_kind = classify_entry_sync(
                     entry,
                     path.join(base_dir, entry.name),

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -4,6 +4,10 @@
 
 import * as node_fs from 'fs';
 import * as node_path from 'path';
+import {
+    entry_is_directory_sync,
+    entry_is_file_sync,
+} from './symlink-aware-entry';
 
 // Commands that accept file paths as their first argument
 export const FILE_COMMANDS = new Set([
@@ -191,57 +195,15 @@ function has_extension(name: string): boolean {
 }
 
 // ─── Symlink-aware entry helpers ──────────────────────────────────────────────
+//
+// The symlink-aware classification logic lives in `./symlink-aware-entry` so
+// it is shared with the indexer, `sight check` source discovery, and path
+// completion (issue #219). `RichResolveFs.statSync` satisfies the shared
+// `StatSyncFs` seam, so these thin aliases keep the resolver's existing call
+// sites unchanged.
 
-/**
- * True when `entry` is a directory (direct or via symlink).
- *
- * Fast path: `entry.isDirectory()` (no extra syscall for non-symlinks).
- * Symlink path: `fs.statSync(full_path).isDirectory()` which follows the
- * link. A dangling symlink causes `statSync` to throw; we catch and return
- * false so a broken link is silently skipped rather than crashing the
- * resolver.
- */
-function entry_is_dir(
-    entry: {
-        isDirectory(): boolean;
-        isSymbolicLink(): boolean;
-    },
-    full_path: string,
-    fs: RichResolveFs,
-): boolean {
-    if (entry.isDirectory()) return true;
-    if (!entry.isSymbolicLink()) return false;
-    try {
-        return fs.statSync(full_path).isDirectory();
-    } catch {
-        return false; // dangling symlink — treat as non-matching
-    }
-}
-
-/**
- * True when `entry` is a file (direct or via symlink).
- *
- * Fast path: `entry.isFile()` (no extra syscall for non-symlinks).
- * Symlink path: `fs.statSync(full_path).isFile()` which follows the link.
- * A dangling symlink causes `statSync` to throw; we catch and return false
- * so a broken link is silently skipped rather than crashing the resolver.
- */
-function entry_is_file(
-    entry: {
-        isFile(): boolean;
-        isSymbolicLink(): boolean;
-    },
-    full_path: string,
-    fs: RichResolveFs,
-): boolean {
-    if (entry.isFile()) return true;
-    if (!entry.isSymbolicLink()) return false;
-    try {
-        return fs.statSync(full_path).isFile();
-    } catch {
-        return false; // dangling symlink — treat as non-matching
-    }
-}
+const entry_is_dir = entry_is_directory_sync;
+const entry_is_file = entry_is_file_sync;
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -40,6 +40,30 @@ export const STATA_FILE_EXTENSIONS = ['.do', '.ado', '.doh', '.mata'];
 export const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
 
 /**
+ * True when `the_path` is equal to, or nested under, at least one of `the_roots`
+ * (separator-aware so `/ws-other` is NOT within `/ws`). Used as the scan-root
+ * boundary for recursive directory walks: a symlinked directory is followed
+ * only when its canonicalized target stays within a declared root, so a symlink
+ * cannot make a walk escape into an arbitrary external tree (issue #219).
+ *
+ * Callers should pass already-canonicalized (`realpath`) paths so the boundary
+ * compares physical locations, not symlink aliases.
+ */
+export function is_within_any_root(
+  the_path: string,
+  the_roots: string[],
+): boolean {
+  const norm_path = the_path.split('\\').join('/');
+  for (const my_root of the_roots) {
+    const norm_root = my_root.split('\\').join('/');
+    if (norm_path === norm_root) return true;
+    const my_prefix = norm_root.endsWith('/') ? norm_root : norm_root + '/';
+    if (norm_path.startsWith(my_prefix)) return true;
+  }
+  return false;
+}
+
+/**
  * Check if a command accepts file paths as its first argument
  */
 export function isFileCommand(command: string): boolean {

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -40,30 +40,6 @@ export const STATA_FILE_EXTENSIONS = ['.do', '.ado', '.doh', '.mata'];
 export const VCS_METADATA_DIRS = new Set(['.git', '.hg', '.svn']);
 
 /**
- * True when `the_path` is equal to, or nested under, at least one of `the_roots`
- * (separator-aware so `/ws-other` is NOT within `/ws`). Used as the scan-root
- * boundary for recursive directory walks: a symlinked directory is followed
- * only when its canonicalized target stays within a declared root, so a symlink
- * cannot make a walk escape into an arbitrary external tree (issue #219).
- *
- * Callers should pass already-canonicalized (`realpath`) paths so the boundary
- * compares physical locations, not symlink aliases.
- */
-export function is_within_any_root(
-  the_path: string,
-  the_roots: string[],
-): boolean {
-  const norm_path = the_path.split('\\').join('/');
-  for (const my_root of the_roots) {
-    const norm_root = my_root.split('\\').join('/');
-    if (norm_path === norm_root) return true;
-    const my_prefix = norm_root.endsWith('/') ? norm_root : norm_root + '/';
-    if (norm_path.startsWith(my_prefix)) return true;
-  }
-  return false;
-}
-
-/**
  * Check if a command accepts file paths as its first argument
  */
 export function isFileCommand(command: string): boolean {

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -196,11 +196,11 @@ function has_extension(name: string): boolean {
 
 // ─── Symlink-aware entry helpers ──────────────────────────────────────────────
 //
-// The symlink-aware classification logic lives in `./symlink-aware-entry` so
-// it is shared with the indexer, `sight check` source discovery, and path
-// completion (issue #219). `RichResolveFs.statSync` satisfies the shared
-// `StatSyncFs` seam, so these thin aliases keep the resolver's existing call
-// sites unchanged.
+// The symlink-aware classification logic lives in
+// `./symlink-aware-entry` so it is shared with the indexer, `sight
+// check` source discovery, and path completion (issue #219).
+// `RichResolveFs.statSync` satisfies the shared `StatSyncFs` seam, so
+// these thin aliases keep the resolver's existing call sites unchanged.
 
 const entry_is_dir = entry_is_directory_sync;
 const entry_is_file = entry_is_file_sync;

--- a/src/utils/symlink-aware-entry.ts
+++ b/src/utils/symlink-aware-entry.ts
@@ -21,7 +21,8 @@
  * `await`; callers pick the one matching their surrounding I/O style.
  */
 
-/** Minimal fs seam: a stat that FOLLOWS symlinks (throws on dangling). */
+/** Minimal fs seam: a stat that FOLLOWS symlinks (throws on a dangling
+ * link). */
 export interface StatSyncFs {
     statSync(p: string): { isFile(): boolean; isDirectory(): boolean };
 }

--- a/src/utils/symlink-aware-entry.ts
+++ b/src/utils/symlink-aware-entry.ts
@@ -74,24 +74,11 @@ export function entry_is_file_sync(
 }
 
 /**
- * Async counterpart of {@link entry_is_directory_sync}.
- */
-export async function entry_is_directory_async(
-    entry: DirentLike,
-    full_path: string,
-    fs: StatAsyncFs,
-): Promise<boolean> {
-    if (entry.isDirectory()) return true;
-    if (!entry.isSymbolicLink()) return false;
-    try {
-        return (await fs.stat(full_path)).isDirectory();
-    } catch {
-        return false; // dangling symlink — treat as non-matching
-    }
-}
-
-/**
- * Async counterpart of {@link entry_is_file_sync}.
+ * Async counterpart of {@link entry_is_file_sync}. Used by the async indexer
+ * walks, which descend only real subdirectories (`Dirent.isDirectory()`) but
+ * must still recognize a symlinked *file* as a source file (issue #219). There
+ * is deliberately no async directory variant: the recursive walks do not follow
+ * symlinked directories, so they never need to async-classify one.
  */
 export async function entry_is_file_async(
     entry: DirentLike,
@@ -112,9 +99,10 @@ export type EntryKind = 'directory' | 'file' | 'other';
 
 /**
  * Classify an entry as `'directory'`, `'file'`, or `'other'` with at most ONE
- * stat call. Recursive-walk call sites test directory-then-file on the same
- * entry; the boolean helpers would stat a symlinked entry twice (once per
- * test), so those sites should use this instead.
+ * stat call. Used by path completion, which lists one directory level and wants
+ * to offer both symlinked directories and symlinked files; testing the boolean
+ * helpers directory-then-file would stat a symlinked entry twice, so it uses
+ * this instead.
  *
  * Fast path: the `Dirent` predicates (no syscall for non-symlink entries).
  * Symlink path: a single `statSync` follows the link; a dangling link throws
@@ -130,27 +118,6 @@ export function classify_entry_sync(
     if (!entry.isSymbolicLink()) return 'other';
     try {
         const my_stat = fs.statSync(full_path);
-        if (my_stat.isDirectory()) return 'directory';
-        if (my_stat.isFile()) return 'file';
-        return 'other';
-    } catch {
-        return 'other'; // dangling symlink — skip
-    }
-}
-
-/**
- * Async counterpart of {@link classify_entry_sync}.
- */
-export async function classify_entry_async(
-    entry: DirentLike,
-    full_path: string,
-    fs: StatAsyncFs,
-): Promise<EntryKind> {
-    if (entry.isDirectory()) return 'directory';
-    if (entry.isFile()) return 'file';
-    if (!entry.isSymbolicLink()) return 'other';
-    try {
-        const my_stat = await fs.stat(full_path);
         if (my_stat.isDirectory()) return 'directory';
         if (my_stat.isFile()) return 'file';
         return 'other';

--- a/src/utils/symlink-aware-entry.ts
+++ b/src/utils/symlink-aware-entry.ts
@@ -2,22 +2,23 @@
  * Symlink-aware classification of `readdir` directory entries.
  *
  * A `readdir(..., { withFileTypes: true })` entry for a SYMLINK reports
- * `isDirectory()` and `isFile()` as BOTH false — `isSymbolicLink()` is the only
- * true predicate. Code that classifies entries with only `isDirectory()` /
- * `isFile()` therefore silently drops symlinked directories and symlinked
- * files. These helpers add the missing case: when (and only when) an entry is a
- * symlink, stat the path (following the link) and classify by the target.
+ * `isDirectory()` and `isFile()` as BOTH false — `isSymbolicLink()` is
+ * the only true predicate. Code that classifies entries with only
+ * `isDirectory()` / `isFile()` therefore silently drops symlinked
+ * directories and symlinked files. These helpers add the missing case:
+ * when (and only when) an entry is a symlink, stat the path (following
+ * the link) and classify by the target.
  *
- * Design (mirrors `resolve_path_rich` in `file-path-utils.ts`, PR #216):
+ * Design (mirrors `resolve_path_rich` in `file-path-utils.ts`, #216):
  * - Fast path: the `Dirent` predicate — NO extra syscall for the common
  *   non-symlink entry.
- * - Symlink path: `stat(full_path)` follows the link; classify by the target's
- *   `isFile()` / `isDirectory()`.
- * - A dangling symlink makes `stat` throw; we catch and return `false` so a
- *   broken link is skipped, not crashed.
+ * - Symlink path: `stat(full_path)` follows the link; classify by the
+ *   target's `isFile()` / `isDirectory()`.
+ * - A dangling symlink makes `stat` throw; we catch and return `false`
+ *   so a broken link is skipped, not crashed.
  *
- * Sync and async variants share identical logic and differ only in `await`;
- * callers pick the one matching their surrounding I/O style.
+ * Sync and async variants share identical logic and differ only in
+ * `await`; callers pick the one matching their surrounding I/O style.
  */
 
 /** Minimal fs seam: a stat that FOLLOWS symlinks (throws on dangling). */
@@ -25,7 +26,8 @@ export interface StatSyncFs {
     statSync(p: string): { isFile(): boolean; isDirectory(): boolean };
 }
 
-/** Minimal fs seam: an async stat that FOLLOWS symlinks (rejects on dangling). */
+/** Minimal fs seam: an async stat that FOLLOWS symlinks (rejects on a
+ * dangling link). */
 export interface StatAsyncFs {
     stat(p: string): Promise<{ isFile(): boolean; isDirectory(): boolean }>;
 }
@@ -38,7 +40,7 @@ interface DirentLike {
 }
 
 /**
- * True when `entry` is a directory (direct, or a symlink whose target is a
+ * True when `entry` is a directory (direct, or a symlink to a
  * directory). Dangling symlink → false.
  */
 export function entry_is_directory_sync(
@@ -56,8 +58,8 @@ export function entry_is_directory_sync(
 }
 
 /**
- * True when `entry` is a file (direct, or a symlink whose target is a file).
- * Dangling symlink → false.
+ * True when `entry` is a file (direct, or a symlink whose target is a
+ * file). Dangling symlink → false.
  */
 export function entry_is_file_sync(
     entry: DirentLike,
@@ -74,11 +76,12 @@ export function entry_is_file_sync(
 }
 
 /**
- * Async counterpart of {@link entry_is_file_sync}. Used by the async indexer
- * walks, which descend only real subdirectories (`Dirent.isDirectory()`) but
- * must still recognize a symlinked *file* as a source file (issue #219). There
- * is deliberately no async directory variant: the recursive walks do not follow
- * symlinked directories, so they never need to async-classify one.
+ * Async counterpart of {@link entry_is_file_sync}. Used by the async
+ * indexer walks, which descend only real subdirectories
+ * (`Dirent.isDirectory()`) but must still recognize a symlinked *file*
+ * as a source file (issue #219). There is deliberately no async
+ * directory variant: the recursive walks do not follow symlinked
+ * directories, so they never need to async-classify one.
  */
 export async function entry_is_file_async(
     entry: DirentLike,
@@ -98,15 +101,15 @@ export async function entry_is_file_async(
 export type EntryKind = 'directory' | 'file' | 'other';
 
 /**
- * Classify an entry as `'directory'`, `'file'`, or `'other'` with at most ONE
- * stat call. Used by path completion, which lists one directory level and wants
- * to offer both symlinked directories and symlinked files; testing the boolean
- * helpers directory-then-file would stat a symlinked entry twice, so it uses
- * this instead.
+ * Classify an entry as `'directory'`, `'file'`, or `'other'` with at
+ * most ONE stat call. Used by path completion, which lists one dir
+ * level and wants to offer both symlinked directories and symlinked
+ * files; testing the boolean helpers directory-then-file would stat a
+ * symlinked entry twice, so it uses this instead.
  *
- * Fast path: the `Dirent` predicates (no syscall for non-symlink entries).
- * Symlink path: a single `statSync` follows the link; a dangling link throws
- * and is classified `'other'` (skipped, not crashed).
+ * Fast path: the `Dirent` predicates (no syscall for non-symlinks).
+ * Symlink path: a single `statSync` follows the link; a dangling link
+ * throws and is classified `'other'` (skipped, not crashed).
  */
 export function classify_entry_sync(
     entry: DirentLike,

--- a/src/utils/symlink-aware-entry.ts
+++ b/src/utils/symlink-aware-entry.ts
@@ -1,0 +1,160 @@
+/**
+ * Symlink-aware classification of `readdir` directory entries.
+ *
+ * A `readdir(..., { withFileTypes: true })` entry for a SYMLINK reports
+ * `isDirectory()` and `isFile()` as BOTH false — `isSymbolicLink()` is the only
+ * true predicate. Code that classifies entries with only `isDirectory()` /
+ * `isFile()` therefore silently drops symlinked directories and symlinked
+ * files. These helpers add the missing case: when (and only when) an entry is a
+ * symlink, stat the path (following the link) and classify by the target.
+ *
+ * Design (mirrors `resolve_path_rich` in `file-path-utils.ts`, PR #216):
+ * - Fast path: the `Dirent` predicate — NO extra syscall for the common
+ *   non-symlink entry.
+ * - Symlink path: `stat(full_path)` follows the link; classify by the target's
+ *   `isFile()` / `isDirectory()`.
+ * - A dangling symlink makes `stat` throw; we catch and return `false` so a
+ *   broken link is skipped, not crashed.
+ *
+ * Sync and async variants share identical logic and differ only in `await`;
+ * callers pick the one matching their surrounding I/O style.
+ */
+
+/** Minimal fs seam: a stat that FOLLOWS symlinks (throws on dangling). */
+export interface StatSyncFs {
+    statSync(p: string): { isFile(): boolean; isDirectory(): boolean };
+}
+
+/** Minimal fs seam: an async stat that FOLLOWS symlinks (rejects on dangling). */
+export interface StatAsyncFs {
+    stat(p: string): Promise<{ isFile(): boolean; isDirectory(): boolean }>;
+}
+
+/** The `Dirent` subset these helpers consult. */
+interface DirentLike {
+    isFile(): boolean;
+    isDirectory(): boolean;
+    isSymbolicLink(): boolean;
+}
+
+/**
+ * True when `entry` is a directory (direct, or a symlink whose target is a
+ * directory). Dangling symlink → false.
+ */
+export function entry_is_directory_sync(
+    entry: DirentLike,
+    full_path: string,
+    fs: StatSyncFs,
+): boolean {
+    if (entry.isDirectory()) return true;
+    if (!entry.isSymbolicLink()) return false;
+    try {
+        return fs.statSync(full_path).isDirectory();
+    } catch {
+        return false; // dangling symlink — treat as non-matching
+    }
+}
+
+/**
+ * True when `entry` is a file (direct, or a symlink whose target is a file).
+ * Dangling symlink → false.
+ */
+export function entry_is_file_sync(
+    entry: DirentLike,
+    full_path: string,
+    fs: StatSyncFs,
+): boolean {
+    if (entry.isFile()) return true;
+    if (!entry.isSymbolicLink()) return false;
+    try {
+        return fs.statSync(full_path).isFile();
+    } catch {
+        return false; // dangling symlink — treat as non-matching
+    }
+}
+
+/**
+ * Async counterpart of {@link entry_is_directory_sync}.
+ */
+export async function entry_is_directory_async(
+    entry: DirentLike,
+    full_path: string,
+    fs: StatAsyncFs,
+): Promise<boolean> {
+    if (entry.isDirectory()) return true;
+    if (!entry.isSymbolicLink()) return false;
+    try {
+        return (await fs.stat(full_path)).isDirectory();
+    } catch {
+        return false; // dangling symlink — treat as non-matching
+    }
+}
+
+/**
+ * Async counterpart of {@link entry_is_file_sync}.
+ */
+export async function entry_is_file_async(
+    entry: DirentLike,
+    full_path: string,
+    fs: StatAsyncFs,
+): Promise<boolean> {
+    if (entry.isFile()) return true;
+    if (!entry.isSymbolicLink()) return false;
+    try {
+        return (await fs.stat(full_path)).isFile();
+    } catch {
+        return false; // dangling symlink — treat as non-matching
+    }
+}
+
+/** Single-syscall classification of an entry. */
+export type EntryKind = 'directory' | 'file' | 'other';
+
+/**
+ * Classify an entry as `'directory'`, `'file'`, or `'other'` with at most ONE
+ * stat call. Recursive-walk call sites test directory-then-file on the same
+ * entry; the boolean helpers would stat a symlinked entry twice (once per
+ * test), so those sites should use this instead.
+ *
+ * Fast path: the `Dirent` predicates (no syscall for non-symlink entries).
+ * Symlink path: a single `statSync` follows the link; a dangling link throws
+ * and is classified `'other'` (skipped, not crashed).
+ */
+export function classify_entry_sync(
+    entry: DirentLike,
+    full_path: string,
+    fs: StatSyncFs,
+): EntryKind {
+    if (entry.isDirectory()) return 'directory';
+    if (entry.isFile()) return 'file';
+    if (!entry.isSymbolicLink()) return 'other';
+    try {
+        const my_stat = fs.statSync(full_path);
+        if (my_stat.isDirectory()) return 'directory';
+        if (my_stat.isFile()) return 'file';
+        return 'other';
+    } catch {
+        return 'other'; // dangling symlink — skip
+    }
+}
+
+/**
+ * Async counterpart of {@link classify_entry_sync}.
+ */
+export async function classify_entry_async(
+    entry: DirentLike,
+    full_path: string,
+    fs: StatAsyncFs,
+): Promise<EntryKind> {
+    if (entry.isDirectory()) return 'directory';
+    if (entry.isFile()) return 'file';
+    if (!entry.isSymbolicLink()) return 'other';
+    try {
+        const my_stat = await fs.stat(full_path);
+        if (my_stat.isDirectory()) return 'directory';
+        if (my_stat.isFile()) return 'file';
+        return 'other';
+    } catch {
+        return 'other'; // dangling symlink — skip
+    }
+}

--- a/src/utils/symlink-aware-entry.ts
+++ b/src/utils/symlink-aware-entry.ts
@@ -77,12 +77,12 @@ export function entry_is_file_sync(
 }
 
 /**
- * Async counterpart of {@link entry_is_file_sync}. Used by the async
- * indexer walks, which descend only real subdirectories
- * (`Dirent.isDirectory()`) but must still recognize a symlinked *file*
- * as a source file (issue #219). There is deliberately no async
- * directory variant: the recursive walks do not follow symlinked
- * directories, so they never need to async-classify one.
+ * Async counterpart of {@link entry_is_file_sync}. Used by the
+ * on-demand async `.sthlp` lookup walk (`find_sthlp_file_recursive`),
+ * which descends only real subdirectories (`Dirent.isDirectory()`) but
+ * must still match a symlinked help *file* (issue #219). There is
+ * deliberately no async directory variant: the walk does not follow
+ * symlinked directories, so it never async-classifies one.
  */
 export async function entry_is_file_async(
     entry: DirentLike,

--- a/tests/integration/indexer-follows-symlinks.test.ts
+++ b/tests/integration/indexer-follows-symlinks.test.ts
@@ -1,0 +1,209 @@
+/**
+ * The workspace scan must follow symlinked directories and symlinked source
+ * files (issue #219) — a `readdir` entry for a symlink is neither
+ * `isDirectory()` nor `isFile()`, so the old classification silently dropped
+ * them. It must do so SAFELY: a symlink cycle must terminate, the same
+ * physical file reached via a symlink must not be indexed twice, and a symlink
+ * whose target escapes every declared scan root must not be followed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { StataLSPConfig } from '../../src/types';
+
+let tmp_dir: string;
+
+function build_config(): StataLSPConfig {
+    return {
+        diagnostics: { enabled: true, severity: {} as never, indentation: false },
+        completion: { cacheSize: 200, prefixMaxItems: 200 },
+        formatting: {
+            indentSize: 4, indentStyle: 'spaces', lineWidth: 80,
+            preferredCommentStyle: 'line', normalizeCommentStyle: false,
+            commentLineWidth: 72, mode: 'source-preserving',
+            preserve_alignment: true,
+        },
+        lineCommentStyle: '//',
+        indexing: { maxFileSizeBytes: 500000 },
+        adoPaths: [],
+        indexWorkspace: true,
+        cross_file: {
+            index_workspace: true, max_indexed_files: 1000,
+            assume_call_site: 'end', backward_dependencies: 'auto',
+            max_backward_depth: 10, max_forward_depth: 10, max_chain_depth: 20,
+            max_callee_revalidations: 10,
+            diagnostics: { missing_file: 'warning', max_depth: 'information' },
+        },
+        debug: false,
+    };
+}
+
+/**
+ * Create a symlink, returning false if the platform refuses (e.g. Windows
+ * without the privilege) so the caller can skip rather than fail.
+ */
+function try_symlink(target: string, link_path: string): boolean {
+    try {
+        fs.symlinkSync(target, link_path);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function index(root: string): Promise<string[]> {
+    const indexer = new WorkspaceIndexer();
+    indexer.configure(build_config());
+    await indexer.initialize([root], []);
+    return [...indexer.get_indexed_files().keys()];
+}
+
+describe('indexer follows symlinks safely (#219)', () => {
+    beforeEach(() => {
+        tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'symlink-idx-'));
+    });
+    afterEach(() => {
+        fs.rmSync(tmp_dir, { recursive: true, force: true });
+    });
+
+    it('indexes a symlinked .do file', async () => {
+        const real = path.join(tmp_dir, 'real.do');
+        fs.writeFileSync(real, 'program define foo\nend\n');
+        const link = path.join(tmp_dir, 'aliased.do');
+        if (!try_symlink(real, link)) return; // platform without symlinks
+
+        const indexed = await index(tmp_dir);
+        // Both the regular file and the symlinked file are indexed.
+        expect(indexed.includes(URI.file(real).toString())).toBe(true);
+        expect(indexed.includes(URI.file(link).toString())).toBe(true);
+    });
+
+    it('indexes files inside a symlinked subdirectory', async () => {
+        const real_dir = path.join(tmp_dir, 'realdir');
+        fs.mkdirSync(real_dir);
+        fs.writeFileSync(path.join(real_dir, 'inner.do'), 'display 1\n');
+        const link_dir = path.join(tmp_dir, 'linkdir');
+        if (!try_symlink(real_dir, link_dir)) return;
+
+        const indexed = await index(tmp_dir);
+        // The file is reachable as realdir/inner.do and/or linkdir/inner.do;
+        // at least one must be indexed and exactly one physical copy counts.
+        const inner_count = indexed.filter(
+            (u) => u.endsWith('/inner.do'),
+        ).length;
+        expect(inner_count).toBe(1); // followed once, not double-indexed
+    });
+
+    it('terminates on an ancestor-pointing directory symlink cycle', async () => {
+        const sub = path.join(tmp_dir, 'sub');
+        fs.mkdirSync(sub);
+        fs.writeFileSync(path.join(tmp_dir, 'main.do'), 'display 1\n');
+        // sub/loop -> tmp_dir (cycle back to an ancestor)
+        if (!try_symlink(tmp_dir, path.join(sub, 'loop'))) return;
+
+        // Must complete (no infinite recursion / hang) and still index main.do.
+        const indexed = await index(tmp_dir);
+        expect(indexed.includes(URI.file(path.join(tmp_dir, 'main.do')).toString()))
+            .toBe(true);
+        // main.do must not be double-indexed via the cycle.
+        const main_count = indexed.filter(
+            (u) => u.endsWith('/main.do'),
+        ).length;
+        expect(main_count).toBe(1);
+    });
+
+    it('does NOT double-index a physical file reached via two paths', async () => {
+        const real_dir = path.join(tmp_dir, 'realdir');
+        fs.mkdirSync(real_dir);
+        fs.writeFileSync(path.join(real_dir, 'shared.do'), 'display 1\n');
+        // A second symlink in the SAME root pointing at realdir.
+        if (!try_symlink(real_dir, path.join(tmp_dir, 'alias'))) return;
+
+        const indexed = await index(tmp_dir);
+        const shared_count = indexed.filter(
+            (u) => u.endsWith('/shared.do'),
+        ).length;
+        expect(shared_count).toBe(1);
+    });
+
+    it('does NOT follow a symlink that escapes all declared scan roots', async () => {
+        // An external tree OUTSIDE the workspace root.
+        const external = fs.mkdtempSync(path.join(os.tmpdir(), 'symlink-ext-'));
+        try {
+            fs.writeFileSync(path.join(external, 'outside.do'), 'display 1\n');
+            const root = path.join(tmp_dir, 'ws');
+            fs.mkdirSync(root);
+            fs.writeFileSync(path.join(root, 'inside.do'), 'display 1\n');
+            // root/escape -> external (escapes the declared root `root`)
+            if (!try_symlink(external, path.join(root, 'escape'))) return;
+
+            const indexed = await index(root);
+            expect(indexed.includes(URI.file(path.join(root, 'inside.do')).toString()))
+                .toBe(true);
+            // The escaping symlink's target must NOT be crawled.
+            expect(
+                indexed.includes(URI.file(path.join(external, 'outside.do')).toString()),
+            ).toBe(false);
+            // and not via the symlink path either
+            const outside_count = indexed.filter(
+                (u) => u.endsWith('/outside.do'),
+            ).length;
+            expect(outside_count).toBe(0);
+        } finally {
+            fs.rmSync(external, { recursive: true, force: true });
+        }
+    });
+});
+
+describe('sthlp recursive search follows symlinks safely (#219)', () => {
+    beforeEach(() => {
+        tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'symlink-sthlp-'));
+    });
+    afterEach(() => {
+        fs.rmSync(tmp_dir, { recursive: true, force: true });
+    });
+
+    async function resolve(root: string, topic: string): Promise<string | null> {
+        const indexer = new WorkspaceIndexer();
+        indexer.configure(build_config());
+        await indexer.initialize([root], []);
+        return indexer.resolve_sthlp_file(topic);
+    }
+
+    it('finds a symlinked .sthlp file buried in a subdirectory', async () => {
+        // The recursive search only runs for workspace-root dirs, and only
+        // when the topic is not found directly at the root. Bury a symlinked
+        // .sthlp one level down. File symlinks are not boundary-checked, so the
+        // target may live anywhere.
+        const external = fs.mkdtempSync(path.join(os.tmpdir(), 'sthlp-tgt-'));
+        try {
+            const real_help = path.join(external, 'real.sthlp');
+            fs.writeFileSync(real_help, '{smcl}\nhelp\n');
+            const sub = path.join(tmp_dir, 'sub');
+            fs.mkdirSync(sub);
+            const link = path.join(sub, 'zzsymtopic.sthlp');
+            if (!try_symlink(real_help, link)) return;
+
+            const found = await resolve(tmp_dir, 'zzsymtopic');
+            expect(found).toBe(link);
+        } finally {
+            fs.rmSync(external, { recursive: true, force: true });
+        }
+    });
+
+    it('terminates on a directory symlink cycle while searching', async () => {
+        const sub = path.join(tmp_dir, 'sub');
+        fs.mkdirSync(sub);
+        // A genuine help file reachable below the root.
+        fs.writeFileSync(path.join(sub, 'zzsymtopic.sthlp'), '{smcl}\nhelp\n');
+        // sub/loop -> tmp_dir (cycle); must not hang.
+        if (!try_symlink(tmp_dir, path.join(sub, 'loop'))) return;
+
+        const found = await resolve(tmp_dir, 'zzsymtopic');
+        expect(found).toBe(path.join(sub, 'zzsymtopic.sthlp'));
+    });
+});

--- a/tests/integration/indexer-follows-symlinks.test.ts
+++ b/tests/integration/indexer-follows-symlinks.test.ts
@@ -1,10 +1,12 @@
 /**
- * The workspace scan must follow symlinked directories and symlinked source
- * files (issue #219) — a `readdir` entry for a symlink is neither
- * `isDirectory()` nor `isFile()`, so the old classification silently dropped
- * them. It must do so SAFELY: a symlink cycle must terminate, the same
- * physical file reached via a symlink must not be indexed twice, and a symlink
- * whose target escapes every declared scan root must not be followed.
+ * The workspace scan must follow symlinked source FILES (issue #219) — a
+ * `readdir` entry for a symlink is neither `isDirectory()` nor `isFile()`, so
+ * the old classification silently dropped them. Symlinked DIRECTORIES are
+ * deliberately NOT descended: an in-workspace target is already covered by the
+ * direct scan of its real location, and an out-of-workspace target would crawl
+ * an arbitrary external tree. These tests pin both: symlinked files are
+ * indexed, and symlinked directories are never recursed (so cycles terminate
+ * trivially, nothing is double-indexed, and an external target is not crawled).
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -82,7 +84,7 @@ describe('indexer follows symlinks safely (#219)', () => {
         expect(indexed.includes(URI.file(link).toString())).toBe(true);
     });
 
-    it('indexes files inside a symlinked subdirectory', async () => {
+    it('indexes a symlinked-dir target via its real in-workspace location', async () => {
         const real_dir = path.join(tmp_dir, 'realdir');
         fs.mkdirSync(real_dir);
         fs.writeFileSync(path.join(real_dir, 'inner.do'), 'display 1\n');
@@ -90,47 +92,36 @@ describe('indexer follows symlinks safely (#219)', () => {
         if (!try_symlink(real_dir, link_dir)) return;
 
         const indexed = await index(tmp_dir);
-        // The file is reachable as realdir/inner.do and/or linkdir/inner.do;
-        // at least one must be indexed and exactly one physical copy counts.
+        // The symlinked dir is not descended, but realdir/inner.do is reached
+        // by the direct scan — indexed exactly once, under its real path.
+        expect(indexed).toContain(
+            URI.file(path.join(real_dir, 'inner.do')).toString(),
+        );
         const inner_count = indexed.filter(
             (u) => u.endsWith('/inner.do'),
         ).length;
-        expect(inner_count).toBe(1); // followed once, not double-indexed
+        expect(inner_count).toBe(1); // not double-indexed via the symlink
     });
 
-    it('terminates on an ancestor-pointing directory symlink cycle', async () => {
+    it('terminates trivially on an ancestor-pointing dir symlink (not descended)', async () => {
         const sub = path.join(tmp_dir, 'sub');
         fs.mkdirSync(sub);
         fs.writeFileSync(path.join(tmp_dir, 'main.do'), 'display 1\n');
-        // sub/loop -> tmp_dir (cycle back to an ancestor)
+        // sub/loop -> tmp_dir: a cycle if descended; it is not descended.
         if (!try_symlink(tmp_dir, path.join(sub, 'loop'))) return;
 
-        // Must complete (no infinite recursion / hang) and still index main.do.
+        // Completes (no recursion through the symlink) and indexes main.do once.
         const indexed = await index(tmp_dir);
-        expect(indexed.includes(URI.file(path.join(tmp_dir, 'main.do')).toString()))
-            .toBe(true);
-        // main.do must not be double-indexed via the cycle.
+        expect(indexed).toContain(
+            URI.file(path.join(tmp_dir, 'main.do')).toString(),
+        );
         const main_count = indexed.filter(
             (u) => u.endsWith('/main.do'),
         ).length;
         expect(main_count).toBe(1);
     });
 
-    it('does NOT double-index a physical file reached via two paths', async () => {
-        const real_dir = path.join(tmp_dir, 'realdir');
-        fs.mkdirSync(real_dir);
-        fs.writeFileSync(path.join(real_dir, 'shared.do'), 'display 1\n');
-        // A second symlink in the SAME root pointing at realdir.
-        if (!try_symlink(real_dir, path.join(tmp_dir, 'alias'))) return;
-
-        const indexed = await index(tmp_dir);
-        const shared_count = indexed.filter(
-            (u) => u.endsWith('/shared.do'),
-        ).length;
-        expect(shared_count).toBe(1);
-    });
-
-    it('does NOT follow a symlink that escapes all declared scan roots', async () => {
+    it('does NOT descend a symlinked directory whose target is outside the workspace', async () => {
         // An external tree OUTSIDE the workspace root.
         const external = fs.mkdtempSync(path.join(os.tmpdir(), 'symlink-ext-'));
         try {
@@ -138,17 +129,14 @@ describe('indexer follows symlinks safely (#219)', () => {
             const root = path.join(tmp_dir, 'ws');
             fs.mkdirSync(root);
             fs.writeFileSync(path.join(root, 'inside.do'), 'display 1\n');
-            // root/escape -> external (escapes the declared root `root`)
-            if (!try_symlink(external, path.join(root, 'escape'))) return;
+            // root/external_link -> external (target outside the workspace)
+            if (!try_symlink(external, path.join(root, 'external_link'))) return;
 
             const indexed = await index(root);
-            expect(indexed.includes(URI.file(path.join(root, 'inside.do')).toString()))
-                .toBe(true);
-            // The escaping symlink's target must NOT be crawled.
-            expect(
-                indexed.includes(URI.file(path.join(external, 'outside.do')).toString()),
-            ).toBe(false);
-            // and not via the symlink path either
+            expect(indexed).toContain(
+                URI.file(path.join(root, 'inside.do')).toString(),
+            );
+            // The external target must NOT be crawled (under any path).
             const outside_count = indexed.filter(
                 (u) => u.endsWith('/outside.do'),
             ).length;
@@ -177,8 +165,8 @@ describe('sthlp recursive search follows symlinks safely (#219)', () => {
     it('finds a symlinked .sthlp file buried in a subdirectory', async () => {
         // The recursive search only runs for workspace-root dirs, and only
         // when the topic is not found directly at the root. Bury a symlinked
-        // .sthlp one level down. File symlinks are not boundary-checked, so the
-        // target may live anywhere.
+        // .sthlp one level down (under a REAL subdir). Symlinked files are
+        // followed regardless of where the target lives.
         const external = fs.mkdtempSync(path.join(os.tmpdir(), 'sthlp-tgt-'));
         try {
             const real_help = path.join(external, 'real.sthlp');
@@ -195,12 +183,12 @@ describe('sthlp recursive search follows symlinks safely (#219)', () => {
         }
     });
 
-    it('terminates on a directory symlink cycle while searching', async () => {
+    it('does not recurse through a directory symlink while searching', async () => {
         const sub = path.join(tmp_dir, 'sub');
         fs.mkdirSync(sub);
         // A genuine help file reachable below the root.
         fs.writeFileSync(path.join(sub, 'zzsymtopic.sthlp'), '{smcl}\nhelp\n');
-        // sub/loop -> tmp_dir (cycle); must not hang.
+        // sub/loop -> tmp_dir: would be a cycle if descended; it is not.
         if (!try_symlink(tmp_dir, path.join(sub, 'loop'))) return;
 
         const found = await resolve(tmp_dir, 'zzsymtopic');

--- a/tests/integration/indexer-follows-symlinks.test.ts
+++ b/tests/integration/indexer-follows-symlinks.test.ts
@@ -1,12 +1,13 @@
 /**
- * The workspace scan must follow symlinked source FILES (issue #219) — a
- * `readdir` entry for a symlink is neither `isDirectory()` nor `isFile()`, so
- * the old classification silently dropped them. Symlinked DIRECTORIES are
- * deliberately NOT descended: an in-workspace target is already covered by the
- * direct scan of its real location, and an out-of-workspace target would crawl
- * an arbitrary external tree. These tests pin both: symlinked files are
- * indexed, and symlinked directories are never recursed (so cycles terminate
- * trivially, nothing is double-indexed, and an external target is not crawled).
+ * The persistent workspace indexer follows neither symlinked directories nor
+ * symlinked files (issue #219): it keys entries by path and the file watcher
+ * invalidates by the changed event path, so an alias entry could not be kept
+ * fresh when its real target changes. In-workspace targets are covered via
+ * their real path; symlink-following lives in the one-shot consumers (path
+ * completion, `sight check`, the on-demand `.sthlp` lookup). These tests pin
+ * the indexer side: a symlinked source file is NOT added to the index, a
+ * symlinked directory is never recursed (so cycles terminate trivially and an
+ * external target is not crawled), and real files are unaffected.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -72,29 +73,24 @@ describe('indexer follows symlinks safely (#219)', () => {
         fs.rmSync(tmp_dir, { recursive: true, force: true });
     });
 
-    it('indexes a symlinked .do file', async () => {
+    it('does NOT add a symlinked source file to the persistent index', async () => {
+        // The persistent indexer keys/invalidates by path and cannot keep an
+        // alias entry fresh, so it indexes the real file only (issue #219).
         const real = path.join(tmp_dir, 'real.do');
         fs.writeFileSync(real, 'program define foo\nend\n');
         const link = path.join(tmp_dir, 'aliased.do');
         if (!try_symlink(real, link)) return; // platform without symlinks
 
         const indexed = await index(tmp_dir);
-        // Both the regular file and the symlinked file are indexed.
         expect(indexed.includes(URI.file(real).toString())).toBe(true);
-        expect(indexed.includes(URI.file(link).toString())).toBe(true);
+        expect(indexed.includes(URI.file(link).toString())).toBe(false);
     });
 
-    it('does not index a symlinked non-Stata file', async () => {
-        // The cheap extension filter must gate the symlink stat: a
-        // symlink whose name is not a Stata source extension is never
-        // followed and never indexed (issue #219 review).
-        const real = path.join(tmp_dir, 'notes.txt');
-        fs.writeFileSync(real, 'not stata\n');
-        if (!try_symlink(real, path.join(tmp_dir, 'aliased.txt'))) return;
-        // Also a dangling non-Stata symlink must not break the scan.
+    it('a dangling symlink does not break the scan', async () => {
+        // A dangling symlink (any name) must not throw or be indexed.
         try_symlink(
             path.join(tmp_dir, 'missing-target'),
-            path.join(tmp_dir, 'broken.txt'),
+            path.join(tmp_dir, 'broken.do'),
         );
         fs.writeFileSync(path.join(tmp_dir, 'real.do'), 'display 1\n');
 
@@ -102,7 +98,8 @@ describe('indexer follows symlinks safely (#219)', () => {
         expect(indexed).toContain(
             URI.file(path.join(tmp_dir, 'real.do')).toString(),
         );
-        expect(indexed.some((u) => u.endsWith('.txt'))).toBe(false);
+        expect(indexed.includes(URI.file(path.join(tmp_dir, 'broken.do')).toString()))
+            .toBe(false);
     });
 
     it('indexes a symlinked-dir target via its real in-workspace location', async () => {

--- a/tests/integration/indexer-follows-symlinks.test.ts
+++ b/tests/integration/indexer-follows-symlinks.test.ts
@@ -3,8 +3,9 @@
  * symlinked files (issue #219): it keys entries by path and the file watcher
  * invalidates by the changed event path, so an alias entry could not be kept
  * fresh when its real target changes. In-workspace targets are covered via
- * their real path; symlink-following lives in the one-shot consumers (path
- * completion, `sight check`, the on-demand `.sthlp` lookup). These tests pin
+ * their real path; symlink-following lives in the listing/lookup consumers
+ * (path completion, the on-demand `.sthlp` lookup), not the analyzing ones
+ * (the index and `sight check` both follow real files only). These tests pin
  * the indexer side: a symlinked source file is NOT added to the index, a
  * symlinked directory is never recursed (so cycles terminate trivially and an
  * external target is not crawled), and real files are unaffected.

--- a/tests/integration/indexer-follows-symlinks.test.ts
+++ b/tests/integration/indexer-follows-symlinks.test.ts
@@ -84,6 +84,27 @@ describe('indexer follows symlinks safely (#219)', () => {
         expect(indexed.includes(URI.file(link).toString())).toBe(true);
     });
 
+    it('does not index a symlinked non-Stata file', async () => {
+        // The cheap extension filter must gate the symlink stat: a
+        // symlink whose name is not a Stata source extension is never
+        // followed and never indexed (issue #219 review).
+        const real = path.join(tmp_dir, 'notes.txt');
+        fs.writeFileSync(real, 'not stata\n');
+        if (!try_symlink(real, path.join(tmp_dir, 'aliased.txt'))) return;
+        // Also a dangling non-Stata symlink must not break the scan.
+        try_symlink(
+            path.join(tmp_dir, 'missing-target'),
+            path.join(tmp_dir, 'broken.txt'),
+        );
+        fs.writeFileSync(path.join(tmp_dir, 'real.do'), 'display 1\n');
+
+        const indexed = await index(tmp_dir);
+        expect(indexed).toContain(
+            URI.file(path.join(tmp_dir, 'real.do')).toString(),
+        );
+        expect(indexed.some((u) => u.endsWith('.txt'))).toBe(false);
+    });
+
     it('indexes a symlinked-dir target via its real in-workspace location', async () => {
         const real_dir = path.join(tmp_dir, 'realdir');
         fs.mkdirSync(real_dir);

--- a/tests/integration/indexer-follows-symlinks.test.ts
+++ b/tests/integration/indexer-follows-symlinks.test.ts
@@ -117,7 +117,7 @@ describe('indexer follows symlinks safely (#219)', () => {
             URI.file(path.join(real_dir, 'inner.do')).toString(),
         );
         const inner_count = indexed.filter(
-            (u) => u.endsWith('/inner.do'),
+            (my_uri) => my_uri.endsWith('/inner.do'),
         ).length;
         expect(inner_count).toBe(1); // not double-indexed via the symlink
     });
@@ -135,7 +135,7 @@ describe('indexer follows symlinks safely (#219)', () => {
             URI.file(path.join(tmp_dir, 'main.do')).toString(),
         );
         const main_count = indexed.filter(
-            (u) => u.endsWith('/main.do'),
+            (my_uri) => my_uri.endsWith('/main.do'),
         ).length;
         expect(main_count).toBe(1);
     });
@@ -157,7 +157,7 @@ describe('indexer follows symlinks safely (#219)', () => {
             );
             // The external target must NOT be crawled (under any path).
             const outside_count = indexed.filter(
-                (u) => u.endsWith('/outside.do'),
+                (my_uri) => my_uri.endsWith('/outside.do'),
             ).length;
             expect(outside_count).toBe(0);
         } finally {

--- a/tests/integration/indexer-follows-symlinks.test.ts
+++ b/tests/integration/indexer-follows-symlinks.test.ts
@@ -215,4 +215,19 @@ describe('sthlp recursive search follows symlinks safely (#219)', () => {
         const found = await resolve(tmp_dir, 'zzsymtopic');
         expect(found).toBe(path.join(sub, 'zzsymtopic.sthlp'));
     });
+
+    it('does not return a dangling symlinked .sthlp (search continues)', async () => {
+        const sub = path.join(tmp_dir, 'sub');
+        fs.mkdirSync(sub);
+        // A dangling symlink whose name matches the help basename must not
+        // be returned as a (broken) match — entry_is_file_async stats it,
+        // the stat throws, and the search continues.
+        if (!try_symlink(
+            path.join(sub, 'missing-target'),
+            path.join(sub, 'zzsymtopic.sthlp'),
+        )) return;
+
+        const found = await resolve(tmp_dir, 'zzsymtopic');
+        expect(found).toBeNull();
+    });
 });

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -164,13 +164,13 @@ describe('sight check source files', () => {
 });
 
 /**
- * `sight check` analyzes each discovered file, and analysis is keyed by path
- * (the dependency graph keys callee edges by the resolved real path; the
- * workspace index holds real files only). Analyzing a symlink-alias URI would
- * miss its parents / be reported as un-indexed, so this walk — like the
- * persistent indexer — follows neither symlinked directories nor symlinked
- * files (issue #219). In-workspace symlink targets are covered via their real
- * path; symlink-following lives in the non-analyzing consumers.
+ * `sight check` analyzes each discovered file under its own URI, and the
+ * workspace index holds real files only. Opening a symlink-alias URI the index
+ * never indexed gives unreliable cross-file scope and (past the index cap) a
+ * spurious "file not indexed", so this walk — like the persistent indexer —
+ * follows neither symlinked directories nor symlinked files (issue #219).
+ * In-workspace symlink targets are covered via their real path;
+ * symlink-following lives in the non-analyzing consumers.
  */
 function try_symlink(target: string, link_path: string): boolean {
     try {

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -164,9 +164,10 @@ describe('sight check source files', () => {
 });
 
 /**
- * `sight check` source discovery must follow symlinked directories and
- * symlinked source files (issue #219), while terminating on cycles and not
- * escaping the scan root.
+ * `sight check` source discovery must follow symlinked source FILES (issue
+ * #219). Symlinked DIRECTORIES are deliberately NOT descended: an in-workspace
+ * target is covered by the direct scan of its real location, and an external
+ * target would crawl an arbitrary tree.
  */
 function try_symlink(target: string, link_path: string): boolean {
     try {
@@ -177,7 +178,7 @@ function try_symlink(target: string, link_path: string): boolean {
     }
 }
 
-describe('sight check follows symlinks safely (#219)', () => {
+describe('sight check follows symlinked files, not symlinked dirs (#219)', () => {
     it('discovers a symlinked source file', () => {
         const root = temp_dir();
         const real = path.join(root, 'real.do');
@@ -190,7 +191,7 @@ describe('sight check follows symlinks safely (#219)', () => {
         expect(rels).toContain('real.do');
     });
 
-    it('discovers files inside a symlinked subtree', () => {
+    it('discovers a symlinked-dir target via its real in-workspace location', () => {
         const root = temp_dir();
         const real_dir = path.join(root, 'realdir');
         fs.mkdirSync(real_dir);
@@ -198,23 +199,24 @@ describe('sight check follows symlinks safely (#219)', () => {
         if (!try_symlink(real_dir, path.join(root, 'linkdir'))) return;
 
         const result = collect_report_targets([], root, root);
-        // Followed once (visited set dedupes by physical dir): inner.do shows
-        // up under exactly one of realdir/ or linkdir/.
+        // linkdir is not descended; realdir/inner.do is found by the direct
+        // scan — discovered exactly once, under its real path.
         const inner = result.targets.filter((t) =>
             t.relative_path.endsWith('inner.do'),
         );
         expect(inner).toHaveLength(1);
+        expect(inner[0]!.relative_path).toBe('realdir/inner.do');
         expect(result.operator_errors).toEqual([]);
     });
 
-    it('terminates on a directory symlink cycle', () => {
+    it('does not recurse through a directory symlink (cycle would not hang)', () => {
         const root = temp_dir();
         const sub = path.join(root, 'sub');
         fs.mkdirSync(sub);
         fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
         if (!try_symlink(root, path.join(sub, 'loop'))) return;
 
-        // Must not hang; main.do discovered exactly once.
+        // Completes (loop not descended); main.do discovered exactly once.
         const result = collect_report_targets([], root, root);
         const mains = result.targets.filter((t) =>
             t.relative_path.endsWith('main.do'),
@@ -222,12 +224,12 @@ describe('sight check follows symlinks safely (#219)', () => {
         expect(mains).toHaveLength(1);
     });
 
-    it('does NOT follow a symlink that escapes the scan root', () => {
+    it('does NOT descend a symlinked directory pointing outside the scan root', () => {
         const root = temp_dir();
         const external = temp_dir();
         fs.writeFileSync(path.join(root, 'inside.do'), 'display 1\n');
         fs.writeFileSync(path.join(external, 'outside.do'), 'display 1\n');
-        if (!try_symlink(external, path.join(root, 'escape'))) return;
+        if (!try_symlink(external, path.join(root, 'external_link'))) return;
 
         const result = collect_report_targets([], root, root);
         const rels = result.targets.map((t) => t.relative_path);

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -192,7 +192,7 @@ describe('sight check analyzes real files only, not symlinks (#219)', () => {
         if (!try_symlink(real, path.join(root, 'aliased.do'))) return;
 
         const result = collect_report_targets([], root, root);
-        const rels = result.targets.map((t) => t.relative_path);
+        const rels = result.targets.map((my_target) => my_target.relative_path);
         expect(rels).toContain('real.do');
         expect(rels).not.toContain('aliased.do');
     });
@@ -207,7 +207,8 @@ describe('sight check analyzes real files only, not symlinks (#219)', () => {
         if (!try_symlink(target, path.join(root, 'lib.do'))) return;
 
         const result = collect_report_targets([], root, root);
-        expect(result.targets.map((t) => t.relative_path)).not.toContain('lib.do');
+        const rels = result.targets.map((my_target) => my_target.relative_path);
+        expect(rels).not.toContain('lib.do');
     });
 
     it('does not discover a symlinked non-source file', () => {
@@ -218,9 +219,9 @@ describe('sight check analyzes real files only, not symlinks (#219)', () => {
         fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
 
         const result = collect_report_targets([], root, root);
-        const rels = result.targets.map((t) => t.relative_path);
+        const rels = result.targets.map((my_target) => my_target.relative_path);
         expect(rels).toContain('main.do');
-        expect(rels.some((r) => r.endsWith('.txt'))).toBe(false);
+        expect(rels.some((my_rel) => my_rel.endsWith('.txt'))).toBe(false);
     });
 
     it('discovers a symlinked-dir target via its real in-workspace location', () => {
@@ -233,8 +234,8 @@ describe('sight check analyzes real files only, not symlinks (#219)', () => {
         const result = collect_report_targets([], root, root);
         // linkdir is not descended; realdir/inner.do is found by the direct
         // scan — discovered exactly once, under its real path.
-        const inner = result.targets.filter((t) =>
-            t.relative_path.endsWith('inner.do'),
+        const inner = result.targets.filter((my_target) =>
+            my_target.relative_path.endsWith('inner.do'),
         );
         expect(inner).toHaveLength(1);
         expect(inner[0]!.relative_path).toBe('realdir/inner.do');
@@ -250,8 +251,8 @@ describe('sight check analyzes real files only, not symlinks (#219)', () => {
 
         // Completes (loop not descended); main.do discovered exactly once.
         const result = collect_report_targets([], root, root);
-        const mains = result.targets.filter((t) =>
-            t.relative_path.endsWith('main.do'),
+        const mains = result.targets.filter((my_target) =>
+            my_target.relative_path.endsWith('main.do'),
         );
         expect(mains).toHaveLength(1);
     });
@@ -264,8 +265,9 @@ describe('sight check analyzes real files only, not symlinks (#219)', () => {
         if (!try_symlink(external, path.join(root, 'external_link'))) return;
 
         const result = collect_report_targets([], root, root);
-        const rels = result.targets.map((t) => t.relative_path);
+        const rels = result.targets.map((my_target) => my_target.relative_path);
         expect(rels).toContain('inside.do');
-        expect(rels.some((r) => r.endsWith('outside.do'))).toBe(false);
+        expect(rels.some((my_rel) => my_rel.endsWith('outside.do')))
+            .toBe(false);
     });
 });

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -164,10 +164,13 @@ describe('sight check source files', () => {
 });
 
 /**
- * `sight check` source discovery must follow symlinked source FILES (issue
- * #219). Symlinked DIRECTORIES are deliberately NOT descended: an in-workspace
- * target is covered by the direct scan of its real location, and an external
- * target would crawl an arbitrary tree.
+ * `sight check` analyzes each discovered file, and analysis is keyed by path
+ * (the dependency graph keys callee edges by the resolved real path; the
+ * workspace index holds real files only). Analyzing a symlink-alias URI would
+ * miss its parents / be reported as un-indexed, so this walk — like the
+ * persistent indexer — follows neither symlinked directories nor symlinked
+ * files (issue #219). In-workspace symlink targets are covered via their real
+ * path; symlink-following lives in the non-analyzing consumers.
  */
 function try_symlink(target: string, link_path: string): boolean {
     try {
@@ -178,23 +181,11 @@ function try_symlink(target: string, link_path: string): boolean {
     }
 }
 
-describe('sight check follows symlinked files, not symlinked dirs (#219)', () => {
-    it('discovers a symlinked source file whose target is external', () => {
-        // A symlink to a .do outside the checked tree is the only path to
-        // that content, so it must be discovered.
-        const root = temp_dir();
-        const external = temp_dir();
-        const target = path.join(external, 'lib.do');
-        fs.writeFileSync(target, 'display 1\n');
-        if (!try_symlink(target, path.join(root, 'lib.do'))) return;
-
-        const result = collect_report_targets([], root, root);
-        expect(result.targets.map((t) => t.relative_path)).toContain('lib.do');
-    });
-
-    it('reports a symlink + its in-tree target once (dedup by realpath)', () => {
-        // One physical file reachable by two names must be checked once, so
-        // `sight check` does not emit duplicate diagnostics (#219 review).
+describe('sight check analyzes real files only, not symlinks (#219)', () => {
+    it('does NOT discover a symlinked source file', () => {
+        // The real file is checked; the symlink alias is not a separate
+        // target (analysis is path-keyed; analyzing the alias URI would
+        // mismatch the dep-graph / index).
         const root = temp_dir();
         const real = path.join(root, 'real.do');
         fs.writeFileSync(real, 'display 1\n');
@@ -202,14 +193,24 @@ describe('sight check follows symlinked files, not symlinked dirs (#219)', () =>
 
         const result = collect_report_targets([], root, root);
         const rels = result.targets.map((t) => t.relative_path);
-        // Deduped to the lexically-smallest name; not both.
-        expect(rels.filter((r) => r === 'aliased.do' || r === 'real.do'))
-            .toEqual(['aliased.do']);
+        expect(rels).toContain('real.do');
+        expect(rels).not.toContain('aliased.do');
+    });
+
+    it('does NOT discover a symlinked source file with an external target', () => {
+        // An external-target symlink is not checked; declare the external
+        // location as a workspace folder to check it directly.
+        const root = temp_dir();
+        const external = temp_dir();
+        const target = path.join(external, 'lib.do');
+        fs.writeFileSync(target, 'display 1\n');
+        if (!try_symlink(target, path.join(root, 'lib.do'))) return;
+
+        const result = collect_report_targets([], root, root);
+        expect(result.targets.map((t) => t.relative_path)).not.toContain('lib.do');
     });
 
     it('does not discover a symlinked non-source file', () => {
-        // The extension filter gates the symlink stat: a non-source
-        // symlink name is never followed (issue #219 review).
         const root = temp_dir();
         const real = path.join(root, 'notes.txt');
         fs.writeFileSync(real, 'not stata\n');

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -179,7 +179,22 @@ function try_symlink(target: string, link_path: string): boolean {
 }
 
 describe('sight check follows symlinked files, not symlinked dirs (#219)', () => {
-    it('discovers a symlinked source file', () => {
+    it('discovers a symlinked source file whose target is external', () => {
+        // A symlink to a .do outside the checked tree is the only path to
+        // that content, so it must be discovered.
+        const root = temp_dir();
+        const external = temp_dir();
+        const target = path.join(external, 'lib.do');
+        fs.writeFileSync(target, 'display 1\n');
+        if (!try_symlink(target, path.join(root, 'lib.do'))) return;
+
+        const result = collect_report_targets([], root, root);
+        expect(result.targets.map((t) => t.relative_path)).toContain('lib.do');
+    });
+
+    it('reports a symlink + its in-tree target once (dedup by realpath)', () => {
+        // One physical file reachable by two names must be checked once, so
+        // `sight check` does not emit duplicate diagnostics (#219 review).
         const root = temp_dir();
         const real = path.join(root, 'real.do');
         fs.writeFileSync(real, 'display 1\n');
@@ -187,8 +202,9 @@ describe('sight check follows symlinked files, not symlinked dirs (#219)', () =>
 
         const result = collect_report_targets([], root, root);
         const rels = result.targets.map((t) => t.relative_path);
-        expect(rels).toContain('aliased.do');
-        expect(rels).toContain('real.do');
+        // Deduped to the lexically-smallest name; not both.
+        expect(rels.filter((r) => r === 'aliased.do' || r === 'real.do'))
+            .toEqual(['aliased.do']);
     });
 
     it('does not discover a symlinked non-source file', () => {

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -191,6 +191,21 @@ describe('sight check follows symlinked files, not symlinked dirs (#219)', () =>
         expect(rels).toContain('real.do');
     });
 
+    it('does not discover a symlinked non-source file', () => {
+        // The extension filter gates the symlink stat: a non-source
+        // symlink name is never followed (issue #219 review).
+        const root = temp_dir();
+        const real = path.join(root, 'notes.txt');
+        fs.writeFileSync(real, 'not stata\n');
+        if (!try_symlink(real, path.join(root, 'aliased.txt'))) return;
+        fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
+
+        const result = collect_report_targets([], root, root);
+        const rels = result.targets.map((t) => t.relative_path);
+        expect(rels).toContain('main.do');
+        expect(rels.some((r) => r.endsWith('.txt'))).toBe(false);
+    });
+
     it('discovers a symlinked-dir target via its real in-workspace location', () => {
         const root = temp_dir();
         const real_dir = path.join(root, 'realdir');

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -162,3 +162,76 @@ describe('sight check source files', () => {
         }
     });
 });
+
+/**
+ * `sight check` source discovery must follow symlinked directories and
+ * symlinked source files (issue #219), while terminating on cycles and not
+ * escaping the scan root.
+ */
+function try_symlink(target: string, link_path: string): boolean {
+    try {
+        fs.symlinkSync(target, link_path);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+describe('sight check follows symlinks safely (#219)', () => {
+    it('discovers a symlinked source file', () => {
+        const root = temp_dir();
+        const real = path.join(root, 'real.do');
+        fs.writeFileSync(real, 'display 1\n');
+        if (!try_symlink(real, path.join(root, 'aliased.do'))) return;
+
+        const result = collect_report_targets([], root, root);
+        const rels = result.targets.map((t) => t.relative_path);
+        expect(rels).toContain('aliased.do');
+        expect(rels).toContain('real.do');
+    });
+
+    it('discovers files inside a symlinked subtree', () => {
+        const root = temp_dir();
+        const real_dir = path.join(root, 'realdir');
+        fs.mkdirSync(real_dir);
+        fs.writeFileSync(path.join(real_dir, 'inner.do'), 'display 1\n');
+        if (!try_symlink(real_dir, path.join(root, 'linkdir'))) return;
+
+        const result = collect_report_targets([], root, root);
+        // Followed once (visited set dedupes by physical dir): inner.do shows
+        // up under exactly one of realdir/ or linkdir/.
+        const inner = result.targets.filter((t) =>
+            t.relative_path.endsWith('inner.do'),
+        );
+        expect(inner).toHaveLength(1);
+        expect(result.operator_errors).toEqual([]);
+    });
+
+    it('terminates on a directory symlink cycle', () => {
+        const root = temp_dir();
+        const sub = path.join(root, 'sub');
+        fs.mkdirSync(sub);
+        fs.writeFileSync(path.join(root, 'main.do'), 'display 1\n');
+        if (!try_symlink(root, path.join(sub, 'loop'))) return;
+
+        // Must not hang; main.do discovered exactly once.
+        const result = collect_report_targets([], root, root);
+        const mains = result.targets.filter((t) =>
+            t.relative_path.endsWith('main.do'),
+        );
+        expect(mains).toHaveLength(1);
+    });
+
+    it('does NOT follow a symlink that escapes the scan root', () => {
+        const root = temp_dir();
+        const external = temp_dir();
+        fs.writeFileSync(path.join(root, 'inside.do'), 'display 1\n');
+        fs.writeFileSync(path.join(external, 'outside.do'), 'display 1\n');
+        if (!try_symlink(external, path.join(root, 'escape'))) return;
+
+        const result = collect_report_targets([], root, root);
+        const rels = result.targets.map((t) => t.relative_path);
+        expect(rels).toContain('inside.do');
+        expect(rels.some((r) => r.endsWith('outside.do'))).toBe(false);
+    });
+});

--- a/tests/unit/completion-symlink-path.test.ts
+++ b/tests/unit/completion-symlink-path.test.ts
@@ -71,7 +71,7 @@ describe('path completion offers symlinked entries (#219)', () => {
             line: 0,
             character: content.length,
         });
-        const labels = completions.map((c) => c.label);
+        const labels = completions.map((my_completion) => my_completion.label);
 
         // Symlinked directory offered with trailing slash.
         expect(labels).toContain('linkdir/');
@@ -93,7 +93,10 @@ describe('path completion offers symlinked entries (#219)', () => {
                 line: 0,
                 character: content.length,
             });
-            expect(completions.map((c) => c.label)).toContain('extlink/');
+            const labels = completions.map(
+                (my_completion) => my_completion.label,
+            );
+            expect(labels).toContain('extlink/');
         } finally {
             fs.rmSync(external, { recursive: true, force: true });
         }
@@ -113,7 +116,7 @@ describe('path completion offers symlinked entries (#219)', () => {
             line: 0,
             character: content.length,
         });
-        const labels = completions.map((c) => c.label);
+        const labels = completions.map((my_completion) => my_completion.label);
         expect(labels).toContain('real.do');
         expect(labels).not.toContain('broken.do');
     });

--- a/tests/unit/completion-symlink-path.test.ts
+++ b/tests/unit/completion-symlink-path.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Path completion (after `do "…/`) must offer symlinked directories and
+ * symlinked source files (issue #219). An absolute partial path bypasses
+ * workspace-root resolution, so the completion's `base_dir` is the temp dir
+ * directly. No recursion is involved, so there is no cycle/boundary concern —
+ * only classification.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CompletionProvider } from '../../src/providers/completion';
+import { CommandDatabase } from '../../src/commands';
+import { DocumentState } from '../../src/document-store';
+
+let tmp_dir: string;
+
+function doc_for(content: string): DocumentState {
+    return {
+        uri: 'file:///test.do',
+        version: 1,
+        content,
+        ast: null,
+        symbols: {
+            programs: new Map(),
+            localMacros: new Map(),
+            globalMacros: new Map(),
+            variables: new Map(),
+            scalars: new Map(),
+            matrices: new Map(),
+        },
+        diagnostics: [],
+    } as unknown as DocumentState;
+}
+
+function try_symlink(target: string, link_path: string): boolean {
+    try {
+        fs.symlinkSync(target, link_path);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+describe('path completion offers symlinked entries (#219)', () => {
+    let provider: CompletionProvider;
+
+    beforeEach(() => {
+        provider = new CompletionProvider(new CommandDatabase(), {
+            snippet_support: true,
+        });
+        tmp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'symlink-comp-'));
+    });
+    afterEach(() => {
+        fs.rmSync(tmp_dir, { recursive: true, force: true });
+    });
+
+    it('lists a symlinked directory and a symlinked .do file', async () => {
+        // A real dir + a symlink to it; a real .do + a symlink to it.
+        const real_dir = path.join(tmp_dir, 'realdir');
+        fs.mkdirSync(real_dir);
+        const real_do = path.join(tmp_dir, 'real.do');
+        fs.writeFileSync(real_do, 'display 1\n');
+        const have_dir_link = try_symlink(real_dir, path.join(tmp_dir, 'linkdir'));
+        const have_file_link = try_symlink(real_do, path.join(tmp_dir, 'aliased.do'));
+        if (!have_dir_link || !have_file_link) return; // platform skip
+
+        const content = `do "${tmp_dir}/`;
+        const completions = await provider.get_completions(doc_for(content), {
+            line: 0,
+            character: content.length,
+        });
+        const labels = completions.map((c) => c.label);
+
+        // Symlinked directory offered with trailing slash.
+        expect(labels).toContain('linkdir/');
+        // Symlinked .do file offered like a regular file.
+        expect(labels).toContain('aliased.do');
+        // Sanity: the non-symlinked siblings are present too.
+        expect(labels).toContain('realdir/');
+        expect(labels).toContain('real.do');
+    });
+});

--- a/tests/unit/completion-symlink-path.test.ts
+++ b/tests/unit/completion-symlink-path.test.ts
@@ -81,4 +81,40 @@ describe('path completion offers symlinked entries (#219)', () => {
         expect(labels).toContain('realdir/');
         expect(labels).toContain('real.do');
     });
+
+    it('offers a symlinked dir whose target is outside the listed dir', async () => {
+        // A symlinked directory pointing OUTSIDE the listed directory is
+        // still offered as a navigable folder (listing is not recursion).
+        const external = fs.mkdtempSync(path.join(os.tmpdir(), 'comp-ext-'));
+        try {
+            if (!try_symlink(external, path.join(tmp_dir, 'extlink'))) return;
+            const content = `do "${tmp_dir}/`;
+            const completions = await provider.get_completions(doc_for(content), {
+                line: 0,
+                character: content.length,
+            });
+            expect(completions.map((c) => c.label)).toContain('extlink/');
+        } finally {
+            fs.rmSync(external, { recursive: true, force: true });
+        }
+    });
+
+    it('does not offer a dangling symlink', async () => {
+        // A dangling symlink classifies as `other` and is dropped, not
+        // offered as a broken file.
+        if (!try_symlink(
+            path.join(tmp_dir, 'missing-target'),
+            path.join(tmp_dir, 'broken.do'),
+        )) return;
+        fs.writeFileSync(path.join(tmp_dir, 'real.do'), 'display 1\n');
+
+        const content = `do "${tmp_dir}/`;
+        const completions = await provider.get_completions(doc_for(content), {
+            line: 0,
+            character: content.length,
+        });
+        const labels = completions.map((c) => c.label);
+        expect(labels).toContain('real.do');
+        expect(labels).not.toContain('broken.do');
+    });
 });

--- a/tests/unit/symlink-aware-entry.test.ts
+++ b/tests/unit/symlink-aware-entry.test.ts
@@ -2,10 +2,8 @@ import { describe, it, expect } from 'bun:test';
 import {
     entry_is_directory_sync,
     entry_is_file_sync,
-    entry_is_directory_async,
     entry_is_file_async,
     classify_entry_sync,
-    classify_entry_async,
 } from '../../src/utils/symlink-aware-entry';
 
 // ─── Fake Dirent + stat seam ──────────────────────────────────────────────────
@@ -106,43 +104,41 @@ describe('symlink-aware entry classification (sync)', () => {
 });
 
 describe('symlink-aware entry classification (async)', () => {
-    it('plain directory: dir true, file false, no stat call', async () => {
-        const { fs, calls } = make_async_fs('dir');
-        const e = make_entry('dir');
-        expect(await entry_is_directory_async(e, '/x', fs)).toBe(true);
-        expect(await entry_is_file_async(e, '/x', fs)).toBe(false);
+    it('plain file: true, no stat call (fast path)', async () => {
+        const { fs, calls } = make_async_fs('file');
+        expect(await entry_is_file_async(make_entry('file'), '/x', fs))
+            .toBe(true);
         expect(calls.count).toBe(0);
     });
 
-    it('symlink to directory: dir true (via stat), file false', async () => {
-        const dir_fs = make_async_fs('link-dir');
-        const e = make_entry('link-dir');
-        expect(await entry_is_directory_async(e, '/x', dir_fs.fs)).toBe(true);
-        expect(dir_fs.calls.count).toBe(1);
-
-        const file_fs = make_async_fs('link-dir');
-        expect(await entry_is_file_async(e, '/x', file_fs.fs)).toBe(false);
+    it('plain directory: file false, no stat call', async () => {
+        const { fs, calls } = make_async_fs('dir');
+        expect(await entry_is_file_async(make_entry('dir'), '/x', fs))
+            .toBe(false);
+        expect(calls.count).toBe(0);
     });
 
-    it('symlink to file: file true (via stat), dir false', async () => {
+    it('symlink to file: file true (via single stat)', async () => {
         const file_fs = make_async_fs('link-file');
-        const e = make_entry('link-file');
-        expect(await entry_is_file_async(e, '/x', file_fs.fs)).toBe(true);
+        expect(await entry_is_file_async(make_entry('link-file'), '/x', file_fs.fs))
+            .toBe(true);
         expect(file_fs.calls.count).toBe(1);
-
-        const dir_fs = make_async_fs('link-file');
-        expect(await entry_is_directory_async(e, '/x', dir_fs.fs)).toBe(false);
     });
 
-    it('dangling symlink: both false, does not throw', async () => {
+    it('symlink to directory: file false (via stat)', async () => {
+        const dir_fs = make_async_fs('link-dir');
+        expect(await entry_is_file_async(make_entry('link-dir'), '/x', dir_fs.fs))
+            .toBe(false);
+    });
+
+    it('dangling symlink: false, does not throw', async () => {
         const { fs } = make_async_fs('link-dead');
-        const e = make_entry('link-dead');
-        expect(await entry_is_directory_async(e, '/x', fs)).toBe(false);
-        expect(await entry_is_file_async(e, '/x', fs)).toBe(false);
+        expect(await entry_is_file_async(make_entry('link-dead'), '/x', fs))
+            .toBe(false);
     });
 });
 
-describe('classify_entry (single-syscall, dir-then-file sites)', () => {
+describe('classify_entry_sync (single-syscall, completion listing)', () => {
     it('plain dir / plain file classify without a stat call', () => {
         const dir_fs = make_sync_fs('dir');
         expect(classify_entry_sync(make_entry('dir'), '/x', dir_fs.fs))
@@ -171,21 +167,5 @@ describe('classify_entry (single-syscall, dir-then-file sites)', () => {
         const { fs } = make_sync_fs('link-dead');
         expect(classify_entry_sync(make_entry('link-dead'), '/x', fs))
             .toBe('other');
-    });
-
-    it('async variant mirrors sync', async () => {
-        const dir_fs = make_async_fs('link-dir');
-        expect(await classify_entry_async(make_entry('link-dir'), '/x', dir_fs.fs))
-            .toBe('directory');
-        expect(dir_fs.calls.count).toBe(1);
-
-        const dead_fs = make_async_fs('link-dead');
-        expect(await classify_entry_async(make_entry('link-dead'), '/x', dead_fs.fs))
-            .toBe('other');
-
-        const plain_fs = make_async_fs('file');
-        expect(await classify_entry_async(make_entry('file'), '/x', plain_fs.fs))
-            .toBe('file');
-        expect(plain_fs.calls.count).toBe(0);
     });
 });

--- a/tests/unit/symlink-aware-entry.test.ts
+++ b/tests/unit/symlink-aware-entry.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'bun:test';
+import {
+    entry_is_directory_sync,
+    entry_is_file_sync,
+    entry_is_directory_async,
+    entry_is_file_async,
+    classify_entry_sync,
+    classify_entry_async,
+} from '../../src/utils/symlink-aware-entry';
+
+// ─── Fake Dirent + stat seam ──────────────────────────────────────────────────
+
+type EntryKind = 'dir' | 'file' | 'link-dir' | 'link-file' | 'link-dead';
+
+function make_entry(kind: EntryKind) {
+    return {
+        isDirectory:    () => kind === 'dir',
+        isFile:         () => kind === 'file',
+        isSymbolicLink: () =>
+            kind === 'link-dir' ||
+            kind === 'link-file' ||
+            kind === 'link-dead',
+    };
+}
+
+/**
+ * Build a sync stat seam that resolves `full_path` to a kind and counts how
+ * many times `statSync` was called (to prove the non-symlink fast path never
+ * stats).
+ */
+function make_sync_fs(target: EntryKind) {
+    const calls = { count: 0 };
+    const fs = {
+        statSync: (_p: string) => {
+            calls.count++;
+            if (target === 'link-dead') {
+                throw new Error('ENOENT: dangling symlink');
+            }
+            const is_dir = target === 'dir' || target === 'link-dir';
+            const is_file = target === 'file' || target === 'link-file';
+            return { isDirectory: () => is_dir, isFile: () => is_file };
+        },
+    };
+    return { fs, calls };
+}
+
+function make_async_fs(target: EntryKind) {
+    const calls = { count: 0 };
+    const fs = {
+        stat: async (_p: string) => {
+            calls.count++;
+            if (target === 'link-dead') {
+                throw new Error('ENOENT: dangling symlink');
+            }
+            const is_dir = target === 'dir' || target === 'link-dir';
+            const is_file = target === 'file' || target === 'link-file';
+            return { isDirectory: () => is_dir, isFile: () => is_file };
+        },
+    };
+    return { fs, calls };
+}
+
+describe('symlink-aware entry classification (sync)', () => {
+    it('plain directory: dir true, file false, no stat call', () => {
+        const { fs, calls } = make_sync_fs('dir');
+        const e = make_entry('dir');
+        expect(entry_is_directory_sync(e, '/x', fs)).toBe(true);
+        expect(entry_is_file_sync(e, '/x', fs)).toBe(false);
+        expect(calls.count).toBe(0); // fast path, never stats
+    });
+
+    it('plain file: file true, dir false, no stat call', () => {
+        const { fs, calls } = make_sync_fs('file');
+        const e = make_entry('file');
+        expect(entry_is_file_sync(e, '/x', fs)).toBe(true);
+        expect(entry_is_directory_sync(e, '/x', fs)).toBe(false);
+        expect(calls.count).toBe(0);
+    });
+
+    it('symlink to directory: dir true (via stat), file false', () => {
+        const dir_fs = make_sync_fs('link-dir');
+        const e = make_entry('link-dir');
+        expect(entry_is_directory_sync(e, '/x', dir_fs.fs)).toBe(true);
+        expect(dir_fs.calls.count).toBe(1);
+
+        const file_fs = make_sync_fs('link-dir');
+        expect(entry_is_file_sync(e, '/x', file_fs.fs)).toBe(false);
+    });
+
+    it('symlink to file: file true (via stat), dir false', () => {
+        const file_fs = make_sync_fs('link-file');
+        const e = make_entry('link-file');
+        expect(entry_is_file_sync(e, '/x', file_fs.fs)).toBe(true);
+        expect(file_fs.calls.count).toBe(1);
+
+        const dir_fs = make_sync_fs('link-file');
+        expect(entry_is_directory_sync(e, '/x', dir_fs.fs)).toBe(false);
+    });
+
+    it('dangling symlink: both false, does not throw', () => {
+        const { fs } = make_sync_fs('link-dead');
+        const e = make_entry('link-dead');
+        expect(entry_is_directory_sync(e, '/x', fs)).toBe(false);
+        expect(entry_is_file_sync(e, '/x', fs)).toBe(false);
+    });
+});
+
+describe('symlink-aware entry classification (async)', () => {
+    it('plain directory: dir true, file false, no stat call', async () => {
+        const { fs, calls } = make_async_fs('dir');
+        const e = make_entry('dir');
+        expect(await entry_is_directory_async(e, '/x', fs)).toBe(true);
+        expect(await entry_is_file_async(e, '/x', fs)).toBe(false);
+        expect(calls.count).toBe(0);
+    });
+
+    it('symlink to directory: dir true (via stat), file false', async () => {
+        const dir_fs = make_async_fs('link-dir');
+        const e = make_entry('link-dir');
+        expect(await entry_is_directory_async(e, '/x', dir_fs.fs)).toBe(true);
+        expect(dir_fs.calls.count).toBe(1);
+
+        const file_fs = make_async_fs('link-dir');
+        expect(await entry_is_file_async(e, '/x', file_fs.fs)).toBe(false);
+    });
+
+    it('symlink to file: file true (via stat), dir false', async () => {
+        const file_fs = make_async_fs('link-file');
+        const e = make_entry('link-file');
+        expect(await entry_is_file_async(e, '/x', file_fs.fs)).toBe(true);
+        expect(file_fs.calls.count).toBe(1);
+
+        const dir_fs = make_async_fs('link-file');
+        expect(await entry_is_directory_async(e, '/x', dir_fs.fs)).toBe(false);
+    });
+
+    it('dangling symlink: both false, does not throw', async () => {
+        const { fs } = make_async_fs('link-dead');
+        const e = make_entry('link-dead');
+        expect(await entry_is_directory_async(e, '/x', fs)).toBe(false);
+        expect(await entry_is_file_async(e, '/x', fs)).toBe(false);
+    });
+});
+
+describe('classify_entry (single-syscall, dir-then-file sites)', () => {
+    it('plain dir / plain file classify without a stat call', () => {
+        const dir_fs = make_sync_fs('dir');
+        expect(classify_entry_sync(make_entry('dir'), '/x', dir_fs.fs))
+            .toBe('directory');
+        expect(dir_fs.calls.count).toBe(0);
+
+        const file_fs = make_sync_fs('file');
+        expect(classify_entry_sync(make_entry('file'), '/x', file_fs.fs))
+            .toBe('file');
+        expect(file_fs.calls.count).toBe(0);
+    });
+
+    it('symlinked entry is classified with exactly ONE stat call', () => {
+        const dir_fs = make_sync_fs('link-dir');
+        expect(classify_entry_sync(make_entry('link-dir'), '/x', dir_fs.fs))
+            .toBe('directory');
+        expect(dir_fs.calls.count).toBe(1); // not double-stat
+
+        const file_fs = make_sync_fs('link-file');
+        expect(classify_entry_sync(make_entry('link-file'), '/x', file_fs.fs))
+            .toBe('file');
+        expect(file_fs.calls.count).toBe(1);
+    });
+
+    it('dangling symlink classifies as other, no throw', () => {
+        const { fs } = make_sync_fs('link-dead');
+        expect(classify_entry_sync(make_entry('link-dead'), '/x', fs))
+            .toBe('other');
+    });
+
+    it('async variant mirrors sync', async () => {
+        const dir_fs = make_async_fs('link-dir');
+        expect(await classify_entry_async(make_entry('link-dir'), '/x', dir_fs.fs))
+            .toBe('directory');
+        expect(dir_fs.calls.count).toBe(1);
+
+        const dead_fs = make_async_fs('link-dead');
+        expect(await classify_entry_async(make_entry('link-dead'), '/x', dead_fs.fs))
+            .toBe('other');
+
+        const plain_fs = make_async_fs('file');
+        expect(await classify_entry_async(make_entry('file'), '/x', plain_fs.fs))
+            .toBe('file');
+        expect(plain_fs.calls.count).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

Knit Preview panels now **persist across window reload and full VS Code restart**. Previously, reloading the window (or quitting and reopening) discarded the preview webview and deleted its rendered files, forcing a re-knit — annoying when knitting is slow.

Now an open preview is restored automatically, showing the **last rendered output with no re-knit and no R subprocess** — a static snapshot, exactly as it looked after the last knit. Press **Knit again** to refresh.

Spec: `docs/superpowers/specs/2026-06-22-knit-preview-persistence-design.md` (brainstormed, then adversarially reviewed by Codex before implementation).

## How it works

Two mechanisms previously defeated persistence; both are addressed:

1. **No webview serializer** → register a `WebviewPanelSerializer` for `raven.knitOutput` (plus the `onWebviewPanel:raven.knitOutput` activation event). The shell persists `{ sourceFsPath, outputPath }` via `setState`; `KnitOutputPanel.restore` rebuilds the panel.
2. **Ephemeral temp files** → on restore, the orphaned old-session preview dir is **adopted** into the current session's path (so a later Knit again is a normal in-place update). Deactivation cleanup keeps open-panel `preview/` dirs when persistence is enabled, removing only throwaway `export/`.

If the temp files are gone (swept/cleaned), the panel shows a "press Knit again" placeholder rather than a broken view.

## New surfaces

- **Setting** `raven.knit.persistPreview` (default `true`, `window` scope) — disable to restore the previous behavior (no restore; temp files removed on window close).
- **Command** `Raven: Clean Up Knit Preview Cache` — on-demand reclaim of orphaned session temp dirs. Never touches the current session nor any session written in the last few minutes (spares concurrent windows).

Reboot survival is out of scope (the OS may clear the temp dir). The cross-window cleanup-vs-long-running-knit recency gap is a documented, accepted limitation (lease-file hardening deferred).

## Testing

- **Bun units**: adoption (reuse/adopt/in-progress/containment/source-hash guard/EXDEV fallback/missing), cleanup selection (current-session/age-threshold/unknown-recency sparing), `listSessionDirs`, the deactivation-cleanup gating, and `</script>`-escaping in the shell.
- **vscode-test**: `deserializeWebviewPanel` rebuilds and adopts; placeholder when nothing to restore; sourceless state disposes. All 32 Knit suites pass.
- Compile clean; settings-reference regenerated (no drift). No Rust changes.

## Review

Implementation went through several adversarial `/code-review` passes (robust/total adopt move, source-hash adopt guard, unknown-recency sparing, bounded fs fan-out, shared dir-walk dedup, script-injection escaping), converging to two consecutive clean passes.

https://claude.ai/code/session_01R5DHCptTLyLtbMRSLkh8D2

https://claude.ai/code/session_01QTiSfVjJzbn7u52aijpqJr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Path completion and `.sthlp` lookup now recognize symlinked files and directories more reliably.
  * Recursive workspace indexing now handles symlinked `.sthlp` files and avoids missing valid results.

* **Bug Fixes**
  * Fixed cases where symlinked paths were skipped, misclassified, or duplicated in search and indexing results.
  * Improved handling of dangling symlinks and symlink loops so scans complete safely without breaking results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->