### PR TITLE
Re-index on client-pushed indexing-affecting settings changes (#223)

### DIFF
--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -185,6 +185,36 @@ export function resolve_scoped_client_settings(
     });
 }
 
+// The config keys that change WHICH files are indexed, or how their
+// indexed dependency-graph edges are keyed (and thus require a full
+// index teardown + re-scan). Most settings — severities, formatting,
+// completion, debug — only affect how open documents are
+// validated/resolved, which a revalidation pass handles without
+// re-scanning. `max_backward_depth` is included because the indexer's
+// inherited-WD walk (#218) uses it to key closed-file callee edges, so
+// a depth change must re-index for those edges to stay consistent with
+// the open-document path. (`backward_dependencies` is NOT needed: the
+// indexer walk forces explicit backward resolution, so it is
+// independent of the auto/explicit mode.)
+//
+// This signature is compared on BOTH config-change paths against a
+// single shared `last_applied_indexing_signature`: the `sight.toml`
+// reload (`reload_project_config_once`) and the runtime client-settings
+// push (`onDidChangeConfiguration`). It is computed on the effective
+// merged `StataLSPConfig` so both paths are directly comparable (#223).
+export function indexing_affecting_signature(
+    config: DeepPartial<StataLSPConfig> | undefined
+): string {
+    return JSON.stringify({
+        adoPaths: config?.adoPaths ?? null,
+        indexWorkspace: config?.indexWorkspace ?? null,
+        index_workspace: config?.cross_file?.index_workspace ?? null,
+        max_indexed_files: config?.cross_file?.max_indexed_files ?? null,
+        maxFileSizeBytes: config?.indexing?.maxFileSizeBytes ?? null,
+        max_backward_depth: config?.cross_file?.max_backward_depth ?? null,
+    });
+}
+
 /**
  * Create and start the LSP server with the specified options.
  */
@@ -245,6 +275,27 @@ export async function create_server(options: ServerOptions): Promise<void> {
     let project_config_candidate_dirs: string[] = [];
     let active_workspace_roots: string[] = [];
     let project_config_watch_registration: Disposable | undefined = undefined;
+
+    // Single source of truth for "which indexing-affecting settings are
+    // currently reflected in the workspace index" (#223). Compared on both
+    // the sight.toml reload path and the runtime onDidChangeConfiguration
+    // path to decide whether a full teardown + re-scan is needed. Written
+    // only by `configure_workspace_indexing`. Initialized to the empty
+    // string: a real `indexing_affecting_signature` is always a JSON object
+    // string, so the empty-string sentinel can never collide with one, and
+    // any comparison made before the first index is established reads as
+    // "changed" (the safe outcome). The initial scan itself is
+    // unconditional (via `refresh_workspace_state` ->
+    // `configure_workspace_indexing`), so no first scan is ever skipped.
+    let last_applied_indexing_signature = '';
+
+    // Monotonic counter giving a latest-wins guard for runtime config
+    // changes. Bumped synchronously on every onDidChangeConfiguration
+    // event; the async capability-mode handler applies its settings only if
+    // it is still the latest, so two rapid events cannot write the signature
+    // / start scans out of order. (Indexer scan state is separately
+    // protected by the indexer's own scan_generation guard.)
+    let config_change_seq = 0;
 
     // Initialization options config
     let init_options_config: unknown = undefined;
@@ -707,6 +758,16 @@ export async function create_server(options: ServerOptions): Promise<void> {
             reset_workspace_indexing_state();
         }
 
+        // Record the indexing-affecting signature we are committing to the
+        // moment we decide to apply `settings` (synchronously, not after
+        // the async scan). This is the single writer of
+        // last_applied_indexing_signature; both config-change paths compare
+        // against it. Optimistic by design: if the async scan later fails it
+        // is not rolled back, matching the sight.toml reload path which
+        // likewise commits its new config regardless of scan success.
+        last_applied_indexing_signature =
+            indexing_affecting_signature(settings);
+
         configure_completion_provider(settings);
 
         if (workspace_indexer) {
@@ -757,34 +818,6 @@ export async function create_server(options: ServerOptions): Promise<void> {
         return b.every((value) => set_a.has(value));
     }
 
-    // The project-config keys that change WHICH files are indexed, or how
-    // their indexed dependency-graph edges are keyed (and thus require a full
-    // index teardown + re-scan). Most settings — severities, formatting,
-    // completion, debug — only affect how open documents are
-    // validated/resolved, which a revalidation pass handles without
-    // re-scanning. `max_backward_depth` is included because the indexer's
-    // inherited-WD walk (#218) uses it to key closed-file callee edges, so a
-    // depth change must re-index for those edges to stay consistent with the
-    // open-document path. (`backward_dependencies` is NOT needed: the indexer
-    // walk forces explicit backward resolution, so it is independent of the
-    // auto/explicit mode.) Client/init settings are constant across a
-    // config-file reload, so comparing this subset of project_file_config is
-    // sufficient to detect an effective indexing change. (This is the
-    // project-config reload path; runtime client settings.json changes do not
-    // re-index for any indexing setting — a pre-existing, uniform limitation.)
-    function indexing_affecting_signature(
-        config: DeepPartial<StataLSPConfig> | undefined
-    ): string {
-        return JSON.stringify({
-            adoPaths: config?.adoPaths ?? null,
-            indexWorkspace: config?.indexWorkspace ?? null,
-            index_workspace: config?.cross_file?.index_workspace ?? null,
-            max_indexed_files: config?.cross_file?.max_indexed_files ?? null,
-            maxFileSizeBytes: config?.indexing?.maxFileSizeBytes ?? null,
-            max_backward_depth: config?.cross_file?.max_backward_depth ?? null,
-        });
-    }
-
     async function reload_project_config_once(): Promise<void> {
         const active_root = active_workspace_roots[0];
         if (!active_root) {
@@ -792,8 +825,6 @@ export async function create_server(options: ServerOptions): Promise<void> {
         }
 
         const previous_config_json = JSON.stringify(project_file_config ?? null);
-        const previous_indexing_signature =
-            indexing_affecting_signature(project_file_config);
         const previous_watch_dirs = project_config_watch_dirs();
 
         apply_loaded_project_config(
@@ -812,16 +843,19 @@ export async function create_server(options: ServerOptions): Promise<void> {
             return;
         }
 
-        const indexing_changed =
-            indexing_affecting_signature(project_file_config) !==
-            previous_indexing_signature;
-
         document_settings.clear();
 
         if (!server_capabilities.has_configuration_capability) {
             global_settings = build_non_capability_settings();
         }
         const settings = await get_document_settings('');
+
+        // Compare the new effective settings against the shared last-applied
+        // signature (the same variable the runtime onDidChangeConfiguration
+        // path uses), so both paths agree on what is currently indexed (#223).
+        const indexing_changed =
+            indexing_affecting_signature(settings) !==
+            last_applied_indexing_signature;
 
         if (indexing_changed) {
             configure_workspace_indexing(settings, active_workspace_roots, true);
@@ -1370,18 +1404,59 @@ export async function create_server(options: ServerOptions): Promise<void> {
     );
 
     // Configuration change handler
+    // Apply an effective settings snapshot produced by a runtime
+    // onDidChangeConfiguration event. If an indexing-affecting key
+    // changed, tear down and re-scan the workspace so closed-file edges /
+    // indexed state match the new settings (mirrors the sight.toml reload
+    // path, #223); otherwise keep the index and just reconfigure providers
+    // + revalidate.
+    function apply_runtime_settings_change(settings: StataLSPConfig): void {
+        const new_signature = indexing_affecting_signature(settings);
+        if (new_signature !== last_applied_indexing_signature) {
+            // Indexing-affecting change: full teardown + re-scan.
+            // configure_workspace_indexing reconfigures the completion
+            // provider synchronously, updates
+            // last_applied_indexing_signature, and revalidates open
+            // documents once the async re-scan completes.
+            //
+            // We deliberately do NOT validate open documents immediately
+            // here: the index reset inside configure_workspace_indexing is
+            // synchronous and empties the index, so an immediate
+            // validate-all would resolve every open document against an
+            // empty index and flash false undefined-symbol warnings until
+            // the scan finishes (the same red-squiggle flicker the close
+            // handler avoids). The reload path avoids it the same way.
+            configure_workspace_indexing(
+                settings, active_workspace_roots, true
+            );
+        } else {
+            // No indexing-affecting change: keep the index intact,
+            // reconfigure providers, and revalidate open documents
+            // immediately against the live index. revalidate_all_open_docs
+            // clears each document's published version and re-validates.
+            configure_completion_provider(settings);
+            workspace_indexer?.configure(settings);
+            revalidate_all_open_docs();
+        }
+    }
+
     connection.onDidChangeConfiguration((change) => {
+        // Latest-wins guard (#223): bump synchronously on every event so a
+        // newer event supersedes any pending async (capability-mode)
+        // resolution. The non-capability branch is synchronous, but still
+        // bumps so it correctly supersedes an in-flight async resolution.
+        const my_seq = ++config_change_seq;
         if (server_capabilities.has_configuration_capability) {
             document_settings.clear();
             void get_document_settings('').then((settings) => {
-                configure_completion_provider(settings);
-                // Propagate indexing-affecting settings (e.g.
-                // indexing.maxFileSizeBytes) so the indexer does not stay stale
-                // after a runtime configuration change.
-                workspace_indexer?.configure(settings);
+                if (my_seq !== config_change_seq) {
+                    // Superseded by a newer config event; let that one win.
+                    return;
+                }
+                apply_runtime_settings_change(settings);
             }).catch((err) => {
                 connection.console.error(
-                    `Error refreshing completion config: ${err}`
+                    `Error refreshing config after change: ${err}`
                 );
             });
         } else {
@@ -1389,28 +1464,8 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 change.settings
             );
             global_settings = build_non_capability_settings();
-            configure_completion_provider(global_settings);
-            workspace_indexer?.configure(global_settings);
+            apply_runtime_settings_change(global_settings);
         }
-
-        // Clear published versions so diagnostics will be re-published
-        // even though document versions haven't changed
-        if (diagnostics_provider) {
-            for (const my_doc of documents.all()) {
-                diagnostics_provider.clear_published_version(my_doc.uri);
-            }
-        }
-
-        // Fire-and-forget validation for all documents
-        // Catch errors to prevent unhandled promise rejections
-        documents.all().forEach((doc) => {
-            validate_text_document(doc).catch((err) => {
-                connection.console.error(
-                    `Error validating ${doc.uri} ` +
-                    `after config change: ${err}`
-                );
-            });
-        });
     });
 
     // Document open handler - validate when a document is first opened

--- a/tests/unit/indexing-signature.test.ts
+++ b/tests/unit/indexing-signature.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'bun:test';
+import type { DeepPartial } from '../../src/config-file';
+import { StataLSPConfig } from '../../src/types';
+import { indexing_affecting_signature } from '../../src/server-factory';
+
+// The signature is the decision predicate for "should a runtime/project config
+// change trigger a full workspace re-index?" (#223). Two configs that differ
+// only in an indexing-affecting key MUST yield different signatures; two that
+// differ only in a non-indexing key (severity, formatting, debug, ...) MUST
+// yield equal signatures (so they take the lightweight revalidation path, not
+// an expensive teardown + re-scan).
+describe('indexing_affecting_signature', () => {
+    const base: DeepPartial<StataLSPConfig> = {
+        adoPaths: ['/a'],
+        indexWorkspace: true,
+        cross_file: {
+            index_workspace: true,
+            max_indexed_files: 1000,
+            max_backward_depth: 10,
+        },
+        indexing: { maxFileSizeBytes: 1_000_000 },
+    };
+
+    function with_change(
+        mutate: (config: DeepPartial<StataLSPConfig>) => void
+    ): DeepPartial<StataLSPConfig> {
+        const my_copy: DeepPartial<StataLSPConfig> = JSON.parse(
+            JSON.stringify(base)
+        );
+        mutate(my_copy);
+        return my_copy;
+    }
+
+    it('differs when adoPaths changes', () => {
+        const changed = with_change((c) => { c.adoPaths = ['/a', '/b']; });
+        expect(indexing_affecting_signature(changed)).not.toBe(
+            indexing_affecting_signature(base)
+        );
+    });
+
+    it('differs when indexWorkspace changes', () => {
+        const changed = with_change((c) => { c.indexWorkspace = false; });
+        expect(indexing_affecting_signature(changed)).not.toBe(
+            indexing_affecting_signature(base)
+        );
+    });
+
+    it('differs when cross_file.index_workspace changes', () => {
+        const changed = with_change((c) => {
+            c.cross_file!.index_workspace = false;
+        });
+        expect(indexing_affecting_signature(changed)).not.toBe(
+            indexing_affecting_signature(base)
+        );
+    });
+
+    it('differs when cross_file.max_indexed_files changes', () => {
+        const changed = with_change((c) => {
+            c.cross_file!.max_indexed_files = 500;
+        });
+        expect(indexing_affecting_signature(changed)).not.toBe(
+            indexing_affecting_signature(base)
+        );
+    });
+
+    it('differs when indexing.maxFileSizeBytes changes', () => {
+        const changed = with_change((c) => {
+            c.indexing!.maxFileSizeBytes = 2_000_000;
+        });
+        expect(indexing_affecting_signature(changed)).not.toBe(
+            indexing_affecting_signature(base)
+        );
+    });
+
+    it('differs when cross_file.max_backward_depth changes', () => {
+        const changed = with_change((c) => {
+            c.cross_file!.max_backward_depth = 5;
+        });
+        expect(indexing_affecting_signature(changed)).not.toBe(
+            indexing_affecting_signature(base)
+        );
+    });
+
+    it('is equal when only a non-indexing field changes', () => {
+        // A severity / debug tweak must NOT trigger a re-index.
+        const changed = with_change((c) => {
+            (c as DeepPartial<StataLSPConfig> & { debug?: boolean }).debug =
+                true;
+        });
+        expect(indexing_affecting_signature(changed)).toBe(
+            indexing_affecting_signature(base)
+        );
+    });
+
+    it('treats undefined as an all-absent config', () => {
+        expect(indexing_affecting_signature(undefined)).toBe(
+            indexing_affecting_signature({})
+        );
+    });
+
+    it('never returns the empty-string sentinel', () => {
+        // The pre-baseline sentinel is '' which a real signature must never
+        // collide with (real signatures are JSON object strings).
+        expect(indexing_affecting_signature(undefined)).not.toBe('');
+        expect(indexing_affecting_signature(base)).not.toBe('');
+    });
+});

--- a/tests/unit/server-runtime-settings-reindex.test.ts
+++ b/tests/unit/server-runtime-settings-reindex.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Wiring guards for #223: a client-pushed (onDidChangeConfiguration) change to
+// an indexing-affecting setting must trigger a full workspace re-index, sharing
+// one last-applied signature with the sight.toml reload path. The handler logic
+// lives in create_server closures, so (matching the existing wiring-test style
+// in server-project-config-wiring.test.ts) we assert structure via source text.
+describe('server-factory runtime settings re-index wiring (#223)', () => {
+    const server_factory_path = path.join(
+        __dirname,
+        '../../src/server-factory.ts'
+    );
+    const source = fs.readFileSync(server_factory_path, 'utf8');
+
+    function extract_function_body(
+        text: string,
+        header: string
+    ): string {
+        const start = text.indexOf(header);
+        expect(start).toBeGreaterThanOrEqual(0);
+        // Walk braces from the first '{' after the header to its match.
+        const brace_start = text.indexOf('{', start);
+        let depth = 0;
+        for (let i = brace_start; i < text.length; i++) {
+            if (text[i] === '{') depth++;
+            else if (text[i] === '}') {
+                depth--;
+                if (depth === 0) {
+                    return text.slice(brace_start, i + 1);
+                }
+            }
+        }
+        throw new Error(`Unbalanced braces after ${header}`);
+    }
+
+    it('declares last_applied_indexing_signature exactly once', () => {
+        const the_matches = source.match(
+            /let\s+last_applied_indexing_signature/g
+        );
+        expect(the_matches?.length).toBe(1);
+    });
+
+    it('initializes last_applied_indexing_signature to the empty sentinel',
+        () => {
+            expect(source).toMatch(
+                /let\s+last_applied_indexing_signature\s*=\s*''/
+            );
+        });
+
+    it('declares a config_change_seq counter', () => {
+        expect(source).toMatch(/let\s+config_change_seq\s*=\s*0/);
+    });
+
+    it('sets last_applied_indexing_signature inside ' +
+        'configure_workspace_indexing', () => {
+        const body = extract_function_body(
+            source,
+            'function configure_workspace_indexing('
+        );
+        expect(body).toMatch(
+            /last_applied_indexing_signature\s*=\s*indexing_affecting_signature\(\s*settings\s*\)/
+        );
+    });
+
+    it('apply_runtime_settings_change compares the signature and ' +
+        're-indexes on change', () => {
+        const body = extract_function_body(
+            source,
+            'function apply_runtime_settings_change('
+        );
+        expect(body).toContain('indexing_affecting_signature(');
+        expect(body).toContain('last_applied_indexing_signature');
+        expect(body).toMatch(
+            /configure_workspace_indexing\(\s*settings,\s*active_workspace_roots,\s*true\s*\)/
+        );
+        // Lightweight branch revalidates open docs immediately.
+        expect(body).toContain('revalidate_all_open_docs()');
+    });
+
+    it('routes both onDidChangeConfiguration branches through ' +
+        'apply_runtime_settings_change behind the seq guard', () => {
+        const body = extract_function_body(
+            source,
+            'connection.onDidChangeConfiguration('
+        );
+        // Latest-wins guard.
+        expect(body).toMatch(/\+\+config_change_seq/);
+        expect(body).toMatch(/my_seq\s*!==\s*config_change_seq/);
+        // Both branches delegate to the shared helper.
+        const the_calls = body.match(/apply_runtime_settings_change\(/g);
+        expect(the_calls?.length).toBeGreaterThanOrEqual(2);
+        // The old unconditional immediate validate-all post-block is gone
+        // (it would re-introduce the empty-index flicker on re-index).
+        expect(body).not.toMatch(
+            /documents\.all\(\)\.forEach\([^)]*validate_text_document/
+        );
+    });
+
+    it('reload path still does a full re-index when indexing changed', () => {
+        const body = extract_function_body(
+            source,
+            'async function reload_project_config_once('
+        );
+        // Reuses the shared signature comparison.
+        expect(body).toContain('last_applied_indexing_signature');
+        expect(body).toMatch(
+            /configure_workspace_indexing\(\s*settings,\s*active_workspace_roots,\s*true\s*\)/
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #223. Client-pushed settings changes (`onDidChangeConfiguration`, i.e. VS Code `settings.json`) did **not** trigger a workspace re-index for any indexing-affecting setting — only the `sight.toml` reload path did. After such a change, **closed-file** dependency-graph edges and indexed state stayed stale until the next full re-index (server restart, `sight.toml` change, or workspace-folder change), while open documents were revalidated immediately, so open and closed files diverged.

This unifies the two config-change paths' indexing-change detection so a runtime client-settings change to any of the indexing-affecting keys (`adoPaths`, `indexWorkspace`, `cross_file.index_workspace`, `cross_file.max_indexed_files`, `indexing.maxFileSizeBytes`, `cross_file.max_backward_depth`) re-indexes the workspace, mirroring the `sight.toml` reload path.

## Changes (`src/server-factory.ts`)

- **Hoist + export `indexing_affecting_signature`** — a pure function (unchanged key set) so it can be shared by both paths and unit-tested directly.
- **Single source of truth `last_applied_indexing_signature`** — written only by `configure_workspace_indexing`, from the effective merged `StataLSPConfig` it applies. Both the reload path and the runtime path compare against it, so they agree on what is currently indexed. Initialized to an empty-string sentinel (a real signature is always a JSON object string, so it can never collide; any pre-baseline comparison reads as "changed", the safe outcome).
- **`apply_runtime_settings_change` helper** — on an indexing-affecting change, full teardown + re-scan (deferring revalidation to scan completion to avoid an empty-index red-squiggle flicker); otherwise keep the index and revalidate open docs immediately. Replaces the old unconditional validate-all post-block.
- **`config_change_seq` latest-wins guard** — bumped synchronously on every event; the async capability-mode handler applies only if still latest, so two rapid events can't write the signature / start scans out of order. (Indexer scan state is separately protected by its own `scan_generation` guard.)

The reload path is reworked to compare the new effective-settings signature against the shared variable; its `config_changed` early-return and watcher-refresh logic are unchanged.

### Accepted residual

The narrow init-refresh vs runtime-config **startup** race (the un-awaited init-time `refresh_workspace_state` resolving after an early config event) is explicitly accepted: it self-corrects on the next re-index trigger and is a strictly-narrower instance of the bug this PR's issue already deems acceptable. Hardening it cleanly (a single settings-apply epoch with roots resolved first) is noted as out-of-scope future work.

## Process

Spec'd first and reviewed adversarially by Codex across six revisions until approved, then implemented with TDD. Codex implementation review and `/code-review` both came back clean over two consecutive passes on the final code.

## Testing

- `tests/unit/indexing-signature.test.ts` — behavioral coverage of the signature predicate (differs per indexing key, equal for a non-indexing change, sentinel sanity).
- `tests/unit/server-runtime-settings-reindex.test.ts` — source-text wiring guards (single-writer signature, both handler branches route through the helper, seq guard present, old flicker-prone post-block removed).
- `bun run test` (typecheck + 6171 tests) and `bun run lint` pass.

https://claude.ai/code/session_01AcXfzxJCfcmjMuUGfVFRWm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved how workspace indexing updates are applied when settings change, helping keep search and document features in sync with your configuration.

* **Bug Fixes**
  * Reduced unnecessary full re-indexing when only non-indexing settings change.
  * Improved handling of rapid configuration changes so the latest settings win.
  * Made project config reloads more reliable when indexing-related settings are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->