### PR TITLE
fix(data-browser): clarify skip-restore affordance

### DIFF
--- a/client/src/data-browser/webview/app.tsx
+++ b/client/src/data-browser/webview/app.tsx
@@ -819,7 +819,7 @@ export function App(): ReactElement {
     // sort/filter preferences are reapplied.
     const restore_message = restore_pending
         ? (restore_cancelling
-            ? 'Cancelling…'
+            ? 'Loading…'
             : describe_restore_message(
                 restore_pending.sort,
                 restore_pending.filter
@@ -1155,10 +1155,10 @@ export function App(): ReactElement {
                     {!restore_cancelling && (
                         <button
                             type="button"
-                            className="restore-cancel"
+                            className="restore-skip"
                             onClick={cancel_restore}
                         >
-                            Cancel
+                            Skip and show data now
                         </button>
                     )}
                 </div>

--- a/client/src/data-browser/webview/styles.css
+++ b/client/src/data-browser/webview/styles.css
@@ -74,9 +74,13 @@ body,
 /* Saved sort/filter is being reapplied on open: explains the wait and
    offers a Cancel that abandons it and shows the data unsorted. */
 .toolbar-restore {
+    /* Stack the message and the skip link so the link reads as the
+       message's own follow-up action rather than a detached control
+       floating at the far right of the row. */
     display: flex;
-    align-items: center;
-    gap: 8px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
     padding: 4px 8px;
     border-bottom: 1px solid var(--vscode-panel-border);
     background: var(--vscode-editorGroupHeader-tabsBackground, var(--vscode-editor-background));
@@ -84,34 +88,33 @@ body,
     /* Like `.toolbar`, this is a flex item in the column-flex
        `.browser-root`; `min-width: 0` lets the row shrink to the viewport
        so the message truncates (see the span rule below) instead of the
-       row growing to its content width and clipping the Cancel button. */
+       row growing to its content width. */
     min-width: 0;
 }
 
 .toolbar-restore > span {
-    /* Allow the message to shrink so ellipsis applies in narrow panels;
-       a flex item defaults to min-width:auto and would otherwise overflow
-       and push the Cancel button off-screen. */
-    flex: 1 1 auto;
-    min-width: 0;
+    /* Cap the message to the panel width so a long explanation ellipsizes
+       rather than forcing the banner wider than the viewport. */
+    max-width: 100%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
-.restore-cancel {
-    flex: 0 0 auto;
-    padding: 1px 8px;
+.restore-skip {
+    /* Styled as a link, not a button: it's a low-stakes alternative to
+       waiting, and a link sits naturally beneath the message it modifies. */
+    padding: 0;
     font-size: 12px;
-    color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
-    background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+    color: var(--vscode-textLink-foreground);
+    background: none;
     border: none;
-    border-radius: 2px;
+    text-decoration: underline;
     cursor: pointer;
 }
 
-.restore-cancel:hover {
-    background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+.restore-skip:hover {
+    color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
 }
 
 /* Sort + filter chip strips. Sits between the row count and the action

--- a/client/src/data-browser/webview/styles.css
+++ b/client/src/data-browser/webview/styles.css
@@ -72,7 +72,8 @@ body,
 }
 
 /* Saved sort/filter is being reapplied on open: explains the wait and
-   offers a Cancel that abandons it and shows the data unsorted. */
+   offers a "Skip and show data now" link that abandons the reapply and
+   loads the data immediately. */
 .toolbar-restore {
     /* Stack the message and the skip link so the link reads as the
        message's own follow-up action rather than a detached control
@@ -93,8 +94,8 @@ body,
 }
 
 .toolbar-restore > span {
-    /* Cap the message to the panel width so a long explanation ellipsizes
-       rather than forcing the banner wider than the viewport. */
+    /* Cap the message to the panel width so a long explanation
+       ellipsizes instead of widening the banner past the viewport. */
     max-width: 100%;
     white-space: nowrap;
     overflow: hidden;
@@ -102,11 +103,14 @@ body,
 }
 
 .restore-skip {
-    /* Styled as a link, not a button: it's a low-stakes alternative to
-       waiting, and a link sits naturally beneath the message it modifies. */
+    /* Styled as a link, not a button: a low-stakes alternative to
+       waiting that sits naturally beneath the message it modifies.
+       Underlined at rest (unlike `.popover-action-btn`, which underlines
+       only on hover) because it is the banner's primary affordance and
+       must read as clickable without hovering. */
     padding: 0;
     font-size: 12px;
-    color: var(--vscode-textLink-foreground);
+    color: var(--vscode-textLink-foreground, inherit);
     background: none;
     border: none;
     text-decoration: underline;
@@ -114,7 +118,7 @@ body,
 }
 
 .restore-skip:hover {
-    color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+    color: var(--vscode-textLink-activeForeground, inherit);
 }
 
 /* Sort + filter chip strips. Sits between the row count and the action
@@ -844,7 +848,8 @@ body,
 .filter-chip-body:focus-visible,
 .filter-chip-kebab:focus-visible,
 .filter-strip-clear:focus-visible,
-.filter-popover-btn:focus-visible {
+.filter-popover-btn:focus-visible,
+.restore-skip:focus-visible {
     outline: 1px solid var(--vscode-focusBorder, #007fd4);
     outline-offset: 1px;
 }


### PR DESCRIPTION
## Problem

A user who had already installed `vview` (under the older, vview-only
extension) was re-prompted to install **vview and browse** as though
vview were not installed. This is confusing.

## Root cause

`vview.ado` is already up-to-date on disk, but the new `browse.ado` +
abbreviation ados (`brows`/`brow`/`bro`/`br`) are missing, so the bundle
aggregate state is `missing` and the install flow prompts. The fresh
consent is intentional (the `browse` alias takes over a CLI built-in
name, gated behind a new permission key), but the prompt copy was static
and always named `vview` as if it were a new install. The install
**logic** was already correct — it leaves the up-to-date `vview.ado`
alone and only writes the missing alias files; only the wording was off.

## Fix

- Add `build_install_prompt_message(status)` (pure, unit-tested) that
  tailors the consent copy to on-disk state:
  - When `vview.ado` is already current, frame the prompt around the
    console `browse` alias rather than re-offering vview.
  - Otherwise, offer the full `vview` + `browse` bundle.
- The action verb (**add** / **update** / **add or update**) is derived
  from the pending asset states, so an in-place update of an existing
  alias is never described as a fresh add.
- The abbreviation display list is derived from `ADO_ASSET_DEFS`, so the
  prompt copy can never name a different set than what installs.
- The `prompt_for_install` hook now receives the full
  `BundleInstallStatus` (was just `target_dir`); all call sites updated.

## Review

Both an inline workflow `/code-review` (high effort) and a Codex review
ran on the diff. Both confirmed the targeted bug is fixed with no
regressions; their quality findings (verb accuracy, `my_` naming
convention, canonical alias list) are all addressed here.

## Tests

`tests/unit/data-browser/vview-install.test.ts`: prompt copy for the
already-installed / fresh / outdated-alias / outdated-vview cases, the
canonical abbreviation list, and an orchestration assertion that the
hook receives the full status. `bun run typecheck` and the full
data-browser suite pass; CI green on `workflow_dispatch`.
