### PR TITLE
ci: pin pullfrog workflow actions to full-length SHAs

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -22,11 +22,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
       - name: Run agent
-        uses: pullfrog/pullfrog@v0
+        uses: pullfrog/pullfrog@3beaa0fb16f67a689055eac8df88e71024e423b2 # v0
         with:
           prompt: ${{ inputs.prompt }}
         env:


### PR DESCRIPTION
The Pullfrog workflow failed to run: the jbearak account requires GitHub Actions to be pinned to a full-length commit SHA, and the installer wrote tag refs (`actions/checkout@v6`, `pullfrog/pullfrog@v0`), which are rejected.

Pins both to the SHAs their tags currently point to, version preserved as a trailing comment:

- `actions/checkout` → `df4cb1c…` (v6)
- `pullfrog/pullfrog` → `3beaa0f…` (v0)

Note: re-running the Pullfrog installer may rewrite these back to tags; re-pin if so.

https://claude.ai/code/session_01Ap5k2Q5tHt1Z5V4QM9trEN