### PR TITLE
docs: correct Workspace Config reference to sight.toml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,9 +269,12 @@ Includes LRU eviction and `wait_for_update(uri)` to avoid race conditions betwee
 changes with backpressure handling and metrics.
 
 **Workspace Config** (`src/utils/workspace-config.ts`, `src/utils/config-validator.ts`):
-Loads and validates `.sight.json` (workspace-root config) and maps the
-public schema (README) into the internal config shape used by the server.
-Provides validation and fallback logic for configuration settings.
+Loads and validates the workspace-root project config (`sight.toml`, the
+`PROJECT_CONFIG_FILE` in `src/config-file/types.ts`) and maps the public
+schema (README) into the internal config shape used by the server.
+Provides validation and fallback logic for configuration settings. Note:
+`.sight.json` is the unsupported legacy config (`STALE_JSON_CONFIG_FILE`),
+not the current format.
 
 **Indexer** (`src/indexer/`): Workspace-wide symbol indexing for cross-file
 navigation. Scans `.do`, `.ado`, `.doh`, and `.mata` files, with size and


### PR DESCRIPTION
The `AGENTS.md`/`CLAUDE.md` "Workspace Config" section described the
project config as `.sight.json`, but the current project config file is
`sight.toml` (`PROJECT_CONFIG_FILE` in `src/config-file/types.ts`).
`.sight.json` is the unsupported legacy config (`STALE_JSON_CONFIG_FILE`).

Updates the section to name `sight.toml` and note `.sight.json` as the
legacy format, with pointers to the defining constants.

Docs-only; no code or behavior change.

https://claude.ai/code/session_01QTiSfVjJzbn7u52aijpqJr