### PR TITLE
Make parallel sight check diagnostics byte-identical to sequential runs (#207)

### DIFF
--- a/docs/superpowers/specs/2026-06-27-parallel-check-byte-identical-design.md
+++ b/docs/superpowers/specs/2026-06-27-parallel-check-byte-identical-design.md
@@ -87,6 +87,33 @@ happenstance, and we want a test that fails loudly if that invariant breaks.
 5. Coverage for directives / working-directory inheritance (the paths most
    sensitive to open-document state).
 
+## API changes (explicit)
+
+The implementation introduces exactly these surface changes in `src/cli/check.ts`;
+no other modules change their public API.
+
+1. `CheckContext` gains a field
+   `create_document_store: () => DocumentStore`. It returns a fresh
+   `DocumentStore` wired only to the shared **read-only** infrastructure (see
+   §1 below). The existing `document_store: DocumentStore` field is **kept**
+   (built once via this same factory) so the `context.document_store.dispose()`
+   lifecycle used by existing tests is unaffected.
+2. `collect_check_diagnostics` gains an optional trailing parameter
+   `max_parallel: number = CHECK_MAX_PARALLEL`. `run_check_with_cwd` calls it
+   without the argument (unchanged behavior). Tests pass `1`, `2`, `4`.
+3. `build_check_context` **stops** calling
+   `document_store.set_on_backward_directives_parsed(...)`. This is the only
+   behavioral removal; it is a no-op for `check` output (the overlay it fed has
+   no consumer in the diagnostics path — verified). The wiring that the factory
+   *does* perform is: `set_workspace_roots`, `set_scope_resolver`,
+   `set_scope_resolver_config`.
+
+No new accessors are added to `WorkspaceIndexer`, `DocumentStore`, or
+`ScopeResolver`. The isolation test observes behavior through existing public
+methods (`DocumentStore.getAll()`, and a spy on the existing public
+`WorkspaceIndexer.set_buffer_directives`) plus the new `create_document_store`
+factory — so no production surface exists solely for tests.
+
 ## Approach
 
 Two complementary changes — one structural guarantee, one test that guards it —
@@ -185,15 +212,31 @@ cost is negligible next to lex/parse/analyze.
     diverge if open-doc state leaked across targets);
   - enough targets (> 4) that all worker slots are active and at least one
     worker processes multiple targets.
-- **Direct isolation assertion** (not just output equality): a test wraps
-  `context.create_document_store` to capture every store it hands out, and
-  patches each store's `open` to record `store.getAll().length` at open time.
-  After `collect_check_diagnostics`, assert the recorded peak per store is `≤ 1`
-  and that the buffer overlay was never populated
-  (`workspace_indexer` exposes no live buffer overlay entries). This proves the
-  structural invariant directly rather than inferring it from output equality.
+- **Direct isolation assertion** (not just output equality), using only
+  existing public methods plus the new factory:
+  - Wrap `context.create_document_store` so the test captures every store it
+    hands out, and monkey-patch each captured store's `open` to record
+    `store.getAll().length` immediately after the real `open` resolves. After
+    `collect_check_diagnostics` with `max_parallel = 4`, assert the recorded
+    peak across **every** store is `≤ 1` (no store ever held a sibling target),
+    while the number of distinct stores created is `> 1` (parallelism really
+    happened).
+  - Spy on the context's `workspace_indexer.set_buffer_directives` and assert it
+    is **never called** during collection — proving the buffer overlay stays
+    unpopulated (the dropped-callback guarantee), without needing a private
+    accessor.
 - A small test that passing duplicate explicit target paths produces the same
   output as passing the path once (dedupe behavior is unchanged).
+- **Existing test migration.** `cli-check.test.ts`'s "processes report targets
+  concurrently while preserving output order" currently mocks
+  `context.document_store` and asserts `max_active_opens > 1` on that single
+  shared mock. With per-worker stores there is no shared store to observe, so
+  this test is updated to mock `context.create_document_store` (returning a
+  fresh mock store per call). The mock tracks **global** concurrent opens across
+  all stores (assert `> 1`, proving parallelism survived) and **per-store**
+  concurrent opens (assert `≤ 1`, proving isolation). This is the same test,
+  re-pointed at the new factory, and it doubles as the direct isolation
+  assertion above.
 
 ### 3. Documentation
 

--- a/docs/superpowers/specs/2026-06-27-parallel-check-byte-identical-design.md
+++ b/docs/superpowers/specs/2026-06-27-parallel-check-byte-identical-design.md
@@ -45,13 +45,25 @@ All three were **byte-identical**. This is expected from the CLI wiring:
   before collection and is not mutated during it; its `version_counter` is
   stable, so `ScopeResolver`'s content-hash + graph-version cache keys are
   stable and deterministic.
-- The two shared mutations that `open()` triggers —
-  `ScopeResolver.sync_backward_directive_dependencies` and (via the
-  `on_backward_directives_parsed` callback) `WorkspaceIndexer.set_buffer_directives`
-  — are content-idempotent (each writes the same URI→directives derived from
-  the same on-disk bytes) and feed only **cache invalidation** and
-  **find-references** (`get_related_uris`), neither of which participates in
-  `check` diagnostics.
+- The shared mutations that `open()` triggers are content-idempotent and do
+  not feed `check` diagnostics:
+  - `ScopeResolver.sync_backward_directive_dependencies` and the
+    `scope_resolver.resolve(...)` call made for working-directory inheritance
+    populate the resolver's `file_cache` / `scope_cache` / reverse-dependency
+    maps. These caches are keyed by content hash + dependency-graph version +
+    config; during `check` no file changes and the graph version is stable, so
+    every key is stable and every cached value is a pure function of on-disk
+    bytes. Concurrent workers may race to fill the same key, but each entry is
+    written as a whole object (no torn reads) and all writers compute the same
+    value — so results are deterministic. (The empirical probe confirms this:
+    shared-sequential, which reuses one resolver across targets, matched the
+    fresh-context isolated baseline byte-for-byte.)
+  - The `on_backward_directives_parsed` → `WorkspaceIndexer.set_buffer_directives`
+    overlay feeds **only** `WorkspaceIndexer.get_related_uris`, which is
+    consumed exclusively by the hover / definition / references providers
+    (verified by grep). `check` runs diagnostics only and never calls
+    `get_related_uris`, and `DiagnosticsProvider` does not reference the
+    indexer at all. So the overlay is dead weight in `check`.
 - Output ordering is already parallelism-independent: results are written into
   `the_slots[my_index]` by target index and flattened in order, and
   `collect_report_targets` sorts targets by `relative_path`.
@@ -100,24 +112,45 @@ read-only infrastructure (`ScopeResolver`, `WorkspaceIndexer`,
 
 Implementation:
 
-- Extract the `DocumentStore` wiring from `build_check_context` into a helper
-  `wire_check_document_store(store, deps)` where
-  `deps = { workspace_root, scope_resolver, workspace_indexer, config }`. It
-  sets workspace roots, the scope resolver, the scope-resolver config
-  (`scope_resolver_config_for(config)`), and the `on_backward_directives_parsed`
-  callback (→ `workspace_indexer.set_buffer_directives`). This is exactly the
-  wiring `build_check_context` does today, factored for reuse.
-- `build_check_context` keeps creating and wiring a `document_store` on
-  `CheckContext` via this helper (preserves the existing field and the
-  `context.document_store.dispose()` lifecycle that several tests rely on).
-- `collect_check_diagnostics` creates **one wired store per worker** (not the
-  shared `context.document_store`), uses it for that worker's targets, and
-  disposes it when the worker finishes. With `worker_count =
+- Add a factory `create_document_store()` to `CheckContext` that builds a fresh
+  `DocumentStore` wired to the shared infrastructure:
+  - `set_workspace_roots([workspace_root])`,
+  - `set_scope_resolver(scope_resolver)` (needed so WD inheritance resolves),
+  - `set_scope_resolver_config(scope_resolver_config_for(config))`.
+  - It deliberately does **not** wire the `on_backward_directives_parsed`
+    callback. That callback exists to keep the LSP server's find-references view
+    fresh against unsaved edits; `check` never calls `get_related_uris` and has
+    no unsaved edits (buffer content always equals disk), so populating the
+    shared `buffer_directives_overlay` is pure dead weight and a needless piece
+    of cross-target shared state. Dropping it is verified safe: the overlay has
+    no consumer in the `check` diagnostics path.
+- `build_check_context` creates the shared infra and exposes
+  `create_document_store`. It still creates one `document_store` on
+  `CheckContext` (via the factory) to preserve the existing field and the
+  `context.document_store.dispose()` lifecycle that several tests rely on. The
+  one behavior change to this primary store is that it no longer registers the
+  buffer-directive callback (see above) — a no-op for `check` output.
+- `collect_check_diagnostics` creates **one store per worker** via the factory
+  (not the shared `context.document_store`), uses it for that worker's targets,
+  and disposes it when the worker finishes. With `worker_count =
   min(max_parallel, targets.length)`, that is at most `max_parallel` stores,
-  each holding ≤1 live document.
+  each holding ≤1 live document (because each target is `close()`d in a
+  `finally` before the worker pulls its next index).
 - The shared `context.document_store` is left intact for lifecycle/back-compat;
   it simply isn't used as the analysis store anymore. (We keep it rather than
   remove it to avoid churning ~5 test call sites that dispose it.)
+
+**Scope of the guarantee (deliberately narrow).** The structural invariant is:
+*the `DocumentStore` used to analyze a target exposes only that target* — so any
+consumer that reads the live document set (`getAll()` / `get(other_uri)`) sees a
+single document, and the shared `buffer_directives_overlay` is never populated.
+We do **not** isolate the `ScopeResolver` per worker: it is disk-backed and
+therefore inherently open-document-agnostic, and per-worker resolvers would
+discard the shared file/scope cache and re-read+re-parse every parent per worker
+for no correctness gain (YAGNI). If a future change gives the CLI an
+open-buffer-preferring content provider, that provider must be wired to a
+per-worker store (not a global one) for this invariant to keep holding; the
+regression test below is the backstop that fails loudly if that ever regresses.
 
 This is low-risk: a `DocumentStore` is a handful of `Map`s; per-worker creation
 cost is negligible next to lex/parse/analyze.
@@ -126,17 +159,25 @@ cost is negligible next to lex/parse/analyze.
 
 - Add an optional `max_parallel?: number` parameter to
   `collect_check_diagnostics` (default `CHECK_MAX_PARALLEL`). `run_check_with_cwd`
-  is unchanged (uses the default). This lets a test drive the *same context*
-  at parallelism 1 (sequential) and 4 (parallel) — a faithful sequential-vs-
-  parallel comparison rather than an approximation.
+  is unchanged (uses the default). This lets a test drive collection at
+  parallelism 1 (sequential) and N (parallel).
 - New integration test `tests/integration/cli-check-parallel-determinism.test.ts`:
   build one workspace exercising every open-document-sensitive path, then assert
-  the rendered output (JSON, the canonical serialization) is **byte-identical**
-  across `max_parallel ∈ {1, 2, 4}`, and that ordering is stable. Workspace
-  covers:
+  the rendered output (JSON — the canonical serialization) is **byte-identical**
+  across `max_parallel ∈ {1, 2, 4}`. To prevent shared-cache priming from
+  masking a divergence (a real risk flagged in review — `open()` fills the
+  resolver caches), **build a fresh `CheckContext` for each `max_parallel`
+  run** rather than reusing one context across modes. Also compute a per-target
+  **isolated** baseline (a fresh context per single target) and assert every
+  `max_parallel` run equals it — this is the strongest oracle, since the
+  isolated run provably only ever has one document open.
+  Workspace covers:
   - cross-file `do` chain with a global defined in the parent used in a child
     (auto backward discovery / `done-by` inheritance);
   - `include` chain inheriting a local macro;
+  - explicit `@lsp-done-by` and `@lsp-included-by` directive-only relationships
+    (the directive path that drives the buffer overlay), in addition to the
+    auto-discovered `do`/`include` edges;
   - `@lsp-cd` working-directory inheritance from a parent to a child whose
     diagnostics depend on the resolved WD;
   - two unrelated modules that both define the same global name and the same
@@ -144,10 +185,15 @@ cost is negligible next to lex/parse/analyze.
     diverge if open-doc state leaked across targets);
   - enough targets (> 4) that all worker slots are active and at least one
     worker processes multiple targets.
-- Add a focused unit/integration assertion that a worker's store never holds
-  more than one document (the isolation invariant) — implemented by checking
-  that `collect_check_diagnostics` output matches the per-target **isolated**
-  baseline (fresh context per target), which can only hold one document.
+- **Direct isolation assertion** (not just output equality): a test wraps
+  `context.create_document_store` to capture every store it hands out, and
+  patches each store's `open` to record `store.getAll().length` at open time.
+  After `collect_check_diagnostics`, assert the recorded peak per store is `≤ 1`
+  and that the buffer overlay was never populated
+  (`workspace_indexer` exposes no live buffer overlay entries). This proves the
+  structural invariant directly rather than inferring it from output equality.
+- A small test that passing duplicate explicit target paths produces the same
+  output as passing the path once (dedupe behavior is unchanged).
 
 ### 3. Documentation
 
@@ -173,6 +219,25 @@ cost is negligible next to lex/parse/analyze.
 - Not raising or making `CHECK_MAX_PARALLEL` user-configurable (the param is
   internal, for tests). YAGNI.
 - Not addressing issue #184's transactional-side-effect concern; orthogonal.
+- **Indexer insertion-order nondeterminism is out of scope.** Review noted that
+  `WorkspaceIndexer.initialize` reads directories via `readdir` (unsorted) and
+  commits to `symbol_index` as a worker pool completes, so `get_all_symbols`
+  insertion order can vary *run to run*. This does **not** cause
+  parallel-vs-sequential divergence within a run — #207's actual subject —
+  because `collect_check_diagnostics` captures `workspace_symbols` **once**
+  before the parallel region and passes the same snapshot to every worker, and
+  per CLAUDE.md workspace symbols do not suppress diagnostics or affect
+  diagnostic ordering (output is ordered by target index). Any cross-run
+  ordering effect would be a pre-existing determinism concern independent of
+  parallelization; if it proves to affect rendered output it warrants its own
+  issue.
+- **Parse/analyze timeout divergence under CPU contention is out of scope.**
+  `DocumentStore` wraps lex/parse/analyze in `with_parse_timeout`; under heavy
+  parallel load a pathological file near the wall-clock threshold could time out
+  where a sequential run would not, emitting a timeout diagnostic. This is an
+  inherent property of any parallel executor and a safety valve for pathological
+  input, not normal output; the regression test uses small files that never
+  approach the timeout.
 
 ## Risks and mitigations
 
@@ -188,9 +253,11 @@ cost is negligible next to lex/parse/analyze.
   size/index-limit/read-error per-target diagnostics unchanged (logic moved
   verbatim); (e) output order unchanged (slot-by-index preserved).
 - **Determinism of `DiagnosticsProvider.filtered_cache`** (shared, keyed by
-  `uri:version:config_hash`): per-worker stores all use `version = 1` and
-  distinct URIs per target, so no cross-target cache collision; the cache stays
-  correct.
+  `uri:version:config_hash` — verified in `src/providers/diagnostics.ts`):
+  per-worker stores all use `version = 1` and distinct URIs per target, so no
+  cross-target cache collision; the cache stays correct. The provider also takes
+  no reference to the document store or indexer, so it cannot observe sibling
+  open state.
 
 ## Verification plan
 

--- a/docs/superpowers/specs/2026-06-27-parallel-check-byte-identical-design.md
+++ b/docs/superpowers/specs/2026-06-27-parallel-check-byte-identical-design.md
@@ -292,9 +292,12 @@ cost is negligible next to lex/parse/analyze.
   store." Enumerated contract that must survive: (a) cross-file resolution still
   reads parents from disk (unchanged — same shared resolver); (b) WD inheritance
   still works (the per-worker store is wired with the same scope resolver +
-  config); (c) `set_buffer_directives` still fires (callback preserved); (d)
-  size/index-limit/read-error per-target diagnostics unchanged (logic moved
-  verbatim); (e) output order unchanged (slot-by-index preserved).
+  config); (c) `set_buffer_directives` deliberately no longer fires during
+  `check` because `set_on_backward_directives_parsed` is intentionally not
+  wired (its overlay has no `check` consumer — a dropped capability, reviewed,
+  not a silent regression); (d) size/index-limit/read-error per-target
+  diagnostics unchanged (logic moved verbatim); (e) output order unchanged
+  (slot-by-index preserved).
 - **Determinism of `DiagnosticsProvider.filtered_cache`** (shared, keyed by
   `uri:version:config_hash` — verified in `src/providers/diagnostics.ts`):
   per-worker stores all use `version = 1` and distinct URIs per target, so no

--- a/docs/superpowers/specs/2026-06-27-parallel-check-byte-identical-design.md
+++ b/docs/superpowers/specs/2026-06-27-parallel-check-byte-identical-design.md
@@ -1,0 +1,200 @@
+# Design: Make parallel `sight check` diagnostics byte-identical to sequential runs
+
+Issue: [#207](https://github.com/jbearak/sight/issues/207) — Raven port follow-up to
+[jbearak/raven#485](https://github.com/jbearak/raven#485).
+
+## Problem
+
+`sight check` parallelizes target collection in `src/cli/check.ts`
+(`collect_check_diagnostics`, `CHECK_MAX_PARALLEL = 4`) over a single shared
+`DocumentStore`. Each worker calls `document_store.open(uri, ...)`, reads
+diagnostics, then `close(uri)`. Because up to four workers run concurrently,
+**multiple check targets can be open as documents at the same time**.
+
+The hazard, ported from Raven: if open-document state ever outranks
+indexed/disk state during scope resolution, dependency-edge discovery,
+directive parsing, or working-directory inheritance, then a target analyzed
+while sibling targets happen to be open could produce different diagnostics
+than the same target analyzed alone — i.e. parallel output could diverge from
+a sequential run (and from editor-startup semantics, where the file under
+analysis is the one open document).
+
+## Investigation: is the shared store unsafe today?
+
+I built a probe (cross-file `do`/`include`, `@lsp-cd` working-directory
+inheritance, and two unrelated modules that both define a global `G` plus a
+`@lsp-included-by` local-macro hazard) and compared three execution modes over
+the same workspace, rendering diagnostics to JSON for a byte comparison:
+
+1. **isolated** — a fresh `CheckContext` per target (the true "only this file
+   is open" baseline);
+2. **shared-sequential** — one shared context, one target open at a time;
+3. **parallel** — the current behavior, up to four targets open at once.
+
+All three were **byte-identical**. This is expected from the CLI wiring:
+
+- In `build_check_context`, the `ScopeResolver` uses its **default
+  disk-backed `ContentProvider`** (`fs.promises.readFile` via `fsPath`). Unlike
+  the LSP server, the CLI never injects an open-buffer-preferring content
+  provider, so every parent/callee file is read from disk regardless of which
+  targets are open.
+- `workspace_symbols` is captured **once** (`get_all_symbols()`) before the
+  parallel region and passed by value into every worker, so the global symbol
+  view is a stable snapshot.
+- The dependency graph is fully populated by `workspace_indexer.initialize(...)`
+  before collection and is not mutated during it; its `version_counter` is
+  stable, so `ScopeResolver`'s content-hash + graph-version cache keys are
+  stable and deterministic.
+- The two shared mutations that `open()` triggers —
+  `ScopeResolver.sync_backward_directive_dependencies` and (via the
+  `on_backward_directives_parsed` callback) `WorkspaceIndexer.set_buffer_directives`
+  — are content-idempotent (each writes the same URI→directives derived from
+  the same on-disk bytes) and feed only **cache invalidation** and
+  **find-references** (`get_related_uris`), neither of which participates in
+  `check` diagnostics.
+- Output ordering is already parallelism-independent: results are written into
+  `the_slots[my_index]` by target index and flattened in order, and
+  `collect_report_targets` sorts targets by `relative_path`.
+
+**Conclusion:** today's shared store is safe for `check` diagnostics. The risk
+is a *future* regression — e.g. someone gives the CLI an open-buffer-preferring
+content provider (matching the LSP) or routes some symbol lookup through the
+live document set. We want byte-identical output to hold *robustly*, not by
+happenstance, and we want a test that fails loudly if that invariant breaks.
+
+## Goals (acceptance criteria from the issue)
+
+1. A regression test comparing sequential vs parallel `sight check` diagnostics
+   over a workspace with cross-file `do`/`run`/`include`, open-document
+   precedence hazards, and deterministic output ordering.
+2. If shared-store semantics are unsafe, introduce per-target overlay/isolation
+   so each worker analyzes exactly its target as open.
+3. Output byte-identical and deterministically sorted between sequential and
+   parallel collection.
+4. Document the concurrency invariant near `collect_check_diagnostics`.
+5. Coverage for directives / working-directory inheritance (the paths most
+   sensitive to open-document state).
+
+## Approach
+
+Two complementary changes — one structural guarantee, one test that guards it —
+plus documentation.
+
+### 1. Per-worker document isolation (structural guarantee)
+
+Mirror Raven's "keep the global document set empty; give each worker a
+one-document overlay." In Sight terms: **stop sharing one `DocumentStore`
+across workers; give each worker its own store** wired to the same shared,
+read-only infrastructure (`ScopeResolver`, `WorkspaceIndexer`,
+`DependencyGraph`, `DiagnosticsProvider`, config).
+
+- Each worker opens → analyzes → closes its current target in its **own**
+  store. Because `close()` empties the store between targets, a worker's store
+  holds **at most one document at any instant**, and **no store ever contains a
+  sibling target**. The invariant "each target is analyzed as if it is the only
+  open document" then holds *by construction* — even if a future change makes
+  diagnostics consult the live document set.
+- The shared infrastructure is read-only during collection (the index and
+  dependency graph are already built; the resolver reads from disk), so sharing
+  it across workers is safe and preserves cross-file resolution.
+
+Implementation:
+
+- Extract the `DocumentStore` wiring from `build_check_context` into a helper
+  `wire_check_document_store(store, deps)` where
+  `deps = { workspace_root, scope_resolver, workspace_indexer, config }`. It
+  sets workspace roots, the scope resolver, the scope-resolver config
+  (`scope_resolver_config_for(config)`), and the `on_backward_directives_parsed`
+  callback (→ `workspace_indexer.set_buffer_directives`). This is exactly the
+  wiring `build_check_context` does today, factored for reuse.
+- `build_check_context` keeps creating and wiring a `document_store` on
+  `CheckContext` via this helper (preserves the existing field and the
+  `context.document_store.dispose()` lifecycle that several tests rely on).
+- `collect_check_diagnostics` creates **one wired store per worker** (not the
+  shared `context.document_store`), uses it for that worker's targets, and
+  disposes it when the worker finishes. With `worker_count =
+  min(max_parallel, targets.length)`, that is at most `max_parallel` stores,
+  each holding ≤1 live document.
+- The shared `context.document_store` is left intact for lifecycle/back-compat;
+  it simply isn't used as the analysis store anymore. (We keep it rather than
+  remove it to avoid churning ~5 test call sites that dispose it.)
+
+This is low-risk: a `DocumentStore` is a handful of `Map`s; per-worker creation
+cost is negligible next to lex/parse/analyze.
+
+### 2. Injectable parallelism + regression test
+
+- Add an optional `max_parallel?: number` parameter to
+  `collect_check_diagnostics` (default `CHECK_MAX_PARALLEL`). `run_check_with_cwd`
+  is unchanged (uses the default). This lets a test drive the *same context*
+  at parallelism 1 (sequential) and 4 (parallel) — a faithful sequential-vs-
+  parallel comparison rather than an approximation.
+- New integration test `tests/integration/cli-check-parallel-determinism.test.ts`:
+  build one workspace exercising every open-document-sensitive path, then assert
+  the rendered output (JSON, the canonical serialization) is **byte-identical**
+  across `max_parallel ∈ {1, 2, 4}`, and that ordering is stable. Workspace
+  covers:
+  - cross-file `do` chain with a global defined in the parent used in a child
+    (auto backward discovery / `done-by` inheritance);
+  - `include` chain inheriting a local macro;
+  - `@lsp-cd` working-directory inheritance from a parent to a child whose
+    diagnostics depend on the resolved WD;
+  - two unrelated modules that both define the same global name and the same
+    program name (conflicting-precedence hazard — the case most likely to
+    diverge if open-doc state leaked across targets);
+  - enough targets (> 4) that all worker slots are active and at least one
+    worker processes multiple targets.
+- Add a focused unit/integration assertion that a worker's store never holds
+  more than one document (the isolation invariant) — implemented by checking
+  that `collect_check_diagnostics` output matches the per-target **isolated**
+  baseline (fresh context per target), which can only hold one document.
+
+### 3. Documentation
+
+- A block comment above `collect_check_diagnostics` stating the invariant:
+  *"Each target is analyzed in its own single-document `DocumentStore`, so a
+  target's diagnostics never depend on which sibling targets are concurrently
+  open. Cross-file resolution reads parents/callees from disk via the shared
+  read-only ScopeResolver/index; output is ordered by target index and is
+  therefore byte-identical and deterministic regardless of `max_parallel`. Do
+  not route per-target analysis through a shared multi-document store or an
+  open-buffer-preferring content provider without revisiting this invariant and
+  the cli-check-parallel-determinism test."*
+- Brief note in `CLAUDE.md`? No — keep it local to the code; the issue asks for
+  documentation *near* `collect_check_diagnostics`.
+
+## Out of scope / non-goals
+
+- No change to LSP-server behavior or to how the editor prefers open buffers.
+  This is CLI-only.
+- No change to the dependency-graph/indexer model, scope-resolver caching, or
+  the `buffer_directives_overlay` mechanism (those remain as-is; they are
+  content-idempotent under `check`).
+- Not raising or making `CHECK_MAX_PARALLEL` user-configurable (the param is
+  internal, for tests). YAGNI.
+- Not addressing issue #184's transactional-side-effect concern; orthogonal.
+
+## Risks and mitigations
+
+- **Per-worker store changes lifecycle expectations.** Mitigation: keep
+  `context.document_store` and its `dispose()`; per-worker stores are disposed
+  inside `collect_check_diagnostics`. Existing tests keep passing.
+- **Replaced-primitive contract drift** (per CLAUDE.md review guidance): the
+  only behavioral primitive being swapped is "shared store" → "per-worker
+  store." Enumerated contract that must survive: (a) cross-file resolution still
+  reads parents from disk (unchanged — same shared resolver); (b) WD inheritance
+  still works (the per-worker store is wired with the same scope resolver +
+  config); (c) `set_buffer_directives` still fires (callback preserved); (d)
+  size/index-limit/read-error per-target diagnostics unchanged (logic moved
+  verbatim); (e) output order unchanged (slot-by-index preserved).
+- **Determinism of `DiagnosticsProvider.filtered_cache`** (shared, keyed by
+  `uri:version:config_hash`): per-worker stores all use `version = 1` and
+  distinct URIs per target, so no cross-target cache collision; the cache stays
+  correct.
+
+## Verification plan
+
+- New parallel-determinism test passes at `max_parallel ∈ {1,2,4}`.
+- Full suite green: `bun run test` (typecheck + tests).
+- `bun run lint` clean (not in CI — run manually per CLAUDE.md).
+- Two consecutive clean `codex` reviews and `/code-review` passes before PR.

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -598,7 +598,15 @@ export async function collect_check_diagnostics(
     }
 
     let file_index = 0;
-    const worker_count = Math.min(max_parallel, targets.length);
+    // With no targets there is nothing to drain (0 workers). Otherwise clamp to
+    // >= 1 so a caller passing max_parallel < 1 still drains every target with
+    // one worker rather than silently producing zero workers and an empty
+    // result. The default (CHECK_MAX_PARALLEL) always satisfies this; the guard
+    // only matters for the internal, test-facing parameter.
+    const worker_count =
+        targets.length === 0
+            ? 0
+            : Math.max(1, Math.min(max_parallel, targets.length));
     const the_workers = Array.from(
         { length: worker_count },
         async () => {

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -598,15 +598,19 @@ export async function collect_check_diagnostics(
     }
 
     let file_index = 0;
-    // With no targets there is nothing to drain (0 workers). Otherwise clamp to
-    // >= 1 so a caller passing max_parallel < 1 still drains every target with
-    // one worker rather than silently producing zero workers and an empty
-    // result. The default (CHECK_MAX_PARALLEL) always satisfies this; the guard
-    // only matters for the internal, test-facing parameter.
+    // A worker count must be a finite positive integer. Sanitize the internal,
+    // test-facing max_parallel before clamping: non-finite values (NaN /
+    // Infinity) fall back to the default, and fractional values floor. With no
+    // targets there is nothing to drain (0 workers); otherwise clamp to >= 1 so
+    // a caller passing max_parallel < 1 still drains every target with one
+    // worker rather than silently producing zero workers and an empty result.
+    const requested_parallel = Number.isFinite(max_parallel)
+        ? Math.floor(max_parallel)
+        : CHECK_MAX_PARALLEL;
     const worker_count =
         targets.length === 0
             ? 0
-            : Math.max(1, Math.min(max_parallel, targets.length));
+            : Math.max(1, Math.min(requested_parallel, targets.length));
     const the_workers = Array.from(
         { length: worker_count },
         async () => {

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -354,6 +354,12 @@ export interface CheckContext {
     forward_scope_resolver: ForwardScopeResolver;
     document_store: DocumentStore;
     diagnostics_provider: DiagnosticsProvider;
+    // Builds a fresh DocumentStore wired to the shared, read-only check
+    // infrastructure (scope resolver, workspace roots, scope-resolver config).
+    // Each check worker gets its own store from this factory so that a target
+    // is never analyzed while a sibling target is present as an open document —
+    // see the concurrency-invariant comment on `collect_check_diagnostics`.
+    create_document_store: () => DocumentStore;
 }
 
 export async function build_check_context(
@@ -380,7 +386,6 @@ export async function build_check_context(
     const forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
         max_forward_depth: config.cross_file.max_forward_depth,
     });
-    const document_store = new DocumentStore();
     const diagnostics_provider = new DiagnosticsProvider({
         sendDiagnostics: () => undefined,
     });
@@ -399,14 +404,25 @@ export async function build_check_context(
     dependency_graph.set_workspace_roots([workspace_root]);
     scope_resolver.set_workspace_roots([workspace_root]);
     forward_scope_resolver.set_workspace_roots([workspace_root]);
-    document_store.set_workspace_roots([workspace_root]);
-    document_store.set_scope_resolver(scope_resolver);
-    document_store.set_scope_resolver_config(
-        scope_resolver_config_for(config)
-    );
-    document_store.set_on_backward_directives_parsed((uri, directives) => {
-        workspace_indexer.set_buffer_directives(uri, directives);
-    });
+
+    const scope_resolver_config = scope_resolver_config_for(config);
+    // Builds a DocumentStore wired only to the shared, read-only check
+    // infrastructure. Notably it does NOT register
+    // `set_on_backward_directives_parsed`: that callback exists to keep the LSP
+    // server's find-references view fresh against unsaved edits by populating
+    // `WorkspaceIndexer.buffer_directives_overlay`. `check` runs diagnostics
+    // only, never calls `get_related_uris` (the overlay's sole consumer), and
+    // has no unsaved edits (buffer content always equals disk), so the overlay
+    // is dead weight here — and wiring it would add cross-target shared state we
+    // intentionally avoid (see `collect_check_diagnostics`).
+    const create_document_store = (): DocumentStore => {
+        const store = new DocumentStore();
+        store.set_workspace_roots([workspace_root]);
+        store.set_scope_resolver(scope_resolver);
+        store.set_scope_resolver_config(scope_resolver_config);
+        return store;
+    };
+    const document_store = create_document_store();
 
     await workspace_indexer.initialize([workspace_root], config.adoPaths);
 
@@ -417,6 +433,7 @@ export async function build_check_context(
         forward_scope_resolver,
         document_store,
         diagnostics_provider,
+        create_document_store,
     };
 }
 
@@ -437,18 +454,44 @@ function diagnostic_record(
     return { relative_path, diagnostic };
 }
 
+/**
+ * Concurrency invariant
+ * ----------------------
+ * Each target is analyzed in its **own** single-document `DocumentStore`
+ * (one per worker, from `context.create_document_store`). A worker opens its
+ * target, reads diagnostics, then closes it before pulling the next index, so
+ * a store holds at most one document at any instant and **no store ever
+ * contains a sibling target**. A target's diagnostics therefore never depend on
+ * which other targets happen to be open concurrently — parallel output is
+ * byte-identical to a sequential run, matching editor-startup semantics where
+ * the analyzed file is the one open document.
+ *
+ * This holds because cross-file resolution reads parents/callees from disk via
+ * the shared, read-only `ScopeResolver` (its caches are content-hash +
+ * dependency-graph-version keyed, so concurrent fills are deterministic), and
+ * `workspace_symbols` is a single snapshot captured here before any worker
+ * starts. Output order is independent of `max_parallel`: results are written
+ * into `the_slots[index]` by target index and flattened in order.
+ *
+ * Do NOT route per-target analysis through a shared multi-document store, and
+ * do NOT give the CLI an open-buffer-preferring content provider wired to a
+ * shared store, without revisiting this invariant and the
+ * `cli-check-parallel-determinism` regression test.
+ */
 export async function collect_check_diagnostics(
     context: CheckContext,
     workspace_root: string,
     config: StataLSPConfig,
-    targets: ReportTarget[]
+    targets: ReportTarget[],
+    max_parallel: number = CHECK_MAX_PARALLEL
 ): Promise<DiagnosticRecord[]> {
     const workspace_symbols = context.workspace_indexer.get_all_symbols();
     const files_indexed = context.workspace_indexer.get_metrics().files_indexed;
     const the_slots: DiagnosticRecord[][] = new Array(targets.length);
 
     async function collect_target_diagnostics(
-        target: ReportTarget
+        target: ReportTarget,
+        document_store: DocumentStore
     ): Promise<DiagnosticRecord[]> {
         const records: DiagnosticRecord[] = [];
         const uri = URI.file(target.path).toString();
@@ -520,14 +563,14 @@ export async function collect_check_diagnostics(
 
         let opened = false;
         try {
-            await context.document_store.open(
+            await document_store.open(
                 uri,
                 read_result.text,
                 1,
                 workspace_symbols
             );
             opened = true;
-            const state = context.document_store.get(uri);
+            const state = document_store.get(uri);
             if (!state) {
                 throw new Error(`failed to analyze ${target.path}`);
             }
@@ -547,7 +590,7 @@ export async function collect_check_diagnostics(
             }
         } finally {
             if (opened) {
-                context.document_store.close(uri);
+                document_store.close(uri);
             }
         }
 
@@ -555,18 +598,27 @@ export async function collect_check_diagnostics(
     }
 
     let file_index = 0;
-    const worker_count = Math.min(CHECK_MAX_PARALLEL, targets.length);
+    const worker_count = Math.min(max_parallel, targets.length);
     const the_workers = Array.from(
         { length: worker_count },
         async () => {
-            while (true) {
-                const my_index = file_index++;
-                if (my_index >= targets.length) {
-                    break;
+            // Per-worker store: see the concurrency invariant above. A worker
+            // reuses one store across the targets it pulls, but each target is
+            // closed before the next opens, so the store never holds a sibling.
+            const document_store = context.create_document_store();
+            try {
+                while (true) {
+                    const my_index = file_index++;
+                    if (my_index >= targets.length) {
+                        break;
+                    }
+                    the_slots[my_index] = await collect_target_diagnostics(
+                        targets[my_index],
+                        document_store
+                    );
                 }
-                the_slots[my_index] = await collect_target_diagnostics(
-                    targets[my_index]
-                );
+            } finally {
+                await document_store.dispose();
             }
         }
     );

--- a/tests/integration/cli-check-parallel-determinism.test.ts
+++ b/tests/integration/cli-check-parallel-determinism.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    build_check_context,
+    collect_check_diagnostics,
+    load_check_config,
+} from '../../src/cli/check';
+import { collect_report_targets } from '../../src/cli/source-files';
+import { render_json } from '../../src/cli/shared';
+import type { StataLSPConfig } from '../../src/types';
+
+// Regression coverage for #207: parallel `sight check` must produce
+// byte-identical, deterministically-ordered diagnostics to a sequential run,
+// across a workspace that stresses every open-document-sensitive path
+// (cross-file do/include, explicit done-by/included-by directives,
+// working-directory inheritance, and conflicting global/program names in
+// unrelated modules).
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-parallel-'));
+}
+
+function build_hazard_workspace(): string {
+    const root = temp_dir();
+    fs.mkdirSync(path.join(root, 'wd'));
+
+    // Auto-discovered `do` chain + working-directory inheritance: parent sets a
+    // working directory and a global, then `do`s the child. The child inherits
+    // the non-local global (auto backward discovery) and the working directory.
+    fs.writeFileSync(
+        path.join(root, 'parent.do'),
+        '// @lsp-cd: "wd"\nglobal G_parent 7\ndo child.do\n'
+    );
+    fs.writeFileSync(
+        path.join(root, 'child.do'),
+        'display "$G_parent"\ndisplay "`child_undef\'"\n'
+    );
+
+    // Auto-discovered `include` chain inheriting a local macro.
+    fs.writeFileSync(
+        path.join(root, 'inc_parent.do'),
+        'local L_inc 5\ninclude included.do\n'
+    );
+    fs.writeFileSync(
+        path.join(root, 'included.do'),
+        'display "`L_inc\'"\n'
+    );
+
+    // Explicit directive-only relationships (the directive path that drives the
+    // buffer overlay in the LSP). done-by inherits the parent's global;
+    // included-by inherits the parent's local macro.
+    fs.writeFileSync(
+        path.join(root, 'done_child.do'),
+        '// @lsp-done-by: "parent.do"\ndisplay "$G_parent"\ndisplay "`only_local\'"\n'
+    );
+    fs.writeFileSync(
+        path.join(root, 'inc_child.do'),
+        '// @lsp-included-by: "inc_parent.do"\ndisplay "`L_inc\'"\n'
+    );
+
+    // Two unrelated modules that define the same global and program names. If
+    // open-document state leaked across targets, analyzing one module while the
+    // other is open could change which definition is visible.
+    fs.writeFileSync(
+        path.join(root, 'mod_a.do'),
+        'global SHARED 1\nprogram define shared_prog\n    display "a"\nend\ndisplay "$SHARED"\n'
+    );
+    fs.writeFileSync(
+        path.join(root, 'mod_b.do'),
+        'global SHARED 2\nprogram define shared_prog\n    display "b"\nend\ndisplay "$SHARED"\n'
+    );
+
+    // A plain file with a same-file undefined-macro diagnostic, plus extra
+    // padding files so there are more than CHECK_MAX_PARALLEL (4) targets and
+    // at least one worker processes multiple targets.
+    fs.writeFileSync(
+        path.join(root, 'standalone.do'),
+        'display "`missing\'"\n'
+    );
+    fs.writeFileSync(path.join(root, 'pad1.do'), 'display 1\n');
+    fs.writeFileSync(path.join(root, 'pad2.do'), 'display 2\n');
+
+    return root;
+}
+
+function load_config(root: string): StataLSPConfig {
+    const result = load_check_config({
+        cwd: root,
+        workspace_root: root,
+        no_config: true,
+    });
+    if (result.kind !== 'loaded') {
+        throw new Error(`unexpected config result: ${result.kind}`);
+    }
+    return result.config;
+}
+
+// Render diagnostics for the whole workspace with a fresh context, at the
+// given parallelism. A fresh context per call prevents shared-cache priming
+// from masking a divergence.
+async function render_with_parallelism(
+    root: string,
+    config: StataLSPConfig,
+    max_parallel: number
+): Promise<string> {
+    const targets = collect_report_targets([], root, root).targets;
+    const context = await build_check_context(root, config);
+    try {
+        return render_json(
+            await collect_check_diagnostics(
+                context,
+                root,
+                config,
+                targets,
+                max_parallel
+            )
+        );
+    } finally {
+        await context.document_store.dispose();
+    }
+}
+
+// The strongest oracle: analyze each target with its own fresh context, so a
+// single document is provably the only thing ever open. Concatenate in target
+// order to match the slot-ordered output of a full run.
+async function render_isolated_baseline(
+    root: string,
+    config: StataLSPConfig
+): Promise<string> {
+    const targets = collect_report_targets([], root, root).targets;
+    const all = [];
+    for (const my_target of targets) {
+        const context = await build_check_context(root, config);
+        try {
+            all.push(
+                ...(await collect_check_diagnostics(
+                    context,
+                    root,
+                    config,
+                    [my_target],
+                    1
+                ))
+            );
+        } finally {
+            await context.document_store.dispose();
+        }
+    }
+    return render_json(all);
+}
+
+describe('sight check parallel determinism (#207)', () => {
+    it('produces byte-identical output across parallelism levels and the isolated baseline', async () => {
+        const root = build_hazard_workspace();
+        const config = load_config(root);
+
+        const isolated = await render_isolated_baseline(root, config);
+        const sequential = await render_with_parallelism(root, config, 1);
+        const parallel_2 = await render_with_parallelism(root, config, 2);
+        const parallel_4 = await render_with_parallelism(root, config, 4);
+
+        // Sequential collection must match the fully-isolated baseline.
+        expect(sequential).toBe(isolated);
+        // Parallel collection at every level must match it too.
+        expect(parallel_2).toBe(isolated);
+        expect(parallel_4).toBe(isolated);
+    });
+
+    it('orders output by target path regardless of parallelism', async () => {
+        const root = build_hazard_workspace();
+        const config = load_config(root);
+
+        const parallel_4 = JSON.parse(
+            await render_with_parallelism(root, config, 4)
+        ) as Array<{ path: string }>;
+
+        const files = parallel_4.map((record) => record.path);
+        const sorted = [...files].sort((a, b) => a.localeCompare(b));
+        // Rendered output is grouped/ordered by file path deterministically.
+        expect(files).toEqual(sorted);
+    });
+
+    it('treats duplicate explicit targets the same as a single mention', async () => {
+        const root = build_hazard_workspace();
+        const config = load_config(root);
+
+        const once = collect_report_targets(['child.do'], root, root).targets;
+        const twice = collect_report_targets(
+            ['child.do', 'child.do'],
+            root,
+            root
+        ).targets;
+
+        const context_once = await build_check_context(root, config);
+        const context_twice = await build_check_context(root, config);
+        try {
+            const out_once = render_json(
+                await collect_check_diagnostics(
+                    context_once,
+                    root,
+                    config,
+                    once,
+                    4
+                )
+            );
+            const out_twice = render_json(
+                await collect_check_diagnostics(
+                    context_twice,
+                    root,
+                    config,
+                    twice,
+                    4
+                )
+            );
+            expect(out_twice).toBe(out_once);
+        } finally {
+            await context_once.document_store.dispose();
+            await context_twice.document_store.dispose();
+        }
+    });
+});

--- a/tests/integration/cli-check-parallel-determinism.test.ts
+++ b/tests/integration/cli-check-parallel-determinism.test.ts
@@ -193,9 +193,21 @@ describe('sight check parallel determinism (#207)', () => {
         const zero = await render_with_parallelism(root, config, 0);
         // More workers than targets (clamped down to targets.length).
         const huge = await render_with_parallelism(root, config, 1000);
+        // Non-finite values fall back to the default worker count.
+        const not_a_number = await render_with_parallelism(root, config, NaN);
+        const infinite = await render_with_parallelism(
+            root,
+            config,
+            Number.POSITIVE_INFINITY
+        );
+        // Fractional values floor (2.9 -> 2 workers).
+        const fractional = await render_with_parallelism(root, config, 2.9);
 
         expect(zero).toBe(sequential);
         expect(huge).toBe(sequential);
+        expect(not_a_number).toBe(sequential);
+        expect(infinite).toBe(sequential);
+        expect(fractional).toBe(sequential);
         expect(JSON.parse(sequential).length).toBeGreaterThan(0);
     });
 

--- a/tests/integration/cli-check-parallel-determinism.test.ts
+++ b/tests/integration/cli-check-parallel-determinism.test.ts
@@ -181,18 +181,41 @@ describe('sight check parallel determinism (#207)', () => {
         expect(files).toEqual(sorted);
     });
 
-    it('drains every target even when max_parallel is below 1', async () => {
-        // The internal max_parallel parameter is clamped to >= 1 for non-empty
-        // target sets, so a degenerate value never silently yields zero workers
-        // and an empty report.
+    it('drains every target for degenerate max_parallel values', async () => {
+        // The internal max_parallel parameter is sanitized to a finite positive
+        // integer, so degenerate values never silently yield zero workers and an
+        // empty report, and never change the (order-normalized) output.
         const root = build_hazard_workspace();
         const config = load_config(root);
 
         const sequential = await render_with_parallelism(root, config, 1);
+        // Below 1 (clamped up to one worker).
         const zero = await render_with_parallelism(root, config, 0);
+        // More workers than targets (clamped down to targets.length).
+        const huge = await render_with_parallelism(root, config, 1000);
 
         expect(zero).toBe(sequential);
-        expect(JSON.parse(zero).length).toBeGreaterThan(0);
+        expect(huge).toBe(sequential);
+        expect(JSON.parse(sequential).length).toBeGreaterThan(0);
+    });
+
+    it('returns no diagnostics for an empty target list', async () => {
+        const root = build_hazard_workspace();
+        const config = load_config(root);
+
+        const context = await build_check_context(root, config);
+        try {
+            const records = await collect_check_diagnostics(
+                context,
+                root,
+                config,
+                [],
+                4
+            );
+            expect(records).toEqual([]);
+        } finally {
+            await context.document_store.dispose();
+        }
     });
 
     it('treats duplicate explicit targets the same as a single mention', async () => {

--- a/tests/integration/cli-check-parallel-determinism.test.ts
+++ b/tests/integration/cli-check-parallel-determinism.test.ts
@@ -181,6 +181,20 @@ describe('sight check parallel determinism (#207)', () => {
         expect(files).toEqual(sorted);
     });
 
+    it('drains every target even when max_parallel is below 1', async () => {
+        // The internal max_parallel parameter is clamped to >= 1 for non-empty
+        // target sets, so a degenerate value never silently yields zero workers
+        // and an empty report.
+        const root = build_hazard_workspace();
+        const config = load_config(root);
+
+        const sequential = await render_with_parallelism(root, config, 1);
+        const zero = await render_with_parallelism(root, config, 0);
+
+        expect(zero).toBe(sequential);
+        expect(JSON.parse(zero).length).toBeGreaterThan(0);
+    });
+
     it('treats duplicate explicit targets the same as a single mention', async () => {
         const root = build_hazard_workspace();
         const config = load_config(root);

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -346,25 +346,33 @@ describe('sight check integration', () => {
         let stores_created = 0;
 
         const make_store = () => {
-            let store_active_opens = 0;
+            // Track the documents this store actually holds open. The counts
+            // stay live from open() until close(), not just for the artificial
+            // parse delay, so max_active_opens_per_store catches a regression
+            // where a worker opens the next target before closing the previous
+            // one on the same store.
+            const the_open_uris = new Set<string>();
             return {
-                open: async () => {
+                open: async (uri: string) => {
                     global_active_opens++;
-                    store_active_opens++;
                     global_max_active_opens = Math.max(
                         global_max_active_opens,
                         global_active_opens
                     );
+                    the_open_uris.add(uri);
                     max_active_opens_per_store = Math.max(
                         max_active_opens_per_store,
-                        store_active_opens
+                        the_open_uris.size
                     );
                     await new Promise((resolve) => setTimeout(resolve, 20));
-                    global_active_opens--;
-                    store_active_opens--;
                 },
-                get: (uri: string) => ({ uri }),
-                close: () => undefined,
+                get: (uri: string) =>
+                    the_open_uris.has(uri) ? { uri } : undefined,
+                close: (uri: string) => {
+                    if (the_open_uris.delete(uri)) {
+                        global_active_opens--;
+                    }
+                },
                 dispose: async () => undefined,
             };
         };

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -429,4 +429,60 @@ describe('sight check integration', () => {
             targets.map((target) => target.relative_path)
         );
     });
+
+    it('drives a distinct real DocumentStore per worker through the real factory', async () => {
+        // The isolation test above mocks `create_document_store`, and the
+        // byte-identical determinism test would still pass even if the factory
+        // returned a single shared store (shared-store output is already
+        // identical today). This test closes that gap: it runs real collection
+        // over the real `build_check_context` factory and asserts the factory
+        // actually hands out several distinct stores — none of them the primary
+        // context store — so a regression that returns a shared store is caught.
+        const root = temp_dir();
+        const the_target_files = [
+            'a.do', 'b.do', 'c.do', 'd.do', 'e.do', 'f.do',
+        ];
+        for (const my_file of the_target_files) {
+            fs.writeFileSync(path.join(root, my_file), 'display 1\n');
+        }
+
+        const config_result = load_check_config({
+            cwd: root,
+            workspace_root: root,
+            no_config: true,
+        });
+        expect(config_result.kind).toBe('loaded');
+        if (config_result.kind !== 'loaded') return;
+
+        const targets = collect_report_targets([], root, root).targets;
+        const context = await build_check_context(root, config_result.config);
+
+        // Wrap the real factory to capture every store it actually creates.
+        const real_factory = context.create_document_store.bind(context);
+        const created_stores = new Set<unknown>();
+        context.create_document_store = () => {
+            const store = real_factory();
+            created_stores.add(store);
+            return store;
+        };
+
+        try {
+            await collect_check_diagnostics(
+                context,
+                root,
+                config_result.config,
+                targets,
+                4
+            );
+
+            // Several distinct real stores were created (one per worker), so
+            // the factory is not returning a single shared store.
+            expect(created_stores.size).toBeGreaterThan(1);
+            // None of them is the primary context store reused as the analysis
+            // store.
+            expect(created_stores.has(context.document_store)).toBe(false);
+        } finally {
+            await context.document_store.dispose();
+        }
+    });
 });

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -323,7 +323,7 @@ describe('sight check integration', () => {
         }
     });
 
-    it('processes report targets concurrently while preserving output order', async () => {
+    it('analyzes each target in its own single-document store while running concurrently', async () => {
         const root = temp_dir();
         const targets = ['a.do', 'b.do', 'c.do', 'd.do', 'e.do'].map(
             (file_name) => {
@@ -337,27 +337,52 @@ describe('sight check integration', () => {
             }
         );
 
-        let active_opens = 0;
-        let max_active_opens = 0;
+        // Track concurrency at two scopes: globally (across all per-worker
+        // stores, which proves parallelism survived) and per individual store
+        // (which proves isolation — no store ever holds a sibling target).
+        let global_active_opens = 0;
+        let global_max_active_opens = 0;
+        let max_active_opens_per_store = 0;
+        let stores_created = 0;
+
+        const make_store = () => {
+            let store_active_opens = 0;
+            return {
+                open: async () => {
+                    global_active_opens++;
+                    store_active_opens++;
+                    global_max_active_opens = Math.max(
+                        global_max_active_opens,
+                        global_active_opens
+                    );
+                    max_active_opens_per_store = Math.max(
+                        max_active_opens_per_store,
+                        store_active_opens
+                    );
+                    await new Promise((resolve) => setTimeout(resolve, 20));
+                    global_active_opens--;
+                    store_active_opens--;
+                },
+                get: (uri: string) => ({ uri }),
+                close: () => undefined,
+                dispose: async () => undefined,
+            };
+        };
+
+        let set_buffer_directives_calls = 0;
 
         const context = {
             workspace_indexer: {
                 get_all_symbols: () => create_empty_symbol_table(),
                 get_metrics: () => ({ files_indexed: targets.length }),
                 has_indexed_file: () => true,
-            },
-            document_store: {
-                open: async () => {
-                    active_opens++;
-                    max_active_opens = Math.max(
-                        max_active_opens,
-                        active_opens
-                    );
-                    await new Promise((resolve) => setTimeout(resolve, 20));
-                    active_opens--;
+                set_buffer_directives: () => {
+                    set_buffer_directives_calls++;
                 },
-                get: (uri: string) => ({ uri }),
-                close: () => undefined,
+            },
+            create_document_store: () => {
+                stores_created++;
+                return make_store();
             },
             diagnostics_provider: {
                 get_diagnostics: async (state: { uri: string }) => [{
@@ -385,10 +410,21 @@ describe('sight check integration', () => {
             context,
             root,
             config_result.config,
-            targets
+            targets,
+            4
         );
 
-        expect(max_active_opens).toBeGreaterThan(1);
+        // Parallelism preserved: more than one target is analyzed at once.
+        expect(global_max_active_opens).toBeGreaterThan(1);
+        // Isolation: no single store ever has more than one document open, so a
+        // target's analysis never sees a sibling target as an open document.
+        expect(max_active_opens_per_store).toBe(1);
+        // More than one store means workers really ran in parallel on their own
+        // stores rather than all sharing one.
+        expect(stores_created).toBeGreaterThan(1);
+        // The buffer-directive overlay (a find-references-only concern) is never
+        // populated during check, so no cross-target overlay state leaks.
+        expect(set_buffer_directives_calls).toBe(0);
         expect(records.map((record) => record.relative_path)).toEqual(
             targets.map((target) => target.relative_path)
         );


### PR DESCRIPTION
## Summary

Resolves #207. Makes parallel `sight check` diagnostics byte-identical to a
sequential run by isolating each check worker in its own single-document
`DocumentStore`, so a target is never analyzed while a sibling check target is
present as an open document.

`collect_check_diagnostics` parallelizes target collection over a shared
`DocumentStore`, so up to four targets could be open at once. Investigation
(see the spec) found the CLI diagnostics path is already content-deterministic
today — cross-file resolution reads parents/callees from disk via the shared,
disk-backed `ScopeResolver`, and `workspace_symbols` is a single snapshot — so
no divergence exists now. This change makes that invariant **structural**
rather than incidental, matching the Raven fix (jbearak/raven#485) and guarding
against a future regression (e.g. an open-buffer-preferring content provider).

## Changes

- **Per-worker isolation.** New `CheckContext.create_document_store` factory
  builds a fresh `DocumentStore` wired only to the shared read-only
  infrastructure (scope resolver, workspace roots, scope-resolver config). Each
  worker analyzes its targets in its own store, so a store holds at most one
  document at a time and never a sibling target.
- **Dropped dead wiring.** `build_check_context` no longer registers
  `set_on_backward_directives_parsed`. That callback populates
  `WorkspaceIndexer.buffer_directives_overlay`, whose only consumer is
  `get_related_uris` (hover / definition / references) — never the `check`
  diagnostics path. It is dead weight under `check` and was needless
  cross-target shared state.
- **Injectable parallelism.** `collect_check_diagnostics` gains an internal
  `max_parallel` parameter (default `CHECK_MAX_PARALLEL`), sanitized to a finite
  positive integer, so tests can drive sequential vs parallel collection.
- **Documented invariant** in a block comment above `collect_check_diagnostics`.

## Tests

- `cli-check-parallel-determinism.test.ts`: byte-identical output across
  `max_parallel ∈ {1, 2, 4}` and a per-target isolated baseline, over a
  workspace exercising cross-file `do`/`include`, explicit
  `@lsp-done-by`/`@lsp-included-by` directives, `@lsp-cd` working-directory
  inheritance, and conflicting global/program names in unrelated modules; plus
  degenerate-`max_parallel` and empty-target boundary cases.
- `cli-check.test.ts`: the concurrency test now asserts per-store isolation
  (≤1 open per store) alongside preserved global parallelism, and a new test
  drives the real `build_check_context` factory through real collection to
  assert it hands out distinct stores (catching a shared-store regression).

## Verification

- `bun run test` (typecheck + full suite): green.
- `bun run lint`: clean.
- Reviewed by codex and `/code-review` to two consecutive clean passes.

Design spec: `docs/superpowers/specs/2026-06-27-parallel-check-byte-identical-design.md`

https://claude.ai/code/session_01Bc1TyeSkcspxSxfTpHMNjq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `sight check` now runs parallel diagnostics in a way that keeps results consistent with sequential runs.
  * Output order remains stable by target, even when multiple files are checked at once.

* **Bug Fixes**
  * Fixed a concurrency issue that could cause nondeterministic diagnostics when checking multiple targets in parallel.
  * Improved handling of edge cases like empty target lists, duplicate targets, and unusual parallelism settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->