### PR TITLE
Fix polynomial-ReDoS CodeQL alerts in regex-based parsing

### DIFF
--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -2831,14 +2831,20 @@ export class SemanticAnalyzer {
         const macro_refs: string[] = [];
         
         // Match local macro references: `name'
-        const local_pattern = /`([^']+)'/g;
+        // Exclude backtick from the name class so the scanner restarts at each
+        // backtick without overlap (avoids polynomial ReDoS); macro names
+        // cannot contain a backtick anyway.
+        const local_pattern = /`([^'`]+)'/g;
         let match;
         while ((match = local_pattern.exec(args)) !== null) {
             macro_refs.push(match[1]);
         }
         
         // Match global macro references: $name or ${name}
-        const global_pattern = /\$\{([^}]+)\}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
+        // Exclude '{' from the braced-name class so the scanner restarts at
+        // each '${' without overlap (avoids polynomial ReDoS); macro names
+        // cannot contain a brace.
+        const global_pattern = /\$\{([^{}]+)\}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
         while ((match = global_pattern.exec(args)) !== null) {
             macro_refs.push(match[1] || match[2]);
         }

--- a/src/comment-processor/comment-analysis.ts
+++ b/src/comment-processor/comment-analysis.ts
@@ -191,6 +191,36 @@ export function get_language_context(
 }
 
 /**
+ * Detects a Markdown link `[text](url)` in linear time.
+ *
+ * Exactly equivalent to the prior regex `/\[.+\]\(.+\)/` (which CodeQL flagged
+ * as polynomial ReDoS because of its two unbounded `.+` runs), without the
+ * backtracking: a match exists iff some line holds a `](` with a `[` at least
+ * one character earlier and a `)` at least one character later — `.` in the old
+ * regex never crossed a line terminator, so each link lives on a single line.
+ * We split on the full set of characters `.` excludes (LF, CR, LS, PS) to
+ * preserve that boundary exactly. Scanning with `indexOf`/`lastIndexOf` is O(n).
+ */
+const JS_LINE_TERMINATORS = /[\n\r\u2028\u2029]/;
+
+function contains_markdown_link(content: string): boolean {
+  for (const my_line of content.split(JS_LINE_TERMINATORS)) {
+    const my_first_bracket = my_line.indexOf('[');
+    if (my_first_bracket === -1) continue;
+    const my_last_close_paren = my_line.lastIndexOf(')');
+    if (my_last_close_paren === -1) continue;
+
+    // The `](` must sit at least one char after the first `[` (the `[...]`
+    // run) and at least one char before the last `)` (the `(...)` run).
+    const my_sep = my_line.indexOf('](', my_first_bracket + 2);
+    if (my_sep !== -1 && my_sep + 3 <= my_last_close_paren) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Detects if a comment contains Markdown syntax.
  *
  * @param content - The comment content
@@ -208,7 +238,6 @@ export function contains_markdown(content: string): boolean {
     /__[^_]+__/,         // Bold (alt)
     /\*[^\*]+\*/,        // Italic
     /_[^_]+_/,           // Italic (alt)
-    /\[.+\]\(.+\)/,      // Links
   ];
 
   for (const pattern of markdown_patterns) {
@@ -217,7 +246,8 @@ export function contains_markdown(content: string): boolean {
     }
   }
 
-  return false;
+  // Links — handled in code (see contains_markdown_link) to avoid ReDoS.
+  return contains_markdown_link(content);
 }
 
 /**

--- a/src/providers/section-detector.ts
+++ b/src/providers/section-detector.ts
@@ -38,15 +38,21 @@ export interface RawSection {
 
 const DELIMITER_CHARS = new Set(['*', '-', '=', '+', '/', '#']);
 
-// Single-line section patterns:
+// Single-line section patterns. These capture only the comment marker and the
+// body (from the first non-space char to end-of-line); the trailing delimiter
+// is split off in code by `split_trailing_delimiter`. The earlier single-regex
+// form (`(\S.*?)\s+(-{4,}|...)\s*$`) was rejected by CodeQL as polynomial ReDoS
+// because the lazy `.*?` and the surrounding `\s+` can both match the separating
+// whitespace. These body patterns have no two overlapping repetitions.
+//
 // Slash-style: // Section Name ---- (delimiter: 4+ of - = * +)
-const SLASH_SECTION_PATTERN = /^\s*\/\/\s+(\S.*?)\s+(-{4,}|={4,}|\*{4,}|\+{4,})\s*$/;
+const SLASH_SECTION_BODY_PATTERN = /^\s*\/\/\s+(\S.*)$/;
 
 // Star-style: * Section Name ---- (delimiter: 4+ of - = +, NOT * to avoid starred inline ambiguity)
-const STAR_SECTION_PATTERN = /^\s*\*\s+(\S.*?)\s+(-{4,}|={4,}|\+{4,})\s*$/;
+const STAR_SECTION_BODY_PATTERN = /^\s*\*\s+(\S.*)$/;
 
-// Starred inline: ** Section Name ** or *** Section Name ***
-const STARRED_INLINE_PATTERN = /^\s*(\*{2,})\s+(\S.*?)\s+(\*{2,})\s*$/;
+// Starred inline: ** Section Name ** or *** Section Name *** (delimiter: 2+ *)
+const STARRED_INLINE_BODY_PATTERN = /^\s*(\*{2,})\s+(\S.*)$/;
 
 // Numbered section: * 1. Name, // 1.1 Name, * 1.1.1 Name
 const NUMBERED_SECTION_PATTERN = /^\s*(?:\*|\/\/)\s+(\d+(?:\.\d+)*\.?)\s+(\S.*)$/;
@@ -76,6 +82,77 @@ export function is_delimiter_only(s: string): boolean {
         }
     }
     return true;
+}
+
+/**
+ * Whitespace test matching the regex `\s` class, for a single character.
+ * Using `/\s/.test(c)` on one char is linear and carries no ReDoS risk.
+ */
+function is_whitespace(c: string): boolean {
+    return /\s/.test(c);
+}
+
+/**
+ * Remove trailing characters matching `is_strip_char` from `text`.
+ *
+ * Linear-time replacement for `text.replace(/[...]+$/, '')`. CodeQL flags the
+ * unanchored trailing-character-class form as polynomial ReDoS because the
+ * engine retries the run from every start position; scanning from the end is
+ * O(n) and behaves identically.
+ */
+function strip_trailing(
+    text: string,
+    is_strip_char: (c: string) => boolean
+): string {
+    let my_end = text.length;
+    while (my_end > 0 && is_strip_char(text[my_end - 1])) {
+        my_end--;
+    }
+    return text.substring(0, my_end);
+}
+
+/**
+ * Given a comment body (already stripped of its comment marker and leading
+ * whitespace, so it begins with a non-space character), detect a trailing
+ * section delimiter of the form `<name> <run>`, where `<run>` is `min_run`+
+ * repetitions of a single character drawn from `allowed_delims`, separated
+ * from the name by whitespace and optionally followed by trailing whitespace.
+ *
+ * Returns the trimmed name, or null if the body does not end in such a
+ * delimiter. This replaces a regex of the form `(\S.*?)\s+(-{4,}|...)\s*$`
+ * whose lazy `.*?` and surrounding `\s+` overlap (both can match the
+ * separating whitespace), which CodeQL flags as polynomial ReDoS. The manual
+ * scan is linear.
+ */
+function split_trailing_delimiter(
+    body: string,
+    allowed_delims: string,
+    min_run: number
+): string | null {
+    // Skip trailing whitespace (the regex's `\s*$`).
+    let my_end = body.length;
+    while (my_end > 0 && is_whitespace(body[my_end - 1])) {
+        my_end--;
+    }
+    if (my_end === 0) return null;
+
+    // Measure the trailing run of a single delimiter character.
+    const my_delim_char = body[my_end - 1];
+    if (!allowed_delims.includes(my_delim_char)) return null;
+    let my_run_start = my_end;
+    while (my_run_start > 0 && body[my_run_start - 1] === my_delim_char) {
+        my_run_start--;
+    }
+    if (my_end - my_run_start < min_run) return null;
+
+    // The run must be separated from the name by whitespace (the regex's
+    // `\s+`), and a non-empty name must precede that whitespace.
+    if (my_run_start === 0 || !is_whitespace(body[my_run_start - 1])) {
+        return null;
+    }
+    const my_name = body.substring(0, my_run_start).trim();
+    if (my_name.length === 0) return null;
+    return my_name;
 }
 
 /**
@@ -393,7 +470,10 @@ export function extract_banner_name(line: string): string | null {
     my_text = my_text.replace(/^[\s*\-=+/#]+/, '');
 
     // Strip trailing delimiter chars and whitespace
-    my_text = my_text.replace(/[\s*\-=+/#]+$/, '');
+    my_text = strip_trailing(
+        my_text,
+        c => is_whitespace(c) || '*-=+/#'.includes(c)
+    );
 
     // Trim again
     my_text = my_text.trim();
@@ -425,7 +505,7 @@ export function extract_block_comment_heading(line: string): string | null {
     my_text = my_text.replace(/^[\s*]+/, '');
 
     // Strip trailing asterisks and whitespace
-    my_text = my_text.replace(/[\s*]+$/, '');
+    my_text = strip_trailing(my_text, c => is_whitespace(c) || c === '*');
 
     // Trim again
     my_text = my_text.trim();
@@ -512,15 +592,21 @@ function detect_single_line_sections(
     for (let my_line_num = 0; my_line_num < my_total_lines; my_line_num++) {
         const my_line = get_line(content, line_offsets, my_line_num);
 
-        // Try slash-style first
-        let my_match = my_line.match(SLASH_SECTION_PATTERN);
-        if (!my_match) {
-            // Try star-style
-            my_match = my_line.match(STAR_SECTION_PATTERN);
+        // Try slash-style first, then star-style. Each captures the comment
+        // body; the trailing delimiter is split off in code.
+        let my_name: string | null = null;
+        const my_slash = my_line.match(SLASH_SECTION_BODY_PATTERN);
+        if (my_slash) {
+            my_name = split_trailing_delimiter(my_slash[1], '-=*+', 4);
+        }
+        if (my_name === null) {
+            const my_star = my_line.match(STAR_SECTION_BODY_PATTERN);
+            if (my_star) {
+                my_name = split_trailing_delimiter(my_star[1], '-=+', 4);
+            }
         }
 
-        if (my_match) {
-            const my_name = my_match[1].trim();
+        if (my_name !== null) {
             if (is_delimiter_only(my_name)) continue;
 
             const my_line_length = my_line.length;
@@ -668,10 +754,13 @@ function detect_starred_inline_sections(
         if (consumed_lines.has(my_line_num)) continue;
 
         const my_line = get_line(content, line_offsets, my_line_num);
-        const my_match = my_line.match(STARRED_INLINE_PATTERN);
+        const my_match = my_line.match(STARRED_INLINE_BODY_PATTERN);
         if (!my_match) continue;
 
-        const my_name = my_match[2].trim();
+        // my_match[2] is the body after the opening `**`; the closing `**` is
+        // split off in code (delimiter: 2+ asterisks).
+        const my_name = split_trailing_delimiter(my_match[2], '*', 2);
+        if (my_name === null) continue;
         if (is_delimiter_only(my_name)) continue;
 
         const my_line_length = my_line.length;

--- a/tests/unit/redos-regression.test.ts
+++ b/tests/unit/redos-regression.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Regression tests for the CodeQL `js/polynomial-redos` fixes.
+ *
+ * Each test pairs (a) a behavior check that the rewritten matcher still
+ * recognizes the same inputs it did before, with (b) a worst-case timing check
+ * proving the matcher no longer degrades to polynomial time. The pathological
+ * strings mirror the witnesses CodeQL reported for each alert. A vulnerable
+ * (O(n^2)) implementation would take many seconds on these ~100k-char inputs;
+ * the linear replacements finish in milliseconds, so the generous 1s bound is
+ * safe against CI jitter while still failing loudly on a regression.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+    extract_sections,
+    extract_banner_name,
+    extract_block_comment_heading,
+} from '../../src/providers/section-detector';
+import { contains_markdown } from '../../src/comment-processor/comment-analysis';
+import { SemanticAnalyzer } from '../../src/analyzer';
+import { compute_line_offsets } from '../../src/utils/line-utils';
+
+const TIME_BUDGET_MS = 1000;
+const PUMP = 100_000;
+
+function elapsed_ms(fn: () => void): number {
+    const my_start = performance.now();
+    fn();
+    return performance.now() - my_start;
+}
+
+function section_names(content: string): string[] {
+    const my_offsets = compute_line_offsets(content);
+    return extract_sections(content, my_offsets).map(s => s.name);
+}
+
+describe('ReDoS regression: section-detector single-line patterns', () => {
+    it('still detects slash-, star-, and starred-inline sections', () => {
+        expect(section_names('// Data prep ----')).toEqual(['Data prep']);
+        expect(section_names('* Data prep ====')).toEqual(['Data prep']);
+        expect(section_names('** Data prep **')).toEqual(['Data prep']);
+        expect(section_names('*** Data prep ***')).toEqual(['Data prep']);
+        // Names containing internal delimiter-like text are preserved.
+        expect(section_names('// a -- b ====')).toEqual(['a -- b']);
+    });
+
+    it('still rejects lines without a valid trailing delimiter', () => {
+        // Fewer than 4 delimiter chars, or no whitespace separator.
+        expect(section_names('// not a section ---')).toEqual([]);
+        expect(section_names('// ----')).toEqual([]);
+        expect(section_names('* just a comment')).toEqual([]);
+    });
+
+    it('handles whitespace-heavy pathological lines in linear time', () => {
+        // Witness: "// !" then many spaces, never reaching a delimiter.
+        const my_slash = '// !' + ' '.repeat(PUMP);
+        const my_star = '* !' + ' '.repeat(PUMP);
+        const my_starred = '** !' + ' '.repeat(PUMP);
+        const my_ms = elapsed_ms(() => {
+            section_names(my_slash);
+            section_names(my_star);
+            section_names(my_starred);
+        });
+        expect(my_ms).toBeLessThan(TIME_BUDGET_MS);
+    });
+});
+
+describe('ReDoS regression: section-detector trailing-strip helpers', () => {
+    it('still strips trailing delimiter/whitespace from banner names', () => {
+        expect(extract_banner_name('* Methods ====')).toBe('Methods');
+        expect(extract_banner_name('// === Results === ')).toBe('Results');
+        expect(extract_block_comment_heading(' * Overview ** ')).toBe('Overview');
+    });
+
+    it('handles long trailing delimiter runs in linear time', () => {
+        // The callers `.trim()` first, so a whitespace pump never reaches the
+        // trailing-strip helper; delimiter chars (`=`, `*`) survive trim and do
+        // exercise `strip_trailing`'s scan.
+        const my_banner = '* Methods ' + '='.repeat(PUMP);
+        const my_heading = ' * Overview ' + '*'.repeat(PUMP);
+        let my_banner_name: string | null = null;
+        let my_heading_name: string | null = null;
+        const my_ms = elapsed_ms(() => {
+            my_banner_name = extract_banner_name(my_banner);
+            my_heading_name = extract_block_comment_heading(my_heading);
+        });
+        expect(my_ms).toBeLessThan(TIME_BUDGET_MS);
+        // And the long run is still stripped down to the heading text.
+        expect(my_banner_name).toBe('Methods');
+        expect(my_heading_name).toBe('Overview');
+    });
+});
+
+describe('ReDoS regression: markdown link detection', () => {
+    // The link check is exactly equivalent to the old `/\[.+\]\(.+\)/`; these
+    // cases pin that equivalence (a `[`, then `](`, then `)` on one line).
+    it('still detects markdown links and non-links', () => {
+        expect(contains_markdown('see [docs](http://x)')).toBe(true);
+        expect(contains_markdown('q [docs](http://x?a=1&b=2)')).toBe(true);
+        // URLs with nested parens and bracketed link text match, as the old
+        // greedy `.+` regex did.
+        expect(contains_markdown('[wiki](https://en.wikipedia.org/wiki/Foo_(bar))'))
+            .toBe(true);
+        expect(contains_markdown('[a [b]](url)')).toBe(true);
+        expect(contains_markdown('plain text only')).toBe(false);
+        // Like the old regex: empty text/URL and links spanning any JS line
+        // terminator do not count (each `.+` needs >=1 char and `.` never
+        // crosses LF, CR, LS, or PS).
+        expect(contains_markdown('[x]()')).toBe(false);
+        expect(contains_markdown('[]( )')).toBe(false);
+        expect(contains_markdown('[x](a\nb)')).toBe(false);
+        expect(contains_markdown('[a](b\rc)')).toBe(false);
+        expect(contains_markdown('[a](b\u2028c)')).toBe(false);
+        // A space (not a line terminator) is a valid `.`, so this is a link.
+        expect(contains_markdown('[a]( )')).toBe(true);
+    });
+
+    it('handles the "[a](" repetition witness in linear time', () => {
+        // Many "](" with no closing ')' — the pump that made the old
+        // `\[.+\]\(.+\)` backtrack. It is not a link (no ')'), so detection is
+        // correctly negative; the point is that it resolves in linear time.
+        const my_content = '[a](' + 'a]('.repeat(PUMP);
+        let my_result = true;
+        const my_ms = elapsed_ms(() => {
+            my_result = contains_markdown(my_content);
+        });
+        expect(my_ms).toBeLessThan(TIME_BUDGET_MS);
+        expect(my_result).toBe(false);
+    });
+});
+
+describe('ReDoS regression: analyzer macro-reference extraction', () => {
+    const analyzer = new SemanticAnalyzer();
+
+    it('still extracts local and global macro references', () => {
+        expect(analyzer.extract_macro_refs_from_extended_args("`a' + `b'"))
+            .toEqual(['a', 'b']);
+        expect(analyzer.extract_macro_refs_from_extended_args('${x} + $y'))
+            .toEqual(['x', 'y']);
+    });
+
+    it('handles unterminated local/global witnesses in linear time', () => {
+        // Witness 24: backtick then many non-quote chars, no closing quote.
+        // Each backtick is a candidate start; the old `[^']+` overlapped across
+        // them, the new `[^'`]+` cannot.
+        const my_local = '`' + '`&'.repeat(PUMP);
+        // Witness 25: many "${" with no closing brace. The old `[^}]+` spanned
+        // every "${" from each start (O(n^2)); the new `[^{}]+` stops at the
+        // next "{".
+        const my_global = '${'.repeat(PUMP);
+        const my_ms = elapsed_ms(() => {
+            analyzer.extract_macro_refs_from_extended_args(my_local);
+            analyzer.extract_macro_refs_from_extended_args(my_global);
+        });
+        expect(my_ms).toBeLessThan(TIME_BUDGET_MS);
+    });
+});


### PR DESCRIPTION
## Summary

Resolves all 8 open `js/polynomial-redos` code-scanning alerts (#23–25, #28–32) by replacing ReDoS-prone regexes with linear equivalents, preserving behavior.

| File | Old (ReDoS) | New (linear) |
|---|---|---|
| `src/providers/section-detector.ts` | 3 section patterns `(\S.*?)\s+(-{4,}\|…)\s*$` — lazy `.*?` overlaps the surrounding `\s+` on the separator whitespace | body-capture regex + `split_trailing_delimiter` code helper |
| `src/providers/section-detector.ts` | 2 trailing-strip regexes `[…]+$` | `strip_trailing` code helper |
| `src/analyzer/index.ts` | `` `[^']+' `` and `${[^}]+}` — scanner restarts overlap | narrowed to `` `[^'`]+' `` and `${[^{}]+}` (macro names can't contain `` ` ``/`{`/`}`) |
| `src/comment-processor/comment-analysis.ts` | markdown link `\[.+\]\(.+\)` — two unbounded `.+` | `contains_markdown_link`, an O(n) `indexOf`/`lastIndexOf` scan |

## Behavior preservation

- Section detection: delimiter sets (`-=*+`/min 4, `-=+`/min 4, `*`/min 2) and matching semantics unchanged; covered by the existing section-detector unit + property suites.
- `contains_markdown_link` is **exactly** equivalent to the old `/\[.+\]\(.+\)/` — verified by a differential fuzz of **1,000,005** cases (including all four JS line terminators `.` excludes: LF, CR, U+2028, U+2029) with zero mismatches.
- The analyzer class-narrowing changes behavior only for inputs with a backtick/brace *inside* a macro name, which is not valid Stata.

## Tests

Adds `tests/unit/redos-regression.test.ts` — for each fix, asserts both behavior and linear-time completion on the CodeQL witness inputs. Full suite (`bun run test`) and `bun run lint` are green.

## Verification

Reviewed by Codex and `/code-review` — each passed two consecutive clean rounds on the final diff (no correctness findings).

https://claude.ai/code/session_015kDa8gED6XrFSVnvcozTWd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Markdown links, section headers, and macro references to avoid slowdowns on large or tricky input.
  * Preserved existing matching behavior while making parsing more reliable for edge cases like long delimiters, braces, and line breaks.

* **Tests**
  * Added regression coverage to verify the updated parsing stays fast and continues recognizing the same content formats correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->