### PR TITLE
Audit hub-heavy forward-call traversal; surface cap truncation (#209)

### DIFF
--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -713,10 +713,16 @@ project therefore never *fails* `sight check` merely because it reached a depth
 cap — even under a strict `--max-severity`. The text report adds a dedicated
 summary line, e.g.:
 
-```
+```text
 3 cross-file traversal truncations (depth cap reached — results may be
 incomplete; not undefined-symbol errors)
 ```
+
+Truncation diagnostics honor the `crossFile.diagnostics.maxDepth` setting like
+the other depth diagnostics: it sets their severity, and **`maxDepth = "off"`
+suppresses them entirely** (no `CROSS_FILE_TRUNCATED` diagnostic is emitted).
+The caps themselves still apply — resolution still stops at the cap — you just
+opt out of being told about it.
 
 If you see truncations, either the graph is legitimately deeper than the default
 caps (raise `maxBackwardDepth` / `maxForwardDepth` / `maxChainDepth`) or there is

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -689,6 +689,80 @@ via the `crossFile.diagnostics.callSiteIdentification` setting:
 Note: The `included-by` with `do`/`run` mismatch warning cannot be suppressed
 as it indicates a semantic issue that affects symbol inheritance.
 
+## Traversal Depth Limits and Truncation
+
+Cross-file resolution is bounded by three caps (see
+[Configuration](#configuration)): `maxBackwardDepth` (10), `maxForwardDepth`
+(10), and `maxChainDepth` (20). When a workspace's `do`/`run`/`include` graph is
+deep or dense enough to hit one of these caps, the LSP **stops walking** at that
+point and emits a *truncation* diagnostic.
+
+A truncation means "resolution was cut short here, so some cross-file symbols may
+be missing" — it is **not** a genuine error, and it is distinct from an
+undefined-symbol diagnostic. All three depth-cap diagnostics carry the stable
+code **`7002` (`CROSS_FILE_TRUNCATED`)**:
+
+- *Maximum backward directive depth (N) exceeded*
+- *Maximum forward resolution depth (N) exceeded*
+- *Maximum combined resolution depth (N) exceeded when resolving parent forward
+  calls*
+
+In `sight check`, truncations are surfaced like any other diagnostic but are
+**excluded from the pass/fail tally by code** (not by severity). A deep-but-valid
+project therefore never *fails* `sight check` merely because it reached a depth
+cap — even under a strict `--max-severity`. The text report adds a dedicated
+summary line, e.g.:
+
+```
+3 cross-file traversal truncations (depth cap reached — results may be
+incomplete; not undefined-symbol errors)
+```
+
+If you see truncations, either the graph is legitimately deeper than the default
+caps (raise `maxBackwardDepth` / `maxForwardDepth` / `maxChainDepth`) or there is
+an unintended cycle/fan-out worth investigating. Undefined-symbol warnings for
+symbols that were never reached because of a truncation still fire — the summary
+line tells you *why* a symbol may be unresolved.
+
+## Forward-Closure Caching Semantics
+
+A file's **forward-call closure** is the set of symbols and call sites produced
+by following its `do`/`run`/`include` chain. The LSP's design treats this closure
+as a pure function of the file and its resolution context — **caller-independent**
+by construction. Concretely, the closure depends only on:
+
+- the callee file's content,
+- the **effective call type** it is entered under (`do`/`run` vs `include`,
+  which governs local-macro propagation),
+- the **working directory** in force (which resolves the callee's relative
+  `do`/`run`/`include` paths),
+- the forward **depth budget** (raw depth + `maxForwardDepth`), and
+- the dependency-graph version.
+
+The *identity of the calling file* never varies the closure. Backward-walk state
+and parent forward-call resolution are kept isolated (the parent's forward walk
+runs against a *copy* of the backward `visited` set and a *fresh* forward visited
+map), so an earlier-sourced sibling's symbols are always visible to a later
+sibling in execution order — see
+`tests/integration/hub-heavy-sibling-visibility.test.ts`.
+
+**Interaction with a future per-file standalone opt-out.** A planned
+`@lsp-standalone` directive would let a file resolve its own diagnostics as if it
+had no parents (a *backward* concern). It does **not** introduce caller-dependence
+into the *forward* closure: standalone can change the file's *inherited working
+directory* and the *effective call type* it is entered under, but both are inputs
+the closure already depends on (and would key on, were the closure cached).
+Standalone introduces no other forward-closure variation, and never caller
+identity. This is the assumption a caller-independent forward-closure cache relies
+on; it is enforced by the memo correctness gate
+(`tests/integration/forward-closure-memo-gate.test.ts`), which checks that a
+file's forward closure is identical across distinct callers given the same inputs.
+
+> Implementation status: the cache *key contract* and an enable/disable toggle
+> (`set_forward_closure_memo_enabled`, default **off**) are in place; the cache
+> store/serve path is deferred to a follow-up. The toggle is a behavioral no-op
+> until then, guarded by the on/off correctness gate.
+
 ## Configuration
 
 Cross-file resolution is configured via `sight.toml` in your project root.

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -39,6 +39,7 @@ import {
     OutputFormat,
     SeverityLevel,
     diagnostic_exceeds_threshold,
+    is_truncation_diagnostic,
     error_message,
     parse_color_choice,
     parse_output_format,
@@ -746,6 +747,7 @@ export async function run_check_with_cwd(
             target_result.targets
         );
         const any_failure = diagnostics.some((record) =>
+            !is_truncation_diagnostic(record.diagnostic) &&
             diagnostic_exceeds_threshold(
                 record.diagnostic,
                 result.args.max_severity

--- a/src/cli/shared.ts
+++ b/src/cli/shared.ts
@@ -1,6 +1,7 @@
 import { stdout } from 'process';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { error_message } from '../utils/error-message';
+import { StataDiagnosticCode } from '../types';
 
 export { error_message };
 
@@ -96,6 +97,14 @@ export function diagnostic_exceeds_threshold(
     max_severity: SeverityLevel
 ): boolean {
     return severity_level(diagnostic) > max_severity;
+}
+
+// #209: a cap-induced cross-file traversal truncation. Identified by
+// CODE, not severity, so `sight check` keeps it out of the pass/fail
+// tally regardless of the configured `max_depth` severity — a depth-cap
+// hit means "results may be incomplete", never a genuine error.
+export function is_truncation_diagnostic(diagnostic: Diagnostic): boolean {
+    return diagnostic.code === StataDiagnosticCode.CROSS_FILE_TRUNCATED;
 }
 
 // NO_COLOR semantics (https://no-color.org): present and non-empty disables
@@ -220,11 +229,15 @@ export function render_text(
     options: { quiet: boolean; use_color: boolean }
 ): string {
     const counts = { error: 0, warning: 0, info: 0, hint: 0, note: 0 };
+    let truncation_count = 0;
     const lines: string[] = [];
 
     for (const record of sorted_records(records)) {
         const word = severity_word(record.diagnostic);
         counts[word as keyof typeof counts]++;
+        if (is_truncation_diagnostic(record.diagnostic)) {
+            truncation_count++;
+        }
         const code = code_text(record.diagnostic.code);
         const code_suffix = code ? ` [${code}]` : '';
         lines.push(
@@ -245,6 +258,14 @@ export function render_text(
             `${counts.hint} hints, ` +
             `${counts.note} notes)`
         );
+        if (truncation_count > 0) {
+            const noun = truncation_count === 1 ? 'truncation' : 'truncations';
+            lines.push(
+                `${truncation_count} cross-file traversal ${noun} ` +
+                `(depth cap reached — results may be incomplete; ` +
+                `not undefined-symbol errors)`
+            );
+        }
     }
 
     if (lines.length === 0) {

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -17,7 +17,6 @@ import {
     ForwardCallSite,
     ForwardResolvedScope,
     DuplicateCallDecision,
-    DirectiveDiagnostic,
     MacroSymbol,
     StataDiagnosticCode,
 } from '../types';
@@ -38,6 +37,71 @@ export interface ForwardScopeConfig {
     };
 }
 
+/**
+ * Inputs that fully determine a file's forward-call CLOSURE — and so the
+ * complete cache key for a caller-INDEPENDENT forward-closure memo
+ * (#209, #208). There is deliberately NO caller field: the closure is a
+ * pure function of these inputs, so caller identity can never vary it.
+ * See docs/cross-file.md "Forward-closure caching semantics".
+ *
+ * - `content_hash`        the callee's own text (its forward calls).
+ * - `effective_call_type` `do` vs `include` — governs local propagation.
+ * - `working_directory`   resolves the callee's relative do/run paths.
+ * - `depth`               raw forward depth: subsumes remaining-budget
+ *                         AND the `depth === 0` flag that gates
+ *                         `excluded_locals`.
+ * - `max_forward_depth`   the truncation cap in force.
+ * - `dep_graph_version`   folds the dependency-graph version so stale
+ *                         forward edges can't serve a stale closure.
+ */
+export interface ForwardClosureKeyInputs {
+    callee_uri: string;
+    content_hash: string;
+    effective_call_type: EffectiveCallType;
+    working_directory: string | undefined;
+    depth: number;
+    max_forward_depth: number;
+    dep_graph_version: number;
+}
+
+/**
+ * Build the caller-independent forward-closure cache key (#209). The cache
+ * STORE/SERVE write-path is deferred to a follow-up; this contract ships now
+ * so the follow-up — and the #208 standalone work — can rely on it, guarded
+ * by the memo-on/off correctness gate.
+ *
+ * Encoded as a JSON tuple rather than a delimiter-joined string so the key
+ * is collision-free: a `callee_uri` or `working_directory` containing a
+ * delimiter cannot forge another key, and an absent working directory
+ * (`undefined` → JSON `null`) stays distinct from an empty string (`""`).
+ *
+ * NOTE: the key intentionally OMITS the caller's `visited` map and the
+ * `diagnostic_owner_uri`. These vary `resolve()`'s output but are NOT keyed,
+ * because the deferred store/serve path handles them OUTSIDE the key (encoding
+ * `visited` would make the key caller-dependent, defeating the whole point):
+ *  - duplicate-call (`visited`) divergence is prevented by serving only when
+ *    the cached closure's reachable set is DISJOINT from the caller's
+ *    stack+visited, then replaying its visited-delta;
+ *  - diagnostic/owner divergence is prevented by caching only diagnostic-free,
+ *    owner-suppressed closures (any closure that would emit a diagnostic is
+ *    recomputed live).
+ * See docs/cross-file.md "Forward-closure caching semantics" for the full
+ * deferred design and the memo-on/off correctness gate that enforces it.
+ */
+export function build_forward_closure_key(
+    inputs: ForwardClosureKeyInputs
+): string {
+    return JSON.stringify([
+        inputs.callee_uri,
+        inputs.content_hash,
+        inputs.effective_call_type,
+        inputs.working_directory ?? null,
+        inputs.depth,
+        inputs.max_forward_depth,
+        inputs.dep_graph_version,
+    ]);
+}
+
 const DEFAULT_CONFIG: ForwardScopeConfig = {
     max_forward_depth: 10,
 };
@@ -50,9 +114,29 @@ export class ForwardScopeResolver {
     // When undefined, resolve_path_rich uses the real Node fs.
     private resolve_fs?: RichResolveFs;
 
+    // #209: switch for the (deferred) caller-independent forward-closure
+    // memo. Default OFF — the cache store/serve write-path lands in a
+    // follow-up. The memo-on/off correctness gate flips this to prove the
+    // future cache is behaviorally identical to the live walk; #208's
+    // caller-independence assumption rides on that gate, not on the cache.
+    private forward_closure_memo_enabled = false;
+
     constructor(scope_resolver: ScopeResolver, config: Partial<ForwardScopeConfig> = {}) {
         this.scope_resolver = scope_resolver;
         this.default_config = { ...DEFAULT_CONFIG, ...config };
+    }
+
+    /**
+     * Enable/disable the forward-closure memo (#209). Default OFF. The
+     * store/serve write-path is deferred; until it lands, toggling this is a
+     * behavioral no-op — guarded by the memo-on/off correctness gate.
+     */
+    set_forward_closure_memo_enabled(enabled: boolean): void {
+        this.forward_closure_memo_enabled = enabled;
+    }
+
+    is_forward_closure_memo_enabled(): boolean {
+        return this.forward_closure_memo_enabled;
     }
 
     /**
@@ -286,21 +370,57 @@ export class ForwardScopeResolver {
 
             // Check depth limit
             if (my_context.depth >= resolved_config.max_forward_depth) {
-                // Always emit diagnostic when max depth is exceeded
-                const diagnostic: DirectiveDiagnostic = {
-                    message: `${source_prefix}Maximum forward resolution depth (${resolved_config.max_forward_depth}) exceeded`,
-                    severity: 'information',
-                    range: {
+                // Cap-induced truncation, not a genuine error (#209). Respect
+                // the configured `max_depth` severity, and suppress entirely
+                // when 'off' — consistent with the backward depth cap (this
+                // previously always emitted at 'information', ignoring the
+                // setting). The call is skipped regardless, to bound recursion.
+                // Fallback matches the backward and chain depth caps
+                // ('warning') for consistency when `max_depth` is unset; in
+                // production the resolved config supplies it ('information' per
+                // DEFAULT_SETTINGS), so this fallback only affects unconfigured
+                // callers.
+                const max_depth_setting =
+                    resolved_config.diagnostics?.max_depth ?? 'warning';
+                if (max_depth_setting !== 'off') {
+                    // Anchor the diagnostic to a location in the DIAGNOSTIC-
+                    // OWNER file (#209). A nested truncation (depth > 0)
+                    // would otherwise carry a callee-file line and render
+                    // against the owner file — the backward-directive remap
+                    // does not run for a root file with no directives.
+                    // `root_call_range` (the owner's depth-0 call site)
+                    // anchors it correctly; at depth 0 the call is already in
+                    // `file_uri`, so use its own line. (`call_site_line` is a
+                    // real parsed AST line, never the backward
+                    // `assume_call_site: 'end'` sentinel.)
+                    const anchor_uri =
+                        my_context.root_call_range !== undefined &&
+                        my_context.diagnostic_owner_uri !== undefined
+                            ? my_context.diagnostic_owner_uri
+                            : file_uri;
+                    const anchor_range = my_context.root_call_range ?? {
                         start: { line: my_call.call_site_line, character: 0 },
-                        end: { line: my_call.call_site_line, character: 0 }
-                    },
-                    source: {
-                        source_file: path.basename(my_call.raw_path),
-                        source_line: my_call.call_site_line,
-                        original_range: my_call.range
-                    }
-                };
-                my_context.diagnostics.push(diagnostic);
+                        end: { line: my_call.call_site_line, character: 0 },
+                    };
+                    my_context.diagnostics.push({
+                        message:
+                            `${source_prefix}Maximum forward resolution ` +
+                            `depth (${resolved_config.max_forward_depth}) ` +
+                            `exceeded`,
+                        severity: max_depth_setting,
+                        // Tagged so `sight check` surfaces it distinctly and
+                        // keeps it out of the pass/fail tally.
+                        kind: 'truncation',
+                        code: StataDiagnosticCode.CROSS_FILE_TRUNCATED,
+                        range: anchor_range,
+                        source: {
+                            source_file: path.basename(
+                                URI.parse(anchor_uri).fsPath),
+                            source_line: anchor_range.start.line,
+                            original_range: anchor_range,
+                        },
+                    });
+                }
                 // Skip this call to prevent excessive recursion
                 continue;
             }
@@ -559,6 +679,14 @@ export class ForwardScopeResolver {
                         // owner and therefore suppress their own
                         // path_case_mismatch emission.
                         diagnostic_owner_uri: my_context.diagnostic_owner_uri,
+                        // Anchor nested cap-truncations to the owner file's
+                        // depth-0 call site (#209). Established once, on the
+                        // first owner-rooted recursion, then propagated. Only
+                        // set when an owner is present (not ancestor builds).
+                        root_call_range: my_context.root_call_range ??
+                            (my_context.diagnostic_owner_uri !== undefined
+                                ? my_call.range
+                                : undefined),
                     },
                     my_stack,
                     token,

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -368,13 +368,17 @@ export class ForwardScopeResolver {
                 ? `${call_chain.join(' -> ')}: `
                 : '';
 
-            // Check depth limit
+            // Check depth limit. `my_context.depth` is invariant for this
+            // frame, so once it is at/over the cap EVERY remaining call is
+            // equally truncated: emit ONE diagnostic and `break` (not
+            // `continue`), otherwise `sight check` would count and squiggle the
+            // same truncation once per skipped call (#209).
             if (my_context.depth >= resolved_config.max_forward_depth) {
                 // Cap-induced truncation, not a genuine error (#209). Respect
                 // the configured `max_depth` severity, and suppress entirely
                 // when 'off' — consistent with the backward depth cap (this
                 // previously always emitted at 'information', ignoring the
-                // setting). The call is skipped regardless, to bound recursion.
+                // setting). All calls in this frame are skipped regardless.
                 // Fallback matches the backward and chain depth caps
                 // ('warning') for consistency when `max_depth` is unset; in
                 // production the resolved config supplies it ('information' per
@@ -421,8 +425,9 @@ export class ForwardScopeResolver {
                         },
                     });
                 }
-                // Skip this call to prevent excessive recursion
-                continue;
+                // Depth is frame-invariant: every remaining call is equally
+                // truncated, so stop here rather than re-emitting per call.
+                break;
             }
 
             // Compute effective call type for this call

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -1089,6 +1089,22 @@ export class DiagnosticsProvider {
             };
         }
 
+        // ── truncation branch (#209) ─────────────────────────────────────────
+        // Cap-induced cross-file truncation. Preserve the
+        // CROSS_FILE_TRUNCATED code so `sight check` can surface it
+        // distinctly and exclude it from the pass/fail tally by code (not
+        // severity). Severity is left as emitted (respects
+        // `cross_file.diagnostics.max_depth`); the code drives CI gating.
+        if (diagnostic.kind === 'truncation') {
+            return {
+                range: diagnostic.range,
+                message: diagnostic.message,
+                severity: this.semantic_severity_to_lsp(diagnostic.severity),
+                code: diagnostic.code,
+                source: 'sight',
+            };
+        }
+
         // ── missing_file / legacy branch ─────────────────────────────────────
         // Keyed on `kind === 'missing_file'` OR the legacy prose substring.
         const is_missing_file =

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -1234,19 +1234,74 @@ export class ScopeResolver {
         // Use overall chain depth limit minus current backward depth.
         const remaining_depth = config.max_chain_depth - depth;
         if (remaining_depth <= 0) {
+            // Cap-induced truncation, not a genuine error (#209). Respect the
+            // configured `max_depth` severity and suppress when 'off' —
+            // consistent with the backward and forward depth caps.
+            const max_depth_setting =
+                config.diagnostics?.max_depth ?? 'warning';
+            if (max_depth_setting === 'off') {
+                return {
+                    symbols: create_empty_symbol_table(),
+                    diagnostics: [],
+                    call_sites: [],
+                    all_call_sites: [],
+                };
+            }
+            // Attribute to the parent file's call site so the diagnostic
+            // points somewhere actionable (was 0:0). Guard the sentinel:
+            // with assume_call_site === 'end' the inferred call_site_line
+            // is Number.MAX_SAFE_INTEGER. When the call site is unknown,
+            // anchor the range at line 0 but OMIT source_line — downstream
+            // formatting treats a defined source_line as authoritative and
+            // would mislabel an unknown site as "line 1".
+            const has_known_call_site =
+                Number.isInteger(call_site_line) &&
+                call_site_line >= 0 &&
+                call_site_line < Number.MAX_SAFE_INTEGER;
+            const chain_line = has_known_call_site ? call_site_line : 0;
+            const chain_range = {
+                start: { line: chain_line, character: 0 },
+                end: { line: chain_line, character: 0 },
+            };
+            const parent_basename =
+                path.basename(URI.parse(parent_uri).fsPath);
             return {
                 symbols: create_empty_symbol_table(),
                 diagnostics: [{
-                    message: `Maximum combined resolution depth exceeded when resolving parent forward calls`,
-                    range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-                    severity: 'warning',
+                    message:
+                        `Maximum combined resolution depth ` +
+                        `(${config.max_chain_depth}) exceeded when ` +
+                        `resolving parent forward calls`,
+                    range: chain_range,
+                    severity: max_depth_setting,
+                    kind: 'truncation',
+                    code: StataDiagnosticCode.CROSS_FILE_TRUNCATED,
+                    source: {
+                        source_file: parent_basename,
+                        // Omit source_line when the call site is unknown.
+                        ...(has_known_call_site
+                            ? { source_line: call_site_line }
+                            : {}),
+                        original_range: chain_range,
+                    },
                 }],
                 call_sites: [],
                 all_call_sites: [],
             };
         }
 
-        // Create a recursion stack from visited set for cycle detection.
+        // ISSUE #209 INVARIANT (sibling visibility): isolate the parent's
+        // forward-call walk from the backward walk. We pass a *copy* of the
+        // backward `visited` set (not the live set) as the forward cycle
+        // stack, and a *fresh* forward `visited` Map (line below). Combined
+        // with the caller deleting `my_parent_uri` from `visited` BEFORE
+        // invoking us (see follow_directives), every URI in `recursion_stack`
+        // is the current file or a file already on the active backward chain
+        // — never an independent earlier sibling. So a legitimately earlier-
+        // sourced sibling can never be skipped as a false cycle. Raven
+        // (jbearak/raven#471, #477) shared ONE map across both walks and
+        // dropped such siblings; do not merge these structures. Regression:
+        // tests/integration/hub-heavy-sibling-visibility.test.ts.
         const recursion_stack = new Set<string>(visited);
 
         // Resolve the FULL forward-call list so find-references sees sibling
@@ -1267,7 +1322,12 @@ export class ScopeResolver {
             },
             recursion_stack,
             token,
-            { max_forward_depth: remaining_depth }
+            {
+                max_forward_depth: remaining_depth,
+                // Thread the depth-diagnostic severity/off setting so a
+                // parent's forward truncations honor `max_depth` too (#209).
+                diagnostics: { max_depth: config.diagnostics?.max_depth },
+            }
         );
 
         // Derive pre-site subset + its merged symbol table for scope resolution.
@@ -1505,6 +1565,9 @@ export class ScopeResolver {
                     message: `Maximum backward directive depth (${config.max_backward_depth}) exceeded`,
                     range: default_range,
                     severity: max_depth_severity,
+                    // Cap-induced truncation, not a genuine error (#209).
+                    kind: 'truncation',
+                    code: StataDiagnosticCode.CROSS_FILE_TRUNCATED,
                     source: {
                         source_file: source_filename,
                         source_line: 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -496,6 +496,11 @@ export enum StataDiagnosticCode {
 
   // Cross-file diagnostics
   PATH_CASE_MISMATCH = 7001,
+  // Emitted when a traversal cap (max_backward_depth / max_forward_depth /
+  // max_chain_depth) truncates cross-file resolution. Signals "results may be
+  // incomplete", NOT a genuine undefined symbol — surfaced distinctly by
+  // `sight check` and excluded from its pass/fail tally.
+  CROSS_FILE_TRUNCATED = 7002,
 }
 
 // Structured payload carried on a diagnostic's `data` field for undefined-symbol
@@ -628,7 +633,7 @@ export interface DirectiveDiagnostic {
   severity: 'error' | 'warning' | 'information';
   source?: DiagnosticSource;  // Source attribution for diagnostics from parent files
   /** Structured discriminator for severity routing. */
-  kind?: 'missing_file' | 'path_case_mismatch';
+  kind?: 'missing_file' | 'path_case_mismatch' | 'truncation';
   /** Stable code included on the emitted LSP Diagnostic (e.g. PATH_CASE_MISMATCH). */
   code?: StataDiagnosticCode;
   /**
@@ -881,6 +886,16 @@ export interface ForwardResolveContext {
    * the diagnostic to avoid cascade / double-emit.
    */
   diagnostic_owner_uri?: string;
+  /**
+   * Range of the depth-0 forward call in the diagnostic-owner file that began
+   * this resolution. Set once, on the first recursion into an owner-rooted
+   * call, and propagated unchanged. Used to anchor NESTED cap-truncation
+   * diagnostics (#209) to the owner file's actual call site — otherwise a
+   * nested call's line (in a callee file) would be reported against the owner
+   * file, since the backward-directive remap does not run for a root file with
+   * no directives. Undefined for ancestor-scope builds (no owner).
+   */
+  root_call_range?: Range;
 }
 
 export interface ForwardCallSite {

--- a/tests/integration/cli-check-truncation.test.ts
+++ b/tests/integration/cli-check-truncation.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Issue #209: `sight check` must distinguish cap-induced traversal truncation
+ * from genuine diagnostics. A depth-cap hit means "we stopped walking; results
+ * may be incomplete" — it must NOT fail the check (CI users would otherwise see
+ * spurious failures on deep chains), and it must be surfaced distinctly with the
+ * CROSS_FILE_TRUNCATED code.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { run_check_with_cwd } from '../../src/cli/check';
+import { EXIT_OK } from '../../src/cli/shared';
+import { StataDiagnosticCode } from '../../src/types';
+
+function temp_dir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sight-check-trunc-'));
+}
+
+async function run_capture(argv: string[], cwd: string) {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const code = await run_check_with_cwd(argv, cwd, {
+        stdout: (text) => stdout.push(text),
+        stderr: (text) => stderr.push(text),
+    });
+    return { code, stdout: stdout.join(''), stderr: stderr.join('') };
+}
+
+describe('sight check — cap-truncation surfacing (#209)', () => {
+    it('does not fail the check on a backward depth-cap hit, and surfaces it', async () => {
+        const root = temp_dir();
+        try {
+            // maxBackwardDepth = 1 with a real 3-deep backward chain (each parent
+            // actually calls its child, so call sites resolve and the ONLY
+            // cross-file diagnostic is the depth-cap truncation).
+            fs.writeFileSync(
+                path.join(root, 'sight.toml'),
+                '[crossFile]\nmaxBackwardDepth = 1\n'
+            );
+            fs.writeFileSync(path.join(root, 'g.do'), 'do "p.do"\n');
+            fs.writeFileSync(
+                path.join(root, 'p.do'),
+                '// @lsp-done-by: "g.do"\ndo "b.do"\n'
+            );
+            fs.writeFileSync(
+                path.join(root, 'b.do'),
+                '// @lsp-done-by: "p.do"\n* leaf\n'
+            );
+
+            // At --max-severity hint, an info-severity diagnostic WOULD exceed the
+            // threshold; the truncation must be excluded from the failure tally by
+            // CODE, not severity.
+            const result = await run_capture(
+                ['--workspace', root, 'b.do', '--max-severity', 'hint',
+                    '--no-color'],
+                root
+            );
+
+            // Truncation must not be counted as a failure.
+            expect(result.code).toBe(EXIT_OK);
+            // It must still be surfaced, tagged with the truncation code.
+            expect(result.stdout).toContain(
+                `[${StataDiagnosticCode.CROSS_FILE_TRUNCATED}]`
+            );
+            // A dedicated summary line explains the truncation is a depth-cap
+            // hit, distinct from undefined-symbol errors.
+            expect(result.stdout).toMatch(
+                /1 cross-file traversal truncation.*results may be incomplete/
+            );
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('surfaces a forward depth-cap hit at the owner call site, not a callee line', async () => {
+        const root = temp_dir();
+        try {
+            fs.writeFileSync(
+                path.join(root, 'sight.toml'),
+                '[crossFile]\nmaxForwardDepth = 1\n'
+            );
+            // main -> a -> b: at depth 1, `do b` exceeds maxForwardDepth=1. The
+            // truncation occurs in a.do (its `do b.do` on line 1), but it must be
+            // reported at main.do's OWN call site (line 4, the `do a.do`) — NOT
+            // a.do's line mislabeled against main.do (line 1, a comment).
+            fs.writeFileSync(path.join(root, 'b.do'), 'global b_g 1\n');
+            fs.writeFileSync(path.join(root, 'a.do'), 'do "b.do"\n');
+            fs.writeFileSync(
+                path.join(root, 'main.do'), '* c1\n* c2\n* c3\ndo "a.do"\n');
+
+            const result = await run_capture(
+                ['--workspace', root, 'main.do', '--no-color'], root);
+
+            expect(result.stdout).toContain(
+                `[${StataDiagnosticCode.CROSS_FILE_TRUNCATED}]`);
+            // Reported at main.do line 4 (the do "a.do" call site), not line 1.
+            expect(result.stdout).toMatch(
+                /main\.do:4:\d+ \w+: .*Maximum forward resolution depth/);
+            expect(result.stdout).not.toContain('main.do:1:');
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('suppresses the FORWARD depth-cap diagnostic when maxDepth is off', async () => {
+        const root = temp_dir();
+        try {
+            // maxDepth=off must suppress the forward truncation entirely — it
+            // previously ignored the setting (#209). Assert the MESSAGE is gone
+            // (not merely the code), so the old uncoded diagnostic can't pass.
+            fs.writeFileSync(
+                path.join(root, 'sight.toml'),
+                '[crossFile]\nmaxForwardDepth = 1\n' +
+                '[crossFile.diagnostics]\nmaxDepth = "off"\n'
+            );
+            fs.writeFileSync(path.join(root, 'b.do'), 'global b_g 1\n');
+            fs.writeFileSync(path.join(root, 'a.do'), 'do "b.do"\n');
+            fs.writeFileSync(path.join(root, 'main.do'), 'do "a.do"\n');
+
+            const result = await run_capture(
+                ['--workspace', root, 'main.do', '--max-severity', 'hint',
+                    '--no-color'], root);
+
+            expect(result.code).toBe(EXIT_OK);
+            expect(result.stdout).not.toContain(
+                'Maximum forward resolution depth');
+            expect(result.stdout).not.toContain(
+                `[${StataDiagnosticCode.CROSS_FILE_TRUNCATED}]`);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('suppresses the BACKWARD depth-cap diagnostic when maxDepth is off', async () => {
+        const root = temp_dir();
+        try {
+            fs.writeFileSync(
+                path.join(root, 'sight.toml'),
+                '[crossFile]\nmaxBackwardDepth = 1\n' +
+                '[crossFile.diagnostics]\nmaxDepth = "off"\n'
+            );
+            fs.writeFileSync(path.join(root, 'g.do'), 'do "p.do"\n');
+            fs.writeFileSync(
+                path.join(root, 'p.do'),
+                '// @lsp-done-by: "g.do"\ndo "b.do"\n');
+            fs.writeFileSync(
+                path.join(root, 'b.do'),
+                '// @lsp-done-by: "p.do"\n* leaf\n');
+
+            const result = await run_capture(
+                ['--workspace', root, 'b.do', '--max-severity', 'hint',
+                    '--no-color'], root);
+
+            expect(result.code).toBe(EXIT_OK);
+            expect(result.stdout).not.toContain(
+                'Maximum backward directive depth');
+            expect(result.stdout).not.toContain(
+                `[${StataDiagnosticCode.CROSS_FILE_TRUNCATED}]`);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    // Shared fixture for the combined chain-depth cap: resolving b walks
+    // b -> p -> g; at g (backward depth 1) the parent-forward-call resolution
+    // has maxChainDepth - depth = 1 - 1 = 0 remaining, tripping the chain cap.
+    // g must have a forward call for the cap check to be reached.
+    const write_chain_workspace = (root: string, maxDepthLine: string) => {
+        fs.writeFileSync(
+            path.join(root, 'sight.toml'),
+            '[crossFile]\nmaxChainDepth = 1\n' + maxDepthLine);
+        fs.writeFileSync(path.join(root, 'helper.do'), 'global helper_g 1\n');
+        fs.writeFileSync(
+            path.join(root, 'g.do'), 'do "p.do"\ndo "helper.do"\n');
+        fs.writeFileSync(
+            path.join(root, 'p.do'),
+            '// @lsp-done-by: "g.do"\ndo "b.do"\n');
+        fs.writeFileSync(
+            path.join(root, 'b.do'),
+            '// @lsp-done-by: "p.do"\n* leaf\n');
+    };
+
+    it('surfaces a chain depth-cap hit with the truncation code, without failing', async () => {
+        const root = temp_dir();
+        try {
+            write_chain_workspace(root, '');
+            const result = await run_capture(
+                ['--workspace', root, 'b.do', '--max-severity', 'hint',
+                    '--no-color'], root);
+
+            expect(result.code).toBe(EXIT_OK);
+            expect(result.stdout).toContain('Maximum combined resolution depth');
+            expect(result.stdout).toContain(
+                `[${StataDiagnosticCode.CROSS_FILE_TRUNCATED}]`);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('suppresses the CHAIN depth-cap diagnostic when maxDepth is off', async () => {
+        const root = temp_dir();
+        try {
+            write_chain_workspace(
+                root, '[crossFile.diagnostics]\nmaxDepth = "off"\n');
+            const result = await run_capture(
+                ['--workspace', root, 'b.do', '--max-severity', 'hint',
+                    '--no-color'], root);
+
+            expect(result.code).toBe(EXIT_OK);
+            expect(result.stdout).not.toContain(
+                'Maximum combined resolution depth');
+            expect(result.stdout).not.toContain(
+                `[${StataDiagnosticCode.CROSS_FILE_TRUNCATED}]`);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/integration/cli-check-truncation.test.ts
+++ b/tests/integration/cli-check-truncation.test.ts
@@ -167,10 +167,10 @@ describe('sight check — cap-truncation surfacing (#209)', () => {
     // b -> p -> g; at g (backward depth 1) the parent-forward-call resolution
     // has maxChainDepth - depth = 1 - 1 = 0 remaining, tripping the chain cap.
     // g must have a forward call for the cap check to be reached.
-    const write_chain_workspace = (root: string, maxDepthLine: string) => {
+    const write_chain_workspace = (root: string, max_depth_line: string) => {
         fs.writeFileSync(
             path.join(root, 'sight.toml'),
-            '[crossFile]\nmaxChainDepth = 1\n' + maxDepthLine);
+            '[crossFile]\nmaxChainDepth = 1\n' + max_depth_line);
         fs.writeFileSync(path.join(root, 'helper.do'), 'global helper_g 1\n');
         fs.writeFileSync(
             path.join(root, 'g.do'), 'do "p.do"\ndo "helper.do"\n');
@@ -213,6 +213,34 @@ describe('sight check — cap-truncation surfacing (#209)', () => {
                 'Maximum combined resolution depth');
             expect(result.stdout).not.toContain(
                 `[${StataDiagnosticCode.CROSS_FILE_TRUNCATED}]`);
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('emits one truncation per over-depth frame, not one per skipped call', async () => {
+        const root = temp_dir();
+        try {
+            fs.writeFileSync(
+                path.join(root, 'sight.toml'),
+                '[crossFile]\nmaxForwardDepth = 1\n');
+            // main -> a; a does TWO calls (b, c) at depth 1 — both over the cap.
+            // The truncation must be reported once for a's frame, not once per
+            // skipped call (depth is frame-invariant).
+            fs.writeFileSync(path.join(root, 'b.do'), 'global b_g 1\n');
+            fs.writeFileSync(path.join(root, 'c.do'), 'global c_g 1\n');
+            fs.writeFileSync(path.join(root, 'a.do'), 'do "b.do"\ndo "c.do"\n');
+            fs.writeFileSync(path.join(root, 'main.do'), 'do "a.do"\n');
+
+            const result = await run_capture(
+                ['--workspace', root, 'main.do', '--no-color'], root);
+
+            const occurrences = result.stdout.split(
+                `[${StataDiagnosticCode.CROSS_FILE_TRUNCATED}]`).length - 1;
+            expect(occurrences).toBe(1);
+            expect(result.stdout).toContain('1 cross-file traversal truncation');
+            expect(result.stdout).not.toContain(
+                '2 cross-file traversal truncations');
         } finally {
             fs.rmSync(root, { recursive: true, force: true });
         }

--- a/tests/integration/forward-closure-memo-gate.test.ts
+++ b/tests/integration/forward-closure-memo-gate.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Issue #209 / #208 — forward-closure memo correctness gate.
+ *
+ * Two guarantees:
+ *  (1) CALLER-INDEPENDENCE (the assumption #208 relies on): a file's forward-call
+ *      closure is identical regardless of which caller triggered it, given the
+ *      same keyed inputs (effective call type, working directory, depth, content).
+ *      This holds TODAY and is the contract the deferred cache will exploit.
+ *  (2) MEMO ON/OFF EQUIVALENCE: flipping the (default-OFF) memo toggle must not
+ *      change any caller-observable output. The cache store/serve write-path is
+ *      deferred, so this is currently a no-op equivalence — it becomes the
+ *      regression gate the follow-up must keep green.
+ *
+ * See docs/cross-file.md "Forward-closure caching semantics".
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import type { ResolvedScope, SymbolTable } from '../../src/types';
+import { create_test_scope_resolver_logger } from '../test-logger';
+
+describe('issue #209/#208 — forward-closure memo gate', () => {
+    let scope_resolver: ScopeResolver;
+    let forward_resolver: ForwardScopeResolver;
+    let temp_dir: string;
+
+    beforeEach(() => {
+        scope_resolver = new ScopeResolver(create_test_scope_resolver_logger());
+        forward_resolver = new ForwardScopeResolver(scope_resolver);
+        scope_resolver.set_forward_scope_resolver(forward_resolver);
+        temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memo-gate-209-'));
+    });
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    const create_file = (name: string, content: string): string => {
+        const file_path = path.join(temp_dir, name);
+        const dir = path.dirname(file_path);
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(file_path, content);
+        return file_path;
+    };
+    const to_uri = (p: string): string => `file://${p}`;
+
+    const symbol_names = (t: SymbolTable) => ({
+        programs: [...t.programs.keys()].sort(),
+        localMacros: [...t.localMacros.keys()].sort(),
+        globalMacros: [...t.globalMacros.keys()].sort(),
+        variables: [...t.variables.keys()].sort(),
+        scalars: [...t.scalars.keys()].sort(),
+        matrices: [...t.matrices.keys()].sort(),
+    });
+
+    // The full caller-observable surface a forward-closure memo could corrupt
+    // (codex R4): symbols, call sites (incl. excluded_locals), out-of-scope
+    // records, diagnostics, inherited WD, and the chain forward-call sites.
+    const surface = (r: ResolvedScope) => ({
+        symbols: symbol_names(r.symbols),
+        diagnostics: r.diagnostics.map(d => ({
+            message: d.message, severity: d.severity, code: d.code,
+        })),
+        out_of_scope: (r.out_of_scope_symbols ?? [])
+            .map(o => o.name).sort(),
+        inherited_wd: r.inherited_working_directory ?? null,
+        chain: r.chain.map(c => ({
+            uri: c.uri,
+            forward: (c.forward_call_sites ?? []).map(s => ({
+                uri: s.callee_uri, line: s.call_line, type: s.effective_type,
+                excluded: [...(s.excluded_locals?.keys() ?? [])].sort(),
+            })),
+            all_forward: (c.all_forward_call_sites ?? []).map(s => ({
+                uri: s.callee_uri, line: s.call_line, type: s.effective_type,
+            })),
+        })),
+    });
+
+    it('(1) caller-independence: same callee closure across two disjoint callers', async () => {
+        // hub.do runs helper.do; the hub's forward closure must be identical
+        // whether reached from caller C1 or C2 (disjoint recursion stacks).
+        const helper = create_file('helper.do', `global helper_g 1\n`);
+        const hub = create_file('hub.do', `run "${helper}"\nglobal hub_g 1\n`);
+        const hub_uri = to_uri(hub);
+
+        const parsed = await scope_resolver.get_parsed_file(hub_uri, hub);
+        if ('error' in parsed) throw new Error(parsed.error);
+
+        const resolve_from = async (caller_uri: string) =>
+            forward_resolver.resolve(
+                hub_uri,
+                parsed.forward_calls,
+                'do',
+                {
+                    visited: new Map(),
+                    effective_call_type: 'do',
+                    depth: 0,
+                    diagnostics: [],
+                    working_directory: undefined,
+                    call_chain: [],
+                },
+                new Set([caller_uri]),
+            );
+
+        const r1 = await resolve_from('file:///callers/c1.do');
+        const r2 = await resolve_from('file:///callers/c2.do');
+
+        expect(symbol_names(r1.symbols)).toEqual(symbol_names(r2.symbols));
+        expect(r1.symbols.globalMacros.has('helper_g')).toBe(true);
+        expect(r1.call_sites.map(s => s.callee_uri).sort())
+            .toEqual(r2.call_sites.map(s => s.callee_uri).sort());
+    });
+
+    it('(2) memo on/off equivalence across a hub-heavy battery', async () => {
+        // A small dense graph: parent runs two siblings before the child; each
+        // sibling shares a hub; the child inherits via @lsp-done-by.
+        const hub = create_file('hub.do', `global hub_g 1\n`);
+        const a = create_file('a.do', `run "${hub}"\nglobal a_g 1\n`);
+        const d = create_file('d.do', `run "${hub}"\nglobal d_g 1\n`);
+        const parent = create_file('parent.do',
+            `run "${a}"\nrun "${d}"\ndo "child.do"\n`);
+        const child_content =
+            `// @lsp-done-by: "${parent}" match="child.do"\n` +
+            `display "\${a_g} \${d_g} \${hub_g}"\n`;
+        create_file('child.do', child_content);
+        const child_uri = to_uri(path.join(temp_dir, 'child.do'));
+
+        forward_resolver.set_forward_closure_memo_enabled(false);
+        const off = await scope_resolver.resolve(child_uri, child_content);
+        const off_surface = surface(off);
+
+        // Fresh resolver state so the comparison isn't a cache-warm artifact.
+        scope_resolver.clear_cache();
+        forward_resolver.set_forward_closure_memo_enabled(true);
+        const on = await scope_resolver.resolve(child_uri, child_content);
+
+        expect(surface(on)).toEqual(off_surface);
+        // sanity: the battery actually exercises forward inheritance
+        expect(on.symbols.globalMacros.has('hub_g')).toBe(true);
+    });
+});

--- a/tests/integration/forward-closure-memo-gate.test.ts
+++ b/tests/integration/forward-closure-memo-gate.test.ts
@@ -18,9 +18,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { pathToFileURL } from 'node:url';
 import { ScopeResolver } from '../../src/scope-resolver';
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
-import type { ResolvedScope, SymbolTable } from '../../src/types';
+import type {
+    ResolvedScope, SymbolTable, ForwardResolvedScope,
+} from '../../src/types';
 import { create_test_scope_resolver_logger } from '../test-logger';
 
 describe('issue #209/#208 — forward-closure memo gate', () => {
@@ -45,7 +48,38 @@ describe('issue #209/#208 — forward-closure memo gate', () => {
         fs.writeFileSync(file_path, content);
         return file_path;
     };
-    const to_uri = (p: string): string => `file://${p}`;
+    const to_uri = (file_path: string): string =>
+        pathToFileURL(file_path).toString();
+
+    // Build a fresh resolver pair so two caller-independence runs cannot share
+    // cache state (when the deferred memo store/serve lands, a shared instance
+    // could serve caller 2 from caller 1's cached closure and mask a
+    // caller-DEPENDENT closure).
+    const make_resolver = (): {
+        scope: ScopeResolver; forward: ForwardScopeResolver;
+    } => {
+        const scope = new ScopeResolver(create_test_scope_resolver_logger());
+        const forward = new ForwardScopeResolver(scope);
+        scope.set_forward_scope_resolver(forward);
+        return { scope, forward };
+    };
+
+    // Full caller-observable surface of a FORWARD resolution (symbols, call
+    // sites incl. effective_type + excluded_locals, and diagnostics) — so the
+    // caller-independence gate regresses if a future memo varies any of them by
+    // caller, not just symbol names + callee URIs.
+    const forward_surface = (r: ForwardResolvedScope) => ({
+        symbols: symbol_names(r.symbols),
+        call_sites: r.call_sites.map(s => ({
+            uri: s.callee_uri,
+            line: s.call_line,
+            type: s.effective_type,
+            excluded: [...(s.excluded_locals?.keys() ?? [])].sort(),
+        })),
+        diagnostics: r.diagnostics.map(d => ({
+            message: d.message, severity: d.severity, code: d.code,
+        })),
+    });
 
     const symbol_names = (t: SymbolTable) => ({
         programs: [...t.programs.keys()].sort(),
@@ -86,11 +120,13 @@ describe('issue #209/#208 — forward-closure memo gate', () => {
         const hub = create_file('hub.do', `run "${helper}"\nglobal hub_g 1\n`);
         const hub_uri = to_uri(hub);
 
-        const parsed = await scope_resolver.get_parsed_file(hub_uri, hub);
-        if ('error' in parsed) throw new Error(parsed.error);
-
-        const resolve_from = async (caller_uri: string) =>
-            forward_resolver.resolve(
+        // Each caller gets its OWN resolver instance (separate cache), so the
+        // gate stays honest once the deferred memo store/serve lands.
+        const resolve_from = async (caller_uri: string) => {
+            const { scope, forward } = make_resolver();
+            const parsed = await scope.get_parsed_file(hub_uri, hub);
+            if ('error' in parsed) throw new Error(parsed.error);
+            return forward.resolve(
                 hub_uri,
                 parsed.forward_calls,
                 'do',
@@ -104,14 +140,14 @@ describe('issue #209/#208 — forward-closure memo gate', () => {
                 },
                 new Set([caller_uri]),
             );
+        };
 
         const r1 = await resolve_from('file:///callers/c1.do');
         const r2 = await resolve_from('file:///callers/c2.do');
 
-        expect(symbol_names(r1.symbols)).toEqual(symbol_names(r2.symbols));
+        // Compare the FULL forward surface, not just symbols + callee URIs.
+        expect(forward_surface(r1)).toEqual(forward_surface(r2));
         expect(r1.symbols.globalMacros.has('helper_g')).toBe(true);
-        expect(r1.call_sites.map(s => s.callee_uri).sort())
-            .toEqual(r2.call_sites.map(s => s.callee_uri).sort());
     });
 
     it('(2) memo on/off equivalence across a hub-heavy battery', async () => {

--- a/tests/integration/hub-heavy-sibling-visibility.test.ts
+++ b/tests/integration/hub-heavy-sibling-visibility.test.ts
@@ -22,6 +22,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { pathToFileURL } from 'node:url';
 import { ScopeResolver } from '../../src/scope-resolver';
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
 import { create_test_scope_resolver_logger } from '../test-logger';
@@ -49,7 +50,8 @@ describe('issue #209 — hub-heavy sibling visibility (regression)', () => {
         fs.writeFileSync(file_path, content);
         return file_path;
     };
-    const to_uri = (p: string): string => `file://${p}`;
+    const to_uri = (file_path: string): string =>
+        pathToFileURL(file_path).toString();
 
     // T1: baseline dense sibling. P does A (global S) then does B. B done-by P.
     it('T1 baseline: earlier sibling global visible in later sibling', async () => {

--- a/tests/integration/hub-heavy-sibling-visibility.test.ts
+++ b/tests/integration/hub-heavy-sibling-visibility.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression suite for issue #209 (ported Raven jbearak/raven#471, #477).
+ *
+ * Raven had a dense cross-file graph bug: an earlier-sourced sibling's symbol
+ * disappeared from a later sibling because the backward-walk `visited` set and
+ * parent forward-call resolution shared ONE visited map. Sight does NOT share
+ * them — `ScopeResolver.resolve_parent_forward_calls` seeds the forward resolver
+ * with a *copy* `recursion_stack = new Set(visited)` and a *fresh*
+ * `visited: new Map()`, and the parent is deleted from `visited` before its
+ * forward calls resolve. So every URI in `recursion_stack` is the current file
+ * or a file already on the active backward chain — never an independent earlier
+ * sibling — and the suppression cannot occur.
+ *
+ * These tests LOCK that invariant: an earlier sibling's symbol must stay visible
+ * in a later sibling across hub-heavy / diamond / dedup topologies. They have
+ * teeth — dropping the earliest forward static call turns every case red.
+ *
+ * See docs/cross-file.md ("Forward-closure caching semantics") and the issue.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { create_test_scope_resolver_logger } from '../test-logger';
+
+describe('issue #209 — hub-heavy sibling visibility (regression)', () => {
+    let scope_resolver: ScopeResolver;
+    let forward_resolver: ForwardScopeResolver;
+    let temp_dir: string;
+
+    beforeEach(() => {
+        scope_resolver = new ScopeResolver(create_test_scope_resolver_logger());
+        forward_resolver = new ForwardScopeResolver(scope_resolver);
+        scope_resolver.set_forward_scope_resolver(forward_resolver);
+        temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hub-heavy-209-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    const create_file = (name: string, content: string): string => {
+        const file_path = path.join(temp_dir, name);
+        const dir = path.dirname(file_path);
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(file_path, content);
+        return file_path;
+    };
+    const to_uri = (p: string): string => `file://${p}`;
+
+    // T1: baseline dense sibling. P does A (global S) then does B. B done-by P.
+    it('T1 baseline: earlier sibling global visible in later sibling', async () => {
+        const a_path = create_file('A.do', `global S_from_a 1\n`);
+        const p_path = create_file('P.do', `run "${a_path}"\ndo "B.do"\n`);
+        const b_content = `// @lsp-done-by: "${p_path}" match="B.do"\n` +
+            `display "\${S_from_a}"\n`;
+        create_file('B.do', b_content);
+        const result = await scope_resolver.resolve(
+            to_uri(path.join(temp_dir, 'B.do')), b_content);
+        expect(result.symbols.globalMacros.has('S_from_a')).toBe(true);
+    });
+
+    // T2: hub grandparent on the backward chain. B done-by A; A done-by P.
+    // P runs C (global U) then does A. C is an earlier sibling of A inside P.
+    // Exercises recursion_stack = {B, A} when P's forward calls resolve.
+    it('T2 hub: grandparent earlier sibling visible through done-by chain', async () => {
+        const c_path = create_file('C.do', `global U_from_c 1\n`);
+        const a_path = create_file('A.do', '');
+        const p_path = create_file('P.do', `run "${c_path}"\ndo "${a_path}"\n`);
+        fs.writeFileSync(a_path,
+            `// @lsp-done-by: "${p_path}" match="A.do"\n` + `do "B.do"\n`);
+        const b_content = `// @lsp-done-by: "${a_path}" match="B.do"\n` +
+            `display "\${U_from_c}"\n`;
+        create_file('B.do', b_content);
+        const result = await scope_resolver.resolve(
+            to_uri(path.join(temp_dir, 'B.do')), b_content);
+        expect(result.symbols.globalMacros.has('U_from_c')).toBe(true);
+    });
+
+    // T3: diamond — sibling is also a backward ancestor; local carried by the
+    // parent include. P includes A (line0) then includes B (line1). A defines a
+    // local; included-by keeps locals; A runs before B under P.
+    it('T3 diamond: sibling-also-ancestor local carried by parent include', async () => {
+        const a_path = create_file('A.do', '');
+        const p_path = create_file('P.do',
+            `include "${a_path}"\ninclude "B.do"\n`);
+        fs.writeFileSync(a_path,
+            `// @lsp-included-by: "${p_path}" match="A.do"\n` +
+            `local la_macro = 1\n`);
+        const b_content = `// @lsp-included-by: "${p_path}" match="B.do"\n` +
+            `display "\`la_macro'"\n`;
+        create_file('B.do', b_content);
+        const result = await scope_resolver.resolve(
+            to_uri(path.join(temp_dir, 'B.do')), b_content);
+        expect(result.symbols.localMacros.has('la_macro')).toBe(true);
+    });
+
+    // T4: shared hub via an earlier sibling. P does A then does B. A does HUB
+    // (global T). B references T transitively through the earlier sibling A.
+    it('T4 shared hub: transitive global through earlier sibling visible', async () => {
+        const hub_path = create_file('HUB.do', `global T_from_hub 1\n`);
+        const a_path = create_file('A.do',
+            `run "${hub_path}"\nglobal S_from_a 1\n`);
+        const p_path = create_file('P.do', `run "${a_path}"\ndo "B.do"\n`);
+        const b_content = `// @lsp-done-by: "${p_path}" match="B.do"\n` +
+            `display "\${S_from_a} \${T_from_hub}"\n`;
+        create_file('B.do', b_content);
+        const result = await scope_resolver.resolve(
+            to_uri(path.join(temp_dir, 'B.do')), b_content);
+        expect(result.symbols.globalMacros.has('S_from_a')).toBe(true);
+        expect(result.symbols.globalMacros.has('T_from_hub')).toBe(true);
+    });
+
+    // T5: two earlier siblings share the same hub (forward dedup). P does A
+    // (does HUB), does D (does HUB again), does B. B references the hub global.
+    it('T5 dedup: hub sourced by multiple earlier siblings stays visible', async () => {
+        const hub_path = create_file('HUB.do', `global T_from_hub 1\n`);
+        const a_path = create_file('A.do', `run "${hub_path}"\n`);
+        const d_path = create_file('D.do', `run "${hub_path}"\n`);
+        const p_path = create_file('P.do',
+            `run "${a_path}"\nrun "${d_path}"\ndo "B.do"\n`);
+        const b_content = `// @lsp-done-by: "${p_path}" match="B.do"\n` +
+            `display "\${T_from_hub}"\n`;
+        create_file('B.do', b_content);
+        const result = await scope_resolver.resolve(
+            to_uri(path.join(temp_dir, 'B.do')), b_content);
+        expect(result.symbols.globalMacros.has('T_from_hub')).toBe(true);
+    });
+
+    // T6: double-hub fan-out (codex counterexample shape). P does A then does D;
+    // both do HUB. Dedup of HUB across two earlier siblings must not suppress
+    // the later sibling's view of the hub global.
+    it('T6 double-hub: dedup across two earlier siblings keeps hub visible', async () => {
+        const hub_path = create_file('HUB.do', `global H_from_hub 1\n`);
+        const a_path = create_file('A.do', `do "${hub_path}"\n`);
+        const d_path = create_file('D.do', `do "${hub_path}"\n`);
+        const p_path = create_file('P.do',
+            `do "${a_path}"\ndo "${d_path}"\ndo "B.do"\n`);
+        const b_content = `// @lsp-done-by: "${p_path}" match="B.do"\n` +
+            `display "\${H_from_hub}"\n`;
+        create_file('B.do', b_content);
+        const result = await scope_resolver.resolve(
+            to_uri(path.join(temp_dir, 'B.do')), b_content);
+        expect(result.symbols.globalMacros.has('H_from_hub')).toBe(true);
+    });
+
+    // T7: working-directory inheritance feeds forward path resolution. Parent
+    // sets @lsp-cd subdir and runs a helper there before the child; the child
+    // (in subdir) sees the helper's global only because the parent's inherited
+    // WD resolved the sibling's relative path. Guards the #208 decision that the
+    // forward closure depends on the WD input.
+    it('T7 wd-inheritance: sibling resolved via inherited working directory', async () => {
+        create_file('subdir/helper.do', `global wd_helper_global 1\n`);
+        const loop_path = create_file('subdir/loop.do',
+            `// @lsp-cd ../subdir\n` +
+            `run "helper.do"\ndo "survey.do"\n`);
+        const survey_content = `// @lsp-done-by: "${loop_path}" match="survey.do"\n` +
+            `display "\${wd_helper_global}"\n`;
+        create_file('subdir/survey.do', survey_content);
+        const result = await scope_resolver.resolve(
+            to_uri(path.join(temp_dir, 'subdir/survey.do')), survey_content);
+        expect(result.symbols.globalMacros.has('wd_helper_global')).toBe(true);
+    });
+});

--- a/tests/performance/forward-closure-hub.test.ts
+++ b/tests/performance/forward-closure-hub.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Issue #209 — hub-heavy forward-call performance coverage.
+ *
+ * A parent runs N sibling files before its child; every sibling sources one
+ * shared hub. This is the dense shape that motivated the (deferred) forward-
+ * closure memo. The guard here is a REGRESSION guard, not a timing benchmark:
+ * resolving the child must keep file reads BOUNDED (no accidental O(N^2)
+ * blowup in full-workspace `sight check`), and the memo toggle must not change
+ * read counts today (write-path deferred → ON ≡ OFF).
+ *
+ * Note: the request-scoped `file_cache` already dedupes disk READS (the shared
+ * hub is read once even with N siblings), so reads are a cache-busting
+ * regression guard, not where the memo's win shows. The deferred memo targets
+ * closure RE-COMPUTATION across callers (CPU, not I/O); the follow-up that adds
+ * the cache store/serve will add a recomputation counter and assert the N→1
+ * collapse here.
+ */
+
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { ContentProvider } from '../../src/types';
+import { describe, it, expect } from 'bun:test';
+import { URI } from 'vscode-uri';
+
+const N_SIBLINGS = 20;
+
+function build_hub_workspace(): {
+    resolver: ScopeResolver;
+    forward: ForwardScopeResolver;
+    read_counts: Map<string, number>;
+    child_uri: string;
+    child_content: string;
+} {
+    const read_counts = new Map<string, number>();
+
+    // parent.do: run sibling_0 .. run sibling_{N-1}, then do child.do
+    const sibling_runs = Array.from({ length: N_SIBLINGS },
+        (_unused, i) => `run "sibling_${i}.do"`).join('\n');
+    const parent_content = `${sibling_runs}\ndo "child.do"\n`;
+    // Each sibling sources the shared hub, then defines its own global.
+    const sibling_content = (i: number) =>
+        `run "hub.do"\nglobal sib_${i}_g 1\n`;
+    const hub_content = `global hub_shared_g 1\n`;
+    const child_content =
+        `* @lsp-done-by: "parent.do" match="child.do"\n` +
+        `display "\${hub_shared_g}"\n`;
+
+    const content_for = (uri: string): string => {
+        if (uri.endsWith('parent.do')) return parent_content;
+        if (uri.endsWith('hub.do')) return hub_content;
+        if (uri.endsWith('child.do')) return child_content;
+        const m = uri.match(/sibling_(\d+)\.do$/);
+        if (m) return sibling_content(Number(m[1]));
+        return '';
+    };
+
+    const content_provider: ContentProvider = {
+        read_file: async (uri: string) => {
+            read_counts.set(uri, (read_counts.get(uri) || 0) + 1);
+            return content_for(uri);
+        },
+        exists: async () => true,
+        stat: async (uri: string) => ({
+            mtimeMs: 1000,
+            size: Buffer.byteLength(content_for(uri), 'utf8'),
+        }),
+    };
+
+    const resolver = new ScopeResolver(undefined, content_provider);
+    const forward = new ForwardScopeResolver(resolver);
+    resolver.set_forward_scope_resolver(forward);
+    const child_uri = URI.file('/ws/child.do').toString();
+    return { resolver, forward, read_counts, child_uri, child_content };
+}
+
+function total_reads(read_counts: Map<string, number>): number {
+    let total = 0;
+    for (const [, count] of read_counts) total += count;
+    return total;
+}
+
+describe('hub-heavy forward-call performance (#209)', () => {
+    it('keeps reads bounded (no O(N^2) blowup) when N siblings share one hub', async () => {
+        const ws = build_hub_workspace();
+        await ws.resolver.resolve(ws.child_uri, ws.child_content);
+
+        const reads = total_reads(ws.read_counts);
+        // The shared hub global must reach the child.
+        const resolved = await ws.resolver.resolve(
+            ws.child_uri, ws.child_content);
+        expect(resolved.symbols.globalMacros.has('hub_shared_g')).toBe(true);
+
+        // Linear guard: a healthy resolution reads each file ~once (observed
+        // ≈ N+3 with the shared hub read a single time, thanks to file_cache).
+        // O(N^2) (each sibling re-reading the hub and/or siblings) would be
+        // ~400+. 2*N tolerates a constant-factor of extra passes while still
+        // catching any quadratic / cache-busting regression.
+        expect(reads).toBeLessThanOrEqual(2 * N_SIBLINGS);
+    });
+
+    it('memo ON ≡ OFF read counts today (cache write-path deferred)', async () => {
+        const off = build_hub_workspace();
+        off.forward.set_forward_closure_memo_enabled(false);
+        await off.resolver.resolve(off.child_uri, off.child_content);
+
+        const on = build_hub_workspace();
+        on.forward.set_forward_closure_memo_enabled(true);
+        await on.resolver.resolve(on.child_uri, on.child_content);
+
+        // No cache yet → enabling the memo must not change reads. When the
+        // follow-up lands its store/serve, the ON hub read count should drop.
+        expect(total_reads(on.read_counts))
+            .toBe(total_reads(off.read_counts));
+    });
+});

--- a/tests/unit/forward-closure-memo-plumbing.test.ts
+++ b/tests/unit/forward-closure-memo-plumbing.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Issue #209 — forward-closure memo plumbing (gate + toggle).
+ *
+ * The cache STORE/SERVE write-path is deferred to a follow-up; this PR ships the
+ * toggle and the caller-independent key contract that the follow-up implements.
+ * The key must capture every input that varies a file's forward closure and
+ * NOTHING about the calling file's identity (the #208 caller-independence
+ * assumption). See docs/cross-file.md "Forward-closure caching semantics".
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { build_forward_closure_key } from '../../src/forward-scope-resolver';
+import type { ForwardClosureKeyInputs } from '../../src/forward-scope-resolver';
+import { create_test_scope_resolver_logger } from '../test-logger';
+
+describe('forward-closure memo toggle', () => {
+    let forward_resolver: ForwardScopeResolver;
+    beforeEach(() => {
+        const scope_resolver = new ScopeResolver(
+            create_test_scope_resolver_logger());
+        forward_resolver = new ForwardScopeResolver(scope_resolver);
+        scope_resolver.set_forward_scope_resolver(forward_resolver);
+    });
+
+    it('is disabled by default (write-path deferred)', () => {
+        expect(forward_resolver.is_forward_closure_memo_enabled()).toBe(false);
+    });
+
+    it('reflects the toggle', () => {
+        forward_resolver.set_forward_closure_memo_enabled(true);
+        expect(forward_resolver.is_forward_closure_memo_enabled()).toBe(true);
+        forward_resolver.set_forward_closure_memo_enabled(false);
+        expect(forward_resolver.is_forward_closure_memo_enabled()).toBe(false);
+    });
+});
+
+describe('forward-closure cache key (caller-independent)', () => {
+    const base: ForwardClosureKeyInputs = {
+        callee_uri: 'file:///ws/hub.do',
+        content_hash: 'abc123',
+        effective_call_type: 'do',
+        working_directory: '/ws',
+        depth: 0,
+        max_forward_depth: 10,
+        dep_graph_version: 7,
+    };
+
+    it('is stable for identical inputs', () => {
+        expect(build_forward_closure_key(base))
+            .toBe(build_forward_closure_key({ ...base }));
+    });
+
+    it('does not depend on caller identity (no caller field exists)', () => {
+        // The key is built solely from the callee + its resolution context.
+        // There is no caller parameter to pass — caller-independence by
+        // construction. The string must NOT contain any caller marker.
+        const key = build_forward_closure_key(base);
+        expect(key).toContain('file:///ws/hub.do');
+        expect(key).not.toContain('caller');
+    });
+
+    // Each keyed input must change the key (codex rounds 2-5: all of these vary
+    // the closure and must force a cache miss).
+    const variations: Array<[string, Partial<ForwardClosureKeyInputs>]> = [
+        ['content_hash', { content_hash: 'def456' }],
+        ['effective_call_type', { effective_call_type: 'include' }],
+        ['working_directory', { working_directory: '/other' }],
+        ['depth', { depth: 1 }],
+        ['max_forward_depth', { max_forward_depth: 5 }],
+        ['dep_graph_version', { dep_graph_version: 8 }],
+    ];
+    for (const [name, override] of variations) {
+        it(`changes when ${name} changes`, () => {
+            expect(build_forward_closure_key({ ...base, ...override }))
+                .not.toBe(build_forward_closure_key(base));
+        });
+    }
+
+    it('keeps undefined working directory distinct from empty string', () => {
+        // An absent WD and an empty-string WD are different resolution contexts
+        // and must not collide in the key (codex review: delimiter/undefined
+        // ambiguity).
+        const none = build_forward_closure_key(
+            { ...base, working_directory: undefined });
+        const empty = build_forward_closure_key(
+            { ...base, working_directory: '' });
+        expect(none).not.toBe(empty);
+        // ...but undefined is stable against itself.
+        expect(none).toBe(build_forward_closure_key(
+            { ...base, working_directory: undefined }));
+    });
+
+    it('cannot be forged by a value containing the delimiter syntax', () => {
+        // A callee_uri that literally contains another field's serialization
+        // must not collide with a genuinely different input set.
+        const sneaky = build_forward_closure_key({
+            ...base,
+            callee_uri: 'file:///ws/hub.do","abc123","do',
+        });
+        expect(sneaky).not.toBe(build_forward_closure_key(base));
+    });
+});


### PR DESCRIPTION
Closes #209. Folds in the deferred forward-closure caching decision from #208.

## Reproduction first

This started as a reproduction audit of a ported Raven bug (jbearak/raven#471, #477), where an earlier-sourced sibling's symbol disappeared during a parent forward-call walk because backward traversal and forward resolution shared one `visited` map.

**Finding: the bug does NOT reproduce in Sight.** `ScopeResolver.resolve_parent_forward_calls` already isolates the two walks — it passes the forward resolver a *copy* of the backward `visited` set as the cycle stack and a *fresh* forward `visited` map, and the parent is deleted from `visited` before its forward calls resolve. So every URI in the forward recursion stack is the current file or a file already on the active backward chain — never an independent earlier sibling. `tests/integration/hub-heavy-sibling-visibility.test.ts` proves this across 7 hub/diamond/dedup topologies (and the tests have teeth — they fail if the earliest sibling is dropped).

## What this PR delivers

- **Sibling-visibility regression suite** + an invariant comment at the isolation site.
- **Cap-truncation surfacing in `sight check`.** New `StataDiagnosticCode.CROSS_FILE_TRUNCATED` (7002) + `DirectiveDiagnostic` kind `'truncation'` on all three depth caps (backward/forward/chain). Each now consistently respects `crossFile.diagnostics.maxDepth` (severity + suppression on `off`), and truncations are excluded from the `sight check` pass/fail tally **by code, not severity** — so a deep-but-valid project never fails CI merely for hitting a cap, even under a strict `--max-severity`. A dedicated summary line distinguishes truncation from undefined-symbol errors. Nested forward truncations are anchored to the owner file's call site (previously a callee line could be mislabeled against the root file).
- **Forward-closure memo plumbing** — an enable/disable toggle (default **off**) + a caller-independent JSON cache key + a **memo-on/off and caller-independence correctness gate**. The cache store/serve write-path is **deferred to a follow-up** (see below); the gate proves the caller-independence assumption #208 relies on.
- **#208 decision documented** in `docs/cross-file.md` ("Forward-closure caching semantics"), including how a future `@lsp-standalone` opt-out interacts with caller-independent caching (only via the working-directory and effective-call-type key inputs, never caller identity).
- **Hub-heavy performance regression guard.**

## Verification

- `bun run test` (typecheck + 6223 tests): green.
- `bun run lint` (not in CI): clean.
- `git diff --check`: clean.
- Reviewed adversarially by codex (un-sandboxed) and `/code-review` — two consecutive fully-clean rounds on the final diff, after earlier rounds caught and fixed real issues (cache-key collisions, a source-line mis-attribution, the nested-truncation mislocation, and several consistency/coverage gaps).

## Deferred

The forward-closure cache **store/serve write-path** is intentionally deferred (tracked in a follow-up issue) — adversarial review surfaced enough correctness subtlety (visited-delta replay, clean-only caching, transitive invalidation) that shipping it behind a default-off gate now and implementing the write-path separately is the safer path. #208 is unblocked by the documented semantics + the green correctness gate.

https://claude.ai/code/session_01AiygV2Fh2omxChuEoN3xdP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated cross-file traversal truncation diagnostic code **7002**, and surfaced truncation as “results may be incomplete” during checks.
  * Introduced caller-independent forward-closure memo key support with a memoization toggle (default **off**; currently gated/no-op).
* **Bug Fixes**
  * `sight check` no longer fails the build on truncation; truncations can be suppressed via `crossFile.diagnostics.maxDepth="off"`.
  * Improved truncation attribution to the correct owning/root call site and consistent single-truncation-per-over-depth-frame behavior.
* **Documentation**
  * Expanded cross-file resolution depth-cap and forward-closure memoization documentation.
* **Tests**
  * Added integration/unit coverage for truncation, memo gating, and hub-heavy visibility/performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->