### PR TITLE
Data viewer: explain & let users cancel the saved sort/filter reload

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -1,0 +1,58 @@
+# PULLFROG ACTION — DO NOT EDIT EXCEPT WHERE INDICATED
+name: Pullfrog
+run-name: ${{ inputs.name || github.workflow }}
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        type: string
+        description: Agent prompt
+      name:
+        type: string
+        description: Run name
+
+permissions:
+  contents: read
+
+jobs:
+  pullfrog:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 1
+      - name: Run agent
+        uses: pullfrog/pullfrog@3beaa0fb16f67a689055eac8df88e71024e423b2 # v0
+        with:
+          prompt: ${{ inputs.prompt }}
+        env:
+          # add at least one provider API key
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY:
+            ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          
+          # for Amazon Bedrock (https://docs.pullfrog.com/bedrock)
+          # AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # AWS_REGION: us-east-1
+          # BEDROCK_MODEL_ID: <bedrock-model-id>
+          
+          # for Google Vertex AI (https://docs.pullfrog.com/vertex)
+          # VERTEX_SERVICE_ACCOUNT_JSON: >-
+          #   ${{ secrets.VERTEX_SERVICE_ACCOUNT_JSON }}
+          # GOOGLE_CLOUD_PROJECT: my-project
+          # VERTEX_LOCATION: global
+          # VERTEX_MODEL_ID: <vertex-model-id>

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "stata-lsp",
       "dependencies": {
-        "@jbearak/dta-parser": "^0.1.1",
+        "@jbearak/dta-parser": "^0.2.0",
         "smol-toml": "^1.6.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11",
@@ -30,10 +30,10 @@
     },
     "client": {
       "name": "sight",
-      "version": "0.7.2",
+      "version": "0.8.4",
       "dependencies": {
         "@glideapps/glide-data-grid": "^6.0.3",
-        "@jbearak/dta-parser": "^0.1.1",
+        "@jbearak/dta-parser": "^0.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "vscode-languageclient": "^8.1.0",
@@ -252,7 +252,7 @@
 
     "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
 
-    "@jbearak/dta-parser": ["@jbearak/dta-parser@0.1.1", "", {}, "sha512-BcQ257+HJMfhiSenEA7HVfsIT0ciQrQ86nE2svELtpHx6QTd36qS3OLyJH/evmmyE7LI7kbd4PnSEZx/QtnIAw=="],
+    "@jbearak/dta-parser": ["@jbearak/dta-parser@0.2.0", "", {}, "sha512-WTzMHgThwHofwBJ3xL6gMUAxEz0SfNK7scobe9yDGaKMYOx+6FSgun1XlzBg0UEHvnRaQRaxgehMcbQLOrHphA=="],
 
     "@jest/console": ["@jest/console@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@types/node": "*", "chalk": "^4.0.0", "jest-message-util": "^29.7.0", "jest-util": "^29.7.0", "slash": "^3.0.0" } }, "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -750,7 +750,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jbearak/dta-parser": "^0.1.1",
+    "@jbearak/dta-parser": "^0.2.0",
     "@glideapps/glide-data-grid": "^6.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -125,18 +125,16 @@ export class DataBrowserPanel implements vscode.Disposable {
     private filter: FilterState = EMPTY_FILTER;
     private filtered_indices: Uint32Array | null = null;
     private filter_restored = false;
-    // Saved-preference restore on open: aborts the column reads when the
-    // user cancels; `restore_id` (the generation at restore start) keys
-    // the restorePending/cancelRestore handshake so a stale or late
-    // cancel from a prior lifecycle is ignored. `restoring` gates the
-    // in-flight vs. already-completed cancel paths; `restore_cancelled`
-    // tells send_metadata to forget + show natural order;
-    // `restore_failed` records a non-abort read failure (notice + keep
-    // prefs). `restore_id === -1` means "no cancellable restore".
+    // Saved-preference restore on open. Cancellation is carried by the
+    // AbortController's signal (captured locally per send_metadata call),
+    // not a shared boolean, so a concurrent send_metadata can't erase an
+    // in-flight cancel. `restore_id` (the generation at restore start)
+    // keys the restorePending/cancelRestore handshake so a stale or late
+    // cancel is ignored; `restore_id === -1` means "no cancellable
+    // restore". `restoring` gates the in-flight vs. already-completed
+    // cancel paths.
     private restore_abort: AbortController | null = null;
-    private restore_cancelled = false;
     private restoring = false;
-    private restore_failed = false;
     private restore_id = -1;
     // The filter survivor set composed with the sort permutation: the
     // single effective permutation handed to the reader. Recomputed
@@ -224,9 +222,7 @@ export class DataBrowserPanel implements vscode.Disposable {
         // Reset the saved-preference restore handshake; a fresh restore
         // begins (if applicable) when initialize() re-sends metadata.
         this.restore_abort = null;
-        this.restore_cancelled = false;
         this.restoring = false;
-        this.restore_failed = false;
         this.restore_id = -1;
 
         // Clean up the old temp file on Windows before
@@ -351,15 +347,6 @@ export class DataBrowserPanel implements vscode.Disposable {
     private async send_metadata(): Promise<void> {
         if (!this.dta_file) return;
 
-        // Per-attempt restore flags. Reset here (not only in
-        // maybe_begin_restore, which is skipped when no restore begins)
-        // so a cancel/failure from an earlier open can't leak into a
-        // later send_metadata — e.g. a webview reload that re-sends
-        // 'ready' must not run apply_cancel_forget against a sort the
-        // user applied manually in the meantime.
-        this.restore_cancelled = false;
-        this.restore_failed = false;
-
         try {
             const my_missing_style =
                 vscode.workspace
@@ -412,22 +399,28 @@ export class DataBrowserPanel implements vscode.Disposable {
             // the finally only cleans up its own restore, not one a
             // concurrent refresh may have started.
             const my_began = this.maybe_begin_restore(my_schema_hash);
-            const my_abort = this.restore_abort;
+            // Cancellation is read from this restore's own AbortSignal
+            // (null when no restore began), so a concurrent send_metadata
+            // reassigning this.restore_abort can't change what THIS call
+            // sees. `my_failed` aggregates non-abort read failures from
+            // the restore helpers (returned, not stored on the instance).
+            const my_abort = my_began ? this.restore_abort : null;
+            const is_cancelled = () => my_abort?.signal.aborted === true;
             try {
                 const my_signal = my_abort?.signal;
-                await this.maybe_restore_sort(
+                let my_failed = await this.maybe_restore_sort(
                     my_schema_hash, my_signal
                 );
                 if (!this.dta_file) return;
                 // A cancel during the sort read must not kick off a long
                 // filter read; skip it and fall through to forget.
-                if (!this.restore_cancelled) {
-                    await this.maybe_restore_filter(
+                if (!is_cancelled()) {
+                    my_failed = await this.maybe_restore_filter(
                         my_schema_hash, my_signal
-                    );
+                    ) || my_failed;
                     if (!this.dta_file) return;
                 }
-                if (this.restore_cancelled) {
+                if (is_cancelled()) {
                     // Undo any sort that completed before the cancel
                     // landed (memory only here), so chips and effective
                     // order agree on "natural" before metadata is posted.
@@ -440,10 +433,10 @@ export class DataBrowserPanel implements vscode.Disposable {
                 // A restored filter changes the visible row count; the
                 // webview learns the effective count from filterApplied
                 // (metadata.nobs stays the full dataset size).
-                if (!this.restore_cancelled && this.filtered_indices) {
+                if (!is_cancelled() && this.filtered_indices) {
                     this.post_filter_applied();
                 }
-                if (this.restore_failed) {
+                if (my_failed) {
                     vscode.window.showWarningMessage(
                         'Could not reapply the saved sort/filter for '
                         + 'this dataset; showing it unsorted and '
@@ -453,7 +446,7 @@ export class DataBrowserPanel implements vscode.Disposable {
                 // Persist the "forget" only after metadata is posted, so
                 // a store-write failure cannot strand the webview waiting
                 // on a metadata it never receives.
-                if (this.restore_cancelled) {
+                if (is_cancelled()) {
                     await this.forget_persisted_prefs(my_schema_hash);
                 }
             } finally {
@@ -544,8 +537,8 @@ export class DataBrowserPanel implements vscode.Disposable {
             && this.has_applicable_stored_filter(schema_hash_value);
         if (!my_has_sort && !my_has_filter) return false;
 
-        // restore_cancelled / restore_failed are reset at the top of
-        // send_metadata, which is this method's only caller.
+        // A fresh controller per restore; cancellation is read from its
+        // signal, so there is no shared boolean to reset.
         this.restore_abort = new AbortController();
         this.restore_id = this.generation;
         this.restoring = true;
@@ -639,7 +632,8 @@ export class DataBrowserPanel implements vscode.Disposable {
     ): Promise<void> {
         if (msg.restore_id !== this.restore_id) return;
         if (this.restoring) {
-            this.restore_cancelled = true;
+            // Abort the in-flight reads; send_metadata reads the same
+            // signal and takes its cancelled path (forget + natural).
             this.restore_abort?.abort();
             return;
         }
@@ -789,20 +783,22 @@ export class DataBrowserPanel implements vscode.Disposable {
      * On first metadata for a dataset, restore any persisted sort for
      * this dataset_key × schema_hash and recompute its permutation.
      * No-op on later metadata re-sends (the in-memory sort wins).
+     * Returns true iff a genuine (non-abort) read failure occurred, so
+     * the caller can warn and keep the saved pref.
      */
     private async maybe_restore_sort(
         schema_hash_value: string,
         signal?: AbortSignal
-    ): Promise<void> {
-        if (this.sort_restored) return;
+    ): Promise<boolean> {
+        if (this.sort_restored) return false;
         this.sort_restored = true;
-        if (!this.dta_file || !this.persist_sort_enabled()) return;
+        if (!this.dta_file || !this.persist_sort_enabled()) return false;
 
         const my_stored = this.sort_state_store.get(
             this.dataset_key,
             schema_hash_value
         );
-        if (!my_stored) return;
+        if (!my_stored) return false;
 
         const my_generation = this.generation;
         let my_permutation: Uint32Array | null = null;
@@ -812,19 +808,17 @@ export class DataBrowserPanel implements vscode.Disposable {
                     my_stored, signal
                 );
         } catch (my_err) {
-            // A user cancel aborts the read; leave natural order
-            // silently. A genuine read failure is recorded so the
+            // A user cancel aborts the read → natural order, silent. A
+            // genuine read failure → natural order, but report so the
             // caller can warn and keep the saved pref for next time.
-            if (!is_abort_error(my_err)) {
-                this.restore_failed = true;
-            }
-            return;
+            return !is_abort_error(my_err);
         }
-        if (my_generation !== this.generation) return;
+        if (my_generation !== this.generation) return false;
         if (my_permutation) {
             this.sort = my_stored;
             this.permutation = my_permutation;
         }
+        return false;
     }
 
     /**
@@ -1013,16 +1007,18 @@ export class DataBrowserPanel implements vscode.Disposable {
     private async maybe_restore_filter(
         schema_hash_value: string,
         signal?: AbortSignal
-    ): Promise<void> {
-        if (this.filter_restored) return;
+    ): Promise<boolean> {
+        if (this.filter_restored) return false;
         this.filter_restored = true;
-        if (!this.dta_file || !this.persist_filters_enabled()) return;
+        if (!this.dta_file || !this.persist_filters_enabled()) {
+            return false;
+        }
 
         const my_stored = this.filter_state_store.get(
             this.dataset_key,
             schema_hash_value
         );
-        if (!my_stored) return;
+        if (!my_stored) return false;
 
         // The persistence key folds in column name + type but not the
         // display format, so a column re-saved with a different
@@ -1039,7 +1035,7 @@ export class DataBrowserPanel implements vscode.Disposable {
                     my_var
                 );
         });
-        if (the_kept_entries.length === 0) return;
+        if (the_kept_entries.length === 0) return false;
         const my_filter: FilterState = {
             entries: the_kept_entries,
             labels_on_when_filtered: my_stored.labels_on_when_filtered,
@@ -1053,16 +1049,14 @@ export class DataBrowserPanel implements vscode.Disposable {
             );
         } catch (my_err) {
             // Cancel → natural order silently; genuine failure →
-            // natural order, record so the caller can warn and keep
+            // natural order, reported so the caller can warn and keep
             // the saved filter. Either way, don't restore the chips.
-            if (!is_abort_error(my_err)) {
-                this.restore_failed = true;
-            }
-            return;
+            return !is_abort_error(my_err);
         }
-        if (my_generation !== this.generation) return;
+        if (my_generation !== this.generation) return false;
         this.filter = my_filter;
         this.filtered_indices = my_indices;
+        return false;
     }
 
     /**

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -437,6 +437,12 @@ export class DataBrowserPanel implements vscode.Disposable {
                     my_schema_hash, my_signal
                 );
                 if (!this.dta_file) return;
+                // A refresh/reload during the sort read supersedes this
+                // attempt; bail before maybe_restore_filter consumes its
+                // one-shot flag, so the queued send re-restores fully.
+                // (A user cancel does not bump generation and falls
+                // through to the forget path below.)
+                if (my_generation !== this.generation) return;
                 // A cancel during the sort read must not kick off a long
                 // filter read; skip it and fall through to forget.
                 if (!is_cancelled()) {

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -221,6 +221,13 @@ export class DataBrowserPanel implements vscode.Disposable {
         this.filter_restored = false;
         this.effective_perm = null;
         this.histogram_cache.clear();
+        // Reset the saved-preference restore handshake; a fresh restore
+        // begins (if applicable) when initialize() re-sends metadata.
+        this.restore_abort = null;
+        this.restore_cancelled = false;
+        this.restoring = false;
+        this.restore_failed = false;
+        this.restore_id = -1;
 
         // Clean up the old temp file on Windows before
         // overwriting the path (other platforms unlink
@@ -344,6 +351,15 @@ export class DataBrowserPanel implements vscode.Disposable {
     private async send_metadata(): Promise<void> {
         if (!this.dta_file) return;
 
+        // Per-attempt restore flags. Reset here (not only in
+        // maybe_begin_restore, which is skipped when no restore begins)
+        // so a cancel/failure from an earlier open can't leak into a
+        // later send_metadata — e.g. a webview reload that re-sends
+        // 'ready' must not run apply_cancel_forget against a sort the
+        // user applied manually in the meantime.
+        this.restore_cancelled = false;
+        this.restore_failed = false;
+
         try {
             const my_missing_style =
                 vscode.workspace
@@ -412,12 +428,10 @@ export class DataBrowserPanel implements vscode.Disposable {
                     if (!this.dta_file) return;
                 }
                 if (this.restore_cancelled) {
-                    // Forget the saved prefs and undo any sort that
-                    // completed before the cancel landed, so chips,
-                    // persistence, and effective order all agree on
-                    // "natural".
-                    await this.apply_cancel_forget(my_schema_hash);
-                    if (!this.dta_file) return;
+                    // Undo any sort that completed before the cancel
+                    // landed (memory only here), so chips and effective
+                    // order agree on "natural" before metadata is posted.
+                    this.reset_restored_prefs();
                 }
                 this.recompute_effective();
 
@@ -435,6 +449,12 @@ export class DataBrowserPanel implements vscode.Disposable {
                         + 'this dataset; showing it unsorted and '
                         + 'unfiltered.'
                     );
+                }
+                // Persist the "forget" only after metadata is posted, so
+                // a store-write failure cannot strand the webview waiting
+                // on a metadata it never receives.
+                if (this.restore_cancelled) {
+                    await this.forget_persisted_prefs(my_schema_hash);
                 }
             } finally {
                 // Only the call that began this restore clears its
@@ -524,8 +544,8 @@ export class DataBrowserPanel implements vscode.Disposable {
             && this.has_applicable_stored_filter(schema_hash_value);
         if (!my_has_sort && !my_has_filter) return false;
 
-        this.restore_cancelled = false;
-        this.restore_failed = false;
+        // restore_cancelled / restore_failed are reset at the top of
+        // send_metadata, which is this method's only caller.
         this.restore_abort = new AbortController();
         this.restore_id = this.generation;
         this.restoring = true;
@@ -577,20 +597,23 @@ export class DataBrowserPanel implements vscode.Disposable {
     }
 
     /**
-     * Drop the restored sort/filter from memory and forget the
-     * persisted preferences for this dataset×schema. Used both when an
-     * in-flight restore is cancelled and when a late cancel lands after
-     * the restore completed. Setting `restore_id = -1` consumes the
-     * handshake so a duplicate cancel is ignored.
+     * Drop the restored sort/filter from memory (synchronous). Setting
+     * `restore_id = -1` consumes the handshake so a duplicate cancel is
+     * ignored. The caller invalidates caches / posts updates and then
+     * persists the forget via {@link forget_persisted_prefs}.
      */
-    private async apply_cancel_forget(
-        schema_hash_value: string
-    ): Promise<void> {
+    private reset_restored_prefs(): void {
         this.restore_id = -1;
         this.sort = EMPTY_SORT;
         this.permutation = null;
         this.filter = EMPTY_FILTER;
         this.filtered_indices = null;
+    }
+
+    /** Forget the persisted sort/filter for this dataset×schema. */
+    private async forget_persisted_prefs(
+        schema_hash_value: string
+    ): Promise<void> {
         if (this.persist_sort_enabled()) {
             await this.sort_state_store.set(
                 this.dataset_key, schema_hash_value, EMPTY_SORT
@@ -621,12 +644,17 @@ export class DataBrowserPanel implements vscode.Disposable {
             return;
         }
         if (!this.dta_file) return;
-        await this.apply_cancel_forget(this.current_schema_hash());
+        const my_schema_hash = this.current_schema_hash();
+        // Invalidate and re-request synchronously BEFORE awaiting the
+        // store writes, so no in-flight requestRows can land stale
+        // sorted/filtered rows after the user has cancelled.
+        this.reset_restored_prefs();
         this.generation++;
         this.row_cache.clear();
         this.recompute_effective();
         this.post_sort_applied();
         this.post_filter_applied();
+        await this.forget_persisted_prefs(my_schema_hash);
     }
 
     // -------------------------------------------------------

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -433,7 +433,10 @@ export class DataBrowserPanel implements vscode.Disposable {
             const is_cancelled = () => my_abort?.signal.aborted === true;
             try {
                 const my_signal = my_abort?.signal;
-                let my_failed = await this.maybe_restore_sort(
+                // Track sort/filter failure separately so the warning
+                // names only what actually failed (the other may have
+                // applied successfully).
+                const my_sort_failed = await this.maybe_restore_sort(
                     my_schema_hash, my_signal
                 );
                 if (!this.dta_file) return;
@@ -445,10 +448,11 @@ export class DataBrowserPanel implements vscode.Disposable {
                 if (my_generation !== this.generation) return;
                 // A cancel during the sort read must not kick off a long
                 // filter read; skip it and fall through to forget.
+                let my_filter_failed = false;
                 if (!is_cancelled()) {
-                    my_failed = await this.maybe_restore_filter(
+                    my_filter_failed = await this.maybe_restore_filter(
                         my_schema_hash, my_signal
-                    ) || my_failed;
+                    );
                     if (!this.dta_file) return;
                 }
                 // A refresh / reload during the reads supersedes this
@@ -474,11 +478,13 @@ export class DataBrowserPanel implements vscode.Disposable {
                 if (!is_cancelled() && this.filtered_indices) {
                     this.post_filter_applied();
                 }
-                if (my_failed) {
+                if (my_sort_failed || my_filter_failed) {
+                    const what = my_sort_failed && my_filter_failed
+                        ? 'sort and filter'
+                        : my_sort_failed ? 'sort' : 'filter';
                     vscode.window.showWarningMessage(
-                        'Could not reapply the saved sort/filter for '
-                        + 'this dataset; showing it unsorted and '
-                        + 'unfiltered.'
+                        `Could not reapply the saved ${what} for this `
+                        + 'dataset; it was not applied.'
                     );
                 }
                 // Persist the "forget" only after metadata is posted, so

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -366,6 +366,12 @@ export class DataBrowserPanel implements vscode.Disposable {
     private async send_metadata_impl(): Promise<void> {
         if (!this.dta_file) return;
 
+        // Snapshot the generation; a refresh or a webview-reload 'ready'
+        // bumps it. If it changes while we read columns, this attempt is
+        // stale — bail before posting so we never ship metadata for an
+        // outdated dataset/schema (a newer queued send_metadata posts).
+        const my_generation = this.generation;
+
         try {
             const my_missing_style =
                 vscode.workspace
@@ -439,6 +445,13 @@ export class DataBrowserPanel implements vscode.Disposable {
                     ) || my_failed;
                     if (!this.dta_file) return;
                 }
+                // A refresh / reload during the reads supersedes this
+                // attempt. Bail before posting (and before forgetting),
+                // leaving prefs intact for the queued send to reapply; a
+                // user cancel does NOT bump generation, so it still falls
+                // through to the forget path below.
+                if (my_generation !== this.generation) return;
+
                 if (is_cancelled()) {
                     // Undo any sort that completed before the cancel
                     // landed (memory only here), so chips and effective
@@ -684,6 +697,21 @@ export class DataBrowserPanel implements vscode.Disposable {
                 } else {
                     this.generation++;
                     this.row_cache.clear();
+                    // If a webview reload interrupts an in-flight
+                    // restore, the bumped generation makes that restore
+                    // discard its result — but it already consumed the
+                    // one-shot restore flags. Clear them so the queued
+                    // re-send reapplies the saved prefs instead of
+                    // showing natural order. (When no restore is in
+                    // flight, the in-memory sort/filter are already set
+                    // and re-sent as-is — no re-read.)
+                    if (this.restoring) {
+                        this.sort_restored = false;
+                        this.filter_restored = false;
+                        this.restoring = false;
+                        this.restore_abort = null;
+                        this.restore_id = -1;
+                    }
                     await this.send_metadata();
                 }
                 break;

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -729,6 +729,14 @@ export class DataBrowserPanel implements vscode.Disposable {
                     // flight, the in-memory sort/filter are already set
                     // and re-sent as-is — no re-read.)
                     if (this.restoring) {
+                        // Abort the in-flight restore's reads so the
+                        // serialized send_metadata chain advances at once;
+                        // otherwise the reload's replacement restore (and
+                        // its Cancel banner) can't start until the old
+                        // read finishes, stranding the user on a bare
+                        // "Loading…". The generation bump above makes the
+                        // aborted restore bail without forgetting prefs.
+                        this.restore_abort?.abort();
                         this.sort_restored = false;
                         this.filter_restored = false;
                         this.restoring = false;

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -63,8 +63,15 @@ import type {
     RequestHistogramMessage,
     HistogramDataMessage,
     HistogramBin,
+    RestorePendingMessage,
+    CancelRestoreMessage,
 } from './types.js';
 import { EMPTY_SORT, EMPTY_FILTER } from './types.js';
+
+/** A read aborted via AbortSignal (vs. a genuine read failure). */
+function is_abort_error(err: unknown): boolean {
+    return err instanceof Error && err.name === 'AbortError';
+}
 
 /** %tc / %tC store milliseconds since 1960; other date formats store
  *  days. Consulted when building a {@link FilterColumn} for date
@@ -118,6 +125,19 @@ export class DataBrowserPanel implements vscode.Disposable {
     private filter: FilterState = EMPTY_FILTER;
     private filtered_indices: Uint32Array | null = null;
     private filter_restored = false;
+    // Saved-preference restore on open: aborts the column reads when the
+    // user cancels; `restore_id` (the generation at restore start) keys
+    // the restorePending/cancelRestore handshake so a stale or late
+    // cancel from a prior lifecycle is ignored. `restoring` gates the
+    // in-flight vs. already-completed cancel paths; `restore_cancelled`
+    // tells send_metadata to forget + show natural order;
+    // `restore_failed` records a non-abort read failure (notice + keep
+    // prefs). `restore_id === -1` means "no cancellable restore".
+    private restore_abort: AbortController | null = null;
+    private restore_cancelled = false;
+    private restoring = false;
+    private restore_failed = false;
+    private restore_id = -1;
     // The filter survivor set composed with the sort permutation: the
     // single effective permutation handed to the reader. Recomputed
     // whenever sort or filter changes (null === identity order).
@@ -368,55 +388,245 @@ export class DataBrowserPanel implements vscode.Disposable {
             );
 
             const my_schema_hash = schema_hash(my_variables);
-            await this.maybe_restore_sort(my_schema_hash);
-            if (!this.dta_file) return;
-            await this.maybe_restore_filter(my_schema_hash);
-            if (!this.dta_file) return;
-            this.recompute_effective();
 
-            const my_metadata: MetadataMessage = {
-                type: 'metadata',
-                nobs: this.dta_file.nobs,
-                missing_value_style: my_missing_style,
-                variables: my_variables,
-                schema_hash: my_schema_hash,
-                stored_sort: this.sort.keys.length > 0
-                    ? this.sort
-                    : undefined,
-                stored_filter: this.filter.entries.length > 0
-                    ? this.filter
-                    : undefined,
-                name: this.sidecar.name,
-                dataset_key: this.dataset_key,
-                stored_column_widths:
-                    this.column_width_store.get(
-                        this.dataset_key,
-                        this.dataset_key_aliases
-                    ),
-                stored_hidden_columns:
-                    this.column_visibility_store.get(
-                        this.dataset_key,
-                        this.dataset_key_aliases
-                    ),
-                subsetted: this.sidecar.subsetted,
-                varlist: this.sidecar.varlist,
-                if_condition: this.sidecar.if,
-                in_condition: this.sidecar.in,
-            };
+            // Begin a cancellable restore if saved prefs apply. This
+            // posts `restorePending` before the (potentially long)
+            // column reads so the webview can explain the wait and offer
+            // Cancel. `my_abort` identifies this restore's controller so
+            // the finally only cleans up its own restore, not one a
+            // concurrent refresh may have started.
+            const my_began = this.maybe_begin_restore(my_schema_hash);
+            const my_abort = this.restore_abort;
+            try {
+                const my_signal = my_abort?.signal;
+                await this.maybe_restore_sort(
+                    my_schema_hash, my_signal
+                );
+                if (!this.dta_file) return;
+                // A cancel during the sort read must not kick off a long
+                // filter read; skip it and fall through to forget.
+                if (!this.restore_cancelled) {
+                    await this.maybe_restore_filter(
+                        my_schema_hash, my_signal
+                    );
+                    if (!this.dta_file) return;
+                }
+                if (this.restore_cancelled) {
+                    // Forget the saved prefs and undo any sort that
+                    // completed before the cancel landed, so chips,
+                    // persistence, and effective order all agree on
+                    // "natural".
+                    await this.apply_cancel_forget(my_schema_hash);
+                    if (!this.dta_file) return;
+                }
+                this.recompute_effective();
 
-            this.panel.webview.postMessage(my_metadata);
+                this.post_metadata(my_variables, my_schema_hash, my_missing_style);
 
-            // A restored filter changes the visible row count; the
-            // webview learns the effective count from filterApplied
-            // (metadata.nobs stays the full dataset size).
-            if (this.filtered_indices) {
-                this.post_filter_applied();
+                // A restored filter changes the visible row count; the
+                // webview learns the effective count from filterApplied
+                // (metadata.nobs stays the full dataset size).
+                if (!this.restore_cancelled && this.filtered_indices) {
+                    this.post_filter_applied();
+                }
+                if (this.restore_failed) {
+                    vscode.window.showWarningMessage(
+                        'Could not reapply the saved sort/filter for '
+                        + 'this dataset; showing it unsorted and '
+                        + 'unfiltered.'
+                    );
+                }
+            } finally {
+                // Only the call that began this restore clears its
+                // state, and only if a concurrent refresh hasn't already
+                // swapped in a newer restore controller.
+                if (my_began && this.restore_abort === my_abort) {
+                    this.restoring = false;
+                    this.restore_abort = null;
+                }
             }
         } catch (my_err) {
             vscode.window.showErrorMessage(
                 `Failed to open .dta file: ${my_err}`
             );
         }
+    }
+
+    /** Build and post the metadata message for the current dataset. */
+    private post_metadata(
+        variables: MetadataMessage['variables'],
+        schema_hash_value: string,
+        missing_value_style: MissingValueStyle
+    ): void {
+        if (!this.dta_file) return;
+        const my_metadata: MetadataMessage = {
+            type: 'metadata',
+            nobs: this.dta_file.nobs,
+            missing_value_style: missing_value_style,
+            variables: variables,
+            schema_hash: schema_hash_value,
+            // After a cancel these are EMPTY, so stored_sort/filter
+            // are omitted and the webview renders no chips.
+            stored_sort: this.sort.keys.length > 0
+                ? this.sort
+                : undefined,
+            stored_filter: this.filter.entries.length > 0
+                ? this.filter
+                : undefined,
+            name: this.sidecar.name,
+            dataset_key: this.dataset_key,
+            stored_column_widths:
+                this.column_width_store.get(
+                    this.dataset_key,
+                    this.dataset_key_aliases
+                ),
+            stored_hidden_columns:
+                this.column_visibility_store.get(
+                    this.dataset_key,
+                    this.dataset_key_aliases
+                ),
+            subsetted: this.sidecar.subsetted,
+            varlist: this.sidecar.varlist,
+            if_condition: this.sidecar.if,
+            in_condition: this.sidecar.in,
+        };
+
+        this.panel.webview.postMessage(my_metadata);
+    }
+
+    // -------------------------------------------------------
+    // Saved-preference restore handshake
+    // -------------------------------------------------------
+
+    /**
+     * If a saved sort and/or filter applies to this dataset×schema,
+     * start a cancellable restore: reset the restore flags, create the
+     * AbortController, stamp `restore_id`, and post `restorePending`
+     * before the column reads. Returns true if a restore was begun.
+     *
+     * Gated on the prefs *existing and fitting the schema* (a cheap
+     * store peek) — not on whether they will ultimately yield rows,
+     * which can't be known without the very read this explains.
+     */
+    private maybe_begin_restore(
+        schema_hash_value: string
+    ): boolean {
+        // Restore happens once per lifetime; both flags are set
+        // together on the first send_metadata and reset by refresh().
+        if (this.sort_restored && this.filter_restored) {
+            return false;
+        }
+        const my_has_sort =
+            this.persist_sort_enabled()
+            && this.has_applicable_stored_sort(schema_hash_value);
+        const my_has_filter =
+            this.persist_filters_enabled()
+            && this.has_applicable_stored_filter(schema_hash_value);
+        if (!my_has_sort && !my_has_filter) return false;
+
+        this.restore_cancelled = false;
+        this.restore_failed = false;
+        this.restore_abort = new AbortController();
+        this.restore_id = this.generation;
+        this.restoring = true;
+
+        const my_msg: RestorePendingMessage = {
+            type: 'restorePending',
+            restore_id: this.restore_id,
+            sort: my_has_sort,
+            filter: my_has_filter,
+        };
+        this.panel.webview.postMessage(my_msg);
+        return true;
+    }
+
+    /** Whether a persisted sort with at least one key exists. */
+    private has_applicable_stored_sort(
+        schema_hash_value: string
+    ): boolean {
+        const my_stored = this.sort_state_store.get(
+            this.dataset_key,
+            schema_hash_value
+        );
+        return !!my_stored && my_stored.keys.length > 0;
+    }
+
+    /**
+     * Whether a persisted filter exists with at least one entry whose
+     * predicate still fits its column's current kind (mirrors the
+     * keep-filter logic in maybe_restore_filter).
+     */
+    private has_applicable_stored_filter(
+        schema_hash_value: string
+    ): boolean {
+        if (!this.dta_file) return false;
+        const my_stored = this.filter_state_store.get(
+            this.dataset_key,
+            schema_hash_value
+        );
+        if (!my_stored) return false;
+        return my_stored.entries.some(my_entry => {
+            const my_var =
+                this.dta_file!.variables[my_entry.col_index];
+            return my_var !== undefined
+                && this.predicate_fits_column(
+                    my_entry.predicate,
+                    my_var
+                );
+        });
+    }
+
+    /**
+     * Drop the restored sort/filter from memory and forget the
+     * persisted preferences for this dataset×schema. Used both when an
+     * in-flight restore is cancelled and when a late cancel lands after
+     * the restore completed. Setting `restore_id = -1` consumes the
+     * handshake so a duplicate cancel is ignored.
+     */
+    private async apply_cancel_forget(
+        schema_hash_value: string
+    ): Promise<void> {
+        this.restore_id = -1;
+        this.sort = EMPTY_SORT;
+        this.permutation = null;
+        this.filter = EMPTY_FILTER;
+        this.filtered_indices = null;
+        if (this.persist_sort_enabled()) {
+            await this.sort_state_store.set(
+                this.dataset_key, schema_hash_value, EMPTY_SORT
+            );
+        }
+        if (this.persist_filters_enabled()) {
+            await this.filter_state_store.set(
+                this.dataset_key, schema_hash_value, EMPTY_FILTER
+            );
+        }
+    }
+
+    /**
+     * Handle a webview Cancel of the saved-preference restore. Ignores a
+     * stale/consumed id. While the restore is in flight, aborts the
+     * column reads (send_metadata's cancelled path forgets + posts
+     * natural-order metadata). If the restore already completed (the
+     * cross-window race), honors the click as an explicit clear-and-
+     * forget so it is never silently dropped.
+     */
+    private async handle_cancel_restore(
+        msg: CancelRestoreMessage
+    ): Promise<void> {
+        if (msg.restore_id !== this.restore_id) return;
+        if (this.restoring) {
+            this.restore_cancelled = true;
+            this.restore_abort?.abort();
+            return;
+        }
+        if (!this.dta_file) return;
+        await this.apply_cancel_forget(this.current_schema_hash());
+        this.generation++;
+        this.row_cache.clear();
+        this.recompute_effective();
+        this.post_sort_applied();
+        this.post_filter_applied();
     }
 
     // -------------------------------------------------------
@@ -461,6 +671,9 @@ export class DataBrowserPanel implements vscode.Disposable {
                 break;
             case 'requestHistogram':
                 await this.handle_request_histogram(msg);
+                break;
+            case 'cancelRestore':
+                await this.handle_cancel_restore(msg);
                 break;
             case 'copyColumn':
                 await this.handle_copy_column(
@@ -550,7 +763,8 @@ export class DataBrowserPanel implements vscode.Disposable {
      * No-op on later metadata re-sends (the in-memory sort wins).
      */
     private async maybe_restore_sort(
-        schema_hash_value: string
+        schema_hash_value: string,
+        signal?: AbortSignal
     ): Promise<void> {
         if (this.sort_restored) return;
         this.sort_restored = true;
@@ -566,9 +780,17 @@ export class DataBrowserPanel implements vscode.Disposable {
         let my_permutation: Uint32Array | null = null;
         try {
             my_permutation =
-                await this.compute_sort_permutation(my_stored);
-        } catch {
-            my_permutation = null;
+                await this.compute_sort_permutation(
+                    my_stored, signal
+                );
+        } catch (my_err) {
+            // A user cancel aborts the read; leave natural order
+            // silently. A genuine read failure is recorded so the
+            // caller can warn and keep the saved pref for next time.
+            if (!is_abort_error(my_err)) {
+                this.restore_failed = true;
+            }
+            return;
         }
         if (my_generation !== this.generation) return;
         if (my_permutation) {
@@ -577,16 +799,25 @@ export class DataBrowserPanel implements vscode.Disposable {
         }
     }
 
-    /** Read one full column as raw cells (length === nobs). */
+    /**
+     * Read one full column as raw cells (length === nobs).
+     *
+     * When `signal` is provided, the read is chunked and cancellable:
+     * aborting rejects with an `AbortError`. This is what makes a saved-
+     * preference restore interruptible; the viewport reads pass no signal
+     * and keep the single-shot fast path.
+     */
     private async read_full_column(
-        col_index: number
+        col_index: number,
+        signal?: AbortSignal
     ): Promise<RowCell[]> {
         if (!this.dta_file) return [];
         const the_rows = await this.dta_file.read_rows(
             0,
             this.dta_file.nobs,
             col_index,
-            col_index + 1
+            col_index + 1,
+            signal ? { signal } : undefined
         );
         return the_rows.map(my_row => my_row[0]);
     }
@@ -598,7 +829,8 @@ export class DataBrowserPanel implements vscode.Disposable {
      * after the await, since column reads are asynchronous.
      */
     private async compute_sort_permutation(
-        sort: SortState
+        sort: SortState,
+        signal?: AbortSignal
     ): Promise<Uint32Array | null> {
         if (!this.dta_file || sort.keys.length === 0) {
             return null;
@@ -629,7 +861,8 @@ export class DataBrowserPanel implements vscode.Disposable {
                 has_value_labels: my_has_value_labels,
             });
             const my_values = await this.read_full_column(
-                my_key.col_index
+                my_key.col_index,
+                signal
             );
             // A refresh during the await nulls dta_file; bail so the
             // caller's generation check discards this stale result.
@@ -750,7 +983,8 @@ export class DataBrowserPanel implements vscode.Disposable {
      * metadata re-sends (the in-memory filter wins).
      */
     private async maybe_restore_filter(
-        schema_hash_value: string
+        schema_hash_value: string,
+        signal?: AbortSignal
     ): Promise<void> {
         if (this.filter_restored) return;
         this.filter_restored = true;
@@ -786,9 +1020,17 @@ export class DataBrowserPanel implements vscode.Disposable {
         const my_generation = this.generation;
         let my_indices: Uint32Array | null = null;
         try {
-            my_indices = await this.compute_filter_indices(my_filter);
-        } catch {
-            my_indices = null;
+            my_indices = await this.compute_filter_indices(
+                my_filter, signal
+            );
+        } catch (my_err) {
+            // Cancel → natural order silently; genuine failure →
+            // natural order, record so the caller can warn and keep
+            // the saved filter. Either way, don't restore the chips.
+            if (!is_abort_error(my_err)) {
+                this.restore_failed = true;
+            }
+            return;
         }
         if (my_generation !== this.generation) return;
         this.filter = my_filter;
@@ -849,7 +1091,8 @@ export class DataBrowserPanel implements vscode.Disposable {
      * the await, since column reads are asynchronous.
      */
     private async compute_filter_indices(
-        filter: FilterState
+        filter: FilterState,
+        signal?: AbortSignal
     ): Promise<Uint32Array | null> {
         if (!this.dta_file) return null;
         const the_active = filter.entries.filter(
@@ -872,7 +1115,8 @@ export class DataBrowserPanel implements vscode.Disposable {
         const the_columns = new Map<number, FilterColumn>();
         for (const my_col_index of the_needed) {
             const my_values = await this.read_full_column(
-                my_col_index
+                my_col_index,
+                signal
             );
             // A refresh during the await nulls dta_file; bail so the
             // caller's generation check discards this stale result.

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -226,10 +226,10 @@ export class DataBrowserPanel implements vscode.Disposable {
         this.effective_perm = null;
         this.histogram_cache.clear();
         // Reset the saved-preference restore handshake; a fresh restore
-        // begins (if applicable) when initialize() re-sends metadata.
-        this.restore_abort = null;
-        this.restoring = false;
-        this.restore_id = -1;
+        // begins (if applicable) when initialize() re-sends metadata. The
+        // generation bump above makes any aborted in-flight restore bail
+        // without forgetting prefs.
+        this.abort_and_clear_restore();
 
         // Clean up the old temp file on Windows before
         // overwriting the path (other platforms unlink
@@ -649,6 +649,11 @@ export class DataBrowserPanel implements vscode.Disposable {
      * `restore_id = -1` consumes the handshake so a duplicate cancel is
      * ignored. The caller invalidates caches / posts updates and then
      * persists the forget via {@link forget_persisted_prefs}.
+     *
+     * This shares the `restore_id = -1` line with
+     * {@link consume_restore_handshake} but is deliberately distinct: this
+     * runs in the cancel/forget path and must ALSO clear sort/filter, so
+     * the two must not be merged.
      */
     private reset_restored_prefs(): void {
         this.restore_id = -1;
@@ -656,6 +661,33 @@ export class DataBrowserPanel implements vscode.Disposable {
         this.permutation = null;
         this.filter = EMPTY_FILTER;
         this.filtered_indices = null;
+    }
+
+    /**
+     * Consume the restore handshake because the user has superseded the
+     * restored prefs (a new sort/filter). A later cancelRestore carrying
+     * the old id then no longer reaches handle_cancel_restore's late
+     * clear-and-forget branch, so it cannot wipe what the user applied.
+     * Only a cancel that genuinely raced completion (no user change since)
+     * still finds a matching id.
+     */
+    private consume_restore_handshake(): void {
+        this.restore_id = -1;
+    }
+
+    /**
+     * Abort the in-flight restore's reads and clear the handshake. Used
+     * by the lifecycle-interruption paths (a webview reload's `ready` and
+     * `refresh()` to a new dataset): both bump the generation first, which
+     * makes the aborted restore bail without forgetting prefs, while the
+     * abort lets the serialized send_metadata chain advance at once
+     * instead of waiting behind the old, still-running column read.
+     */
+    private abort_and_clear_restore(): void {
+        this.restore_abort?.abort();
+        this.restore_abort = null;
+        this.restoring = false;
+        this.restore_id = -1;
     }
 
     /** Forget the persisted sort/filter for this dataset×schema. */
@@ -729,19 +761,16 @@ export class DataBrowserPanel implements vscode.Disposable {
                     // flight, the in-memory sort/filter are already set
                     // and re-sent as-is — no re-read.)
                     if (this.restoring) {
-                        // Abort the in-flight restore's reads so the
-                        // serialized send_metadata chain advances at once;
-                        // otherwise the reload's replacement restore (and
-                        // its Cancel banner) can't start until the old
-                        // read finishes, stranding the user on a bare
-                        // "Loading…". The generation bump above makes the
-                        // aborted restore bail without forgetting prefs.
-                        this.restore_abort?.abort();
+                        // Re-arm the one-shot restore flags so the queued
+                        // re-send reapplies the saved prefs, then abort the
+                        // in-flight reads and clear the handshake so the
+                        // serialized send_metadata chain advances at once
+                        // (otherwise the reload's replacement restore and
+                        // its Cancel banner can't start until the old read
+                        // finishes, stranding the user on a bare "Loading…").
                         this.sort_restored = false;
                         this.filter_restored = false;
-                        this.restoring = false;
-                        this.restore_abort = null;
-                        this.restore_id = -1;
+                        this.abort_and_clear_restore();
                     }
                     await this.send_metadata();
                 }
@@ -800,6 +829,10 @@ export class DataBrowserPanel implements vscode.Disposable {
         // re-sort then. (During the initial restore there is no grid to
         // sort from; this guards the refresh-with-visible-grid case.)
         if (this.restoring) return;
+
+        // The user is superseding the restored prefs, so the restore
+        // handshake is over.
+        this.consume_restore_handshake();
 
         // Bump the generation so any row request that is already
         // in-flight under the previous permutation is dropped instead of
@@ -1030,6 +1063,10 @@ export class DataBrowserPanel implements vscode.Disposable {
         // flight (see handle_set_sort): a generation bump here would
         // strand the restore with no metadata posted.
         if (this.restoring) return;
+
+        // The user is superseding the restored prefs, so the restore
+        // handshake is over (see handle_set_sort).
+        this.consume_restore_handshake();
 
         // Bump the generation so an in-flight row request under the old
         // effective permutation is dropped rather than posting stale rows

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -344,7 +344,26 @@ export class DataBrowserPanel implements vscode.Disposable {
         await this.send_metadata();
     }
 
-    private async send_metadata(): Promise<void> {
+    /**
+     * Serialize metadata sends so two restores never overlap. Without
+     * this, a webview reload (a second `ready`) during a slow restore
+     * would start a concurrent send_metadata that overwrites the shared
+     * restore AbortController, so a Cancel could abort the wrong restore
+     * while an earlier one keeps reading. Chaining guarantees one restore
+     * at a time; a Cancel (handled out of band) still aborts the active
+     * one, which then completes and lets the next send proceed.
+     */
+    private send_metadata_chain: Promise<void> = Promise.resolve();
+
+    private send_metadata(): Promise<void> {
+        const my_next = this.send_metadata_chain
+            .catch(() => {})
+            .then(() => this.send_metadata_impl());
+        this.send_metadata_chain = my_next;
+        return my_next;
+    }
+
+    private async send_metadata_impl(): Promise<void> {
         if (!this.dta_file) return;
 
         try {

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -68,9 +68,15 @@ import type {
 } from './types.js';
 import { EMPTY_SORT, EMPTY_FILTER } from './types.js';
 
-/** A read aborted via AbortSignal (vs. a genuine read failure). */
+/**
+ * A read aborted via AbortSignal (vs. a genuine read failure). Matches on
+ * `name` rather than `instanceof Error` because the abort is thrown as a
+ * `DOMException`, which is not an `Error` subclass on every runtime.
+ */
 function is_abort_error(err: unknown): boolean {
-    return err instanceof Error && err.name === 'AbortError';
+    return typeof err === 'object'
+        && err !== null
+        && (err as { name?: unknown }).name === 'AbortError';
 }
 
 /** %tc / %tC store milliseconds since 1960; other date formats store

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -478,7 +478,12 @@ export class DataBrowserPanel implements vscode.Disposable {
                 if (!is_cancelled() && this.filtered_indices) {
                     this.post_filter_applied();
                 }
-                if (my_sort_failed || my_filter_failed) {
+                // Suppress the failure warning when the user cancelled:
+                // a read may have genuinely failed before the cancel
+                // landed, but the user explicitly chose natural order, so
+                // a "couldn't reapply" popup would be confusing noise.
+                if (!is_cancelled()
+                    && (my_sort_failed || my_filter_failed)) {
                     const what = my_sort_failed && my_filter_failed
                         ? 'sort and filter'
                         : my_sort_failed ? 'sort' : 'filter';

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -768,6 +768,13 @@ export class DataBrowserPanel implements vscode.Disposable {
         msg: SetSortMessage
     ): Promise<void> {
         if (!this.dta_file) return;
+        // Ignore sort commands while a saved-preference restore is in
+        // flight: bumping generation here would make the restore discard
+        // its result without posting metadata, stranding the panel. The
+        // restore posts authoritative metadata momentarily; the user can
+        // re-sort then. (During the initial restore there is no grid to
+        // sort from; this guards the refresh-with-visible-grid case.)
+        if (this.restoring) return;
 
         // Bump the generation so any row request that is already
         // in-flight under the previous permutation is dropped instead of
@@ -994,6 +1001,10 @@ export class DataBrowserPanel implements vscode.Disposable {
         msg: SetFiltersMessage
     ): Promise<void> {
         if (!this.dta_file) return;
+        // Ignore filter commands while a saved-preference restore is in
+        // flight (see handle_set_sort): a generation bump here would
+        // strand the restore with no metadata posted.
+        if (this.restoring) return;
 
         // Bump the generation so an in-flight row request under the old
         // effective permutation is dropped rather than posting stale rows

--- a/client/src/data-browser/types.ts
+++ b/client/src/data-browser/types.ts
@@ -57,6 +57,18 @@ export interface RequestHistogramMessage {
     col_index: number;
 }
 
+/**
+ * Asks the host to abandon the in-progress restore of saved sort/filter
+ * and show the data unsorted/unfiltered, forgetting the saved
+ * preferences. `restore_id` echoes the value from the `restorePending`
+ * the webview is cancelling, so a stale cancel from a prior lifecycle is
+ * ignored by the host.
+ */
+export interface CancelRestoreMessage {
+    type: 'cancelRestore';
+    restore_id: number;
+}
+
 export type WebviewMessage =
     | RowRequest
     | ReadyMessage
@@ -65,7 +77,8 @@ export type WebviewMessage =
     | CopyColumnRequest
     | SetSortMessage
     | SetFiltersMessage
-    | RequestHistogramMessage;
+    | RequestHistogramMessage
+    | CancelRestoreMessage;
 
 // Extension → Webview messages
 
@@ -128,6 +141,20 @@ export interface HistogramDataMessage {
     bins: HistogramBin[];
 }
 
+/**
+ * Sent before the host reads columns to reapply a saved sort/filter on
+ * open, so the webview can explain the wait (instead of a bare
+ * "Loading…") and offer a Cancel control. `restore_id` identifies this
+ * restore so a `cancelRestore` can be matched to it. `sort` / `filter`
+ * say which preferences are being applied (for the message wording).
+ */
+export interface RestorePendingMessage {
+    type: 'restorePending';
+    restore_id: number;
+    sort: boolean;
+    filter: boolean;
+}
+
 export type ExtensionMessage =
     | RowResponse
     | MetadataMessage
@@ -135,7 +162,8 @@ export type ExtensionMessage =
     | SortStatusMessage
     | FilterAppliedMessage
     | FilterStatusMessage
-    | HistogramDataMessage;
+    | HistogramDataMessage
+    | RestorePendingMessage;
 
 export interface VariableDescription {
     name: string;

--- a/client/src/data-browser/webview/app.tsx
+++ b/client/src/data-browser/webview/app.tsx
@@ -22,6 +22,7 @@ import {
     collect_sampled_value_width_hints,
     type BrowserGridColumn,
     describe_browser_row_count,
+    describe_restore_message,
     describe_subset,
     get_cell_display_value,
     get_variable_header_tooltip,
@@ -274,6 +275,9 @@ export function App(): ReactElement {
         histograms,
         request_histogram,
         update_viewport,
+        restore_pending,
+        restore_cancelling,
+        cancel_restore,
     } = use_row_loader();
     const [show_labels, set_show_labels] = useState(true);
     const [show_formats, set_show_formats] = useState(true);
@@ -827,6 +831,17 @@ export function App(): ReactElement {
     if (filter_pending) the_progress_parts.push('Filtering…');
     const sort_filter_progress_text = the_progress_parts.join(' · ');
 
+    // On open, explain (and let the user cancel) the wait while saved
+    // sort/filter preferences are reapplied.
+    const restore_message = restore_pending
+        ? (restore_cancelling
+            ? 'Cancelling…'
+            : describe_restore_message(
+                restore_pending.sort,
+                restore_pending.filter
+            ))
+        : null;
+
     // Drop the sort/filter chips onto their own row when they would
     // otherwise crowd the action buttons off the toolbar. `hidden_columns.size`
     // is a dependency because it drives the Columns button's count badge,
@@ -1129,6 +1144,20 @@ export function App(): ReactElement {
             {sort_filter_progress_text && (
                 <div className="toolbar-progress" role="status">
                     {sort_filter_progress_text}
+                </div>
+            )}
+            {restore_message && (
+                <div className="toolbar-restore" role="status">
+                    <span>{restore_message}</span>
+                    {!restore_cancelling && (
+                        <button
+                            type="button"
+                            className="restore-cancel"
+                            onClick={cancel_restore}
+                        >
+                            Cancel
+                        </button>
+                    )}
                 </div>
             )}
             {subset_text && (

--- a/client/src/data-browser/webview/app.tsx
+++ b/client/src/data-browser/webview/app.tsx
@@ -21,9 +21,9 @@ import {
     clamp_column_width,
     collect_sampled_value_width_hints,
     type BrowserGridColumn,
-    describe_browser_row_count,
     describe_restore_message,
     describe_subset,
+    describe_toolbar_row_count,
     get_cell_display_value,
     get_variable_header_tooltip,
     merge_persisted_and_default_widths,
@@ -815,22 +815,6 @@ export function App(): ReactElement {
         }
     };
 
-    const row_count_text = describe_browser_row_count(
-        metadata,
-        nobs_effective,
-        first_visible_row,
-        visible_row_count
-    );
-
-    const subset_text = describe_subset(metadata);
-    // Sort and filter are usually mutually exclusive, but both can be
-    // in flight at once; show every pending operation rather than
-    // letting one mask the other.
-    const the_progress_parts: string[] = [];
-    if (sort_pending) the_progress_parts.push('Sorting…');
-    if (filter_pending) the_progress_parts.push('Filtering…');
-    const sort_filter_progress_text = the_progress_parts.join(' · ');
-
     // On open, explain (and let the user cancel) the wait while saved
     // sort/filter preferences are reapplied.
     const restore_message = restore_pending
@@ -841,6 +825,25 @@ export function App(): ReactElement {
                 restore_pending.filter
             ))
         : null;
+
+    // While the restore banner is up it explains the wait, so suppress
+    // the bare "Loading…" row-count that would otherwise stack above it.
+    const row_count_text = describe_toolbar_row_count(
+        metadata,
+        nobs_effective,
+        first_visible_row,
+        visible_row_count,
+        restore_message !== null
+    );
+
+    const subset_text = describe_subset(metadata);
+    // Sort and filter are usually mutually exclusive, but both can be
+    // in flight at once; show every pending operation rather than
+    // letting one mask the other.
+    const the_progress_parts: string[] = [];
+    if (sort_pending) the_progress_parts.push('Sorting…');
+    if (filter_pending) the_progress_parts.push('Filtering…');
+    const sort_filter_progress_text = the_progress_parts.join(' · ');
 
     // Drop the sort/filter chips onto their own row when they would
     // otherwise crowd the action buttons off the toolbar. `hidden_columns.size`

--- a/client/src/data-browser/webview/grid-model.ts
+++ b/client/src/data-browser/webview/grid-model.ts
@@ -296,6 +296,30 @@ export function describe_browser_row_count(
 }
 
 /**
+ * The toolbar row-count text. While a saved-preference restore banner is
+ * showing (`restore_active`), returns '' so that banner's explanation
+ * ("Applying your saved sort…") replaces the unexplained "Loading…"
+ * rather than stacking above it.
+ */
+export function describe_toolbar_row_count(
+    metadata: MetadataMessage | null,
+    nobs_effective: number | undefined,
+    first_visible_row: number,
+    visible_row_count: number,
+    restore_active: boolean
+): string {
+    if (restore_active) {
+        return '';
+    }
+    return describe_browser_row_count(
+        metadata,
+        nobs_effective,
+        first_visible_row,
+        visible_row_count
+    );
+}
+
+/**
  * Explains the saved-preference restore wait on open. `sort`/`filter`
  * say which preferences are being reapplied; at least one is true.
  */

--- a/client/src/data-browser/webview/grid-model.ts
+++ b/client/src/data-browser/webview/grid-model.ts
@@ -295,6 +295,23 @@ export function describe_browser_row_count(
     );
 }
 
+/**
+ * Explains the saved-preference restore wait on open. `sort`/`filter`
+ * say which preferences are being reapplied; at least one is true.
+ */
+export function describe_restore_message(
+    sort: boolean,
+    filter: boolean
+): string {
+    if (sort && filter) {
+        return 'Applying your saved sort & filter…';
+    }
+    if (sort) {
+        return 'Applying your saved sort…';
+    }
+    return 'Applying your saved filter…';
+}
+
 /** Toolbar subset banner, e.g. "Subsetted (vars: make, price; if
  *  foreign == 1; in 1/10)". Returns null when the browse covers the
  *  full dataset, so callers can skip rendering the row entirely. */

--- a/client/src/data-browser/webview/styles.css
+++ b/client/src/data-browser/webview/styles.css
@@ -81,9 +81,19 @@ body,
     border-bottom: 1px solid var(--vscode-panel-border);
     background: var(--vscode-editorGroupHeader-tabsBackground, var(--vscode-editor-background));
     font-size: 12px;
+    /* Like `.toolbar`, this is a flex item in the column-flex
+       `.browser-root`; `min-width: 0` lets the row shrink to the viewport
+       so the message truncates (see the span rule below) instead of the
+       row growing to its content width and clipping the Cancel button. */
+    min-width: 0;
 }
 
 .toolbar-restore > span {
+    /* Allow the message to shrink so ellipsis applies in narrow panels;
+       a flex item defaults to min-width:auto and would otherwise overflow
+       and push the Cancel button off-screen. */
+    flex: 1 1 auto;
+    min-width: 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/client/src/data-browser/webview/styles.css
+++ b/client/src/data-browser/webview/styles.css
@@ -71,6 +71,39 @@ body,
     text-overflow: ellipsis;
 }
 
+/* Saved sort/filter is being reapplied on open: explains the wait and
+   offers a Cancel that abandons it and shows the data unsorted. */
+.toolbar-restore {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    background: var(--vscode-editorGroupHeader-tabsBackground, var(--vscode-editor-background));
+    font-size: 12px;
+}
+
+.toolbar-restore > span {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.restore-cancel {
+    flex: 0 0 auto;
+    padding: 1px 8px;
+    font-size: 12px;
+    color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+    background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+    border: none;
+    border-radius: 2px;
+    cursor: pointer;
+}
+
+.restore-cancel:hover {
+    background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+}
+
 /* Sort + filter chip strips. Sits between the row count and the action
    buttons on a single row, and drops to its own full-width row (via the
    .is-wrapped modifier below) when it would otherwise crowd the buttons. */

--- a/client/src/data-browser/webview/use-row-loader.ts
+++ b/client/src/data-browser/webview/use-row-loader.ts
@@ -14,6 +14,7 @@ import type {
     HistogramBin,
     HistogramDataMessage,
     MetadataMessage,
+    RestorePendingMessage,
     RowResponse,
     SortAppliedMessage,
     SortKey,
@@ -26,6 +27,20 @@ import {
     get_needed_page_starts,
     PAGE_SIZE,
 } from './grid-model.js';
+
+/**
+ * Delay before the "applying saved sort/filter" UI appears. A restore
+ * that finishes faster than this (small/fast files) never flashes the
+ * message; only a genuinely slow restore reveals it (and its Cancel).
+ */
+export const RESTORE_DEBOUNCE_MS = 200;
+
+/** Which saved preferences a restore is reapplying. */
+export interface RestorePendingState {
+    restore_id: number;
+    sort: boolean;
+    filter: boolean;
+}
 
 declare function acquireVsCodeApi(): VsCodeApi;
 
@@ -49,6 +64,11 @@ export interface UseRowLoaderResult {
     histograms: Map<number, HistogramBin[]>;
     request_histogram: (col_index: number) => void;
     update_viewport: (start_row: number, end_row: number) => void;
+    // Non-null (after the debounce) while a saved sort/filter is being
+    // reapplied on open and the grid is not yet showing.
+    restore_pending: RestorePendingState | null;
+    restore_cancelling: boolean;
+    cancel_restore: () => void;
 }
 
 type IncomingMessage =
@@ -58,7 +78,8 @@ type IncomingMessage =
     | SortStatusMessage
     | FilterAppliedMessage
     | FilterStatusMessage
-    | HistogramDataMessage;
+    | HistogramDataMessage
+    | RestorePendingMessage;
 
 export function use_row_loader(): UseRowLoaderResult {
     const vscode_api = useMemo(() => acquireVsCodeApi(), []);
@@ -79,6 +100,15 @@ export function use_row_loader(): UseRowLoaderResult {
         useState<number | undefined>(undefined);
     const [histograms, set_histograms] =
         useState<Map<number, HistogramBin[]>>(() => new Map());
+    // Saved-preference restore UI: `restore_pending` is set only after
+    // the debounce timer fires, so a fast restore never flashes it.
+    const [restore_pending, set_restore_pending] =
+        useState<RestorePendingState | null>(null);
+    const [restore_cancelling, set_restore_cancelling] = useState(false);
+    const restore_timer = useRef<ReturnType<typeof setTimeout> | null>(
+        null
+    );
+    const restore_id_ref = useRef<number | null>(null);
     // Columns whose histogram has been requested (pending or arrived), so
     // opening a numeric filter popover repeatedly doesn't re-request.
     const requested_histograms = useRef<Set<number>>(new Set());
@@ -110,7 +140,38 @@ export function use_row_loader(): UseRowLoaderResult {
         function on_message(event: MessageEvent) {
             const my_msg = event.data as IncomingMessage;
 
+            if (my_msg.type === 'restorePending') {
+                // Defer showing the UI until the debounce elapses; a
+                // restore that completes sooner clears the timer on
+                // 'metadata' below and never flashes the message.
+                restore_id_ref.current = my_msg.restore_id;
+                set_restore_cancelling(false);
+                if (restore_timer.current !== null) {
+                    clearTimeout(restore_timer.current);
+                }
+                const my_info: RestorePendingState = {
+                    restore_id: my_msg.restore_id,
+                    sort: my_msg.sort,
+                    filter: my_msg.filter,
+                };
+                restore_timer.current = setTimeout(() => {
+                    set_restore_pending(my_info);
+                    restore_timer.current = null;
+                }, RESTORE_DEBOUNCE_MS);
+                return;
+            }
+
             if (my_msg.type === 'metadata') {
+                // Both the normal and cancelled restore paths end by
+                // posting metadata, so clear the restore UI here.
+                if (restore_timer.current !== null) {
+                    clearTimeout(restore_timer.current);
+                    restore_timer.current = null;
+                }
+                set_restore_pending(null);
+                set_restore_cancelling(false);
+                restore_id_ref.current = null;
+
                 set_metadata(my_msg);
                 set_pages(new Map());
                 pending_pages.current.clear();
@@ -196,8 +257,22 @@ export function use_row_loader(): UseRowLoaderResult {
         vscode_api.postMessage({ type: 'ready' });
         return () => {
             window.removeEventListener('message', on_message);
+            if (restore_timer.current !== null) {
+                clearTimeout(restore_timer.current);
+                restore_timer.current = null;
+            }
         };
     }, [vscode_api, request_page]);
+
+    const cancel_restore = useCallback(() => {
+        const my_id = restore_id_ref.current;
+        if (my_id === null) return;
+        set_restore_cancelling(true);
+        vscode_api.postMessage({
+            type: 'cancelRestore',
+            restore_id: my_id,
+        });
+    }, [vscode_api]);
 
     function ensure_rows(start_row: number, end_row: number) {
         const the_page_starts = get_needed_page_starts(
@@ -287,5 +362,8 @@ export function use_row_loader(): UseRowLoaderResult {
         histograms,
         request_histogram,
         update_viewport,
+        restore_pending,
+        restore_cancelling,
+        cancel_restore,
     };
 }

--- a/client/src/data-browser/webview/use-row-loader.ts
+++ b/client/src/data-browser/webview/use-row-loader.ts
@@ -154,6 +154,12 @@ export function use_row_loader(): UseRowLoaderResult {
                     sort: my_msg.sort,
                     filter: my_msg.filter,
                 };
+                // If a banner is already visible (a prior restore whose
+                // debounce elapsed), swap its wording to this restore at
+                // once rather than showing stale text until the timer.
+                set_restore_pending(my_prev =>
+                    my_prev ? my_info : my_prev
+                );
                 restore_timer.current = setTimeout(() => {
                     set_restore_pending(my_info);
                     restore_timer.current = null;

--- a/docs/superpowers/specs/2026-06-27-data-viewer-restore-messaging-cancel-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-restore-messaging-cancel-design.md
@@ -126,9 +126,13 @@ read_rows(
   ~65 536). For each chunk, in order:
   1. If `signal.aborted`, throw `DOMException('The read was aborted',
      'AbortError')` (Node provides global `DOMException`).
-  2. If the file was closed mid-read (`this._closed` / fd null), stop and return
-     the rows accumulated so far (consistent with the existing "closed returns
-     `[]`" contract; the caller discards partial results on abort anyway).
+  2. If the file was closed mid-read (`this._closed` / fd null), return `[]`
+     — **never the partially-accumulated rows.** Matching the existing "closed
+     returns `[]`" contract keeps a truncated read from masquerading as a
+     successful short read; a partial column must never be silently handed back,
+     since a caller computing a sort/filter over it would produce wrong results.
+     (The signal-less path keeps its current single-shot behavior; this rule is
+     specifically about the chunked loop, where a close can land between chunks.)
   3. `read_data_rows(fd, metadata, chunk_start, chunk_count)` → parse via
      `read_rows_from_data_buffer` → if any strL column falls in
      `[col_start, col_end)`, `_resolve_strls` on **that chunk's** rows and
@@ -158,7 +162,8 @@ release the loop for that handler to run.
   `AbortError` and reads nothing.
 - **Abort mid-read:** aborting after the first `setImmediate` yield rejects with
   `AbortError`; no rows are returned to the caller.
-- **Closed mid-read:** closing the file between chunks stops cleanly.
+- **Closed mid-read:** closing the file between chunks returns `[]` (not a
+  partial column) — assert the result is empty, not truncated.
 
 ### Release / consumption
 
@@ -174,24 +179,34 @@ git dependency) so Part 2 can be built and tested end-to-end.
 
 ### Message protocol (`client/src/data-browser/webview/types.ts`)
 
-Add two messages:
+Add two messages. Both carry a `restore_id` (the panel's `generation` value at
+the moment `restorePending` is posted) so stale/crossed messages from an earlier
+lifecycle can be dropped at the protocol level rather than relying on ordering
+assumptions:
 
-- **Extension → webview:** `{ type: 'restorePending'; sort: boolean; filter: boolean }`
+- **Extension → webview:** `{ type: 'restorePending'; restore_id: number; sort: boolean; filter: boolean }`
   — posted at the top of `send_metadata`, *before* the column reads, when a
   stored sort and/or filter actually exists for this `dataset_key × schema_hash`.
-- **Webview → extension:** `{ type: 'cancelRestore' }` — posted when the user
-  clicks Cancel.
+- **Webview → extension:** `{ type: 'cancelRestore'; restore_id: number }` —
+  posted when the user clicks Cancel, echoing the `restore_id` it is cancelling.
+
+The extension ignores a `cancelRestore` whose `restore_id` does not match the
+current restore (see late-cancel handling below). The webview records the latest
+`restore_id` from `restorePending` and stamps it onto any `cancelRestore`.
 
 ### Extension side (`browser-panel.ts`)
 
 State added to the panel: `restore_abort: AbortController | null`,
-`restore_cancelled: boolean`, `restoring: boolean`.
+`restore_cancelled: boolean`, `restoring: boolean`, `restore_id: number`.
 
 `send_metadata`, on first restore for the dataset:
 
-1. Peek both stores. If either has a stored pref, set `restoring = true`, create
-   `this.restore_abort = new AbortController()`, and post
-   `restorePending { sort, filter }` **before** the heavy reads.
+1. Peek both stores. If either has a stored pref, **reset the restore state**
+   (`restore_cancelled = false`, fresh `this.restore_abort =
+   new AbortController()`, `restore_id = this.generation`, `restoring = true`),
+   then post `restorePending { restore_id, sort, filter }` **before** the heavy
+   reads. Resetting `restore_cancelled` here (not just on cancel) keeps a prior
+   cancel from poisoning a later restore — see finding #4.
 2. Call `maybe_restore_sort` / `maybe_restore_filter`, threading
    `this.restore_abort.signal` down:
    - `read_full_column(col, signal)` →
@@ -200,26 +215,48 @@ State added to the panel: `restore_abort: AbortController | null`,
    - `read_rows(0, nobs, col, col+1, { signal })`.
 3. Between the two restores, short-circuit if `restore_cancelled` so a cancel
    during the sort read does not then trigger a long filter read.
-4. The existing `try { … } catch { … = null }` around each compute turns an
-   `AbortError` (or any read failure) into "no permutation / no indices," i.e.
-   natural order. `maybe_restore_*` already only apply `this.sort` /
-   `this.filter` when the compute returned a non-null result, so an aborted
-   restore leaves them empty.
-5. On the cancelled path, `send_metadata`:
+4. **Distinguish abort from real failure.** The compute wrappers must catch and
+   classify: an `AbortError` (or `restore_cancelled === true`) → quiet natural
+   order; any *other* error (corruption, I/O, parser bug) → natural order **plus**
+   a non-blocking notice (e.g. a toolbar note / `showWarningMessage`,
+   "Couldn't reapply saved sort/filter"), and the persisted prefs are **kept**
+   (only an explicit user cancel forgets them — finding #7). A bare
+   `catch { … = null }` that swallows everything is explicitly rejected.
+5. On the **cancelled** path (user cancel, `restore_cancelled === true`),
+   `send_metadata`:
+   - **resets all in-memory restore effects**, not just the persisted/chip view:
+     `this.sort = { keys: [], … }`, `this.permutation = null`,
+     `this.filter = { entries: [], … }`, `this.filtered_indices = null`, then
+     `recompute_effective()`. This is required because a *completed* sort restore
+     may already have applied `this.sort` / `this.permutation` before the cancel
+     landed during the filter read — without this reset the grid would show
+     sorted rows with no chip (finding #1);
    - clears **both** persisted prefs for this `dataset_key × schema_hash`
      (`sort_state_store.set(…, { keys: [], … })` and the filter equivalent;
      set-empty deletes the entry, sort-state.ts:145–152) — *forget entirely*;
    - posts `metadata` with `stored_sort` / `stored_filter` **omitted** (so no
      chips render);
    - skips `post_filter_applied` (no filter is active).
-6. Clear `restoring` (and `restore_abort`) once `metadata` is posted, on both
-   the normal and cancelled paths.
+6. **Cleanup in a `finally`,** not only after a successful `postMessage`: clear
+   `restoring`, null `restore_abort`. Tying cleanup to a `finally` ensures an
+   early throw inside `send_metadata` (before `metadata` is posted) cannot strand
+   the panel in a permanent `restoring` state (finding #3). The existing
+   `try/catch` that surfaces "Failed to open .dta file" stays; the cleanup is its
+   `finally`.
 
-`handle_message` gains a `cancelRestore` case:
+`handle_message` gains a `cancelRestore` case keyed on `restore_id`:
 
-- If `!this.restoring`, ignore (defensive against a stray/late cancel after the
-  grid is already up).
-- Otherwise: `this.restore_cancelled = true; this.restore_abort?.abort();`
+- If `msg.restore_id !== this.restore_id`, ignore (stale cancel from a previous
+  lifecycle — finding #6).
+- Else if `this.restoring` is still true: `restore_cancelled = true;
+  this.restore_abort?.abort();` (the normal in-flight cancel).
+- Else (the restore already completed and posted `metadata` in the cross-window
+  race — finding #5): the user still asked to cancel, so honor it as an explicit
+  **clear-and-forget**: reset in-memory sort/filter as in step 5, clear both
+  persisted stores, bump `generation`, clear the row cache, and post
+  `sortApplied` / `filterApplied` (and an updated `metadata` if chips must
+  disappear) so the grid drops to natural order. This guarantees a click that the
+  user saw as "Cancel" is never silently dropped.
 
 Note: on the normal (non-cancelled) completion, behavior is exactly as today —
 `metadata` is posted with the restored sort/filter applied; the only difference
@@ -228,9 +265,9 @@ arrives.
 
 ### Webview side (`app.tsx`, `use-row-loader.ts`, `grid-model.ts`)
 
-- Track `restore_pending: { sort: boolean; filter: boolean } | null`. Set it on
-  `restorePending`; clear it when `metadata` arrives (both the normal and
-  cancelled paths end by posting `metadata`).
+- Track `restore_pending: { restore_id: number; sort: boolean; filter: boolean } | null`.
+  Set it on `restorePending` (recording `restore_id`); clear it when `metadata`
+  arrives (both the normal and cancelled paths end by posting `metadata`).
 - While `restore_pending` is set and `metadata` is still `null`, render — in
   place of the bare `Loading…`, reusing the `toolbar-progress` styling — an
   explanatory line plus an inline **Cancel** button:
@@ -240,35 +277,73 @@ arrives.
 - **Debounce:** only reveal this UI if `restore_pending` persists past ~200 ms,
   so small/fast files (where `metadata` arrives almost immediately) do not flash
   the message.
-- The Cancel button posts `cancelRestore` and optimistically shows a transient
-  *"Cancelling…"* until `metadata` arrives, after which the grid renders in
-  natural order with no chips.
+- The Cancel button posts `cancelRestore { restore_id }` and optimistically
+  shows a transient *"Cancelling…"* until `metadata` arrives. On the normal path
+  the grid then renders in natural order with no chips. In the cross-window race
+  (the extension had already completed the restore when the cancel arrived), the
+  extension honors the late cancel as a clear-and-forget (see extension side), so
+  the grid still ends in natural order — the optimistic UI is never contradicted.
 
 ### Edge cases
 
 - **Persistence disabled** (`persistSort` / `persistFilters` = false): no stored
   prefs → no `restorePending` → behavior unchanged.
-- **Stored filter that drops all chips** on schema mismatch, or yields an empty
-  survivor set: only post `restorePending` when a stored pref genuinely exists to
-  apply (peek the stores, mirroring `maybe_restore_*`'s own guards).
-- **Refresh** (`ready` received while `dta_file` is already set): same path; the
-  `generation` bump on refresh already discards stale in-flight reads.
-- **Cancel arriving after restore completed:** guarded by `restoring`; the
-  webview also stops showing the button once `metadata` arrives, so it should
-  not be sent — but the guard makes it a no-op regardless.
+- **`restorePending` gating is on *existence*, not outcome (finding #8):** post
+  `restorePending` whenever a stored pref *exists and is schema-applicable* —
+  which is exactly what the cheap store peek can determine (mirroring
+  `maybe_restore_*`'s own guards: persistence enabled, entry present, predicate
+  fits the column kind). Whether the filter ultimately yields an *empty survivor
+  set* is unknowable without the very read the UI exists to explain, so it must
+  **not** gate `restorePending`. A stored filter that later resolves to zero rows
+  still shows the explanation while it computes; `metadata` then clears it.
+- **Restore read fails for a real reason (not cancel) (finding #7):** the dataset
+  opens in natural order, a non-blocking notice tells the user the saved
+  sort/filter couldn't be reapplied, and the persisted prefs are **retained** so
+  the next reopen can retry. This is deliberately distinct from cancel
+  (forget) and must not be silently conflated with it.
+- **Refresh** (`ready` received while `dta_file` is already set): `maybe_restore_*`
+  are one-shot (`sort_restored` / `filter_restored` guards), so a refresh does not
+  re-read columns; `restorePending` may still be posted but the debounce
+  suppresses the flash. The `generation` bump on refresh discards stale in-flight
+  reads, and the fresh `restore_id` (step 1) makes any crossed `cancelRestore`
+  from the prior lifecycle a no-op.
+- **Late cancel after completion (finding #5):** handled by the `restore_id`
+  match + clear-and-forget fallback in `handle_message`, so the user's click is
+  honored rather than dropped.
 - **Cancel during the sort read, with a filter also stored:** the
-  `restore_cancelled` short-circuit (step 3) prevents the subsequent filter read.
+  `restore_cancelled` short-circuit (step 3) prevents the subsequent filter read;
+  step 5's in-memory reset guarantees a sort that *did* complete before the cancel
+  is also undone (finding #1).
 
 ### Tests (sight)
 
-- **Extension unit:** a `cancelRestore` during restore (a) aborts the read,
-  (b) clears both persisted stores, (c) results in `send_metadata` emitting
-  natural-order `metadata` with no `stored_sort` / `stored_filter` and no
+- **Extension unit — basic cancel:** a `cancelRestore` during restore (a) aborts
+  the read, (b) clears both persisted stores, (c) results in `send_metadata`
+  emitting natural-order `metadata` with no `stored_sort` / `stored_filter` and no
   `filterApplied`; a normal completion still applies the stored sort/filter and
   emits `restorePending` before `metadata`.
+- **Extension unit — sort-done, filter-cancelled (finding #1):** with a stored
+  sort *and* filter, complete the sort restore then cancel during the filter
+  read; assert the final state is fully natural order — `this.permutation` is
+  null, `effective_nobs` is the full count, and `metadata` carries no chips. (A
+  naive implementation that only omits `stored_sort` would leave `permutation`
+  set; this test must fail against that.)
+- **Extension unit — real read error vs cancel (finding #7):** a non-`AbortError`
+  failure from `read_rows` opens in natural order, surfaces the notice, and
+  **keeps** the persisted prefs; assert the stores are unchanged (contrast with
+  the cancel test, which clears them).
+- **Extension unit — stale/late cancel (findings #5, #6):** a `cancelRestore`
+  with a non-matching `restore_id` is a no-op; a matching one that arrives after
+  completion drops the grid to natural order and forgets the prefs.
+- **Extension unit — no stranded state (finding #3):** force `send_metadata` to
+  throw before posting `metadata`; assert `restoring` is cleared and
+  `restore_abort` nulled (the `finally`).
+- **dta-parser — closed mid-read (finding #2):** closing the file between chunks
+  yields `[]`, asserted empty (not a truncated column).
 - **Webview unit (`grid-model` / loader):** `restorePending` produces the
   correct explanatory text per flag combination; the message is suppressed
-  before the debounce threshold and shown after; it clears on `metadata`.
+  before the debounce threshold and shown after; it clears on `metadata`; a
+  `cancelRestore` echoes the recorded `restore_id`.
 - **Integration (`data-browser-smoke` style):** reopen a `.dta` with saved
   sort and filter → `restorePending` is posted before `metadata`; without
   cancel, the restored order is applied.
@@ -279,9 +354,9 @@ Normal reopen with saved prefs:
 
 ```
 webview: ready
-ext:     restorePending {sort,filter}      ← new; webview shows explanation (after 200ms)
+ext:     restorePending {restore_id,sort,filter}  ← new; webview shows explanation (after 200ms)
 ext:     [chunked, cancellable column reads]
-ext:     metadata (stored_sort/filter set) ← webview clears restore_pending, renders sorted
+ext:     metadata (stored_sort/filter set)        ← webview clears restore_pending, renders sorted
 ext:     filterApplied (if filtered)
 ```
 
@@ -289,8 +364,9 @@ Cancelled reopen:
 
 ```
 webview: ready
-ext:     restorePending {sort,filter}
-webview: [user clicks Cancel] → cancelRestore
-ext:     controller.abort() → reads reject AbortError → prefs forgotten
-ext:     metadata (no stored_sort/filter)  ← webview renders natural order, no chips
+ext:     restorePending {restore_id,sort,filter}
+webview: [user clicks Cancel] → cancelRestore {restore_id}
+ext:     restore_id matches & restoring → controller.abort()
+ext:       reads reject AbortError → reset in-memory sort+filter, recompute_effective, prefs forgotten
+ext:     metadata (no stored_sort/filter)         ← webview renders natural order, no chips
 ```

--- a/docs/superpowers/specs/2026-06-27-data-viewer-restore-messaging-cancel-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-restore-messaging-cancel-design.md
@@ -1,0 +1,296 @@
+# Data viewer: explain (and let users cancel) the saved-sort/filter reload
+
+## Problem
+
+Sight's `.dta` viewer (opened via `vview` or by clicking a `.dta` file) opens
+instantly because it uses a virtualized grid: only the visible window of rows is
+read from disk at any moment. Sorting and filtering break that frugality — to
+apply either, the extension must read the relevant column(s) *in their entirety*
+into memory to compute a sort permutation or a filter survivor set.
+
+Sort and filter preferences are persisted per `dataset_key × schema_hash` and
+**re-applied automatically on reopen** (`browser-panel.ts` `maybe_restore_sort` /
+`maybe_restore_filter`). On reopen of a file with saved preferences, the
+extension does the heavy column reads *before* it posts the `metadata` message:
+
+```
+initialize() → send_metadata():
+    maybe_restore_sort(schema_hash)     // reads sort-key column(s) fully
+    maybe_restore_filter(schema_hash)   // reads filter column(s) fully
+    recompute_effective()
+    postMessage(metadata)               // only now does the grid populate
+```
+
+Until `metadata` arrives, the webview has `metadata === null`, so
+`describe_browser_row_count()` (`grid-model.ts:282`) returns a bare `'Loading…'`.
+
+Two user-facing problems result:
+
+1. **No explanation.** A user who reopens a large file sees `Loading…` for a
+   few seconds — or much longer — with no hint that the wait exists *because*
+   Sight is reapplying their remembered sort/filter and reading whole columns to
+   do it. (There is already a clearer `'Sorting…'` / `'Filtering…'` progress
+   string, but it is only wired to *interactive* sort/filter changes made after
+   the grid is up — never to this initial restore.)
+
+2. **No escape hatch.** There is no way to say "skip it, just show me the data."
+   The user must wait for the full restore to finish.
+
+## Goal
+
+On reopen with saved preferences:
+
+1. Replace the bare `Loading…` with an explanation — e.g. *"Applying your saved
+   sort & filter…"* — so the wait is self-explanatory.
+2. Offer a **Cancel** control. Cancelling abandons the restore, **forgets** the
+   saved preferences for this dataset (clears the persisted sort/filter), and
+   shows the data in its natural (unsorted, unfiltered) order.
+3. Keep today's "no visible reorder" property: rows must never appear in the
+   wrong order and then jump. Data appears only once its final order is known
+   (or, on cancel, in natural order).
+
+For Cancel to be meaningful, the column read it interrupts must actually yield
+the event loop — which today it does not (see Background). This requires a small
+change to `@jbearak/dta-parser` as well.
+
+## Non-goals
+
+- **Showing the grid in natural order first, then re-sorting** (an alternative
+  that makes Cancel trivial). Rejected: it causes a visible reorder "jump,"
+  which the goal explicitly forbids.
+- **Cancel for interactive sort/filter** (`handle_set_sort` /
+  `handle_set_filters`, applied after the grid is up). Out of scope; those keep
+  their single-shot reads. Noted as a possible follow-up — they would benefit
+  from the same chunked read for event-loop responsiveness.
+- **Interruptible permutation/index computation.** Cancel interrupts the
+  *column-reading* phase (the dominant cost). The final `compute_permutation`
+  and the filter-index scan over `nobs` are synchronous CPU and remain
+  uninterruptible; they are comparatively cheap. Acceptable, documented
+  limitation.
+- **"Remember but don't auto-apply" semantics.** Cancel means *forget entirely*.
+
+## Background: why Cancel needs a dta-parser change
+
+`DtaFile.read_rows` (`@jbearak/dta-parser`, node entry) is declared `async` but
+does **no awaiting internally** — its body is fully synchronous:
+
+```js
+async read_rows(start, count, col_start, col_end) {
+    const my_data_buffer = read_data_rows(this._fd, ...);   // fs.readSync (blocking)
+    const the_rows = read_rows_from_data_buffer(...);        // synchronous parse
+    if (this._strl_col_indices.length > 0) this._resolve_strls(...);
+    return the_rows;
+}
+```
+
+`read_data_rows` → `read_range` uses `fs.readSync`. `read_full_column` in sight
+reads a whole column with a single `read_rows(0, nobs, col, col+1)` call. Because
+that call runs to completion synchronously, it **blocks the host event loop for
+its entire duration**. A `cancelRestore` message posted from the webview sits
+unprocessed in the IPC queue until the read returns — so a naive Cancel button
+would have no effect until the very read it targets has already finished. The
+`generation`-counter checkpoints only help *between* awaits, and the full-column
+read is effectively one uninterruptible await.
+
+Therefore the column read must become **chunked and yield to the event loop**
+between chunks, so the abort message can be processed. The fix belongs in the
+library (decided): the bulk read is a library-level operation, and a first-class
+cancellable API is reusable and keeps sight's call sites simple.
+
+---
+
+## Part 1 — `@jbearak/dta-parser` (0.1.1 → 0.1.2)
+
+### API
+
+Extend `read_rows` with an optional, backward-compatible options argument:
+
+```ts
+read_rows(
+    start: number,
+    count: number,
+    col_start?: number,
+    col_end?: number,
+    options?: { signal?: AbortSignal; chunk_rows?: number }
+): Promise<Row[]>
+```
+
+### Behavior
+
+- **No `options.signal` (default / existing callers):** unchanged — a single
+  `read_data_rows` + `read_rows_from_data_buffer` + (if needed) `_resolve_strls`,
+  no chunking, no yields. The fast virtualized-viewport path and all existing
+  perf/tests are untouched. This is the critical backward-compat guarantee.
+
+- **With `options.signal`:** read in chunks of `chunk_rows` rows (default
+  ~65 536). For each chunk, in order:
+  1. If `signal.aborted`, throw `DOMException('The read was aborted',
+     'AbortError')` (Node provides global `DOMException`).
+  2. If the file was closed mid-read (`this._closed` / fd null), stop and return
+     the rows accumulated so far (consistent with the existing "closed returns
+     `[]`" contract; the caller discards partial results on abort anyway).
+  3. `read_data_rows(fd, metadata, chunk_start, chunk_count)` → parse via
+     `read_rows_from_data_buffer` → if any strL column falls in
+     `[col_start, col_end)`, `_resolve_strls` on **that chunk's** rows and
+     buffer. (Per-chunk resolution is correct: the layout is row-major
+     (`read_data_rows` reads `count * obs_length` contiguous bytes at the row
+     offset, node.js:1755/1780), so each chunk's buffer fully covers its own
+     rows.)
+  4. Append the chunk's rows to the accumulator.
+  5. `await new Promise(resolve => setImmediate(resolve))` to release the event
+     loop so a queued abort is observed on the next chunk's check.
+
+  After the loop, a final `signal.aborted` check before returning.
+
+The `setImmediate` yield is load-bearing: aborting depends on the host event
+loop running the handler that calls `controller.abort()`; chunk reads must
+release the loop for that handler to run.
+
+### Tests (dta-parser)
+
+- **Regression / equivalence:** a signal-less `read_rows` returns byte-identical
+  `Row[]` to the current implementation (covers the fast path).
+- **Chunk-boundary equivalence:** with a deliberately small `chunk_rows`, the
+  chunked result equals the single-shot result — including a dataset with a
+  strL column whose rows span a chunk boundary, and including `col_start`/
+  `col_end` sub-ranges.
+- **Abort before first chunk:** an already-aborted signal rejects with
+  `AbortError` and reads nothing.
+- **Abort mid-read:** aborting after the first `setImmediate` yield rejects with
+  `AbortError`; no rows are returned to the caller.
+- **Closed mid-read:** closing the file between chunks stops cleanly.
+
+### Release / consumption
+
+Bump to `0.1.2`; build esm + cjs + types; publish. Sight's existing `^0.1.1`
+range accepts `0.1.2`, so no manifest edit is strictly required once published —
+only a lockfile update via `bun install`. For development *before* publish, link
+the local build into the sight worktrees (`bun link`, or a temporary `file:` /
+git dependency) so Part 2 can be built and tested end-to-end.
+
+---
+
+## Part 2 — sight data viewer
+
+### Message protocol (`client/src/data-browser/webview/types.ts`)
+
+Add two messages:
+
+- **Extension → webview:** `{ type: 'restorePending'; sort: boolean; filter: boolean }`
+  — posted at the top of `send_metadata`, *before* the column reads, when a
+  stored sort and/or filter actually exists for this `dataset_key × schema_hash`.
+- **Webview → extension:** `{ type: 'cancelRestore' }` — posted when the user
+  clicks Cancel.
+
+### Extension side (`browser-panel.ts`)
+
+State added to the panel: `restore_abort: AbortController | null`,
+`restore_cancelled: boolean`, `restoring: boolean`.
+
+`send_metadata`, on first restore for the dataset:
+
+1. Peek both stores. If either has a stored pref, set `restoring = true`, create
+   `this.restore_abort = new AbortController()`, and post
+   `restorePending { sort, filter }` **before** the heavy reads.
+2. Call `maybe_restore_sort` / `maybe_restore_filter`, threading
+   `this.restore_abort.signal` down:
+   - `read_full_column(col, signal)` →
+   - `compute_sort_permutation(sort, signal)` /
+     `compute_filter_indices(filter, signal)` →
+   - `read_rows(0, nobs, col, col+1, { signal })`.
+3. Between the two restores, short-circuit if `restore_cancelled` so a cancel
+   during the sort read does not then trigger a long filter read.
+4. The existing `try { … } catch { … = null }` around each compute turns an
+   `AbortError` (or any read failure) into "no permutation / no indices," i.e.
+   natural order. `maybe_restore_*` already only apply `this.sort` /
+   `this.filter` when the compute returned a non-null result, so an aborted
+   restore leaves them empty.
+5. On the cancelled path, `send_metadata`:
+   - clears **both** persisted prefs for this `dataset_key × schema_hash`
+     (`sort_state_store.set(…, { keys: [], … })` and the filter equivalent;
+     set-empty deletes the entry, sort-state.ts:145–152) — *forget entirely*;
+   - posts `metadata` with `stored_sort` / `stored_filter` **omitted** (so no
+     chips render);
+   - skips `post_filter_applied` (no filter is active).
+6. Clear `restoring` (and `restore_abort`) once `metadata` is posted, on both
+   the normal and cancelled paths.
+
+`handle_message` gains a `cancelRestore` case:
+
+- If `!this.restoring`, ignore (defensive against a stray/late cancel after the
+  grid is already up).
+- Otherwise: `this.restore_cancelled = true; this.restore_abort?.abort();`
+
+Note: on the normal (non-cancelled) completion, behavior is exactly as today —
+`metadata` is posted with the restored sort/filter applied; the only difference
+is the earlier `restorePending` signal, which the webview clears when `metadata`
+arrives.
+
+### Webview side (`app.tsx`, `use-row-loader.ts`, `grid-model.ts`)
+
+- Track `restore_pending: { sort: boolean; filter: boolean } | null`. Set it on
+  `restorePending`; clear it when `metadata` arrives (both the normal and
+  cancelled paths end by posting `metadata`).
+- While `restore_pending` is set and `metadata` is still `null`, render — in
+  place of the bare `Loading…`, reusing the `toolbar-progress` styling — an
+  explanatory line plus an inline **Cancel** button:
+  - both → *"Applying your saved sort & filter…"*
+  - sort only → *"Applying your saved sort…"*
+  - filter only → *"Applying your saved filter…"*
+- **Debounce:** only reveal this UI if `restore_pending` persists past ~200 ms,
+  so small/fast files (where `metadata` arrives almost immediately) do not flash
+  the message.
+- The Cancel button posts `cancelRestore` and optimistically shows a transient
+  *"Cancelling…"* until `metadata` arrives, after which the grid renders in
+  natural order with no chips.
+
+### Edge cases
+
+- **Persistence disabled** (`persistSort` / `persistFilters` = false): no stored
+  prefs → no `restorePending` → behavior unchanged.
+- **Stored filter that drops all chips** on schema mismatch, or yields an empty
+  survivor set: only post `restorePending` when a stored pref genuinely exists to
+  apply (peek the stores, mirroring `maybe_restore_*`'s own guards).
+- **Refresh** (`ready` received while `dta_file` is already set): same path; the
+  `generation` bump on refresh already discards stale in-flight reads.
+- **Cancel arriving after restore completed:** guarded by `restoring`; the
+  webview also stops showing the button once `metadata` arrives, so it should
+  not be sent — but the guard makes it a no-op regardless.
+- **Cancel during the sort read, with a filter also stored:** the
+  `restore_cancelled` short-circuit (step 3) prevents the subsequent filter read.
+
+### Tests (sight)
+
+- **Extension unit:** a `cancelRestore` during restore (a) aborts the read,
+  (b) clears both persisted stores, (c) results in `send_metadata` emitting
+  natural-order `metadata` with no `stored_sort` / `stored_filter` and no
+  `filterApplied`; a normal completion still applies the stored sort/filter and
+  emits `restorePending` before `metadata`.
+- **Webview unit (`grid-model` / loader):** `restorePending` produces the
+  correct explanatory text per flag combination; the message is suppressed
+  before the debounce threshold and shown after; it clears on `metadata`.
+- **Integration (`data-browser-smoke` style):** reopen a `.dta` with saved
+  sort and filter → `restorePending` is posted before `metadata`; without
+  cancel, the restored order is applied.
+
+## Sequence summary
+
+Normal reopen with saved prefs:
+
+```
+webview: ready
+ext:     restorePending {sort,filter}      ← new; webview shows explanation (after 200ms)
+ext:     [chunked, cancellable column reads]
+ext:     metadata (stored_sort/filter set) ← webview clears restore_pending, renders sorted
+ext:     filterApplied (if filtered)
+```
+
+Cancelled reopen:
+
+```
+webview: ready
+ext:     restorePending {sort,filter}
+webview: [user clicks Cancel] → cancelRestore
+ext:     controller.abort() → reads reject AbortError → prefs forgotten
+ext:     metadata (no stored_sort/filter)  ← webview renders natural order, no chips
+```

--- a/docs/superpowers/specs/2026-06-27-data-viewer-restore-messaging-cancel-design.md
+++ b/docs/superpowers/specs/2026-06-27-data-viewer-restore-messaging-cancel-design.md
@@ -99,7 +99,7 @@ cancellable API is reusable and keeps sight's call sites simple.
 
 ---
 
-## Part 1 — `@jbearak/dta-parser` (0.1.1 → 0.1.2)
+## Part 1 — `@jbearak/dta-parser` (0.1.1 → 0.2.0)
 
 ### API
 
@@ -167,9 +167,9 @@ release the loop for that handler to run.
 
 ### Release / consumption
 
-Bump to `0.1.2`; build esm + cjs + types; publish. Sight's existing `^0.1.1`
-range accepts `0.1.2`, so no manifest edit is strictly required once published —
-only a lockfile update via `bun install`. For development *before* publish, link
+Bump to `0.2.0`; build esm + cjs + types; publish. Sight's manifests
+(`package.json` and `client/package.json`) are updated to `^0.2.0`, plus a
+lockfile update via `bun install`. For development *before* publish, link
 the local build into the sight worktrees (`bun link`, or a temporary `file:` /
 git dependency) so Part 2 can be built and tested end-to-end.
 
@@ -197,32 +197,41 @@ current restore (see late-cancel handling below). The webview records the latest
 ### Extension side (`browser-panel.ts`)
 
 State added to the panel: `restore_abort: AbortController | null`,
-`restore_cancelled: boolean`, `restoring: boolean`, `restore_id: number`.
+`restoring: boolean`, `restore_id: number`. Cancellation is read directly from
+the restore's `AbortSignal` (there is no separate `restore_cancelled` flag):
+each `send_metadata` captures its own controller as `my_abort` and tests
+`my_abort.signal.aborted` through a local `is_cancelled()`, so a concurrent
+`send_metadata` reassigning `this.restore_abort` cannot change what the
+in-flight call sees. `restore_id` is the `generation` at restore start, with
+`-1` meaning "no active restore".
 
 `send_metadata`, on first restore for the dataset:
 
-1. Peek both stores. If either has a stored pref, **reset the restore state**
-   (`restore_cancelled = false`, fresh `this.restore_abort =
-   new AbortController()`, `restore_id = this.generation`, `restoring = true`),
-   then post `restorePending { restore_id, sort, filter }` **before** the heavy
-   reads. Resetting `restore_cancelled` here (not just on cancel) keeps a prior
-   cancel from poisoning a later restore — see finding #4.
-2. Call `maybe_restore_sort` / `maybe_restore_filter`, threading
-   `this.restore_abort.signal` down:
+1. `maybe_begin_restore(schema_hash)` peeks both stores. If either has a stored
+   pref, it **arms a fresh restore** (`this.restore_abort =
+   new AbortController()`, `restore_id = this.generation`, `restoring = true`)
+   and posts `restorePending { restore_id, sort, filter }` **before** the heavy
+   reads, returning whether a restore began. A fresh `AbortController` per
+   restore (rather than a reused boolean) keeps a prior cancel from poisoning a
+   later restore — see finding #4.
+2. Call `maybe_restore_sort` / `maybe_restore_filter`, threading the
+   **captured** `my_abort.signal` (not `this.restore_abort.signal`, which a
+   concurrent `send_metadata` could reassign) down:
    - `read_full_column(col, signal)` →
    - `compute_sort_permutation(sort, signal)` /
      `compute_filter_indices(filter, signal)` →
    - `read_rows(0, nobs, col, col+1, { signal })`.
-3. Between the two restores, short-circuit if `restore_cancelled` so a cancel
+3. Between the two restores, short-circuit if `is_cancelled()` so a cancel
    during the sort read does not then trigger a long filter read.
 4. **Distinguish abort from real failure.** The compute wrappers must catch and
-   classify: an `AbortError` (or `restore_cancelled === true`) → quiet natural
+   classify via `is_abort_error()`: an `AbortError` (matched by name, since the
+   chunked reads reject with a `DOMException`) → quiet natural
    order; any *other* error (corruption, I/O, parser bug) → natural order **plus**
    a non-blocking notice (e.g. a toolbar note / `showWarningMessage`,
    "Couldn't reapply saved sort/filter"), and the persisted prefs are **kept**
    (only an explicit user cancel forgets them — finding #7). A bare
    `catch { … = null }` that swallows everything is explicitly rejected.
-5. On the **cancelled** path (user cancel, `restore_cancelled === true`),
+5. On the **cancelled** path (user cancel, `is_cancelled()` true),
    `send_metadata`:
    - **resets all in-memory restore effects**, not just the persisted/chip view:
      `this.sort = { keys: [], … }`, `this.permutation = null`,
@@ -237,19 +246,22 @@ State added to the panel: `restore_abort: AbortController | null`,
    - posts `metadata` with `stored_sort` / `stored_filter` **omitted** (so no
      chips render);
    - skips `post_filter_applied` (no filter is active).
-6. **Cleanup in a `finally`,** not only after a successful `postMessage`: clear
-   `restoring`, null `restore_abort`. Tying cleanup to a `finally` ensures an
-   early throw inside `send_metadata` (before `metadata` is posted) cannot strand
-   the panel in a permanent `restoring` state (finding #3). The existing
-   `try/catch` that surfaces "Failed to open .dta file" stays; the cleanup is its
-   `finally`.
+6. **Cleanup in a `finally`,** not only after a successful `postMessage`: when
+   this call still owns the active restore (`my_began && this.restore_abort ===
+   my_abort`), clear `restoring` and null `restore_abort`. The ownership guard
+   keeps a superseded call from clobbering a restore a concurrent refresh
+   started. Tying cleanup to a `finally` ensures an early throw inside
+   `send_metadata` (before `metadata` is posted) cannot strand the panel in a
+   permanent `restoring` state (finding #3). The existing `try/catch` that
+   surfaces "Failed to open .dta file" stays; the cleanup is its `finally`.
 
 `handle_message` gains a `cancelRestore` case keyed on `restore_id`:
 
 - If `msg.restore_id !== this.restore_id`, ignore (stale cancel from a previous
   lifecycle — finding #6).
-- Else if `this.restoring` is still true: `restore_cancelled = true;
-  this.restore_abort?.abort();` (the normal in-flight cancel).
+- Else if `this.restoring` is still true: `this.restore_abort?.abort();` — the
+  in-flight reads observe the aborted signal via `is_cancelled()` and take the
+  cancelled path (the normal in-flight cancel).
 - Else (the restore already completed and posted `metadata` in the cross-window
   race — finding #5): the user still asked to cancel, so honor it as an explicit
   **clear-and-forget**: reset in-memory sort/filter as in step 5, clear both
@@ -301,17 +313,28 @@ arrives.
   sort/filter couldn't be reapplied, and the persisted prefs are **retained** so
   the next reopen can retry. This is deliberately distinct from cancel
   (forget) and must not be silently conflated with it.
-- **Refresh** (`ready` received while `dta_file` is already set): `maybe_restore_*`
-  are one-shot (`sort_restored` / `filter_restored` guards), so a refresh does not
-  re-read columns; `restorePending` may still be posted but the debounce
-  suppresses the flash. The `generation` bump on refresh discards stale in-flight
-  reads, and the fresh `restore_id` (step 1) makes any crossed `cancelRestore`
-  from the prior lifecycle a no-op.
+- **Reload after a completed restore** (`ready` received while `dta_file` is
+  already set and no restore is in flight): the one-shot guards
+  (`sort_restored` / `filter_restored`) are already consumed, so
+  `maybe_begin_restore` returns early — **no** `restorePending` is posted and no
+  columns are re-read; the queued `send_metadata` simply re-sends the in-memory
+  sort/filter.
+- **Reload/refresh that interrupts an in-flight restore:** here the one-shot
+  guards are deliberately re-armed so the saved prefs *are* re-applied. The
+  `ready` branch resets `sort_restored` / `filter_restored` to `false` and
+  `refresh()` resets them as part of its full dataset reset; both then call
+  `abort_and_clear_restore()` (abort the controller, then clear `restoring` /
+  `restore_abort` / `restore_id`) *after* bumping `generation`. The bump makes
+  the abandoned restore bail before posting or forgetting (so prefs survive),
+  and the abort lets the serialized `send_metadata` chain advance at once
+  instead of waiting on the dropped read; the queued send then re-reads and
+  re-restores. The fresh `restore_id` (step 1) also makes any crossed
+  `cancelRestore` from the prior lifecycle a no-op.
 - **Late cancel after completion (finding #5):** handled by the `restore_id`
   match + clear-and-forget fallback in `handle_message`, so the user's click is
   honored rather than dropped.
 - **Cancel during the sort read, with a filter also stored:** the
-  `restore_cancelled` short-circuit (step 3) prevents the subsequent filter read;
+  `is_cancelled()` short-circuit (step 3) prevents the subsequent filter read;
   step 5's in-memory reset guarantees a sort that *did* complete before the cancel
   is also undone (finding #1).
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "author": "Jonathan Marc Bearak",
   "license": "GPL-3.0",
   "dependencies": {
-    "@jbearak/dta-parser": "^0.1.1",
+    "@jbearak/dta-parser": "^0.2.0",
     "smol-toml": "^1.6.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.11",

--- a/tests/unit/data-browser/browser-panel.test.ts
+++ b/tests/unit/data-browser/browser-panel.test.ts
@@ -11,6 +11,7 @@ import {
     describe_browser_row_count,
     describe_restore_message,
     describe_subset,
+    describe_toolbar_row_count,
     describe_visible_rows,
     get_cell_display_value,
     get_variable_header_subtitle,
@@ -137,6 +138,19 @@ describe('grid-model helpers', () => {
     it('routes missing metadata to the loading row-count label', () => {
         expect(describe_browser_row_count(null, undefined, 0, 0))
             .toBe('Loading…');
+    });
+
+    it('suppresses the toolbar row count while a restore banner shows', () => {
+        // The restore banner already explains the wait, so the bare
+        // "Loading…" must not stack above it (PullFrog finding).
+        expect(describe_toolbar_row_count(null, undefined, 0, 0, true))
+            .toBe('');
+        // No restore in flight: fall through to the normal label.
+        expect(describe_toolbar_row_count(null, undefined, 0, 0, false))
+            .toBe('Loading…');
+        expect(describe_toolbar_row_count(
+            { nobs: 1000 } as never, undefined, 0, 50, true
+        )).toBe('');
     });
 
     it('words the restore message by which prefs apply', () => {

--- a/tests/unit/data-browser/browser-panel.test.ts
+++ b/tests/unit/data-browser/browser-panel.test.ts
@@ -9,6 +9,7 @@ import {
     compute_header_width_px,
     compute_sampled_value_width_px,
     describe_browser_row_count,
+    describe_restore_message,
     describe_subset,
     describe_visible_rows,
     get_cell_display_value,
@@ -136,6 +137,15 @@ describe('grid-model helpers', () => {
     it('routes missing metadata to the loading row-count label', () => {
         expect(describe_browser_row_count(null, undefined, 0, 0))
             .toBe('Loading…');
+    });
+
+    it('words the restore message by which prefs apply', () => {
+        expect(describe_restore_message(true, true))
+            .toBe('Applying your saved sort & filter…');
+        expect(describe_restore_message(true, false))
+            .toBe('Applying your saved sort…');
+        expect(describe_restore_message(false, true))
+            .toBe('Applying your saved filter…');
     });
 
     it('exposes variable labels for header subtitles', () => {

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -179,10 +179,10 @@ describe('send_metadata restore', () => {
         // Sort restore completes (applies sort + permutation)...
         panel_like.compute_sort_permutation = async () =>
             new Uint32Array(10);
-        // ...then a cancel lands during the filter read: the abort sets
-        // restore_cancelled and the read rejects with AbortError.
+        // ...then a cancel lands during the filter read: the controller
+        // is aborted and the read rejects with AbortError.
         panel_like.compute_filter_indices = async () => {
-            panel_like.restore_cancelled = true;
+            panel_like.restore_abort?.abort();
             throw abort_error();
         };
 
@@ -226,7 +226,6 @@ describe('send_metadata restore', () => {
 
         await panel_like.send_metadata();
 
-        expect(panel_like.restore_cancelled).toBe(false);
         expect(panel_like.sort.keys.length).toBe(1);
         expect(panel_like.filter.entries.length).toBe(1);
         // Nothing forgotten.
@@ -268,12 +267,11 @@ describe('send_metadata restore', () => {
 
         await panel_like.send_metadata();
 
-        expect(panel_like.restore_failed).toBe(true);
-        // Natural order, but prefs are NOT forgotten.
+        // Natural order + warning, but prefs are NOT forgotten.
+        expect(warnings.length).toBe(1);
         expect(panel_like.sort.keys.length).toBe(0);
         expect(sort_set).toEqual([]);
         expect(filter_set).toEqual([]);
-        expect(warnings.length).toBe(1);
         const my_meta = posted.find(m => m.type === 'metadata');
         expect(my_meta.stored_sort).toBeUndefined();
     });
@@ -291,7 +289,6 @@ describe('handle_cancel_restore', () => {
             type: 'cancelRestore', restore_id: 4,
         });
 
-        expect(panel_like.restore_cancelled).toBe(false);
         expect(aborted).toBe(false);
     });
 
@@ -306,7 +303,6 @@ describe('handle_cancel_restore', () => {
             type: 'cancelRestore', restore_id: 7,
         });
 
-        expect(panel_like.restore_cancelled).toBe(true);
         expect(aborted).toBe(true);
     });
 
@@ -419,13 +415,17 @@ describe('late-cancel invalidation ordering (finding C-2)', () => {
     });
 });
 
-describe('stale restore flags do not leak across opens (code-review root cause)', () => {
+describe('stale restore state does not leak across opens (code-review root cause)', () => {
     it('a later send_metadata without a restore does not forget manual prefs', async () => {
         const { panel_like, sort_set, filter_set } =
             await make_restore_panel({ stored_sort: STORED_SORT });
-        // Simulate: a prior open was cancelled, then the user manually
-        // applied a sort, then the webview re-sends 'ready'.
-        panel_like.restore_cancelled = true;
+        // Simulate: a prior restore was cancelled (its aborted
+        // controller lingers), the user then manually applied a sort,
+        // and the webview re-sends 'ready'. The new send_metadata begins
+        // no restore (already restored), so it must read no cancel.
+        const my_stale = new AbortController();
+        my_stale.abort();
+        panel_like.restore_abort = my_stale;
         panel_like.sort_restored = true;
         panel_like.filter_restored = true;
         panel_like.sort = STORED_SORT;
@@ -437,6 +437,5 @@ describe('stale restore flags do not leak across opens (code-review root cause)'
         expect(panel_like.sort.keys.length).toBe(1);
         expect(sort_set).toEqual([]);
         expect(filter_set).toEqual([]);
-        expect(panel_like.restore_cancelled).toBe(false);
     });
 });

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -414,6 +414,25 @@ describe('handle_cancel_restore', () => {
     });
 });
 
+describe('webview reload during restore (PullFrog finding)', () => {
+    it('aborts the in-flight restore so the serialized chain can advance', async () => {
+        const { panel_like } = await make_restore_panel();
+        panel_like.restoring = true;
+        const my_ctrl = new AbortController();
+        panel_like.restore_abort = my_ctrl;
+        // Stub the queued re-send so the test isolates reload handling.
+        let resend = false;
+        panel_like.send_metadata = async () => { resend = true; };
+
+        await panel_like.handle_message({ type: 'ready' });
+
+        expect(my_ctrl.signal.aborted).toBe(true);
+        expect(panel_like.restoring).toBe(false);
+        expect(panel_like.restore_id).toBe(-1);
+        expect(resend).toBe(true);
+    });
+});
+
 describe('sort/filter ignored while restoring (round 6)', () => {
     it('handle_set_sort is a no-op while a restore is in flight', async () => {
         const { panel_like, posted } = await make_restore_panel();

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -93,6 +93,7 @@ async function make_restore_panel(opts: {
     panel_like.restoring = false;
     panel_like.restore_failed = false;
     panel_like.restore_id = -1;
+    panel_like.send_metadata_chain = Promise.resolve();
     panel_like.row_cache = { clear: () => undefined };
 
     panel_like.panel = {
@@ -255,6 +256,32 @@ describe('send_metadata restore', () => {
 
         expect(panel_like.restoring).toBe(false);
         expect(panel_like.restore_abort).toBeNull();
+    });
+
+    it('serializes send_metadata so a reload cannot start a concurrent restore', async () => {
+        const { panel_like, posted } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+        });
+        let release_first: (() => void) | null = null;
+        const my_gate = new Promise<void>(r => { release_first = r; });
+        let calls = 0;
+        panel_like.compute_sort_permutation = async () => {
+            if (calls++ === 0) await my_gate;
+            return new Uint32Array(10);
+        };
+
+        const p1 = panel_like.send_metadata();
+        const p2 = panel_like.send_metadata();
+        // Let microtasks settle; without serialization p2 would begin its
+        // own restore (and post a second restorePending) before p1 ends.
+        await Promise.resolve();
+        release_first!();
+        await Promise.all([p1, p2]);
+
+        const the_pendings = posted.filter(
+            m => m.type === 'restorePending'
+        );
+        expect(the_pendings.length).toBe(1);
     });
 
     it('real read error keeps prefs and warns (finding #7)', async () => {

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -89,9 +89,7 @@ async function make_restore_panel(opts: {
     panel_like.filter_restored = false;
     panel_like.effective_perm = null;
     panel_like.restore_abort = null;
-    panel_like.restore_cancelled = false;
     panel_like.restoring = false;
-    panel_like.restore_failed = false;
     panel_like.restore_id = -1;
     panel_like.send_metadata_chain = Promise.resolve();
     panel_like.row_cache = { clear: () => undefined };

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -25,10 +25,10 @@ import {
     type FilterState,
 } from '../../../client/src/data-browser/types';
 
-function abort_error(): Error {
-    const my_err = new Error('The read was aborted');
-    my_err.name = 'AbortError';
-    return my_err;
+// Mirror what dta-parser actually throws on abort (a DOMException, not a
+// plain Error) so the tests exercise is_abort_error's real input type.
+function abort_error(): unknown {
+    return new DOMException('The read was aborted', 'AbortError');
 }
 
 interface RestoreHarness {

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -284,6 +284,24 @@ describe('send_metadata restore', () => {
         expect(the_pendings.length).toBe(1);
     });
 
+    it('bails without posting or forgetting if generation changes mid-restore (round 4)', async () => {
+        const { panel_like, posted, sort_set } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+        });
+        // Simulate a refresh / webview-reload bumping generation while
+        // the restore column read is in flight.
+        panel_like.compute_sort_permutation = async () => {
+            panel_like.generation++;
+            return new Uint32Array(10);
+        };
+
+        await panel_like.send_metadata();
+
+        // Stale attempt: no metadata posted, prefs left intact.
+        expect(posted.some(m => m.type === 'metadata')).toBe(false);
+        expect(sort_set).toEqual([]);
+    });
+
     it('real read error keeps prefs and warns (finding #7)', async () => {
         const { panel_like, posted, sort_set, filter_set } =
             await make_restore_panel({ stored_sort: STORED_SORT });

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -433,6 +433,103 @@ describe('webview reload during restore (PullFrog finding)', () => {
     });
 });
 
+describe('refresh during restore (PullFrog finding)', () => {
+    it('aborts the in-flight restore before discarding the controller', async () => {
+        const { panel_like } = await make_restore_panel();
+        panel_like.restoring = true;
+        panel_like.restore_id = 0;
+        const my_ctrl = new AbortController();
+        panel_like.restore_abort = my_ctrl;
+        panel_like.histogram_cache = { clear: () => undefined };
+        panel_like.dta_file = { close: () => undefined };
+        // Isolate refresh handling from the full re-open.
+        let reinit = false;
+        panel_like.initialize = async () => { reinit = true; };
+
+        await panel_like.refresh(
+            { name: 'ds2', subsetted: false },
+            '/tmp/ds2.dta'
+        );
+
+        // The old read must be aborted (not just dropped) so the queued
+        // send_metadata for the new dataset is not stuck behind it.
+        expect(my_ctrl.signal.aborted).toBe(true);
+        expect(panel_like.restore_abort).toBeNull();
+        expect(panel_like.restoring).toBe(false);
+        expect(panel_like.restore_id).toBe(-1);
+        expect(reinit).toBe(true);
+    });
+});
+
+describe('restore_id consumed on user pref change (PullFrog finding)', () => {
+    it('handle_set_sort consumes restore_id so a stale late cancel cannot clear it', async () => {
+        const { panel_like, sort_set } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+        });
+        // Restore already completed; the user now applies a new sort.
+        panel_like.restoring = false;
+        panel_like.restore_id = 4;
+        panel_like.current_schema_hash = () => 'h';
+        panel_like.recompute_effective = () => undefined;
+        panel_like.post_sort_status = () => undefined;
+        panel_like.post_sort_applied = () => undefined;
+        panel_like.compute_sort_permutation =
+            async () => new Uint32Array(10);
+
+        await panel_like.handle_set_sort({
+            type: 'setSort',
+            keys: [{ col_index: 1, direction: 'desc' }],
+            labels_on: true,
+        });
+
+        // The handshake id is consumed: a delayed cancelRestore carrying
+        // the old id must no longer reach the clear-and-forget branch.
+        expect(panel_like.restore_id).toBe(-1);
+
+        const my_writes_before = sort_set.length;
+        panel_like.generation++;
+        await panel_like.handle_cancel_restore({
+            type: 'cancelRestore', restore_id: 4,
+        });
+        expect(sort_set.length).toBe(my_writes_before);
+    });
+
+    it('handle_set_filters consumes restore_id so a stale late cancel cannot clear it', async () => {
+        const { panel_like, filter_set } = await make_restore_panel({
+            stored_filter: STORED_FILTER,
+        });
+        panel_like.restoring = false;
+        panel_like.restore_id = 9;
+        panel_like.current_schema_hash = () => 'h';
+        panel_like.recompute_effective = () => undefined;
+        panel_like.post_filter_status = () => undefined;
+        panel_like.post_filter_applied = () => undefined;
+        panel_like.compute_filter_indices =
+            async () => new Uint32Array(10);
+
+        await panel_like.handle_set_filters({
+            type: 'setFilters',
+            entries: [{
+                id: 'f2',
+                col_index: 0,
+                predicate: { kind: 'isNotEmpty' },
+                enabled: true,
+                include_missing: false,
+            }],
+            labels_on: true,
+        });
+
+        expect(panel_like.restore_id).toBe(-1);
+
+        const my_writes_before = filter_set.length;
+        panel_like.generation++;
+        await panel_like.handle_cancel_restore({
+            type: 'cancelRestore', restore_id: 9,
+        });
+        expect(filter_set.length).toBe(my_writes_before);
+    });
+});
+
 describe('sort/filter ignored while restoring (round 6)', () => {
     it('handle_set_sort is a no-op while a restore is in flight', async () => {
         const { panel_like, posted } = await make_restore_panel();

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -390,6 +390,37 @@ describe('handle_cancel_restore', () => {
     });
 });
 
+describe('sort/filter ignored while restoring (round 6)', () => {
+    it('handle_set_sort is a no-op while a restore is in flight', async () => {
+        const { panel_like, posted } = await make_restore_panel();
+        panel_like.restoring = true;
+        const my_gen_before = panel_like.generation;
+
+        await panel_like.handle_set_sort({
+            type: 'setSort', keys: [{ col_index: 0, direction: 'asc' }],
+            labels_on: true,
+        });
+
+        // No generation bump, no status posted: the command was ignored
+        // so the in-flight restore can post metadata uninterrupted.
+        expect(panel_like.generation).toBe(my_gen_before);
+        expect(posted).toEqual([]);
+    });
+
+    it('handle_set_filters is a no-op while a restore is in flight', async () => {
+        const { panel_like, posted } = await make_restore_panel();
+        panel_like.restoring = true;
+        const my_gen_before = panel_like.generation;
+
+        await panel_like.handle_set_filters({
+            type: 'setFilters', entries: [], labels_on: true,
+        });
+
+        expect(panel_like.generation).toBe(my_gen_before);
+        expect(posted).toEqual([]);
+    });
+});
+
 describe('reset_restored_prefs / forget_persisted_prefs', () => {
     it('reset clears memory and consumes the id synchronously', async () => {
         const { panel_like, sort_set, filter_set } =

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -312,8 +312,10 @@ describe('send_metadata restore', () => {
 
         await panel_like.send_metadata();
 
-        // Natural order + warning, but prefs are NOT forgotten.
+        // Natural order + an accurate warning (sort only), prefs kept.
         expect(warnings.length).toBe(1);
+        expect(warnings[0]).toContain('sort');
+        expect(warnings[0]).not.toContain('filter');
         expect(panel_like.sort.keys.length).toBe(0);
         expect(sort_set).toEqual([]);
         expect(filter_set).toEqual([]);

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -349,8 +349,8 @@ describe('handle_cancel_restore', () => {
     });
 });
 
-describe('apply_cancel_forget', () => {
-    it('resets memory, clears stores, and consumes the id', async () => {
+describe('reset_restored_prefs / forget_persisted_prefs', () => {
+    it('reset clears memory and consumes the id synchronously', async () => {
         const { panel_like, sort_set, filter_set } =
             await make_restore_panel();
         panel_like.sort = STORED_SORT;
@@ -359,14 +359,84 @@ describe('apply_cancel_forget', () => {
         panel_like.filtered_indices = new Uint32Array(2);
         panel_like.restore_id = 9;
 
-        await panel_like.apply_cancel_forget('h');
+        panel_like.reset_restored_prefs();
 
         expect(panel_like.sort.keys.length).toBe(0);
         expect(panel_like.permutation).toBeNull();
         expect(panel_like.filter.entries.length).toBe(0);
         expect(panel_like.filtered_indices).toBeNull();
         expect(panel_like.restore_id).toBe(-1);
+        // No persistence writes from the synchronous reset.
+        expect(sort_set).toEqual([]);
+        expect(filter_set).toEqual([]);
+    });
+
+    it('forget writes empty state to both stores', async () => {
+        const { panel_like, sort_set, filter_set } =
+            await make_restore_panel();
+        await panel_like.forget_persisted_prefs('h');
         expect(sort_set[0].keys.length).toBe(0);
         expect(filter_set[0].entries.length).toBe(0);
+    });
+});
+
+describe('late-cancel invalidation ordering (finding C-2)', () => {
+    it('bumps generation and clears cache before awaiting persistence', async () => {
+        const { panel_like } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+        });
+        panel_like.restore_id = 2;
+        panel_like.restoring = false;
+        panel_like.sort = STORED_SORT;
+        panel_like.permutation = new Uint32Array(10);
+        panel_like.current_schema_hash = () => 'h';
+        panel_like.recompute_effective = () => undefined;
+        panel_like.post_sort_applied = () => undefined;
+        panel_like.post_filter_applied = () => undefined;
+
+        let cache_cleared_at: number | null = null;
+        let order = 0;
+        panel_like.row_cache = {
+            clear: () => { cache_cleared_at = order++; },
+        };
+        // A slow store write: generation/cache must already be
+        // invalidated by the time this is awaited.
+        let persisted_at: number | null = null;
+        panel_like.sort_state_store.set = async () => {
+            persisted_at = order++;
+        };
+
+        const my_gen_before = panel_like.generation;
+        await panel_like.handle_cancel_restore({
+            type: 'cancelRestore', restore_id: 2,
+        });
+
+        expect(panel_like.generation).toBe(my_gen_before + 1);
+        expect(cache_cleared_at).toBe(0);
+        // Persistence happened strictly after invalidation.
+        expect(persisted_at).not.toBeNull();
+        expect(persisted_at! > cache_cleared_at!).toBe(true);
+    });
+});
+
+describe('stale restore flags do not leak across opens (code-review root cause)', () => {
+    it('a later send_metadata without a restore does not forget manual prefs', async () => {
+        const { panel_like, sort_set, filter_set } =
+            await make_restore_panel({ stored_sort: STORED_SORT });
+        // Simulate: a prior open was cancelled, then the user manually
+        // applied a sort, then the webview re-sends 'ready'.
+        panel_like.restore_cancelled = true;
+        panel_like.sort_restored = true;
+        panel_like.filter_restored = true;
+        panel_like.sort = STORED_SORT;
+        panel_like.permutation = new Uint32Array(10);
+
+        await panel_like.send_metadata();
+
+        // The manually-applied sort survives; nothing forgotten.
+        expect(panel_like.sort.keys.length).toBe(1);
+        expect(sort_set).toEqual([]);
+        expect(filter_set).toEqual([]);
+        expect(panel_like.restore_cancelled).toBe(false);
     });
 });

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+
+// vscode is mocked so browser-panel can be imported headless. Includes
+// showWarningMessage (used by the real-error restore path).
+let warnings: string[] = [];
+mock.module('vscode', () => ({
+    workspace: {
+        getConfiguration: () => ({
+            get: (_key: string, default_value: unknown) => default_value,
+        }),
+    },
+    window: {
+        showErrorMessage: () => undefined,
+        showWarningMessage: (msg: string) => {
+            warnings.push(msg);
+            return undefined;
+        },
+    },
+}));
+
+import {
+    EMPTY_SORT,
+    EMPTY_FILTER,
+    type SortState,
+    type FilterState,
+} from '../../../client/src/data-browser/types';
+
+function abort_error(): Error {
+    const my_err = new Error('The read was aborted');
+    my_err.name = 'AbortError';
+    return my_err;
+}
+
+interface RestoreHarness {
+    panel_like: any;
+    posted: any[];
+    sort_set: SortState[];
+    filter_set: FilterState[];
+}
+
+const STORED_SORT: SortState = {
+    keys: [{ col_index: 0, direction: 'asc' }],
+    labels_on_when_sorted: true,
+};
+
+const STORED_FILTER: FilterState = {
+    entries: [{
+        id: 'f1',
+        col_index: 1,
+        predicate: { kind: 'isNotEmpty' },
+        enabled: true,
+        include_missing: false,
+    }],
+    labels_on_when_filtered: true,
+};
+
+async function make_restore_panel(opts: {
+    stored_sort?: SortState | undefined;
+    stored_filter?: FilterState | undefined;
+} = {}): Promise<RestoreHarness> {
+    const { DataBrowserPanel } = await import(
+        '../../../client/src/data-browser/browser-panel'
+    );
+    const posted: any[] = [];
+    const sort_set: SortState[] = [];
+    const filter_set: FilterState[] = [];
+    const panel_like: any = Object.create(DataBrowserPanel.prototype);
+
+    panel_like.dta_file = {
+        nobs: 10,
+        nvar: 2,
+        variables: [
+            { name: 'a', type: 'int', format: '%9.0g',
+                label: '', value_label_name: '' },
+            { name: 'b', type: 'str10', format: '%10s',
+                label: '', value_label_name: '' },
+        ],
+        value_label_tables: new Map(),
+    };
+    panel_like.sidecar = { name: 'ds', subsetted: false };
+    panel_like.dataset_key = 'k';
+    panel_like.dataset_key_aliases = [];
+    panel_like.generation = 0;
+    panel_like.sort = EMPTY_SORT;
+    panel_like.permutation = null;
+    panel_like.sort_restored = false;
+    panel_like.filter = EMPTY_FILTER;
+    panel_like.filtered_indices = null;
+    panel_like.filter_restored = false;
+    panel_like.effective_perm = null;
+    panel_like.restore_abort = null;
+    panel_like.restore_cancelled = false;
+    panel_like.restoring = false;
+    panel_like.restore_failed = false;
+    panel_like.restore_id = -1;
+    panel_like.row_cache = { clear: () => undefined };
+
+    panel_like.panel = {
+        webview: {
+            postMessage: (m: any) => { posted.push(m); return true; },
+        },
+    };
+    panel_like.sort_state_store = {
+        get: () => opts.stored_sort,
+        set: async (_k: string, _h: string, s: SortState) => {
+            sort_set.push(s);
+        },
+    };
+    panel_like.filter_state_store = {
+        get: () => opts.stored_filter,
+        set: async (_k: string, _h: string, f: FilterState) => {
+            filter_set.push(f);
+        },
+    };
+    panel_like.column_width_store = { get: () => undefined };
+    panel_like.column_visibility_store = { get: () => undefined };
+
+    return { panel_like, posted, sort_set, filter_set };
+}
+
+beforeEach(() => { warnings = []; });
+
+describe('maybe_begin_restore', () => {
+    it('posts restorePending and arms the restore when prefs apply', async () => {
+        const { panel_like, posted } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+            stored_filter: STORED_FILTER,
+        });
+
+        const my_began = panel_like.maybe_begin_restore('h');
+
+        expect(my_began).toBe(true);
+        expect(panel_like.restoring).toBe(true);
+        expect(panel_like.restore_abort).not.toBeNull();
+        expect(panel_like.restore_id).toBe(0);
+        expect(posted[0]).toEqual({
+            type: 'restorePending',
+            restore_id: 0,
+            sort: true,
+            filter: true,
+        });
+    });
+
+    it('does not begin when no prefs are stored', async () => {
+        const { panel_like, posted } = await make_restore_panel();
+        expect(panel_like.maybe_begin_restore('h')).toBe(false);
+        expect(panel_like.restoring).toBe(false);
+        expect(posted).toEqual([]);
+    });
+
+    it('does not begin once already restored', async () => {
+        const { panel_like, posted } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+        });
+        panel_like.sort_restored = true;
+        panel_like.filter_restored = true;
+        expect(panel_like.maybe_begin_restore('h')).toBe(false);
+        expect(posted).toEqual([]);
+    });
+
+    it('flags sort-only vs filter-only correctly', async () => {
+        const { panel_like, posted } = await make_restore_panel({
+            stored_filter: STORED_FILTER,
+        });
+        panel_like.maybe_begin_restore('h');
+        expect(posted[0].sort).toBe(false);
+        expect(posted[0].filter).toBe(true);
+    });
+});
+
+describe('send_metadata restore', () => {
+    it('completed sort + cancelled filter ends in natural order (finding #1)', async () => {
+        const { panel_like, posted, sort_set, filter_set } =
+            await make_restore_panel({
+                stored_sort: STORED_SORT,
+                stored_filter: STORED_FILTER,
+            });
+
+        // Sort restore completes (applies sort + permutation)...
+        panel_like.compute_sort_permutation = async () =>
+            new Uint32Array(10);
+        // ...then a cancel lands during the filter read: the abort sets
+        // restore_cancelled and the read rejects with AbortError.
+        panel_like.compute_filter_indices = async () => {
+            panel_like.restore_cancelled = true;
+            throw abort_error();
+        };
+
+        await panel_like.send_metadata();
+
+        // In-memory restore effects fully undone.
+        expect(panel_like.sort.keys.length).toBe(0);
+        expect(panel_like.permutation).toBeNull();
+        expect(panel_like.filter.entries.length).toBe(0);
+        expect(panel_like.filtered_indices).toBeNull();
+
+        // Persisted prefs forgotten (set with empty state).
+        expect(sort_set.length).toBe(1);
+        expect(sort_set[0].keys.length).toBe(0);
+        expect(filter_set.length).toBe(1);
+        expect(filter_set[0].entries.length).toBe(0);
+
+        // restorePending preceded metadata; metadata carries no chips.
+        expect(posted[0].type).toBe('restorePending');
+        const my_meta = posted.find(m => m.type === 'metadata');
+        expect(my_meta).toBeDefined();
+        expect(my_meta.stored_sort).toBeUndefined();
+        expect(my_meta.stored_filter).toBeUndefined();
+
+        // No spurious filterApplied, and restore state cleaned up.
+        expect(posted.some(m => m.type === 'filterApplied')).toBe(false);
+        expect(panel_like.restoring).toBe(false);
+        expect(panel_like.restore_abort).toBeNull();
+    });
+
+    it('normal completion applies and ships the saved prefs', async () => {
+        const { panel_like, posted, sort_set, filter_set } =
+            await make_restore_panel({
+                stored_sort: STORED_SORT,
+                stored_filter: STORED_FILTER,
+            });
+        panel_like.compute_sort_permutation = async () =>
+            new Uint32Array(10);
+        panel_like.compute_filter_indices = async () =>
+            new Uint32Array([0, 1, 2]);
+
+        await panel_like.send_metadata();
+
+        expect(panel_like.restore_cancelled).toBe(false);
+        expect(panel_like.sort.keys.length).toBe(1);
+        expect(panel_like.filter.entries.length).toBe(1);
+        // Nothing forgotten.
+        expect(sort_set).toEqual([]);
+        expect(filter_set).toEqual([]);
+
+        expect(posted[0].type).toBe('restorePending');
+        const my_meta = posted.find(m => m.type === 'metadata');
+        expect(my_meta.stored_sort).toEqual(STORED_SORT);
+        expect(my_meta.stored_filter).toEqual(STORED_FILTER);
+        // Active filter → effective count announced.
+        expect(posted.some(m => m.type === 'filterApplied')).toBe(true);
+    });
+
+    it('clears restoring even if it throws before metadata (finding #3)', async () => {
+        const { panel_like } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+        });
+        panel_like.compute_sort_permutation = async () =>
+            new Uint32Array(10);
+        // Throw after the restore began but before metadata is posted.
+        panel_like.recompute_effective = () => {
+            throw new Error('boom');
+        };
+
+        await panel_like.send_metadata();
+
+        expect(panel_like.restoring).toBe(false);
+        expect(panel_like.restore_abort).toBeNull();
+    });
+
+    it('real read error keeps prefs and warns (finding #7)', async () => {
+        const { panel_like, posted, sort_set, filter_set } =
+            await make_restore_panel({ stored_sort: STORED_SORT });
+        // A genuine (non-abort) failure during the sort column read.
+        panel_like.compute_sort_permutation = async () => {
+            throw new Error('decode failed');
+        };
+
+        await panel_like.send_metadata();
+
+        expect(panel_like.restore_failed).toBe(true);
+        // Natural order, but prefs are NOT forgotten.
+        expect(panel_like.sort.keys.length).toBe(0);
+        expect(sort_set).toEqual([]);
+        expect(filter_set).toEqual([]);
+        expect(warnings.length).toBe(1);
+        const my_meta = posted.find(m => m.type === 'metadata');
+        expect(my_meta.stored_sort).toBeUndefined();
+    });
+});
+
+describe('handle_cancel_restore', () => {
+    it('ignores a stale restore_id', async () => {
+        const { panel_like } = await make_restore_panel();
+        panel_like.restore_id = 5;
+        panel_like.restoring = true;
+        let aborted = false;
+        panel_like.restore_abort = { abort: () => { aborted = true; } };
+
+        await panel_like.handle_cancel_restore({
+            type: 'cancelRestore', restore_id: 4,
+        });
+
+        expect(panel_like.restore_cancelled).toBe(false);
+        expect(aborted).toBe(false);
+    });
+
+    it('aborts an in-flight restore on a matching id', async () => {
+        const { panel_like } = await make_restore_panel();
+        panel_like.restore_id = 7;
+        panel_like.restoring = true;
+        let aborted = false;
+        panel_like.restore_abort = { abort: () => { aborted = true; } };
+
+        await panel_like.handle_cancel_restore({
+            type: 'cancelRestore', restore_id: 7,
+        });
+
+        expect(panel_like.restore_cancelled).toBe(true);
+        expect(aborted).toBe(true);
+    });
+
+    it('honors a late cancel as clear-and-forget (finding #5)', async () => {
+        const { panel_like, posted, sort_set, filter_set } =
+            await make_restore_panel({
+                stored_sort: STORED_SORT,
+                stored_filter: STORED_FILTER,
+            });
+        // Restore already completed: not restoring, sort applied.
+        panel_like.restore_id = 3;
+        panel_like.restoring = false;
+        panel_like.sort = STORED_SORT;
+        panel_like.permutation = new Uint32Array(10);
+        panel_like.current_schema_hash = () => 'h';
+        panel_like.recompute_effective = () => undefined;
+        panel_like.post_sort_applied = () =>
+            posted.push({ type: 'sortApplied' });
+        panel_like.post_filter_applied = () =>
+            posted.push({ type: 'filterApplied' });
+
+        await panel_like.handle_cancel_restore({
+            type: 'cancelRestore', restore_id: 3,
+        });
+
+        expect(panel_like.sort.keys.length).toBe(0);
+        expect(panel_like.permutation).toBeNull();
+        expect(sort_set[0].keys.length).toBe(0);
+        expect(filter_set[0].entries.length).toBe(0);
+        expect(panel_like.restore_id).toBe(-1); // consumed
+        expect(posted.some(m => m.type === 'sortApplied')).toBe(true);
+        expect(posted.some(m => m.type === 'filterApplied')).toBe(true);
+
+        // A duplicate late cancel is now ignored (id consumed).
+        const my_before = sort_set.length;
+        await panel_like.handle_cancel_restore({
+            type: 'cancelRestore', restore_id: 3,
+        });
+        expect(sort_set.length).toBe(my_before);
+    });
+});
+
+describe('apply_cancel_forget', () => {
+    it('resets memory, clears stores, and consumes the id', async () => {
+        const { panel_like, sort_set, filter_set } =
+            await make_restore_panel();
+        panel_like.sort = STORED_SORT;
+        panel_like.permutation = new Uint32Array(3);
+        panel_like.filter = STORED_FILTER;
+        panel_like.filtered_indices = new Uint32Array(2);
+        panel_like.restore_id = 9;
+
+        await panel_like.apply_cancel_forget('h');
+
+        expect(panel_like.sort.keys.length).toBe(0);
+        expect(panel_like.permutation).toBeNull();
+        expect(panel_like.filter.entries.length).toBe(0);
+        expect(panel_like.filtered_indices).toBeNull();
+        expect(panel_like.restore_id).toBe(-1);
+        expect(sort_set[0].keys.length).toBe(0);
+        expect(filter_set[0].entries.length).toBe(0);
+    });
+});

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -300,6 +300,30 @@ describe('send_metadata restore', () => {
         expect(sort_set).toEqual([]);
     });
 
+    it('suppresses the failure warning when the user cancels (round 9)', async () => {
+        const { panel_like, sort_set, filter_set } =
+            await make_restore_panel({
+                stored_sort: STORED_SORT,
+                stored_filter: STORED_FILTER,
+            });
+        // Sort read genuinely fails (non-abort)...
+        panel_like.compute_sort_permutation = async () => {
+            throw new Error('decode failed');
+        };
+        // ...then the user cancels during the filter read.
+        panel_like.compute_filter_indices = async () => {
+            panel_like.restore_abort?.abort();
+            throw abort_error();
+        };
+
+        await panel_like.send_metadata();
+
+        // Cancel wins: prefs forgotten, and NO confusing failure popup.
+        expect(warnings).toEqual([]);
+        expect(sort_set[0].keys.length).toBe(0);
+        expect(filter_set[0].entries.length).toBe(0);
+    });
+
     it('real read error keeps prefs and warns (finding #7)', async () => {
         const { panel_like, posted, sort_set, filter_set } =
             await make_restore_panel({ stored_sort: STORED_SORT });


### PR DESCRIPTION
## Problem

Sight's `.dta` viewer opens instantly (virtualized grid), but on reopen it silently reapplies your remembered **sort/filter** by reading whole columns into memory — during which the toolbar showed a bare `Loading…` with no explanation and no way out. On a large file that's a confusing, uninterruptible wait.

## What this does

On reopen with saved preferences, the host now:
- posts a `restorePending` signal **before** the column reads, so the webview shows **"Applying your saved sort & filter…"** (after a 200 ms debounce, so fast files don't flash it) with a **Cancel** button — instead of a bare `Loading…`;
- reads the columns through a **cancellable, chunked** read (`@jbearak/dta-parser` 0.2.0);
- on **Cancel**, abandons the restore, **forgets** the saved sort/filter, and shows the data in natural order — with in-memory state, persistence, and chips all reset together.

Rows still only ever appear in their final order (no unsorted→sorted "jump").

## Notes

- Requires **`@jbearak/dta-parser` ^0.2.0** (adds the `{ signal, chunk_rows }` option to `read_rows`; the no-signal viewport path is byte-identical to before). Published; lockfile updated.
- Genuine (non-abort) read failures are distinguished from cancels: natural order + a notice naming only what failed, and the saved prefs are **kept** (only an explicit cancel forgets).
- A `restore_id` handshake + `send_metadata` serialization + generation guards make the restore robust against refresh / webview-reload / sort-click races (these were hardened across review).

## Design

`docs/superpowers/specs/2026-06-27-data-viewer-restore-messaging-cancel-design.md`

## Testing

`tests/unit/data-browser/restore-cancel.test.ts` (19 tests: cancel forgets + natural order, completed-sort/cancelled-filter reset, abort-vs-error, late-cancel clear-and-forget, serialization, generation-guard bail, lifecycle interrupts). Full suite: typecheck clean, 6175 pass; eslint clean.

## Review

Adversarially reviewed over multiple rounds (Codex + code-review); final pass clean from both.

https://claude.ai/code/session_01Ap5k2Q5tHt1Z5V4QM9trEN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “saved sort/filter is being reapplied” banner when reopening the Data Browser, including an inline Cancel option.
  * Improved toolbar row-count messaging during restore (suppressed while restore is pending, with clear restore-specific text).
* **Bug Fixes**
  * Made restore/cancel lifecycle reliable across reloads by using a restore-id handshake, serialized restore execution, and safe cancellation behavior.
  * Ignored conflicting user sort/filter commands during restore to prevent overwriting newer choices.
* **Tests**
  * Added unit coverage for restore/cancel flows and restore message behavior.
* **Chores**
  * Updated the underlying DTA parser dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->