### PR TITLE
ci: pin pullfrog workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -22,11 +22,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
       - name: Run agent
-        uses: pullfrog/pullfrog@v0
+        uses: pullfrog/pullfrog@3beaa0fb16f67a689055eac8df88e71024e423b2 # v0
         with:
           prompt: ${{ inputs.prompt }}
         env:


### PR DESCRIPTION
## Problem

The Pullfrog workflow failed to run:

> the actions actions/checkout@v6 and pullfrog/pullfrog@v0 are not allowed … All actions must also be pinned to a full-length commit SHA.

The repo's action policy requires every `uses:` to be pinned to a full commit SHA. Both actions are allow-listed, but the tag refs (`@v6` / `@v0`) are rejected for not being SHA-pinned.

## Fix

Pin both to the commit each tag currently points to, keeping the version as a trailing comment (matching how other workflows in this repo pin, e.g. `actions/checkout@<sha> # v5`). SHAs verified via the GitHub API (both tags resolve directly to commit objects):

- `actions/checkout` v6 → `df4cb1c069e1874edd31b4311f1884172cec0e10`
- `pullfrog/pullfrog` v0 → `3beaa0fb16f67a689055eac8df88e71024e423b2`

These are the only two `uses:` lines in the file.

Note: the file header says "DO NOT EDIT EXCEPT WHERE INDICATED" — SHA-pinning is the one change the policy forces. If Pullfrog's installer later rewrites these back to tags, they'll need re-pinning.

https://claude.ai/code/session_01Ap5k2Q5tHt1Z5V4QM9trEN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation dependencies to use fixed versions for more consistent and reliable workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->