### PR TITLE
fix(data-browser): paint-first non-blocking saved sort/filter restore

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "stata-lsp",
       "dependencies": {
-        "@jbearak/dta-parser": "^0.2.0",
+        "@jbearak/dta-parser": "^0.3.0",
         "smol-toml": "^1.6.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11",
@@ -33,7 +33,7 @@
       "version": "0.8.4",
       "dependencies": {
         "@glideapps/glide-data-grid": "^6.0.3",
-        "@jbearak/dta-parser": "^0.2.0",
+        "@jbearak/dta-parser": "^0.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "vscode-languageclient": "^8.1.0",
@@ -252,7 +252,7 @@
 
     "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
 
-    "@jbearak/dta-parser": ["@jbearak/dta-parser@0.2.0", "", {}, "sha512-WTzMHgThwHofwBJ3xL6gMUAxEz0SfNK7scobe9yDGaKMYOx+6FSgun1XlzBg0UEHvnRaQRaxgehMcbQLOrHphA=="],
+    "@jbearak/dta-parser": ["@jbearak/dta-parser@0.3.0", "", {}, "sha512-R0hZJfI/uCevvlOXr44U7Z/hUZHsUfyathkkJ3EBBx9+d7yEiugx9+cluUV2ApypLSmo9Tc3zjOf1eBb9syaNQ=="],
 
     "@jest/console": ["@jest/console@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@types/node": "*", "chalk": "^4.0.0", "jest-message-util": "^29.7.0", "jest-util": "^29.7.0", "slash": "^3.0.0" } }, "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -750,7 +750,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@jbearak/dta-parser": "^0.2.0",
+    "@jbearak/dta-parser": "^0.3.0",
     "@glideapps/glide-data-grid": "^6.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -381,6 +381,32 @@ export class DataBrowserPanel implements vscode.Disposable {
         return my_next;
     }
 
+    /**
+     * Serialize expensive user actions that mutate the effective row
+     * order. Without this, a filter and sort can overlap: the later
+     * action bumps `generation`, the earlier action discards its result,
+     * and its pending status is never cleared in the webview.
+     */
+    private action_chain: Promise<void> = Promise.resolve();
+
+    private enqueue_user_action(
+        action: () => Promise<void>
+    ): Promise<void> {
+        const my_dta_file = this.dta_file;
+        const my_next = this.action_chain
+            .catch(() => {})
+            .then(() => {
+                // A queued action belongs to the dataset that produced
+                // the webview message. If refresh/dispose swaps or clears
+                // the file before this action starts, no pending status has
+                // been posted for it yet, so silently drop the stale click.
+                if (this.dta_file !== my_dta_file) return;
+                return action();
+            });
+        this.action_chain = my_next.catch(() => {});
+        return my_next;
+    }
+
     private async send_metadata_impl(): Promise<void> {
         if (!this.dta_file) return;
 
@@ -494,10 +520,31 @@ export class DataBrowserPanel implements vscode.Disposable {
         let my_settled = false;
         try {
             const my_signal = my_abort?.signal;
+            let my_restore_columns:
+                Map<number, RowCell[]> | undefined;
+            try {
+                my_restore_columns =
+                    await this.read_restore_columns(
+                        my_schema_hash,
+                        my_signal
+                    );
+            } catch (my_err) {
+                // If the unified read is aborted, the existing
+                // maybe_restore_* paths observe the aborted signal and
+                // settle/forget just as they did when their own reads were
+                // interrupted. For a non-abort failure, fall back to the
+                // older per-column reads so warning behavior stays local to
+                // the sort/filter phase that actually fails.
+                if (!is_abort_error(my_err)) {
+                    my_restore_columns = undefined;
+                }
+            }
+            if (!this.dta_file || this.disposed) return;
+            if (my_generation !== this.generation) return;
             // Track sort/filter failure separately so the warning names
             // only what actually failed (the other may have applied).
             const my_sort_failed = await this.maybe_restore_sort(
-                my_schema_hash, my_signal
+                my_schema_hash, my_signal, my_restore_columns
             );
             if (!this.dta_file || this.disposed) return;
             // A refresh/reload/user-sort during the sort read bumps
@@ -511,7 +558,7 @@ export class DataBrowserPanel implements vscode.Disposable {
             let my_filter_failed = false;
             if (!is_cancelled()) {
                 my_filter_failed = await this.maybe_restore_filter(
-                    my_schema_hash, my_signal
+                    my_schema_hash, my_signal, my_restore_columns
                 );
                 if (!this.dta_file || this.disposed) return;
             }
@@ -906,6 +953,7 @@ export class DataBrowserPanel implements vscode.Disposable {
                 }
                 break;
             case 'columnWidthsChanged':
+                if (msg.dataset_key !== this.dataset_key) break;
                 await this.column_width_store.set(
                     this.dataset_key,
                     msg.widths,
@@ -913,6 +961,7 @@ export class DataBrowserPanel implements vscode.Disposable {
                 );
                 break;
             case 'columnVisibilityChanged':
+                if (msg.dataset_key !== this.dataset_key) break;
                 await this.column_visibility_store.set(
                     this.dataset_key,
                     msg.hidden_columns,
@@ -923,10 +972,14 @@ export class DataBrowserPanel implements vscode.Disposable {
                 await this.handle_row_request(msg);
                 break;
             case 'setSort':
-                await this.handle_set_sort(msg);
+                await this.enqueue_user_action(
+                    () => this.handle_set_sort(msg)
+                );
                 break;
             case 'setFilters':
-                await this.handle_set_filters(msg);
+                await this.enqueue_user_action(
+                    () => this.handle_set_filters(msg)
+                );
                 break;
             case 'requestHistogram':
                 await this.handle_request_histogram(msg);
@@ -976,8 +1029,9 @@ export class DataBrowserPanel implements vscode.Disposable {
 
         // Bump the generation so any row request that is already
         // in-flight under the previous permutation is dropped instead of
-        // posting stale rows after this sort lands, and so that a later
-        // setSort supersedes an earlier (slower) one rather than racing.
+        // posting stale rows after this sort lands. User sort/filter
+        // messages are serialized by handle_message, so this generation
+        // marks this action's row-order boundary.
         this.generation++;
         const my_generation = this.generation;
         this.post_sort_status('pending');
@@ -1046,7 +1100,8 @@ export class DataBrowserPanel implements vscode.Disposable {
      */
     private async maybe_restore_sort(
         schema_hash_value: string,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        column_values?: Map<number, RowCell[]>
     ): Promise<boolean> {
         if (this.sort_restored) return false;
         this.sort_restored = true;
@@ -1063,7 +1118,7 @@ export class DataBrowserPanel implements vscode.Disposable {
         try {
             my_permutation =
                 await this.compute_sort_permutation(
-                    my_stored, signal
+                    my_stored, signal, column_values
                 );
         } catch (my_err) {
             // A user cancel aborts the read → natural order, silent. A
@@ -1092,14 +1147,81 @@ export class DataBrowserPanel implements vscode.Disposable {
         signal?: AbortSignal
     ): Promise<RowCell[]> {
         if (!this.dta_file) return [];
-        const the_rows = await this.dta_file.read_rows(
-            0,
-            this.dta_file.nobs,
-            col_index,
-            col_index + 1,
+        const the_columns = await this.read_columns(
+            [col_index],
+            signal
+        );
+        return the_columns.get(col_index) ?? [];
+    }
+
+    /**
+     * Read several full columns in one row-major scan. Used by saved
+     * preference restore to avoid one full data-section scan per sort key
+     * or filter column.
+     */
+    private async read_columns(
+        col_indices: Iterable<number>,
+        signal?: AbortSignal
+    ): Promise<Map<number, RowCell[]>> {
+        if (!this.dta_file) return new Map();
+        const the_indices = [...new Set(col_indices)];
+        if (the_indices.length === 0) return new Map();
+        return this.dta_file.read_columns(
+            the_indices,
             signal ? { signal } : undefined
         );
-        return the_rows.map(my_row => my_row[0]);
+    }
+
+    /**
+     * Collect and pre-read the distinct columns that a saved sort/filter
+     * restore will need. Invalid stale columns are skipped here; the
+     * compute paths still validate and treat those prefs as inapplicable.
+     */
+    private async read_restore_columns(
+        schema_hash_value: string,
+        signal?: AbortSignal
+    ): Promise<Map<number, RowCell[]>> {
+        if (!this.dta_file) return new Map();
+        const the_needed = new Set<number>();
+        const my_nvar = this.dta_file.nvar;
+
+        if (!this.sort_restored && this.persist_sort_enabled()) {
+            const my_stored_sort = this.sort_state_store.get(
+                this.dataset_key,
+                schema_hash_value
+            );
+            for (const my_key of my_stored_sort?.keys ?? []) {
+                if (
+                    my_key.col_index >= 0
+                    && my_key.col_index < my_nvar
+                ) {
+                    the_needed.add(my_key.col_index);
+                }
+            }
+        }
+
+        if (!this.filter_restored && this.persist_filters_enabled()) {
+            const my_stored_filter = this.filter_state_store.get(
+                this.dataset_key,
+                schema_hash_value
+            );
+            for (const my_entry of my_stored_filter?.entries ?? []) {
+                if (!my_entry.enabled) continue;
+                const my_var =
+                    this.dta_file.variables[my_entry.col_index];
+                if (
+                    my_var !== undefined
+                    && this.predicate_fits_column(
+                        my_entry.predicate,
+                        my_var
+                    )
+                ) {
+                    the_needed.add(my_entry.col_index);
+                }
+            }
+        }
+
+        return this.read_columns(the_needed, signal);
     }
 
     /**
@@ -1110,7 +1232,8 @@ export class DataBrowserPanel implements vscode.Disposable {
      */
     private async compute_sort_permutation(
         sort: SortState,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        column_values?: Map<number, RowCell[]>
     ): Promise<Uint32Array | null> {
         if (!this.dta_file || sort.keys.length === 0) {
             return null;
@@ -1140,10 +1263,11 @@ export class DataBrowserPanel implements vscode.Disposable {
                 format: my_var.format,
                 has_value_labels: my_has_value_labels,
             });
-            const my_values = await this.read_full_column(
-                my_key.col_index,
-                signal
-            );
+            const my_values = column_values?.get(my_key.col_index)
+                ?? await this.read_full_column(
+                    my_key.col_index,
+                    signal
+                );
             // A refresh during the await nulls dta_file; bail so the
             // caller's generation check discards this stale result.
             if (!this.dta_file) return null;
@@ -1216,8 +1340,9 @@ export class DataBrowserPanel implements vscode.Disposable {
 
         // Bump the generation so an in-flight row request under the old
         // effective permutation is dropped rather than posting stale rows
-        // after this filter lands, and so a later setFilters supersedes an
-        // earlier (slower) one.
+        // after this filter lands. User sort/filter messages are
+        // serialized by handle_message, so this generation marks this
+        // action's row-order boundary.
         this.generation++;
         const my_generation = this.generation;
         this.post_filter_status('pending');
@@ -1278,7 +1403,8 @@ export class DataBrowserPanel implements vscode.Disposable {
      */
     private async maybe_restore_filter(
         schema_hash_value: string,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        column_values?: Map<number, RowCell[]>
     ): Promise<boolean> {
         if (this.filter_restored) return false;
         this.filter_restored = true;
@@ -1317,7 +1443,7 @@ export class DataBrowserPanel implements vscode.Disposable {
         let my_indices: Uint32Array | null = null;
         try {
             my_indices = await this.compute_filter_indices(
-                my_filter, signal
+                my_filter, signal, column_values
             );
         } catch (my_err) {
             // Cancel → natural order silently; genuine failure →
@@ -1386,7 +1512,8 @@ export class DataBrowserPanel implements vscode.Disposable {
      */
     private async compute_filter_indices(
         filter: FilterState,
-        signal?: AbortSignal
+        signal?: AbortSignal,
+        column_values?: Map<number, RowCell[]>
     ): Promise<Uint32Array | null> {
         if (!this.dta_file) return null;
         const the_active = filter.entries.filter(
@@ -1408,10 +1535,11 @@ export class DataBrowserPanel implements vscode.Disposable {
 
         const the_columns = new Map<number, FilterColumn>();
         for (const my_col_index of the_needed) {
-            const my_values = await this.read_full_column(
-                my_col_index,
-                signal
-            );
+            const my_values = column_values?.get(my_col_index)
+                ?? await this.read_full_column(
+                    my_col_index,
+                    signal
+                );
             // A refresh during the await nulls dta_file; bail so the
             // caller's generation check discards this stale result.
             if (!this.dta_file) return null;

--- a/client/src/data-browser/browser-panel.ts
+++ b/client/src/data-browser/browser-panel.ts
@@ -64,6 +64,7 @@ import type {
     HistogramDataMessage,
     HistogramBin,
     RestorePendingMessage,
+    RestoreSettledMessage,
     CancelRestoreMessage,
 } from './types.js';
 import { EMPTY_SORT, EMPTY_FILTER } from './types.js';
@@ -213,6 +214,11 @@ export class DataBrowserPanel implements vscode.Disposable {
         dta_path: string
     ): Promise<void> {
         this.generation++;
+        // Abort any in-flight background restore BEFORE closing the file,
+        // so its chunked reads bail on the abort signal instead of racing
+        // a closed fd (the generation bump above also makes the aborted
+        // restore discard its result without forgetting prefs).
+        this.abort_and_clear_restore();
         const my_old_path = this.dta_path;
         this.dta_file?.close();
         this.dta_file = null;
@@ -225,11 +231,9 @@ export class DataBrowserPanel implements vscode.Disposable {
         this.filter_restored = false;
         this.effective_perm = null;
         this.histogram_cache.clear();
-        // Reset the saved-preference restore handshake; a fresh restore
-        // begins (if applicable) when initialize() re-sends metadata. The
-        // generation bump above makes any aborted in-flight restore bail
-        // without forgetting prefs.
-        this.abort_and_clear_restore();
+        // (The in-flight restore was already aborted above, before the
+        // file was closed; a fresh restore begins, if applicable, when
+        // initialize() re-sends metadata.)
 
         // Clean up the old temp file on Windows before
         // overwriting the path (other platforms unlink
@@ -270,6 +274,14 @@ export class DataBrowserPanel implements vscode.Disposable {
     ): void {
         if (this.disposed) return;
         this.disposed = true;
+
+        // Under paint-first a restore can still be reading in the
+        // background when the panel closes. Bump the generation and abort
+        // its reads BEFORE closing the file, so the awaited restore bails
+        // (its `this.disposed` / generation checks) instead of reading a
+        // closed fd and surfacing an error dialog on a dead panel.
+        this.generation++;
+        this.abort_and_clear_restore();
 
         this.dta_file?.close();
         this.dta_file = null;
@@ -378,6 +390,10 @@ export class DataBrowserPanel implements vscode.Disposable {
         // outdated dataset/schema (a newer queued send_metadata posts).
         const my_generation = this.generation;
 
+        // --- Open / metadata phase. Errors here are genuine open/metadata
+        // failures, so they surface the "Failed to open" dialog. ---
+        let my_schema_hash: string;
+        let my_applies: { sort: boolean; filter: boolean };
         try {
             const my_missing_style =
                 vscode.workspace
@@ -421,110 +437,186 @@ export class DataBrowserPanel implements vscode.Disposable {
                 }
             );
 
-            const my_schema_hash = schema_hash(my_variables);
+            my_schema_hash = schema_hash(my_variables);
 
-            // Begin a cancellable restore if saved prefs apply. This
-            // posts `restorePending` before the (potentially long)
-            // column reads so the webview can explain the wait and offer
-            // Cancel. `my_abort` identifies this restore's controller so
-            // the finally only cleans up its own restore, not one a
-            // concurrent refresh may have started.
-            const my_began = this.maybe_begin_restore(my_schema_hash);
-            // Cancellation is read from this restore's own AbortSignal
-            // (null when no restore began), so a concurrent send_metadata
-            // reassigning this.restore_abort can't change what THIS call
-            // sees. `my_failed` aggregates non-abort read failures from
-            // the restore helpers (returned, not stored on the instance).
-            const my_abort = my_began ? this.restore_abort : null;
-            const is_cancelled = () => my_abort?.signal.aborted === true;
-            try {
-                const my_signal = my_abort?.signal;
-                // Track sort/filter failure separately so the warning
-                // names only what actually failed (the other may have
-                // applied successfully).
-                const my_sort_failed = await this.maybe_restore_sort(
-                    my_schema_hash, my_signal
-                );
-                if (!this.dta_file) return;
-                // A refresh/reload during the sort read supersedes this
-                // attempt; bail before maybe_restore_filter consumes its
-                // one-shot flag, so the queued send re-restores fully.
-                // (A user cancel does not bump generation and falls
-                // through to the forget path below.)
-                if (my_generation !== this.generation) return;
-                // A cancel during the sort read must not kick off a long
-                // filter read; skip it and fall through to forget.
-                let my_filter_failed = false;
-                if (!is_cancelled()) {
-                    my_filter_failed = await this.maybe_restore_filter(
-                        my_schema_hash, my_signal
-                    );
-                    if (!this.dta_file) return;
-                }
-                // A refresh / reload during the reads supersedes this
-                // attempt. Bail before posting (and before forgetting),
-                // leaving prefs intact for the queued send to reapply; a
-                // user cancel does NOT bump generation, so it still falls
-                // through to the forget path below.
-                if (my_generation !== this.generation) return;
-
-                if (is_cancelled()) {
-                    // Undo any sort that completed before the cancel
-                    // landed (memory only here), so chips and effective
-                    // order agree on "natural" before metadata is posted.
-                    this.reset_restored_prefs();
-                }
-                this.recompute_effective();
-
-                this.post_metadata(my_variables, my_schema_hash, my_missing_style);
-
-                // A restored filter changes the visible row count; the
-                // webview learns the effective count from filterApplied
-                // (metadata.nobs stays the full dataset size).
-                if (!is_cancelled() && this.filtered_indices) {
-                    this.post_filter_applied();
-                }
-                // Suppress the failure warning when the user cancelled:
-                // a read may have genuinely failed before the cancel
-                // landed, but the user explicitly chose natural order, so
-                // a "couldn't reapply" popup would be confusing noise.
-                if (!is_cancelled()
-                    && (my_sort_failed || my_filter_failed)) {
-                    const what = my_sort_failed && my_filter_failed
-                        ? 'sort and filter'
-                        : my_sort_failed ? 'sort' : 'filter';
-                    vscode.window.showWarningMessage(
-                        `Could not reapply the saved ${what} for this `
-                        + 'dataset; it was not applied.'
-                    );
-                }
-                // Persist the "forget" only after metadata is posted, so
-                // a store-write failure cannot strand the webview waiting
-                // on a metadata it never receives.
-                if (is_cancelled()) {
-                    await this.forget_persisted_prefs(my_schema_hash);
-                }
-            } finally {
-                // Only the call that began this restore clears its
-                // state, and only if a concurrent refresh hasn't already
-                // swapped in a newer restore controller.
-                if (my_began && this.restore_abort === my_abort) {
-                    this.restoring = false;
-                    this.restore_abort = null;
-                }
+            // Paint-first: decide whether a restore will run, then post
+            // metadata *immediately* so the grid renders in natural order
+            // at once instead of staying blank until the (potentially
+            // multi-second) column reads finish. When a restore is
+            // pending we omit the stored sort/filter from metadata so the
+            // grid shows natural order with no chips; the chips and the
+            // sorted/filtered order arrive later via `restoreSettled`.
+            my_applies = this.restore_applies(my_schema_hash);
+            const my_will_restore = my_applies.sort || my_applies.filter;
+            this.post_metadata(
+                my_variables,
+                my_schema_hash,
+                my_missing_style,
+                my_will_restore
+            );
+            if (this.disposed) return;
+            if (!my_will_restore) {
+                // No restore this send (first open with no prefs, or a
+                // reload after the one-shot restore was already consumed).
+                // If an in-memory filter is active (a reload that kept the
+                // restored/user filter), the metadata above carried the
+                // chips but reset nobs_effective, so re-announce the
+                // effective (post-filter) count — otherwise the grid sizes
+                // for the full dataset and scrolls into empty space. (Sort
+                // alone never changes the row count, so it needs nothing.)
+                if (this.filtered_indices) this.post_filter_applied();
+                return;
             }
         } catch (my_err) {
-            vscode.window.showErrorMessage(
-                `Failed to open .dta file: ${my_err}`
+            if (!this.disposed) {
+                vscode.window.showErrorMessage(
+                    `Failed to open .dta file: ${my_err}`
+                );
+            }
+            return;
+        }
+
+        // --- Restore phase. The file is already open and the grid is
+        // painted, so a failure here is NOT an open failure and must not
+        // show that dialog. Begin the cancellable restore: this posts
+        // `restorePending` (now *after* metadata) so the webview explains
+        // the wait over the live grid and offers Skip. `my_abort` /
+        // `my_restore_id` identify this restore so the finally and the
+        // settle only act on their own restore, not one a refresh started.
+        const my_began = this.maybe_begin_restore(my_applies);
+        if (!my_began) return;
+        const my_abort = this.restore_abort;
+        const my_restore_id = this.restore_id;
+        const is_cancelled = () => my_abort?.signal.aborted === true;
+        // Whether the settle (which dismisses the webview banner) was
+        // posted. If the catch fires before this, we must still dismiss the
+        // banner so a settle-phase throw can't strand it on "Applying…".
+        let my_settled = false;
+        try {
+            const my_signal = my_abort?.signal;
+            // Track sort/filter failure separately so the warning names
+            // only what actually failed (the other may have applied).
+            const my_sort_failed = await this.maybe_restore_sort(
+                my_schema_hash, my_signal
             );
+            if (!this.dta_file || this.disposed) return;
+            // A refresh/reload/user-sort during the sort read bumps
+            // generation and supersedes this attempt; bail before
+            // maybe_restore_filter consumes its one-shot flag, so the
+            // queued send (or the user action) takes over. (A Skip does
+            // not bump generation and falls through to settle.)
+            if (my_generation !== this.generation) return;
+            // A cancel during the sort read must not kick off a long
+            // filter read; skip it and fall through to settle.
+            let my_filter_failed = false;
+            if (!is_cancelled()) {
+                my_filter_failed = await this.maybe_restore_filter(
+                    my_schema_hash, my_signal
+                );
+                if (!this.dta_file || this.disposed) return;
+            }
+            // A refresh / reload / user action during the reads supersedes
+            // this attempt. Bail before settling, leaving prefs intact for
+            // the queued send (or the user's own sort/filter) to take over;
+            // a Skip does NOT bump generation, so it still settles+forgets.
+            if (my_generation !== this.generation) return;
+
+            if (is_cancelled()) {
+                // Undo any sort that completed before the Skip landed
+                // (memory only here), so chips and effective order agree
+                // on "natural" before we settle.
+                this.reset_restored_prefs();
+            }
+            // Settle the restore.
+            this.recompute_effective();
+            // Only invalidate the natural-order pages cached / in flight
+            // while the grid was live if the restore actually CHANGED the
+            // order (same recipe as handle_set_sort: bump generation so any
+            // in-flight natural read is discarded at its post-await check,
+            // and clear the row cache). On a settle to natural order — Skip,
+            // an empty restore, or a disabled-only filter — those pages stay
+            // valid; bumping there would drop in-flight reads that the
+            // webview (which keeps its pages on such settles) never
+            // re-requests, stranding blank viewport slots. This mirrors the
+            // webview's `my_order_changed` gate so the two sides agree.
+            if (this.effective_perm !== null) {
+                this.generation++;
+                this.row_cache.clear();
+            }
+            this.post_restore_settled(my_restore_id);
+            my_settled = true;
+
+            // Suppress the failure warning when the user cancelled: a read
+            // may have genuinely failed before the Skip landed, but the
+            // user explicitly chose natural order, so a "couldn't reapply"
+            // popup would be confusing noise.
+            if (!is_cancelled()
+                && (my_sort_failed || my_filter_failed)) {
+                const what = my_sort_failed && my_filter_failed
+                    ? 'sort and filter'
+                    : my_sort_failed ? 'sort' : 'filter';
+                vscode.window.showWarningMessage(
+                    `Could not reapply the saved ${what} for this `
+                    + 'dataset; it was not applied.'
+                );
+            }
+            // Persist the "forget" only after the settle is posted, so a
+            // store-write failure cannot strand the webview waiting on a
+            // settle it never receives. A rejection here is caught below
+            // (the settle already dismissed the banner).
+            if (is_cancelled()) {
+                await this.forget_persisted_prefs(my_schema_hash);
+            }
+        } catch {
+            // Restore-phase failure on an already-open, painted grid. The
+            // column reads handle their own failures inside
+            // maybe_restore_*; realistically only a forget_persisted_prefs
+            // store-write rejects here, after the settle was posted. Leave
+            // the data in natural order — do NOT show "Failed to open".
+            //
+            // If the throw beat the settle (so the banner was never
+            // dismissed), fall back to natural order and post a best-effort
+            // EMPTY settle so the webview can't stay stuck on "Applying…".
+            // (A duplicate settle after a real one is ignored by the
+            // webview's restore_id guard.)
+            if (!my_settled && !this.disposed
+                && this.restore_abort === my_abort) {
+                this.reset_restored_prefs();
+                this.effective_perm = null;
+                try {
+                    this.post_restore_settled(my_restore_id);
+                } catch {
+                    /* webview gone; nothing to dismiss */
+                }
+            }
+        } finally {
+            // Consume the handshake and clear restore state when this
+            // attempt ends and no newer restore has taken over. restore_id
+            // is cleared HERE (not inline after the settle) so that even a
+            // settle-phase throw consumes it — otherwise a Skip racing the
+            // settle could still match handle_cancel_restore's late-cancel
+            // branch and forget the just-restored prefs.
+            if (my_began && this.restore_abort === my_abort) {
+                this.restoring = false;
+                this.restore_abort = null;
+                this.restore_id = -1;
+            }
         }
     }
 
-    /** Build and post the metadata message for the current dataset. */
+    /**
+     * Build and post the metadata message for the current dataset. When
+     * `restore_pending` is true a paint-first restore is about to run, so
+     * the stored sort/filter are omitted: the grid renders natural order
+     * with no chips and the restored order/chips arrive via
+     * `restoreSettled`. When false (e.g. a reload with sort/filter already
+     * applied in memory) they are included so chips render immediately.
+     */
     private post_metadata(
         variables: MetadataMessage['variables'],
         schema_hash_value: string,
-        missing_value_style: MissingValueStyle
+        missing_value_style: MissingValueStyle,
+        restore_pending: boolean
     ): void {
         if (!this.dta_file) return;
         const my_metadata: MetadataMessage = {
@@ -533,14 +625,15 @@ export class DataBrowserPanel implements vscode.Disposable {
             missing_value_style: missing_value_style,
             variables: variables,
             schema_hash: schema_hash_value,
-            // After a cancel these are EMPTY, so stored_sort/filter
-            // are omitted and the webview renders no chips.
-            stored_sort: this.sort.keys.length > 0
+            // Omitted while a restore is pending (chips arrive on settle)
+            // and after a cancel (EMPTY), so the webview renders no chips.
+            stored_sort: !restore_pending && this.sort.keys.length > 0
                 ? this.sort
                 : undefined,
-            stored_filter: this.filter.entries.length > 0
-                ? this.filter
-                : undefined,
+            stored_filter:
+                !restore_pending && this.filter.entries.length > 0
+                    ? this.filter
+                    : undefined,
             name: this.sidecar.name,
             dataset_key: this.dataset_key,
             stored_column_widths:
@@ -562,35 +655,66 @@ export class DataBrowserPanel implements vscode.Disposable {
         this.panel.webview.postMessage(my_metadata);
     }
 
+    /**
+     * Terminal message for a paint-first restore: switch the (already
+     * painted, natural-order) grid to the restored sort/filter. Carries
+     * EMPTY sort/filter when the restore was cancelled/failed/empty. The
+     * `restore_id` lets the webview ignore a settle from a superseded
+     * lifecycle (a reload/refresh started a newer restore).
+     */
+    private post_restore_settled(restore_id: number): void {
+        const my_msg: RestoreSettledMessage = {
+            type: 'restoreSettled',
+            restore_id,
+            sort: this.sort,
+            filter: this.filter,
+            nobs_effective: this.effective_nobs(),
+        };
+        this.panel.webview.postMessage(my_msg);
+    }
+
     // -------------------------------------------------------
     // Saved-preference restore handshake
     // -------------------------------------------------------
 
     /**
-     * If a saved sort and/or filter applies to this dataset×schema,
-     * start a cancellable restore: reset the restore flags, create the
-     * AbortController, stamp `restore_id`, and post `restorePending`
-     * before the column reads. Returns true if a restore was begun.
+     * Side-effect-free peek: which saved preferences (if any) a restore
+     * would reapply now. Returned booleans feed both the paint-first
+     * metadata (whether to omit chips) and {@link maybe_begin_restore}
+     * (the single source of the begin/skip decision), so the two can
+     * never disagree.
      *
-     * Gated on the prefs *existing and fitting the schema* (a cheap
-     * store peek) — not on whether they will ultimately yield rows,
-     * which can't be known without the very read this explains.
+     * Gated on the prefs *existing and fitting the schema* (a cheap store
+     * peek) — not on whether they will ultimately yield rows, which can't
+     * be known without the very read this explains.
+     */
+    private restore_applies(
+        schema_hash_value: string
+    ): { sort: boolean; filter: boolean } {
+        // Restore happens once per lifetime; both flags are set together
+        // on the first send_metadata and reset by refresh().
+        if (this.sort_restored && this.filter_restored) {
+            return { sort: false, filter: false };
+        }
+        return {
+            sort: this.persist_sort_enabled()
+                && this.has_applicable_stored_sort(schema_hash_value),
+            filter: this.persist_filters_enabled()
+                && this.has_applicable_stored_filter(schema_hash_value),
+        };
+    }
+
+    /**
+     * Start a cancellable restore for the preferences {@link restore_applies}
+     * found: create the AbortController, stamp `restore_id`, and post
+     * `restorePending` (now after the paint-first metadata) so the webview
+     * can explain the wait over the live grid and offer Skip. Returns true
+     * if a restore was begun.
      */
     private maybe_begin_restore(
-        schema_hash_value: string
+        applies: { sort: boolean; filter: boolean }
     ): boolean {
-        // Restore happens once per lifetime; both flags are set
-        // together on the first send_metadata and reset by refresh().
-        if (this.sort_restored && this.filter_restored) {
-            return false;
-        }
-        const my_has_sort =
-            this.persist_sort_enabled()
-            && this.has_applicable_stored_sort(schema_hash_value);
-        const my_has_filter =
-            this.persist_filters_enabled()
-            && this.has_applicable_stored_filter(schema_hash_value);
-        if (!my_has_sort && !my_has_filter) return false;
+        if (!applies.sort && !applies.filter) return false;
 
         // A fresh controller per restore; cancellation is read from its
         // signal, so there is no shared boolean to reset.
@@ -601,8 +725,8 @@ export class DataBrowserPanel implements vscode.Disposable {
         const my_msg: RestorePendingMessage = {
             type: 'restorePending',
             restore_id: this.restore_id,
-            sort: my_has_sort,
-            filter: my_has_filter,
+            sort: applies.sort,
+            filter: applies.filter,
         };
         this.panel.webview.postMessage(my_msg);
         return true;
@@ -650,10 +774,10 @@ export class DataBrowserPanel implements vscode.Disposable {
      * ignored. The caller invalidates caches / posts updates and then
      * persists the forget via {@link forget_persisted_prefs}.
      *
-     * This shares the `restore_id = -1` line with
-     * {@link consume_restore_handshake} but is deliberately distinct: this
-     * runs in the cancel/forget path and must ALSO clear sort/filter, so
-     * the two must not be merged.
+     * A user superseding the restore goes through
+     * {@link abort_and_clear_restore} instead, which also sets
+     * `restore_id = -1` but must ALSO abort the in-flight reads (and does
+     * not clear sort/filter, since the user is applying their own).
      */
     private reset_restored_prefs(): void {
         this.restore_id = -1;
@@ -664,15 +788,21 @@ export class DataBrowserPanel implements vscode.Disposable {
     }
 
     /**
-     * Consume the restore handshake because the user has superseded the
-     * restored prefs (a new sort/filter). A later cancelRestore carrying
-     * the old id then no longer reaches handle_cancel_restore's late
-     * clear-and-forget branch, so it cannot wipe what the user applied.
-     * Only a cancel that genuinely raced completion (no user change since)
-     * still finds a matching id.
+     * The user superseded an in-flight restore with their own sort/filter.
+     * Discard any sort/filter the restore committed but never announced
+     * ({@link reset_restored_prefs}), AND mark the one-shot restore
+     * consumed so a later webview reload (which sees `restoring` already
+     * false) does not start a fresh restore that resurrects a saved pref
+     * the user never applied — e.g. the saved filter when they sorted
+     * during the saved-sort read, before the filter was ever fetched.
+     *
+     * The persisted prefs are NOT forgotten: a full reopen (refresh)
+     * re-arms both flags and reapplies them.
      */
-    private consume_restore_handshake(): void {
-        this.restore_id = -1;
+    private supersede_restore_attempt(): void {
+        this.reset_restored_prefs();
+        this.sort_restored = true;
+        this.filter_restored = true;
     }
 
     /**
@@ -822,17 +952,27 @@ export class DataBrowserPanel implements vscode.Disposable {
         msg: SetSortMessage
     ): Promise<void> {
         if (!this.dta_file) return;
-        // Ignore sort commands while a saved-preference restore is in
-        // flight: bumping generation here would make the restore discard
-        // its result without posting metadata, stranding the panel. The
-        // restore posts authoritative metadata momentarily; the user can
-        // re-sort then. (During the initial restore there is no grid to
-        // sort from; this guards the refresh-with-visible-grid case.)
-        if (this.restoring) return;
-
-        // The user is superseding the restored prefs, so the restore
-        // handshake is over.
-        this.consume_restore_handshake();
+        // The user is superseding the restored prefs. With paint-first the
+        // grid is live during a background restore, so a user sort can land
+        // mid-restore: abort the in-flight restore reads and clear the
+        // handshake (null-safe when no restore is running). The aborted
+        // restore bails at its post-await generation check below (this
+        // bumps generation), so it neither settles nor forgets prefs.
+        //
+        // Invariant: superseding does NOT forget saved prefs. This sort is
+        // persisted (overwriting the saved sort); any saved filter that
+        // had not yet applied this session stays stored and reapplies on
+        // the next open.
+        const my_was_restoring = this.restoring;
+        this.abort_and_clear_restore();
+        // Discard any sort/filter the aborted restore committed in memory
+        // but never announced (the saved sort commits before the saved
+        // filter read finishes) and mark the restore attempt consumed, so
+        // the grid never renders an unannounced restored order and a later
+        // reload cannot resurrect a not-yet-applied saved pref. Gated on
+        // `my_was_restoring` so a normal sort over an existing user filter
+        // is untouched.
+        if (my_was_restoring) this.supersede_restore_attempt();
 
         // Bump the generation so any row request that is already
         // in-flight under the previous permutation is dropped instead of
@@ -1059,14 +1199,20 @@ export class DataBrowserPanel implements vscode.Disposable {
         msg: SetFiltersMessage
     ): Promise<void> {
         if (!this.dta_file) return;
-        // Ignore filter commands while a saved-preference restore is in
-        // flight (see handle_set_sort): a generation bump here would
-        // strand the restore with no metadata posted.
-        if (this.restoring) return;
-
-        // The user is superseding the restored prefs, so the restore
-        // handshake is over (see handle_set_sort).
-        this.consume_restore_handshake();
+        // The user is superseding the restored prefs (see handle_set_sort):
+        // abort any in-flight background restore so it bails at its
+        // generation check below without settling or forgetting prefs.
+        // Superseding does NOT forget saved prefs; this filter is
+        // persisted and any not-yet-applied saved sort reapplies next open.
+        const my_was_restoring = this.restoring;
+        this.abort_and_clear_restore();
+        // Discard any restored sort committed in memory but not yet
+        // announced (so the grid does not render sorted+filtered under a
+        // filter-only chip) and mark the restore attempt consumed (so a
+        // later reload cannot resurrect the not-yet-applied saved sort).
+        // Gated on `my_was_restoring` so a normal filter over an existing
+        // user sort is untouched.
+        if (my_was_restoring) this.supersede_restore_attempt();
 
         // Bump the generation so an in-flight row request under the old
         // effective permutation is dropped rather than posting stale rows

--- a/client/src/data-browser/types.ts
+++ b/client/src/data-browser/types.ts
@@ -155,6 +155,23 @@ export interface RestorePendingMessage {
     filter: boolean;
 }
 
+/**
+ * Terminal signal for a paint-first restore: the host has finished
+ * reapplying (or cancelling) the saved sort/filter that a matching
+ * `restorePending` announced. Posted *after* the grid was already painted
+ * in natural order, so this carries the final order to switch to. `sort`
+ * / `filter` are EMPTY when the restore was cancelled, failed, or yielded
+ * nothing. `restore_id` matches the `restorePending` so the webview
+ * ignores a settle from a superseded lifecycle (reload/refresh).
+ */
+export interface RestoreSettledMessage {
+    type: 'restoreSettled';
+    restore_id: number;
+    sort: SortState;
+    filter: FilterState;
+    nobs_effective: number;
+}
+
 export type ExtensionMessage =
     | RowResponse
     | MetadataMessage
@@ -163,7 +180,8 @@ export type ExtensionMessage =
     | FilterAppliedMessage
     | FilterStatusMessage
     | HistogramDataMessage
-    | RestorePendingMessage;
+    | RestorePendingMessage
+    | RestoreSettledMessage;
 
 export interface VariableDescription {
     name: string;

--- a/client/src/data-browser/webview/app.tsx
+++ b/client/src/data-browser/webview/app.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react';
 import {
     DataEditor,
+    type DataEditorRef,
     type DrawHeaderCallback,
     GridCellKind,
     type GridSelection,
@@ -52,6 +53,7 @@ import {
     apply_sort_pick,
     sort_priority_map,
 } from './sort-actions.js';
+import { visible_cell_damage } from './visible-cell-damage.js';
 import type { FilterEntry, SortKey } from '../types.js';
 
 const HEADER_HEIGHT_PX = 40;
@@ -303,6 +305,7 @@ export function App(): ReactElement {
         useState<ContextMenuState | null>(null);
     const [filter_editor, set_filter_editor] =
         useState<FilterEditorState | null>(null);
+    const data_editor_ref = useRef<DataEditorRef>(null);
     const grid_shell_ref = useRef<HTMLDivElement>(null);
     const toolbar_ref = useRef<HTMLDivElement>(null);
     const row_count_ref = useRef<HTMLSpanElement>(null);
@@ -515,6 +518,24 @@ export function App(): ReactElement {
         () => metadata?.variables.map(my_v => my_v.name) ?? [],
         [metadata]
     );
+
+    useEffect(() => {
+        const my_damage = visible_cell_damage({
+            column_count: the_columns.length,
+            first_row: first_visible_row,
+            row_count: visible_row_count,
+            total_rows: nobs_effective ?? metadata?.nobs ?? 0,
+        });
+        if (my_damage.length === 0) return;
+        data_editor_ref.current?.updateCells(my_damage);
+    }, [
+        pages,
+        the_columns.length,
+        first_visible_row,
+        visible_row_count,
+        nobs_effective,
+        metadata?.nobs,
+    ]);
 
     const sort_info = useMemo(
         () => sort_priority_map(sort.keys),
@@ -1169,6 +1190,7 @@ export function App(): ReactElement {
             )}
             <div className="grid-shell" ref={grid_shell_ref}>
                 <DataEditor
+                    ref={data_editor_ref}
                     theme={vscode_theme}
 
                     width="100%"

--- a/client/src/data-browser/webview/app.tsx
+++ b/client/src/data-browser/webview/app.tsx
@@ -21,9 +21,9 @@ import {
     clamp_column_width,
     collect_sampled_value_width_hints,
     type BrowserGridColumn,
+    describe_browser_row_count,
     describe_restore_message,
     describe_subset,
-    describe_toolbar_row_count,
     get_cell_display_value,
     get_variable_header_tooltip,
     merge_persisted_and_default_widths,
@@ -815,25 +815,26 @@ export function App(): ReactElement {
         }
     };
 
-    // On open, explain (and let the user cancel) the wait while saved
-    // sort/filter preferences are reapplied.
+    // While saved sort/filter preferences are reapplied, the grid already
+    // shows the data in natural order (paint-first), so the banner just
+    // explains the in-progress reordering and offers Cancel.
     const restore_message = restore_pending
         ? (restore_cancelling
-            ? 'Loading…'
+            ? 'Cancelling…'
             : describe_restore_message(
                 restore_pending.sort,
                 restore_pending.filter
             ))
         : null;
 
-    // While the restore banner is up it explains the wait, so suppress
-    // the bare "Loading…" row-count that would otherwise stack above it.
-    const row_count_text = describe_toolbar_row_count(
+    // Paint-first: the grid shows natural-order data while a saved
+    // sort/filter is reapplied in the background, so show the real row
+    // count alongside the restore banner rather than suppressing it.
+    const row_count_text = describe_browser_row_count(
         metadata,
         nobs_effective,
         first_visible_row,
-        visible_row_count,
-        restore_message !== null
+        visible_row_count
     );
 
     const subset_text = describe_subset(metadata);
@@ -1158,7 +1159,7 @@ export function App(): ReactElement {
                             className="restore-skip"
                             onClick={cancel_restore}
                         >
-                            Skip and show data now
+                            Cancel
                         </button>
                     )}
                 </div>

--- a/client/src/data-browser/webview/app.tsx
+++ b/client/src/data-browser/webview/app.tsx
@@ -819,7 +819,7 @@ export function App(): ReactElement {
     // sort/filter preferences are reapplied.
     const restore_message = restore_pending
         ? (restore_cancelling
-            ? 'Cancelling…'
+            ? 'Loading…'
             : describe_restore_message(
                 restore_pending.sort,
                 restore_pending.filter
@@ -1155,10 +1155,10 @@ export function App(): ReactElement {
                     {!restore_cancelling && (
                         <button
                             type="button"
-                            className="restore-cancel"
+                            className="restore-skip"
                             onClick={cancel_restore}
                         >
-                            Cancel
+                            Skip and show data now
                         </button>
                     )}
                 </div>

--- a/client/src/data-browser/webview/filter-intent.ts
+++ b/client/src/data-browser/webview/filter-intent.ts
@@ -1,0 +1,122 @@
+import type {
+    FilterEntry,
+    FilterPredicate,
+    FilterState,
+} from '../types.js';
+
+export interface FilterAppliedOutcome {
+    pending_filter: FilterState | null;
+    refetch_rows: boolean;
+}
+
+function clone_predicate(predicate: FilterPredicate): FilterPredicate {
+    switch (predicate.kind) {
+        case 'setIn':
+        case 'setNotIn':
+            return {
+                ...predicate,
+                values: [...predicate.values],
+            };
+        default:
+            return { ...predicate };
+    }
+}
+
+function clone_entry(entry: FilterEntry): FilterEntry {
+    return {
+        ...entry,
+        predicate: clone_predicate(entry.predicate),
+    };
+}
+
+export function build_pending_filter(
+    entries: readonly FilterEntry[],
+    labels_on: boolean
+): FilterState {
+    return {
+        entries: entries.map(clone_entry),
+        labels_on_when_filtered: labels_on,
+    };
+}
+
+export function visible_filter_state(
+    applied_filter: FilterState,
+    pending_filter: FilterState | null
+): FilterState {
+    return pending_filter ?? applied_filter;
+}
+
+function arrays_equal(a: readonly unknown[], b: readonly unknown[]): boolean {
+    return a.length === b.length
+        && a.every((my_value, i) => my_value === b[i]);
+}
+
+function predicate_values_equal(a: unknown, b: unknown): boolean {
+    if (Array.isArray(a) || Array.isArray(b)) {
+        return Array.isArray(a)
+            && Array.isArray(b)
+            && arrays_equal(a, b);
+    }
+    return a === b;
+}
+
+function predicates_equal(
+    a: FilterPredicate,
+    b: FilterPredicate
+): boolean {
+    if (a.kind !== b.kind) return false;
+    const my_a = a as unknown as Record<string, unknown>;
+    const my_b = b as unknown as Record<string, unknown>;
+    const the_keys = Object.keys(my_a);
+    if (the_keys.length !== Object.keys(my_b).length) return false;
+    return the_keys.every(my_key =>
+        predicate_values_equal(my_a[my_key], my_b[my_key])
+    );
+}
+
+function entries_equal(a: FilterEntry, b: FilterEntry): boolean {
+    return a.id === b.id
+        && a.col_index === b.col_index
+        && a.enabled === b.enabled
+        && a.include_missing === b.include_missing
+        && predicates_equal(a.predicate, b.predicate);
+}
+
+function filter_states_equal(a: FilterState, b: FilterState): boolean {
+    if (a.labels_on_when_filtered !== b.labels_on_when_filtered) {
+        return false;
+    }
+    if (a.entries.length !== b.entries.length) return false;
+    return a.entries.every((my_entry, i) =>
+        entries_equal(my_entry, b.entries[i])
+    );
+}
+
+export function pending_filter_after_applied(
+    applied_filter: FilterState,
+    pending_filter: FilterState | null
+): FilterState | null {
+    if (!pending_filter) return null;
+    return filter_states_equal(applied_filter, pending_filter)
+        ? null
+        : pending_filter;
+}
+
+export function filter_applied_outcome(
+    applied_filter: FilterState,
+    pending_filter: FilterState | null
+): FilterAppliedOutcome {
+    const my_pending_filter =
+        pending_filter_after_applied(applied_filter, pending_filter);
+    return {
+        pending_filter: my_pending_filter,
+        refetch_rows: my_pending_filter === null,
+    };
+}
+
+export function filter_work_pending(
+    host_pending: boolean,
+    pending_filter: FilterState | null
+): boolean {
+    return host_pending || pending_filter !== null;
+}

--- a/client/src/data-browser/webview/grid-model.ts
+++ b/client/src/data-browser/webview/grid-model.ts
@@ -296,30 +296,6 @@ export function describe_browser_row_count(
 }
 
 /**
- * The toolbar row-count text. While a saved-preference restore banner is
- * showing (`restore_active`), returns '' so that banner's explanation
- * ("Applying your saved sort…") replaces the unexplained "Loading…"
- * rather than stacking above it.
- */
-export function describe_toolbar_row_count(
-    metadata: MetadataMessage | null,
-    nobs_effective: number | undefined,
-    first_visible_row: number,
-    visible_row_count: number,
-    restore_active: boolean
-): string {
-    if (restore_active) {
-        return '';
-    }
-    return describe_browser_row_count(
-        metadata,
-        nobs_effective,
-        first_visible_row,
-        visible_row_count
-    );
-}
-
-/**
  * Explains the saved-preference restore wait on open. `sort`/`filter`
  * say which preferences are being reapplied; at least one is true.
  */

--- a/client/src/data-browser/webview/refetch-page-starts.ts
+++ b/client/src/data-browser/webview/refetch-page-starts.ts
@@ -1,0 +1,25 @@
+import { get_needed_page_starts } from './grid-model.js';
+
+interface PageStartsToRefetchArgs {
+    viewport_start: number;
+    viewport_end: number;
+    page_size: number;
+    loaded_page_starts: Iterable<number>;
+}
+
+export function page_starts_to_refetch({
+    viewport_start,
+    viewport_end,
+    page_size,
+    loaded_page_starts,
+}: PageStartsToRefetchArgs): number[] {
+    if (viewport_end > viewport_start) {
+        return get_needed_page_starts(
+            viewport_start,
+            viewport_end,
+            page_size
+        );
+    }
+
+    return [...new Set(loaded_page_starts)].sort((a, b) => a - b);
+}

--- a/client/src/data-browser/webview/row-request-tracker.ts
+++ b/client/src/data-browser/webview/row-request-tracker.ts
@@ -1,0 +1,34 @@
+/**
+ * Tracks outstanding row-page requests by both page start and request id.
+ *
+ * A page can be cleared and re-requested after sort/filter changes. If the
+ * older response arrives late, the page start alone is ambiguous; the request
+ * id lets the webview ignore stale rows instead of repainting an old order.
+ */
+export class RowRequestTracker {
+    private readonly pending_by_page = new Map<number, string>();
+    private request_counter = 0;
+
+    track(page_start: number): string {
+        this.request_counter += 1;
+        const request_id = 'req_' + String(this.request_counter);
+        this.pending_by_page.set(page_start, request_id);
+        return request_id;
+    }
+
+    has_pending(page_start: number): boolean {
+        return this.pending_by_page.has(page_start);
+    }
+
+    accepts(page_start: number, request_id: string): boolean {
+        if (this.pending_by_page.get(page_start) !== request_id) {
+            return false;
+        }
+        this.pending_by_page.delete(page_start);
+        return true;
+    }
+
+    clear(): void {
+        this.pending_by_page.clear();
+    }
+}

--- a/client/src/data-browser/webview/sort-intent.ts
+++ b/client/src/data-browser/webview/sort-intent.ts
@@ -1,0 +1,64 @@
+import type { SortKey, SortState } from '../types.js';
+
+export interface SortAppliedOutcome {
+    pending_sort: SortState | null;
+    refetch_rows: boolean;
+}
+
+export function build_pending_sort(
+    keys: readonly SortKey[],
+    labels_on: boolean
+): SortState {
+    return {
+        keys: keys.map(my_key => ({ ...my_key })),
+        labels_on_when_sorted: labels_on,
+    };
+}
+
+export function visible_sort_state(
+    applied_sort: SortState,
+    pending_sort: SortState | null
+): SortState {
+    return pending_sort ?? applied_sort;
+}
+
+function sort_states_equal(a: SortState, b: SortState): boolean {
+    if (a.labels_on_when_sorted !== b.labels_on_when_sorted) {
+        return false;
+    }
+    if (a.keys.length !== b.keys.length) return false;
+    return a.keys.every((my_key, i) => {
+        const my_other = b.keys[i];
+        return my_key.col_index === my_other.col_index
+            && my_key.direction === my_other.direction;
+    });
+}
+
+export function pending_sort_after_applied(
+    applied_sort: SortState,
+    pending_sort: SortState | null
+): SortState | null {
+    if (!pending_sort) return null;
+    return sort_states_equal(applied_sort, pending_sort)
+        ? null
+        : pending_sort;
+}
+
+export function sort_applied_outcome(
+    applied_sort: SortState,
+    pending_sort: SortState | null
+): SortAppliedOutcome {
+    const my_pending_sort =
+        pending_sort_after_applied(applied_sort, pending_sort);
+    return {
+        pending_sort: my_pending_sort,
+        refetch_rows: my_pending_sort === null,
+    };
+}
+
+export function sort_work_pending(
+    host_pending: boolean,
+    pending_sort: SortState | null
+): boolean {
+    return host_pending || pending_sort !== null;
+}

--- a/client/src/data-browser/webview/styles.css
+++ b/client/src/data-browser/webview/styles.css
@@ -74,9 +74,13 @@ body,
 /* Saved sort/filter is being reapplied on open: explains the wait and
    offers a Cancel that abandons it and shows the data unsorted. */
 .toolbar-restore {
+    /* Stack the message and the skip link so the link reads as the
+       message's own follow-up action rather than a detached control
+       floating at the far right of the row. */
     display: flex;
-    align-items: center;
-    gap: 8px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
     padding: 4px 8px;
     border-bottom: 1px solid var(--vscode-panel-border);
     background: var(--vscode-editorGroupHeader-tabsBackground, var(--vscode-editor-background));
@@ -84,34 +88,33 @@ body,
     /* Like `.toolbar`, this is a flex item in the column-flex
        `.browser-root`; `min-width: 0` lets the row shrink to the viewport
        so the message truncates (see the span rule below) instead of the
-       row growing to its content width and clipping the Cancel button. */
+       row growing to its content width. */
     min-width: 0;
 }
 
 .toolbar-restore > span {
-    /* Allow the message to shrink so ellipsis applies in narrow panels;
-       a flex item defaults to min-width:auto and would otherwise overflow
-       and push the Cancel button off-screen. */
-    flex: 1 1 auto;
-    min-width: 0;
+    /* Cap the message to the panel width so a long explanation ellipsizes
+       rather than forcing the banner wider than the viewport. */
+    max-width: 100%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
-.restore-cancel {
-    flex: 0 0 auto;
-    padding: 1px 8px;
+.restore-skip {
+    /* Styled as a link, not a button: it's a low-stakes alternative to
+       waiting, and a link sits naturally beneath the message it modifies. */
+    padding: 0;
     font-size: 12px;
-    color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
-    background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+    color: var(--vscode-textLink-foreground);
+    background: none;
     border: none;
-    border-radius: 2px;
+    text-decoration: underline;
     cursor: pointer;
 }
 
-.restore-cancel:hover {
-    background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+.restore-skip:hover {
+    color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
 }
 
 /* Sort + filter chip strips. Sits between the row count and the action

--- a/client/src/data-browser/webview/styles.css
+++ b/client/src/data-browser/webview/styles.css
@@ -72,7 +72,8 @@ body,
 }
 
 /* Saved sort/filter is being reapplied on open: explains the wait and
-   offers a Cancel that abandons it and shows the data unsorted. */
+   offers a "Skip and show data now" link that abandons the reapply and
+   loads the data immediately. */
 .toolbar-restore {
     /* Stack the message and the skip link so the link reads as the
        message's own follow-up action rather than a detached control
@@ -93,8 +94,8 @@ body,
 }
 
 .toolbar-restore > span {
-    /* Cap the message to the panel width so a long explanation ellipsizes
-       rather than forcing the banner wider than the viewport. */
+    /* Cap the message to the panel width so a long explanation
+       ellipsizes instead of widening the banner past the viewport. */
     max-width: 100%;
     white-space: nowrap;
     overflow: hidden;
@@ -102,11 +103,14 @@ body,
 }
 
 .restore-skip {
-    /* Styled as a link, not a button: it's a low-stakes alternative to
-       waiting, and a link sits naturally beneath the message it modifies. */
+    /* Styled as a link, not a button: a low-stakes alternative to
+       waiting that sits naturally beneath the message it modifies.
+       Underlined at rest (unlike `.popover-action-btn`, which underlines
+       only on hover) because it is the banner's primary affordance and
+       must read as clickable without hovering. */
     padding: 0;
     font-size: 12px;
-    color: var(--vscode-textLink-foreground);
+    color: var(--vscode-textLink-foreground, inherit);
     background: none;
     border: none;
     text-decoration: underline;
@@ -114,7 +118,7 @@ body,
 }
 
 .restore-skip:hover {
-    color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+    color: var(--vscode-textLink-activeForeground, inherit);
 }
 
 /* Sort + filter chip strips. Sits between the row count and the action
@@ -844,7 +848,8 @@ body,
 .filter-chip-body:focus-visible,
 .filter-chip-kebab:focus-visible,
 .filter-strip-clear:focus-visible,
-.filter-popover-btn:focus-visible {
+.filter-popover-btn:focus-visible,
+.restore-skip:focus-visible {
     outline: 1px solid var(--vscode-focusBorder, #007fd4);
     outline-offset: 1px;
 }

--- a/client/src/data-browser/webview/use-row-loader.ts
+++ b/client/src/data-browser/webview/use-row-loader.ts
@@ -15,6 +15,7 @@ import type {
     HistogramDataMessage,
     MetadataMessage,
     RestorePendingMessage,
+    RestoreSettledMessage,
     RowResponse,
     SortAppliedMessage,
     SortKey,
@@ -79,7 +80,8 @@ type IncomingMessage =
     | FilterAppliedMessage
     | FilterStatusMessage
     | HistogramDataMessage
-    | RestorePendingMessage;
+    | RestorePendingMessage
+    | RestoreSettledMessage;
 
 export function use_row_loader(): UseRowLoaderResult {
     const vscode_api = useMemo(() => acquireVsCodeApi(), []);
@@ -121,6 +123,19 @@ export function use_row_loader(): UseRowLoaderResult {
         end: 0,
     });
 
+    // Dismiss the saved-preference restore banner (timer + state). Used
+    // when a restore settles, when the user supersedes it with their own
+    // sort/filter, and on fresh metadata.
+    const clear_restore_ui = useCallback(() => {
+        if (restore_timer.current !== null) {
+            clearTimeout(restore_timer.current);
+            restore_timer.current = null;
+        }
+        set_restore_pending(null);
+        set_restore_cancelling(false);
+        restore_id_ref.current = null;
+    }, []);
+
     const request_page = useCallback(
         (page_start: number) => {
             pending_pages.current.add(page_start);
@@ -135,6 +150,24 @@ export function use_row_loader(): UseRowLoaderResult {
         },
         [vscode_api]
     );
+
+    // The visible order changed (a sort/filter applied or a restore
+    // settled to a non-natural order): drop the cached pages and re-request
+    // the viewport so the host serves rows in the new order. The host has
+    // cleared its own cache and bumped its generation, so any in-flight
+    // row read under the old order is discarded host-side.
+    const reset_pages_and_refetch_viewport = useCallback(() => {
+        set_pages(new Map());
+        pending_pages.current.clear();
+        const my_viewport = viewport_ref.current;
+        for (const my_start of get_needed_page_starts(
+            my_viewport.start,
+            my_viewport.end,
+            PAGE_SIZE
+        )) {
+            request_page(my_start);
+        }
+    }, [request_page]);
 
     useEffect(() => {
         function on_message(event: MessageEvent) {
@@ -168,15 +201,10 @@ export function use_row_loader(): UseRowLoaderResult {
             }
 
             if (my_msg.type === 'metadata') {
-                // Both the normal and cancelled restore paths end by
-                // posting metadata, so clear the restore UI here.
-                if (restore_timer.current !== null) {
-                    clearTimeout(restore_timer.current);
-                    restore_timer.current = null;
-                }
-                set_restore_pending(null);
-                set_restore_cancelling(false);
-                restore_id_ref.current = null;
+                // Metadata is posted first (paint-first); a `restorePending`
+                // for this dataset follows and re-arms the banner. Clearing
+                // here resets any stale banner from a prior lifecycle.
+                clear_restore_ui();
 
                 set_metadata(my_msg);
                 set_pages(new Map());
@@ -192,6 +220,11 @@ export function use_row_loader(): UseRowLoaderResult {
             }
 
             if (my_msg.type === 'rowData') {
+                // No generation/epoch guard is needed here: the host never
+                // posts stale rows — handle_row_request re-checks its
+                // generation after every read and drops the response on a
+                // mismatch, so a row read started under the old order can't
+                // land after a sort/filter/settle changed it.
                 pending_pages.current.delete(my_msg.start);
                 set_pages(my_previous => {
                     const my_next = new Map(my_previous);
@@ -202,21 +235,13 @@ export function use_row_loader(): UseRowLoaderResult {
             }
 
             if (my_msg.type === 'sortApplied') {
+                // A user sort during a background restore supersedes it;
+                // dismiss the restore banner (the host aborted the restore).
+                clear_restore_ui();
                 set_sort(my_msg.sort);
                 set_nobs_effective(my_msg.nobs_effective);
-                set_pages(new Map());
-                pending_pages.current.clear();
                 set_sort_pending(false);
-                // Re-request the current viewport in the new order;
-                // the host has cleared its cache for this permutation.
-                const my_viewport = viewport_ref.current;
-                for (const my_start of get_needed_page_starts(
-                    my_viewport.start,
-                    my_viewport.end,
-                    PAGE_SIZE
-                )) {
-                    request_page(my_start);
-                }
+                reset_pages_and_refetch_viewport();
                 return;
             }
 
@@ -226,26 +251,50 @@ export function use_row_loader(): UseRowLoaderResult {
             }
 
             if (my_msg.type === 'filterApplied') {
+                // A user filter during a background restore supersedes it;
+                // dismiss the restore banner (the host aborted the restore).
+                clear_restore_ui();
                 set_filter(my_msg.filter);
                 set_nobs_effective(my_msg.nobs_filtered);
-                set_pages(new Map());
-                pending_pages.current.clear();
                 set_filter_pending(false);
-                // Re-request the current viewport in the new (filtered)
-                // order; the host cleared its cache for this permutation.
-                const my_viewport = viewport_ref.current;
-                for (const my_start of get_needed_page_starts(
-                    my_viewport.start,
-                    my_viewport.end,
-                    PAGE_SIZE
-                )) {
-                    request_page(my_start);
-                }
+                reset_pages_and_refetch_viewport();
                 return;
             }
 
             if (my_msg.type === 'filterStatus') {
                 set_filter_pending(my_msg.state === 'pending');
+                return;
+            }
+
+            if (my_msg.type === 'restoreSettled') {
+                // Ignore a settle from a superseded lifecycle (a reload /
+                // refresh started a newer restore, or a user action already
+                // dismissed the banner and nulled the id).
+                if (my_msg.restore_id !== restore_id_ref.current) {
+                    return;
+                }
+                clear_restore_ui();
+                // Switch the (already painted, natural-order) grid to the
+                // restored order.
+                set_sort(my_msg.sort);
+                set_filter(my_msg.filter);
+                set_nobs_effective(my_msg.nobs_effective);
+                set_sort_pending(false);
+                set_filter_pending(false);
+                // Only re-request when the settle actually changed the
+                // order. A settle that leaves natural order — no sort keys
+                // and no ENABLED filter entry (e.g. Skip, an empty restore,
+                // or a restored filter whose entries are all disabled) —
+                // leaves the already-painted natural rows valid, so
+                // blanking and reloading them would be a pointless flicker.
+                const my_order_changed =
+                    my_msg.sort.keys.length > 0
+                    || my_msg.filter.entries.some(
+                        my_entry => my_entry.enabled
+                    );
+                if (my_order_changed) {
+                    reset_pages_and_refetch_viewport();
+                }
                 return;
             }
 
@@ -268,7 +317,7 @@ export function use_row_loader(): UseRowLoaderResult {
                 restore_timer.current = null;
             }
         };
-    }, [vscode_api, request_page]);
+    }, [vscode_api, reset_pages_and_refetch_viewport, clear_restore_ui]);
 
     const cancel_restore = useCallback(() => {
         const my_id = restore_id_ref.current;
@@ -320,24 +369,29 @@ export function use_row_loader(): UseRowLoaderResult {
 
     const apply_sort = useCallback(
         (keys: SortKey[], labels_on: boolean) => {
+            // Dismiss the restore banner at once: the host's sortApplied
+            // can be seconds away for a large user sort, and the saved
+            // restore is already superseded.
+            clear_restore_ui();
             vscode_api.postMessage({
                 type: 'setSort',
                 keys,
                 labels_on,
             });
         },
-        [vscode_api]
+        [vscode_api, clear_restore_ui]
     );
 
     const apply_filter = useCallback(
         (entries: FilterEntry[], labels_on: boolean) => {
+            clear_restore_ui();
             vscode_api.postMessage({
                 type: 'setFilters',
                 entries,
                 labels_on,
             });
         },
-        [vscode_api]
+        [vscode_api, clear_restore_ui]
     );
 
     const request_histogram = useCallback(

--- a/client/src/data-browser/webview/use-row-loader.ts
+++ b/client/src/data-browser/webview/use-row-loader.ts
@@ -28,6 +28,20 @@ import {
     get_needed_page_starts,
     PAGE_SIZE,
 } from './grid-model.js';
+import {
+    build_pending_filter,
+    filter_applied_outcome,
+    filter_work_pending,
+    visible_filter_state,
+} from './filter-intent.js';
+import { page_starts_to_refetch } from './refetch-page-starts.js';
+import { RowRequestTracker } from './row-request-tracker.js';
+import {
+    build_pending_sort,
+    sort_applied_outcome,
+    sort_work_pending,
+    visible_sort_state,
+} from './sort-intent.js';
 
 /**
  * Delay before the "applying saved sort/filter" UI appears. A restore
@@ -91,9 +105,16 @@ export function use_row_loader(): UseRowLoaderResult {
     const [pages, set_pages] = useState<Map<number, CellValue[][]>>(
         () => new Map()
     );
+    const pages_ref = useRef<Map<number, CellValue[][]>>(new Map());
     const [sort, set_sort] = useState<SortState>(EMPTY_SORT);
+    const [pending_sort, set_pending_sort] =
+        useState<SortState | null>(null);
+    const pending_sort_ref = useRef<SortState | null>(null);
     const [sort_pending, set_sort_pending] = useState(false);
     const [filter, set_filter] = useState<FilterState>(EMPTY_FILTER);
+    const [pending_filter, set_pending_filter] =
+        useState<FilterState | null>(null);
+    const pending_filter_ref = useRef<FilterState | null>(null);
     const [filter_pending, set_filter_pending] = useState(false);
     // The visible row count after sort+filter. Both sortApplied and
     // filterApplied carry the host's effective count, so a single state
@@ -114,8 +135,7 @@ export function use_row_loader(): UseRowLoaderResult {
     // Columns whose histogram has been requested (pending or arrived), so
     // opening a numeric filter popover repeatedly doesn't re-request.
     const requested_histograms = useRef<Set<number>>(new Set());
-    const pending_pages = useRef<Set<number>>(new Set());
-    const request_counter = useRef(0);
+    const pending_pages = useRef(new RowRequestTracker());
     // Last visible window [start, end), kept in a ref so the message
     // handler (registered once) can re-request it after a sort lands.
     const viewport_ref = useRef<{ start: number; end: number }>({
@@ -136,19 +156,52 @@ export function use_row_loader(): UseRowLoaderResult {
         restore_id_ref.current = null;
     }, []);
 
+    const set_pending_sort_state = useCallback((
+        next_sort: SortState | null
+    ) => {
+        pending_sort_ref.current = next_sort;
+        set_pending_sort(next_sort);
+    }, []);
+
+    const set_pending_filter_state = useCallback((
+        next_filter: FilterState | null
+    ) => {
+        pending_filter_ref.current = next_filter;
+        set_pending_filter(next_filter);
+    }, []);
+
     const request_page = useCallback(
         (page_start: number) => {
-            pending_pages.current.add(page_start);
-            request_counter.current += 1;
+            const request_id = pending_pages.current.track(page_start);
             vscode_api.postMessage({
                 type: 'requestRows',
                 start: page_start,
                 count: PAGE_SIZE,
-                request_id:
-                    'req_' + String(request_counter.current),
+                request_id,
             });
         },
         [vscode_api]
+    );
+
+    useEffect(() => {
+        pages_ref.current = pages;
+    }, [pages]);
+
+    const visible_sort = useMemo(
+        () => visible_sort_state(sort, pending_sort),
+        [sort, pending_sort]
+    );
+    const visible_filter = useMemo(
+        () => visible_filter_state(filter, pending_filter),
+        [filter, pending_filter]
+    );
+    const visible_sort_pending = useMemo(
+        () => sort_work_pending(sort_pending, pending_sort),
+        [sort_pending, pending_sort]
+    );
+    const visible_filter_pending = useMemo(
+        () => filter_work_pending(filter_pending, pending_filter),
+        [filter_pending, pending_filter]
     );
 
     // The visible order changed (a sort/filter applied or a restore
@@ -157,14 +210,20 @@ export function use_row_loader(): UseRowLoaderResult {
     // cleared its own cache and bumped its generation, so any in-flight
     // row read under the old order is discarded host-side.
     const reset_pages_and_refetch_viewport = useCallback(() => {
-        set_pages(new Map());
-        pending_pages.current.clear();
+        const my_pages = new Map<number, CellValue[][]>();
+        const my_loaded_page_starts = pages_ref.current.keys();
         const my_viewport = viewport_ref.current;
-        for (const my_start of get_needed_page_starts(
-            my_viewport.start,
-            my_viewport.end,
-            PAGE_SIZE
-        )) {
+        const the_page_starts = page_starts_to_refetch({
+            viewport_start: my_viewport.start,
+            viewport_end: my_viewport.end,
+            page_size: PAGE_SIZE,
+            loaded_page_starts: my_loaded_page_starts,
+        });
+
+        pages_ref.current = my_pages;
+        set_pages(my_pages);
+        pending_pages.current.clear();
+        for (const my_start of the_page_starts) {
             request_page(my_start);
         }
     }, [request_page]);
@@ -206,12 +265,16 @@ export function use_row_loader(): UseRowLoaderResult {
                 // here resets any stale banner from a prior lifecycle.
                 clear_restore_ui();
 
+                const my_pages = new Map<number, CellValue[][]>();
+                pages_ref.current = my_pages;
                 set_metadata(my_msg);
-                set_pages(new Map());
+                set_pages(my_pages);
                 pending_pages.current.clear();
                 set_sort(my_msg.stored_sort ?? EMPTY_SORT);
+                set_pending_sort_state(null);
                 set_sort_pending(false);
                 set_filter(my_msg.stored_filter ?? EMPTY_FILTER);
+                set_pending_filter_state(null);
                 set_filter_pending(false);
                 set_nobs_effective(undefined);
                 set_histograms(new Map());
@@ -220,15 +283,19 @@ export function use_row_loader(): UseRowLoaderResult {
             }
 
             if (my_msg.type === 'rowData') {
-                // No generation/epoch guard is needed here: the host never
-                // posts stale rows — handle_row_request re-checks its
-                // generation after every read and drops the response on a
-                // mismatch, so a row read started under the old order can't
-                // land after a sort/filter/settle changed it.
-                pending_pages.current.delete(my_msg.start);
+                // Accept only the response for the currently pending request
+                // for this page. Sort/filter resets can clear and re-request
+                // a page while an older response is still in flight.
+                if (!pending_pages.current.accepts(
+                    my_msg.start,
+                    my_msg.request_id
+                )) {
+                    return;
+                }
                 set_pages(my_previous => {
                     const my_next = new Map(my_previous);
                     my_next.set(my_msg.start, my_msg.rows);
+                    pages_ref.current = my_next;
                     return my_next;
                 });
                 return;
@@ -238,10 +305,19 @@ export function use_row_loader(): UseRowLoaderResult {
                 // A user sort during a background restore supersedes it;
                 // dismiss the restore banner (the host aborted the restore).
                 clear_restore_ui();
+                const my_outcome = sort_applied_outcome(
+                    my_msg.sort,
+                    pending_sort_ref.current
+                );
                 set_sort(my_msg.sort);
-                set_nobs_effective(my_msg.nobs_effective);
+                set_pending_sort_state(my_outcome.pending_sort);
+                if (my_outcome.refetch_rows) {
+                    set_nobs_effective(my_msg.nobs_effective);
+                }
                 set_sort_pending(false);
-                reset_pages_and_refetch_viewport();
+                if (my_outcome.refetch_rows) {
+                    reset_pages_and_refetch_viewport();
+                }
                 return;
             }
 
@@ -254,10 +330,19 @@ export function use_row_loader(): UseRowLoaderResult {
                 // A user filter during a background restore supersedes it;
                 // dismiss the restore banner (the host aborted the restore).
                 clear_restore_ui();
+                const my_outcome = filter_applied_outcome(
+                    my_msg.filter,
+                    pending_filter_ref.current
+                );
                 set_filter(my_msg.filter);
-                set_nobs_effective(my_msg.nobs_filtered);
+                set_pending_filter_state(my_outcome.pending_filter);
+                if (my_outcome.refetch_rows) {
+                    set_nobs_effective(my_msg.nobs_filtered);
+                }
                 set_filter_pending(false);
-                reset_pages_and_refetch_viewport();
+                if (my_outcome.refetch_rows) {
+                    reset_pages_and_refetch_viewport();
+                }
                 return;
             }
 
@@ -277,7 +362,9 @@ export function use_row_loader(): UseRowLoaderResult {
                 // Switch the (already painted, natural-order) grid to the
                 // restored order.
                 set_sort(my_msg.sort);
+                set_pending_sort_state(null);
                 set_filter(my_msg.filter);
+                set_pending_filter_state(null);
                 set_nobs_effective(my_msg.nobs_effective);
                 set_sort_pending(false);
                 set_filter_pending(false);
@@ -317,7 +404,13 @@ export function use_row_loader(): UseRowLoaderResult {
                 restore_timer.current = null;
             }
         };
-    }, [vscode_api, reset_pages_and_refetch_viewport, clear_restore_ui]);
+    }, [
+        vscode_api,
+        reset_pages_and_refetch_viewport,
+        clear_restore_ui,
+        set_pending_sort_state,
+        set_pending_filter_state,
+    ]);
 
     const cancel_restore = useCallback(() => {
         const my_id = restore_id_ref.current;
@@ -339,7 +432,7 @@ export function use_row_loader(): UseRowLoaderResult {
         for (const my_page_start of the_page_starts) {
             if (
                 pages.has(my_page_start)
-                || pending_pages.current.has(my_page_start)
+                || pending_pages.current.has_pending(my_page_start)
             ) {
                 continue;
             }
@@ -373,25 +466,29 @@ export function use_row_loader(): UseRowLoaderResult {
             // can be seconds away for a large user sort, and the saved
             // restore is already superseded.
             clear_restore_ui();
+            set_pending_sort_state(build_pending_sort(keys, labels_on));
             vscode_api.postMessage({
                 type: 'setSort',
                 keys,
                 labels_on,
             });
         },
-        [vscode_api, clear_restore_ui]
+        [vscode_api, clear_restore_ui, set_pending_sort_state]
     );
 
     const apply_filter = useCallback(
         (entries: FilterEntry[], labels_on: boolean) => {
             clear_restore_ui();
+            set_pending_filter_state(
+                build_pending_filter(entries, labels_on)
+            );
             vscode_api.postMessage({
                 type: 'setFilters',
                 entries,
                 labels_on,
             });
         },
-        [vscode_api, clear_restore_ui]
+        [vscode_api, clear_restore_ui, set_pending_filter_state]
     );
 
     const request_histogram = useCallback(
@@ -412,10 +509,10 @@ export function use_row_loader(): UseRowLoaderResult {
         get_row,
         pages,
         vscode_api,
-        sort,
-        sort_pending,
-        filter,
-        filter_pending,
+        sort: visible_sort,
+        sort_pending: visible_sort_pending,
+        filter: visible_filter,
+        filter_pending: visible_filter_pending,
         nobs_effective,
         apply_sort,
         apply_filter,

--- a/client/src/data-browser/webview/visible-cell-damage.ts
+++ b/client/src/data-browser/webview/visible-cell-damage.ts
@@ -1,0 +1,27 @@
+interface VisibleCellDamageArgs {
+    column_count: number;
+    first_row: number;
+    row_count: number;
+    total_rows: number;
+}
+
+export function visible_cell_damage({
+    column_count,
+    first_row,
+    row_count,
+    total_rows,
+}: VisibleCellDamageArgs): { cell: [number, number] }[] {
+    if (column_count <= 0 || row_count <= 0 || total_rows <= 0) {
+        return [];
+    }
+
+    const my_start = Math.max(0, first_row);
+    const my_end = Math.min(my_start + row_count, total_rows);
+    const the_damage: { cell: [number, number] }[] = [];
+    for (let row = my_start; row < my_end; row++) {
+        for (let col = 0; col < column_count; col++) {
+            the_damage.push({ cell: [col, row] });
+        }
+    }
+    return the_damage;
+}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "author": "Jonathan Marc Bearak",
   "license": "GPL-3.0",
   "dependencies": {
-    "@jbearak/dta-parser": "^0.2.0",
+    "@jbearak/dta-parser": "^0.3.0",
     "smol-toml": "^1.6.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.11",

--- a/tests/unit/data-browser/browser-panel.test.ts
+++ b/tests/unit/data-browser/browser-panel.test.ts
@@ -11,7 +11,6 @@ import {
     describe_browser_row_count,
     describe_restore_message,
     describe_subset,
-    describe_toolbar_row_count,
     describe_visible_rows,
     get_cell_display_value,
     get_variable_header_subtitle,
@@ -138,19 +137,6 @@ describe('grid-model helpers', () => {
     it('routes missing metadata to the loading row-count label', () => {
         expect(describe_browser_row_count(null, undefined, 0, 0))
             .toBe('Loading…');
-    });
-
-    it('suppresses the toolbar row count while a restore banner shows', () => {
-        // The restore banner already explains the wait, so the bare
-        // "Loading…" must not stack above it (PullFrog finding).
-        expect(describe_toolbar_row_count(null, undefined, 0, 0, true))
-            .toBe('');
-        // No restore in flight: fall through to the normal label.
-        expect(describe_toolbar_row_count(null, undefined, 0, 0, false))
-            .toBe('Loading…');
-        expect(describe_toolbar_row_count(
-            { nobs: 1000 } as never, undefined, 0, 50, true
-        )).toBe('');
     });
 
     it('words the restore message by which prefs apply', () => {

--- a/tests/unit/data-browser/filter-intent.test.ts
+++ b/tests/unit/data-browser/filter-intent.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    build_pending_filter,
+    filter_applied_outcome,
+    filter_work_pending,
+    pending_filter_after_applied,
+    visible_filter_state,
+} from '../../../client/src/data-browser/webview/filter-intent';
+import type {
+    FilterEntry,
+    FilterState,
+} from '../../../client/src/data-browser/types';
+
+const entry = (
+    id: string,
+    col_index: number
+): FilterEntry => ({
+    id,
+    col_index,
+    predicate: { kind: 'isNotEmpty' },
+    enabled: true,
+    include_missing: false,
+});
+
+const filter_state = (
+    entries: FilterEntry[],
+    labels_on_when_filtered = true
+): FilterState => ({
+    entries,
+    labels_on_when_filtered,
+});
+
+describe('data-browser filter intent', () => {
+    it('shows the pending requested filter while the host computes it', () => {
+        const applied = filter_state([]);
+        const pending = filter_state([entry('f1', 0)]);
+
+        expect(visible_filter_state(applied, pending)).toBe(pending);
+    });
+
+    it('falls back to the applied filter when no request is pending', () => {
+        const applied = filter_state([entry('f2', 1)]);
+
+        expect(visible_filter_state(applied, null)).toBe(applied);
+    });
+
+    it('builds a pending filter from requested entries and label mode', () => {
+        const my_entry: FilterEntry = {
+            id: 'f3',
+            col_index: 2,
+            predicate: { kind: 'setIn', values: [1, 3] },
+            enabled: true,
+            include_missing: true,
+        };
+
+        const my_pending = build_pending_filter([my_entry], false);
+
+        expect(my_pending).toEqual({
+            entries: [my_entry],
+            labels_on_when_filtered: false,
+        });
+        expect(my_pending.entries[0]).not.toBe(my_entry);
+        expect(my_pending.entries[0].predicate).not.toBe(
+            my_entry.predicate
+        );
+
+        my_entry.predicate.values.push(5);
+        expect(
+            (my_pending.entries[0].predicate as { values: number[] })
+            .values
+        ).toEqual([1, 3]);
+    });
+
+    it('keeps a newer pending filter when an older filter applies', () => {
+        const pending = filter_state([
+            entry('f1', 0),
+            entry('f2', 1),
+        ]);
+
+        expect(
+            pending_filter_after_applied(
+                filter_state([entry('f1', 0)]),
+                pending
+            )
+        ).toBe(pending);
+    });
+
+    it('clears pending filter once that exact filter applies', () => {
+        const pending = filter_state([
+            entry('f1', 0),
+            entry('f2', 1),
+        ]);
+
+        expect(
+            pending_filter_after_applied(
+                filter_state([entry('f1', 0), entry('f2', 1)]),
+                pending
+            )
+        ).toBeNull();
+    });
+
+    it('treats a locally queued filter intent as pending work', () => {
+        expect(filter_work_pending(false, filter_state([
+            entry('f1', 0),
+        ]))).toBe(true);
+        expect(filter_work_pending(true, null)).toBe(true);
+        expect(filter_work_pending(false, null)).toBe(false);
+    });
+
+    it('does not refetch rows when an older filter applies under a newer pending filter', () => {
+        const pending = filter_state([entry('f2', 1)]);
+
+        expect(
+            filter_applied_outcome(
+                filter_state([entry('f1', 0)]),
+                pending
+            )
+        ).toEqual({
+            pending_filter: pending,
+            refetch_rows: false,
+        });
+    });
+
+    it('refetches rows once the pending filter applies', () => {
+        expect(
+            filter_applied_outcome(
+                filter_state([entry('f2', 1)]),
+                filter_state([entry('f2', 1)])
+            )
+        ).toEqual({
+            pending_filter: null,
+            refetch_rows: true,
+        });
+    });
+});

--- a/tests/unit/data-browser/refetch-page-starts.test.ts
+++ b/tests/unit/data-browser/refetch-page-starts.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test';
+import { page_starts_to_refetch } from '../../../client/src/data-browser/webview/refetch-page-starts';
+
+describe('data-browser page_starts_to_refetch', () => {
+    it('uses viewport page starts when the visible region is known', () => {
+        expect(page_starts_to_refetch({
+            viewport_start: 50,
+            viewport_end: 260,
+            page_size: 200,
+            loaded_page_starts: [0, 400],
+        })).toEqual([0, 200]);
+    });
+
+    it('falls back to loaded pages when the viewport is empty', () => {
+        expect(page_starts_to_refetch({
+            viewport_start: 0,
+            viewport_end: 0,
+            page_size: 200,
+            loaded_page_starts: [400, 0],
+        })).toEqual([0, 400]);
+    });
+});

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -31,6 +31,17 @@ function abort_error(): unknown {
     return new DOMException('The read was aborted', 'AbortError');
 }
 
+function deferred<T = void>(): {
+    promise: Promise<T>;
+    resolve: (value: T | PromiseLike<T>) => void;
+} {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    const promise = new Promise<T>(my_resolve => {
+        resolve = my_resolve;
+    });
+    return { promise, resolve };
+}
+
 interface RestoreHarness {
     panel_like: any;
     posted: any[];
@@ -92,6 +103,7 @@ async function make_restore_panel(opts: {
     panel_like.restoring = false;
     panel_like.restore_id = -1;
     panel_like.send_metadata_chain = Promise.resolve();
+    panel_like.action_chain = Promise.resolve();
     panel_like.row_cache = { clear: () => undefined };
     panel_like.disposed = false;
 
@@ -286,6 +298,87 @@ describe('send_metadata restore', () => {
         expect(my_settled.filter).toEqual(STORED_FILTER);
         // Active filter → effective (post-filter) count announced.
         expect(my_settled.nobs_effective).toBe(3);
+    });
+
+    it('pre-reads distinct restore sort/filter columns once', async () => {
+        const my_sort: SortState = {
+            keys: [
+                { col_index: 0, direction: 'asc' },
+                { col_index: 1, direction: 'desc' },
+            ],
+            labels_on_when_sorted: true,
+        };
+        const my_filter: FilterState = {
+            entries: [{
+                id: 'f3',
+                col_index: 2,
+                predicate: {
+                    kind: 'strContains',
+                    value: 'keep',
+                    case_sensitive: true,
+                    negate: false,
+                },
+                enabled: true,
+                include_missing: false,
+            }],
+            labels_on_when_filtered: true,
+        };
+        const { panel_like, posted } =
+            await make_restore_panel({
+                stored_sort: my_sort,
+                stored_filter: my_filter,
+            });
+        const the_values = new Map<number, unknown[]>([
+            [0, [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]],
+            [1, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']],
+            [2, [
+                'keep', 'drop', 'keep', 'drop', 'keep',
+                'drop', 'keep', 'drop', 'keep', 'drop',
+            ]],
+        ]);
+        const the_read_columns_calls: number[][] = [];
+        let read_rows_calls = 0;
+        panel_like.dta_file = {
+            ...panel_like.dta_file,
+            nvar: 3,
+            variables: [
+                { name: 'a', type: 'int', format: '%9.0g',
+                    label: '', value_label_name: '' },
+                { name: 'b', type: 'str10', format: '%10s',
+                    label: '', value_label_name: '' },
+                { name: 'c', type: 'str10', format: '%10s',
+                    label: '', value_label_name: '' },
+            ],
+            read_columns: async (
+                col_indices: number[],
+                options?: { signal?: AbortSignal }
+            ) => {
+                expect(options?.signal).toBe(
+                    panel_like.restore_abort.signal
+                );
+                the_read_columns_calls.push([...col_indices]);
+                const out = new Map<number, unknown[]>();
+                for (const my_col of col_indices) {
+                    out.set(my_col, the_values.get(my_col) ?? []);
+                }
+                return out;
+            },
+            read_rows: async () => {
+                read_rows_calls++;
+                throw new Error('per-column fallback should not run');
+            },
+        };
+
+        await panel_like.send_metadata();
+
+        expect(the_read_columns_calls).toEqual([[0, 1, 2]]);
+        expect(read_rows_calls).toBe(0);
+        expect(panel_like.sort).toEqual(my_sort);
+        expect(panel_like.filter).toEqual(my_filter);
+        const my_settled = posted.find(
+            m => m.type === 'restoreSettled'
+        );
+        expect(my_settled.nobs_effective).toBe(5);
     });
 
     it('a settle-phase throw still dismisses the banner and clears state (finding #3)', async () => {
@@ -755,6 +848,433 @@ describe('user sort/filter supersedes an in-flight restore (paint-first)', () =>
         expect(panel_like.filter.entries.length).toBe(1);
         expect(filter_set.length).toBe(1);
         expect(posted.some(m => m.type === 'filterApplied')).toBe(true);
+    });
+});
+
+describe('interactive row ordering', () => {
+    it('fresh user sort maps the next row request through the new permutation', async () => {
+        const { panel_like, posted } = await make_restore_panel();
+        const the_rows = [
+            [3, 'c'],
+            [1, 'a'],
+            [2, 'b'],
+        ];
+        let cache_cleared = 0;
+        panel_like.dta_file = {
+            ...panel_like.dta_file,
+            nobs: the_rows.length,
+            nvar: 2,
+            variables: [
+                { name: 'x', type: 'int', format: '%9.0g',
+                    label: '', value_label_name: '' },
+                { name: 'name', type: 'str10', format: '%10s',
+                    label: '', value_label_name: '' },
+            ],
+            value_label_tables: new Map(),
+            read_rows: async (
+                start: number,
+                count: number,
+                col_start = 0,
+                col_end = 2
+            ) => the_rows
+                .slice(start, start + count)
+                .map(my_row => my_row.slice(col_start, col_end)),
+            read_columns: async (cols: number[]) => new Map(
+                cols.map(my_col => [
+                    my_col,
+                    the_rows.map(my_row => my_row[my_col]),
+                ])
+            ),
+        };
+        panel_like.row_cache = {
+            clear: () => { cache_cleared++; },
+            get_page: () => undefined,
+            set_page: () => undefined,
+        };
+
+        await panel_like.handle_set_sort({
+            type: 'setSort',
+            keys: [{ col_index: 0, direction: 'asc' }],
+            labels_on: true,
+        });
+        await panel_like.handle_row_request({
+            type: 'requestRows',
+            start: 0,
+            count: 3,
+            request_id: 'req_1',
+        });
+
+        expect([...panel_like.permutation]).toEqual([1, 2, 0]);
+        expect([...panel_like.effective_perm]).toEqual([1, 2, 0]);
+        expect(cache_cleared).toBe(1);
+        const my_response = posted[posted.length - 1];
+        expect(my_response.type).toBe('rowData');
+        expect(my_response.rows.map((my_row: any[]) => my_row[0].raw))
+            .toEqual([1, 2, 3]);
+    });
+
+    it('fresh user sort reads the sort column through read_columns', async () => {
+        const { panel_like } = await make_restore_panel();
+        const the_sort_values = [3, 1, 2];
+        panel_like.dta_file = {
+            ...panel_like.dta_file,
+            nobs: the_sort_values.length,
+            nvar: 1,
+            variables: [
+                { name: 'x', type: 'int', format: '%9.0g',
+                    label: '', value_label_name: '' },
+            ],
+            value_label_tables: new Map(),
+            read_rows: async () => {
+                throw new Error('full row scan should not be used');
+            },
+            read_columns: async (cols: number[]) => {
+                expect(cols).toEqual([0]);
+                return new Map([[0, the_sort_values]]);
+            },
+        };
+        panel_like.row_cache = { clear: () => undefined };
+
+        await panel_like.handle_set_sort({
+            type: 'setSort',
+            keys: [{ col_index: 0, direction: 'asc' }],
+            labels_on: true,
+        });
+
+        expect([...panel_like.permutation]).toEqual([1, 2, 0]);
+        expect([...panel_like.effective_perm]).toEqual([1, 2, 0]);
+    });
+
+    it('fresh user filter reads filter columns through read_columns', async () => {
+        const { panel_like } = await make_restore_panel();
+        const the_filter_values = ['', 'a', 'b'];
+        panel_like.dta_file = {
+            ...panel_like.dta_file,
+            nobs: the_filter_values.length,
+            nvar: 1,
+            variables: [
+                { name: 'name', type: 'str10', format: '%10s',
+                    label: '', value_label_name: '' },
+            ],
+            value_label_tables: new Map(),
+            read_rows: async () => {
+                throw new Error('full row scan should not be used');
+            },
+            read_columns: async (cols: number[]) => {
+                expect(cols).toEqual([0]);
+                return new Map([[0, the_filter_values]]);
+            },
+        };
+        panel_like.row_cache = { clear: () => undefined };
+
+        await panel_like.handle_set_filters({
+            type: 'setFilters',
+            entries: [{
+                id: 'f1',
+                col_index: 0,
+                predicate: { kind: 'isNotEmpty' },
+                enabled: true,
+                include_missing: false,
+            }],
+            labels_on: true,
+        });
+
+        expect([...panel_like.filtered_indices]).toEqual([1, 2]);
+        expect([...panel_like.effective_perm]).toEqual([1, 2]);
+    });
+});
+
+describe('interactive action queue', () => {
+    it('serializes filter then sort so neither pending state is stranded', async () => {
+        const { panel_like, posted } = await make_restore_panel();
+        let cache_cleared = 0;
+        panel_like.row_cache = { clear: () => { cache_cleared++; } };
+        panel_like.current_schema_hash = () => 'h';
+
+        const filter_started = deferred();
+        const release_filter = deferred();
+        panel_like.compute_filter_indices = async () => {
+            filter_started.resolve();
+            await release_filter.promise;
+            return new Uint32Array([1, 2]);
+        };
+        panel_like.compute_sort_permutation = async () =>
+            new Uint32Array([2, 1, 0]);
+
+        const my_filter_promise = panel_like.handle_message({
+            type: 'setFilters',
+            entries: [{
+                id: 'f1',
+                col_index: 1,
+                predicate: { kind: 'isNotEmpty' },
+                enabled: true,
+                include_missing: false,
+            }],
+            labels_on: true,
+        });
+        await filter_started.promise;
+
+        const my_sort_promise = panel_like.handle_message({
+            type: 'setSort',
+            keys: [{ col_index: 0, direction: 'asc' }],
+            labels_on: true,
+        });
+
+        await Promise.resolve();
+        expect(posted.filter(m => m.type === 'sortStatus'))
+            .toEqual([]);
+
+        release_filter.resolve();
+        await Promise.all([my_filter_promise, my_sort_promise]);
+
+        expect(posted
+            .filter(m =>
+                m.type === 'filterStatus'
+                || m.type === 'sortStatus'
+            )
+            .map(m => `${m.type}:${m.state}`))
+            .toEqual([
+                'filterStatus:pending',
+                'filterStatus:idle',
+                'sortStatus:pending',
+                'sortStatus:idle',
+            ]);
+        expect([...panel_like.filtered_indices]).toEqual([1, 2]);
+        expect([...panel_like.permutation]).toEqual([2, 1, 0]);
+        expect([...panel_like.effective_perm]).toEqual([2, 1]);
+        expect(cache_cleared).toBe(2);
+    });
+
+    it('serializes sort then filter so neither pending state is stranded', async () => {
+        const { panel_like, posted } = await make_restore_panel();
+        let cache_cleared = 0;
+        panel_like.row_cache = { clear: () => { cache_cleared++; } };
+        panel_like.current_schema_hash = () => 'h';
+
+        const sort_started = deferred();
+        const release_sort = deferred();
+        panel_like.compute_sort_permutation = async () => {
+            sort_started.resolve();
+            await release_sort.promise;
+            return new Uint32Array([2, 1, 0]);
+        };
+        panel_like.compute_filter_indices = async () =>
+            new Uint32Array([1, 2]);
+
+        const my_sort_promise = panel_like.handle_message({
+            type: 'setSort',
+            keys: [{ col_index: 0, direction: 'asc' }],
+            labels_on: true,
+        });
+        await sort_started.promise;
+
+        const my_filter_promise = panel_like.handle_message({
+            type: 'setFilters',
+            entries: [{
+                id: 'f1',
+                col_index: 1,
+                predicate: { kind: 'isNotEmpty' },
+                enabled: true,
+                include_missing: false,
+            }],
+            labels_on: true,
+        });
+
+        await Promise.resolve();
+        expect(posted.filter(m => m.type === 'filterStatus'))
+            .toEqual([]);
+
+        release_sort.resolve();
+        await Promise.all([my_sort_promise, my_filter_promise]);
+
+        expect(posted
+            .filter(m =>
+                m.type === 'filterStatus'
+                || m.type === 'sortStatus'
+            )
+            .map(m => `${m.type}:${m.state}`))
+            .toEqual([
+                'sortStatus:pending',
+                'sortStatus:idle',
+                'filterStatus:pending',
+                'filterStatus:idle',
+            ]);
+        expect([...panel_like.permutation]).toEqual([2, 1, 0]);
+        expect([...panel_like.filtered_indices]).toEqual([1, 2]);
+        expect([...panel_like.effective_perm]).toEqual([2, 1]);
+        expect(cache_cleared).toBe(2);
+    });
+
+    it('drops a queued sort if the dataset changes before it starts', async () => {
+        const { panel_like, posted, sort_set } =
+            await make_restore_panel();
+        panel_like.current_schema_hash = () => 'h';
+
+        const filter_started = deferred();
+        const release_filter = deferred();
+        panel_like.compute_filter_indices = async () => {
+            filter_started.resolve();
+            await release_filter.promise;
+            return new Uint32Array([1, 2]);
+        };
+        let sort_calls = 0;
+        panel_like.compute_sort_permutation = async () => {
+            sort_calls++;
+            return new Uint32Array([2, 1, 0]);
+        };
+
+        const my_filter_promise = panel_like.handle_message({
+            type: 'setFilters',
+            entries: [{
+                id: 'f1',
+                col_index: 1,
+                predicate: { kind: 'isNotEmpty' },
+                enabled: true,
+                include_missing: false,
+            }],
+            labels_on: true,
+        });
+        await filter_started.promise;
+
+        const my_sort_promise = panel_like.handle_message({
+            type: 'setSort',
+            keys: [{ col_index: 0, direction: 'asc' }],
+            labels_on: true,
+        });
+
+        // Simulate refresh() switching the panel to a new dataset while
+        // the sort is still queued behind the old filter.
+        panel_like.generation++;
+        panel_like.dta_file = {
+            ...panel_like.dta_file,
+            nobs: 3,
+            variables: [
+                { name: 'new_x', type: 'int', format: '%9.0g',
+                    label: '', value_label_name: '' },
+                { name: 'new_name', type: 'str10', format: '%10s',
+                    label: '', value_label_name: '' },
+            ],
+        };
+        panel_like.dataset_key = 'new_dataset';
+        panel_like.sort = EMPTY_SORT;
+        panel_like.permutation = null;
+        panel_like.filter = EMPTY_FILTER;
+        panel_like.filtered_indices = null;
+        panel_like.effective_perm = null;
+
+        release_filter.resolve();
+        await Promise.all([my_filter_promise, my_sort_promise]);
+
+        expect(sort_calls).toBe(0);
+        expect(posted.filter(m => m.type === 'sortStatus'))
+            .toEqual([]);
+        expect(panel_like.sort.keys).toEqual([]);
+        expect(sort_set).toEqual([]);
+    });
+
+    it('drops a queued filter if the dataset changes before it starts', async () => {
+        const { panel_like, posted, filter_set } =
+            await make_restore_panel();
+        panel_like.current_schema_hash = () => 'h';
+
+        const sort_started = deferred();
+        const release_sort = deferred();
+        panel_like.compute_sort_permutation = async () => {
+            sort_started.resolve();
+            await release_sort.promise;
+            return new Uint32Array([2, 1, 0]);
+        };
+        let filter_calls = 0;
+        panel_like.compute_filter_indices = async () => {
+            filter_calls++;
+            return new Uint32Array([1, 2]);
+        };
+
+        const my_sort_promise = panel_like.handle_message({
+            type: 'setSort',
+            keys: [{ col_index: 0, direction: 'asc' }],
+            labels_on: true,
+        });
+        await sort_started.promise;
+
+        const my_filter_promise = panel_like.handle_message({
+            type: 'setFilters',
+            entries: [{
+                id: 'f1',
+                col_index: 1,
+                predicate: { kind: 'isNotEmpty' },
+                enabled: true,
+                include_missing: false,
+            }],
+            labels_on: true,
+        });
+
+        // Simulate refresh() switching the panel to a new dataset while
+        // the filter is still queued behind the old sort.
+        panel_like.generation++;
+        panel_like.dta_file = {
+            ...panel_like.dta_file,
+            nobs: 3,
+            variables: [
+                { name: 'new_x', type: 'int', format: '%9.0g',
+                    label: '', value_label_name: '' },
+                { name: 'new_name', type: 'str10', format: '%10s',
+                    label: '', value_label_name: '' },
+            ],
+        };
+        panel_like.dataset_key = 'new_dataset';
+        panel_like.sort = EMPTY_SORT;
+        panel_like.permutation = null;
+        panel_like.filter = EMPTY_FILTER;
+        panel_like.filtered_indices = null;
+        panel_like.effective_perm = null;
+
+        release_sort.resolve();
+        await Promise.all([my_sort_promise, my_filter_promise]);
+
+        expect(filter_calls).toBe(0);
+        expect(posted.filter(m => m.type === 'filterStatus'))
+            .toEqual([]);
+        expect(panel_like.filter.entries).toEqual([]);
+        expect(filter_set).toEqual([]);
+    });
+});
+
+describe('dataset-scoped webview messages', () => {
+    it('ignores stale column width messages from a previous dataset', async () => {
+        const { panel_like } = await make_restore_panel();
+        const the_writes: any[] = [];
+        panel_like.dataset_key = 'current_dataset';
+        panel_like.dataset_key_aliases = [];
+        panel_like.column_width_store = {
+            set: async (...args: any[]) => { the_writes.push(args); },
+        };
+
+        await panel_like.handle_message({
+            type: 'columnWidthsChanged',
+            dataset_key: 'previous_dataset',
+            widths: { x: 120 },
+        });
+
+        expect(the_writes).toEqual([]);
+    });
+
+    it('ignores stale column visibility messages from a previous dataset', async () => {
+        const { panel_like } = await make_restore_panel();
+        const the_writes: any[] = [];
+        panel_like.dataset_key = 'current_dataset';
+        panel_like.dataset_key_aliases = [];
+        panel_like.column_visibility_store = {
+            set: async (...args: any[]) => { the_writes.push(args); },
+        };
+
+        await panel_like.handle_message({
+            type: 'columnVisibilityChanged',
+            dataset_key: 'previous_dataset',
+            hidden_columns: ['x'],
+        });
+
+        expect(the_writes).toEqual([]);
     });
 });
 

--- a/tests/unit/data-browser/restore-cancel.test.ts
+++ b/tests/unit/data-browser/restore-cancel.test.ts
@@ -93,6 +93,7 @@ async function make_restore_panel(opts: {
     panel_like.restore_id = -1;
     panel_like.send_metadata_chain = Promise.resolve();
     panel_like.row_cache = { clear: () => undefined };
+    panel_like.disposed = false;
 
     panel_like.panel = {
         webview: {
@@ -119,14 +120,16 @@ async function make_restore_panel(opts: {
 
 beforeEach(() => { warnings = []; });
 
-describe('maybe_begin_restore', () => {
-    it('posts restorePending and arms the restore when prefs apply', async () => {
+describe('restore_applies / maybe_begin_restore', () => {
+    it('maybe_begin_restore posts restorePending and arms the restore', async () => {
         const { panel_like, posted } = await make_restore_panel({
             stored_sort: STORED_SORT,
             stored_filter: STORED_FILTER,
         });
 
-        const my_began = panel_like.maybe_begin_restore('h');
+        const my_began = panel_like.maybe_begin_restore({
+            sort: true, filter: true,
+        });
 
         expect(my_began).toBe(true);
         expect(panel_like.restoring).toBe(true);
@@ -140,28 +143,33 @@ describe('maybe_begin_restore', () => {
         });
     });
 
-    it('does not begin when no prefs are stored', async () => {
+    it('maybe_begin_restore does not begin when nothing applies', async () => {
         const { panel_like, posted } = await make_restore_panel();
-        expect(panel_like.maybe_begin_restore('h')).toBe(false);
+        expect(panel_like.maybe_begin_restore({
+            sort: false, filter: false,
+        })).toBe(false);
         expect(panel_like.restoring).toBe(false);
         expect(posted).toEqual([]);
     });
 
-    it('does not begin once already restored', async () => {
-        const { panel_like, posted } = await make_restore_panel({
+    it('restore_applies reports nothing once already restored', async () => {
+        const { panel_like } = await make_restore_panel({
             stored_sort: STORED_SORT,
         });
         panel_like.sort_restored = true;
         panel_like.filter_restored = true;
-        expect(panel_like.maybe_begin_restore('h')).toBe(false);
-        expect(posted).toEqual([]);
+        expect(panel_like.restore_applies('h')).toEqual({
+            sort: false, filter: false,
+        });
     });
 
-    it('flags sort-only vs filter-only correctly', async () => {
+    it('restore_applies flags sort-only vs filter-only correctly', async () => {
         const { panel_like, posted } = await make_restore_panel({
             stored_filter: STORED_FILTER,
         });
-        panel_like.maybe_begin_restore('h');
+        const my_applies = panel_like.restore_applies('h');
+        expect(my_applies).toEqual({ sort: false, filter: true });
+        panel_like.maybe_begin_restore(my_applies);
         expect(posted[0].sort).toBe(false);
         expect(posted[0].filter).toBe(true);
     });
@@ -199,17 +207,50 @@ describe('send_metadata restore', () => {
         expect(filter_set.length).toBe(1);
         expect(filter_set[0].entries.length).toBe(0);
 
-        // restorePending preceded metadata; metadata carries no chips.
-        expect(posted[0].type).toBe('restorePending');
-        const my_meta = posted.find(m => m.type === 'metadata');
-        expect(my_meta).toBeDefined();
-        expect(my_meta.stored_sort).toBeUndefined();
-        expect(my_meta.stored_filter).toBeUndefined();
+        // Paint-first: metadata is posted first (natural order, no chips),
+        // then restorePending arms the banner.
+        expect(posted[0].type).toBe('metadata');
+        expect(posted[0].stored_sort).toBeUndefined();
+        expect(posted[0].stored_filter).toBeUndefined();
+        expect(posted[1].type).toBe('restorePending');
 
-        // No spurious filterApplied, and restore state cleaned up.
-        expect(posted.some(m => m.type === 'filterApplied')).toBe(false);
+        // The cancelled restore settles to natural order (EMPTY), and
+        // restore state is cleaned up.
+        const my_settled = posted.find(m => m.type === 'restoreSettled');
+        expect(my_settled).toBeDefined();
+        expect(my_settled.sort.keys.length).toBe(0);
+        expect(my_settled.filter.entries.length).toBe(0);
         expect(panel_like.restoring).toBe(false);
         expect(panel_like.restore_abort).toBeNull();
+    });
+
+    it('a Skip racing a successful settle is ignored, keeping prefs (code-review HIGH)', async () => {
+        const { panel_like, posted, sort_set, filter_set } =
+            await make_restore_panel({
+                stored_sort: STORED_SORT,
+                stored_filter: STORED_FILTER,
+            });
+        panel_like.compute_sort_permutation = async () =>
+            new Uint32Array(10);
+        panel_like.compute_filter_indices = async () =>
+            new Uint32Array([0, 1, 2]);
+        panel_like.current_schema_hash = () => 'h';
+
+        await panel_like.send_metadata();
+
+        // A successful settle consumes the handshake.
+        expect(panel_like.restore_id).toBe(-1);
+        expect(panel_like.sort.keys.length).toBe(1);
+        expect(posted.some(m => m.type === 'restoreSettled')).toBe(true);
+
+        // A Skip that raced the settle still carries the original id; it
+        // must now be ignored rather than forgetting the restored prefs.
+        await panel_like.handle_cancel_restore({
+            type: 'cancelRestore', restore_id: 0,
+        });
+        expect(sort_set).toEqual([]);
+        expect(filter_set).toEqual([]);
+        expect(panel_like.sort.keys.length).toBe(1);
     });
 
     it('normal completion applies and ships the saved prefs', async () => {
@@ -231,29 +272,45 @@ describe('send_metadata restore', () => {
         expect(sort_set).toEqual([]);
         expect(filter_set).toEqual([]);
 
-        expect(posted[0].type).toBe('restorePending');
-        const my_meta = posted.find(m => m.type === 'metadata');
-        expect(my_meta.stored_sort).toEqual(STORED_SORT);
-        expect(my_meta.stored_filter).toEqual(STORED_FILTER);
-        // Active filter → effective count announced.
-        expect(posted.some(m => m.type === 'filterApplied')).toBe(true);
+        // Paint-first: metadata first (natural, no chips), then the
+        // restored sort/filter (with chips) arrive via restoreSettled.
+        expect(posted[0].type).toBe('metadata');
+        expect(posted[0].stored_sort).toBeUndefined();
+        expect(posted[0].stored_filter).toBeUndefined();
+        expect(posted[1].type).toBe('restorePending');
+
+        const my_settled = posted.find(m => m.type === 'restoreSettled');
+        expect(my_settled).toBeDefined();
+        expect(my_settled.restore_id).toBe(0);
+        expect(my_settled.sort).toEqual(STORED_SORT);
+        expect(my_settled.filter).toEqual(STORED_FILTER);
+        // Active filter → effective (post-filter) count announced.
+        expect(my_settled.nobs_effective).toBe(3);
     });
 
-    it('clears restoring even if it throws before metadata (finding #3)', async () => {
-        const { panel_like } = await make_restore_panel({
+    it('a settle-phase throw still dismisses the banner and clears state (finding #3)', async () => {
+        const { panel_like, posted } = await make_restore_panel({
             stored_sort: STORED_SORT,
         });
         panel_like.compute_sort_permutation = async () =>
             new Uint32Array(10);
-        // Throw after the restore began but before metadata is posted.
+        // Throw during the settle, before post_restore_settled runs.
         panel_like.recompute_effective = () => {
             throw new Error('boom');
         };
 
         await panel_like.send_metadata();
 
+        // The inner finally releases the restore state...
         expect(panel_like.restoring).toBe(false);
         expect(panel_like.restore_abort).toBeNull();
+        expect(panel_like.restore_id).toBe(-1);
+        // ...and a best-effort EMPTY settle was still posted so the webview
+        // banner can't stay stuck on "Applying…".
+        const my_settled = posted.find(m => m.type === 'restoreSettled');
+        expect(my_settled).toBeDefined();
+        expect(my_settled.sort.keys.length).toBe(0);
+        expect(my_settled.filter.entries.length).toBe(0);
     });
 
     it('serializes send_metadata so a reload cannot start a concurrent restore', async () => {
@@ -295,8 +352,11 @@ describe('send_metadata restore', () => {
 
         await panel_like.send_metadata();
 
-        // Stale attempt: no metadata posted, prefs left intact.
-        expect(posted.some(m => m.type === 'metadata')).toBe(false);
+        // Paint-first posts metadata up front, but a generation change
+        // mid-restore makes the attempt bail before settling: no
+        // restoreSettled, and prefs left intact.
+        expect(posted.some(m => m.type === 'metadata')).toBe(true);
+        expect(posted.some(m => m.type === 'restoreSettled')).toBe(false);
         expect(sort_set).toEqual([]);
     });
 
@@ -343,6 +403,48 @@ describe('send_metadata restore', () => {
         expect(filter_set).toEqual([]);
         const my_meta = posted.find(m => m.type === 'metadata');
         expect(my_meta.stored_sort).toBeUndefined();
+    });
+
+    it('a settle to natural order does not bump generation or clear cache (Codex round 4)', async () => {
+        const { panel_like, posted } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+        });
+        // The sort restore is cancelled → the restore settles to natural.
+        panel_like.compute_sort_permutation = async () => {
+            panel_like.restore_abort?.abort();
+            throw abort_error();
+        };
+        let cache_cleared = 0;
+        panel_like.row_cache = { clear: () => { cache_cleared++; } };
+        const my_gen_before = panel_like.generation;
+
+        await panel_like.send_metadata();
+
+        // Natural order: do NOT invalidate, so natural-order pages and any
+        // row read in flight during restore stay valid (no stranded blanks).
+        expect(panel_like.effective_perm).toBeNull();
+        expect(panel_like.generation).toBe(my_gen_before);
+        expect(cache_cleared).toBe(0);
+        const my_settled = posted.find(m => m.type === 'restoreSettled');
+        expect(my_settled.sort.keys.length).toBe(0);
+    });
+
+    it('a settle that changes order bumps generation and clears cache', async () => {
+        const { panel_like } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+        });
+        panel_like.compute_sort_permutation = async () =>
+            new Uint32Array(10);
+        let cache_cleared = 0;
+        panel_like.row_cache = { clear: () => { cache_cleared++; } };
+        const my_gen_before = panel_like.generation;
+
+        await panel_like.send_metadata();
+
+        // Order changed: invalidate the natural-order pages/reads.
+        expect(panel_like.effective_perm).not.toBeNull();
+        expect(panel_like.generation).toBe(my_gen_before + 1);
+        expect(cache_cleared).toBe(1);
     });
 });
 
@@ -441,7 +543,12 @@ describe('refresh during restore (PullFrog finding)', () => {
         const my_ctrl = new AbortController();
         panel_like.restore_abort = my_ctrl;
         panel_like.histogram_cache = { clear: () => undefined };
-        panel_like.dta_file = { close: () => undefined };
+        // The restore must already be aborted by the time the file is
+        // closed, so an in-flight chunked read never races a closed fd.
+        let aborted_at_close = false;
+        panel_like.dta_file = {
+            close: () => { aborted_at_close = my_ctrl.signal.aborted; },
+        };
         // Isolate refresh handling from the full re-open.
         let reinit = false;
         panel_like.initialize = async () => { reinit = true; };
@@ -452,8 +559,10 @@ describe('refresh during restore (PullFrog finding)', () => {
         );
 
         // The old read must be aborted (not just dropped) so the queued
-        // send_metadata for the new dataset is not stuck behind it.
+        // send_metadata for the new dataset is not stuck behind it...
         expect(my_ctrl.signal.aborted).toBe(true);
+        // ...and the abort must precede the close (finding: close-before-abort).
+        expect(aborted_at_close).toBe(true);
         expect(panel_like.restore_abort).toBeNull();
         expect(panel_like.restoring).toBe(false);
         expect(panel_like.restore_id).toBe(-1);
@@ -530,34 +639,122 @@ describe('restore_id consumed on user pref change (PullFrog finding)', () => {
     });
 });
 
-describe('sort/filter ignored while restoring (round 6)', () => {
-    it('handle_set_sort is a no-op while a restore is in flight', async () => {
-        const { panel_like, posted } = await make_restore_panel();
+describe('user sort/filter supersedes an in-flight restore (paint-first)', () => {
+    it('handle_set_sort aborts the restore and applies the user sort', async () => {
+        const { panel_like, posted, sort_set } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+            stored_filter: STORED_FILTER,
+        });
+        // A background restore is in flight (grid is live under paint-first).
         panel_like.restoring = true;
+        panel_like.restore_id = 0;
+        const my_ctrl = new AbortController();
+        panel_like.restore_abort = my_ctrl;
+        panel_like.current_schema_hash = () => 'h';
+        panel_like.post_sort_status = (s: string) =>
+            posted.push({ type: 'sortStatus', state: s });
+        panel_like.post_sort_applied = () =>
+            posted.push({ type: 'sortApplied' });
+        panel_like.compute_sort_permutation =
+            async () => new Uint32Array(10);
         const my_gen_before = panel_like.generation;
 
         await panel_like.handle_set_sort({
-            type: 'setSort', keys: [{ col_index: 0, direction: 'asc' }],
+            type: 'setSort',
+            keys: [{ col_index: 1, direction: 'desc' }],
             labels_on: true,
         });
 
-        // No generation bump, no status posted: the command was ignored
-        // so the in-flight restore can post metadata uninterrupted.
-        expect(panel_like.generation).toBe(my_gen_before);
-        expect(posted).toEqual([]);
+        // The restore is aborted and its handshake consumed; the user's
+        // sort is applied and persisted.
+        expect(my_ctrl.signal.aborted).toBe(true);
+        expect(panel_like.restoring).toBe(false);
+        expect(panel_like.restore_abort).toBeNull();
+        expect(panel_like.restore_id).toBe(-1);
+        expect(panel_like.generation).toBe(my_gen_before + 1);
+        expect(panel_like.sort.keys[0].direction).toBe('desc');
+        expect(sort_set.length).toBe(1);
+        // Superseding does NOT forget the saved filter (no filter write).
+        expect(posted.some(m => m.type === 'sortApplied')).toBe(true);
+        // The restore attempt is marked consumed so a later reload cannot
+        // resurrect the not-yet-applied saved filter.
+        expect(panel_like.sort_restored).toBe(true);
+        expect(panel_like.filter_restored).toBe(true);
     });
 
-    it('handle_set_filters is a no-op while a restore is in flight', async () => {
-        const { panel_like, posted } = await make_restore_panel();
+    it('a reload after superseding does not resurrect the skipped saved filter (Codex round 2)', async () => {
+        const { panel_like, posted } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+            stored_filter: STORED_FILTER,
+        });
+        // State mid-restore: the saved-sort read set sort_restored, but the
+        // saved filter has not been fetched yet (filter_restored false).
         panel_like.restoring = true;
+        panel_like.restore_id = 0;
+        panel_like.sort_restored = true;
+        panel_like.filter_restored = false;
+        panel_like.restore_abort = new AbortController();
+        panel_like.current_schema_hash = () => 'h';
+        panel_like.post_sort_status = () => undefined;
+        panel_like.post_sort_applied = () =>
+            posted.push({ type: 'sortApplied' });
+        panel_like.compute_sort_permutation =
+            async () => new Uint32Array(10);
+
+        // The user sorts, superseding the restore during the saved-sort read.
+        await panel_like.handle_set_sort({
+            type: 'setSort',
+            keys: [{ col_index: 1, direction: 'desc' }],
+            labels_on: true,
+        });
+
+        // Both one-shot flags are now consumed, so a subsequent reload sees
+        // nothing to restore (it would otherwise refetch the saved filter
+        // that the user never applied and apply it over their sort).
+        expect(panel_like.filter_restored).toBe(true);
+        expect(panel_like.restore_applies('h')).toEqual({
+            sort: false, filter: false,
+        });
+    });
+
+    it('handle_set_filters aborts the restore and applies the user filter', async () => {
+        const { panel_like, posted, filter_set } = await make_restore_panel({
+            stored_sort: STORED_SORT,
+            stored_filter: STORED_FILTER,
+        });
+        panel_like.restoring = true;
+        panel_like.restore_id = 0;
+        const my_ctrl = new AbortController();
+        panel_like.restore_abort = my_ctrl;
+        panel_like.current_schema_hash = () => 'h';
+        panel_like.post_filter_status = (s: string) =>
+            posted.push({ type: 'filterStatus', state: s });
+        panel_like.post_filter_applied = () =>
+            posted.push({ type: 'filterApplied' });
+        panel_like.compute_filter_indices =
+            async () => new Uint32Array([0, 1]);
         const my_gen_before = panel_like.generation;
 
         await panel_like.handle_set_filters({
-            type: 'setFilters', entries: [], labels_on: true,
+            type: 'setFilters',
+            entries: [{
+                id: 'f9',
+                col_index: 0,
+                predicate: { kind: 'isNotEmpty' },
+                enabled: true,
+                include_missing: false,
+            }],
+            labels_on: true,
         });
 
-        expect(panel_like.generation).toBe(my_gen_before);
-        expect(posted).toEqual([]);
+        expect(my_ctrl.signal.aborted).toBe(true);
+        expect(panel_like.restoring).toBe(false);
+        expect(panel_like.restore_abort).toBeNull();
+        expect(panel_like.restore_id).toBe(-1);
+        expect(panel_like.generation).toBe(my_gen_before + 1);
+        expect(panel_like.filter.entries.length).toBe(1);
+        expect(filter_set.length).toBe(1);
+        expect(posted.some(m => m.type === 'filterApplied')).toBe(true);
     });
 });
 
@@ -653,5 +850,149 @@ describe('stale restore state does not leak across opens (code-review root cause
         expect(panel_like.sort.keys.length).toBe(1);
         expect(sort_set).toEqual([]);
         expect(filter_set).toEqual([]);
+    });
+
+    it('a reload after a consumed restore re-announces the effective filter count (code-review round 3)', async () => {
+        const { panel_like, posted } = await make_restore_panel({
+            stored_filter: STORED_FILTER,
+        });
+        // Webview reload after the saved filter was already restored: the
+        // one-shot flags are consumed and the filter is active in memory.
+        panel_like.sort_restored = true;
+        panel_like.filter_restored = true;
+        panel_like.filter = STORED_FILTER;
+        panel_like.filtered_indices = new Uint32Array([0, 1, 2]);
+        panel_like.effective_perm = new Uint32Array([0, 1, 2]);
+
+        await panel_like.send_metadata();
+
+        // No fresh restore begins, but the effective (post-filter) count is
+        // re-announced so the grid does not size for the full dataset.
+        expect(posted.some(m => m.type === 'restorePending')).toBe(false);
+        const my_applied = posted.find(m => m.type === 'filterApplied');
+        expect(my_applied).toBeDefined();
+        expect(my_applied.nobs_filtered).toBe(3);
+    });
+});
+
+describe('user action mid-restore supersedes (paint-first race)', () => {
+    it('a user sort during the restore read: no settle, no forget', async () => {
+        const { panel_like, posted, sort_set, filter_set } =
+            await make_restore_panel({
+                stored_sort: STORED_SORT,
+                stored_filter: STORED_FILTER,
+            });
+        let release: (() => void) | null = null;
+        const my_gate = new Promise<void>(r => { release = r; });
+        let calls = 0;
+        // Gate only the restore's read; the user's later sort runs at once.
+        panel_like.compute_sort_permutation = async () => {
+            if (calls++ === 0) await my_gate;
+            return new Uint32Array(10);
+        };
+        panel_like.current_schema_hash = () => 'h';
+        panel_like.post_sort_status = () => undefined;
+        panel_like.post_sort_applied = () =>
+            posted.push({ type: 'sortApplied' });
+
+        const p = panel_like.send_metadata();
+        // Let the restore begin and park at the gated column read.
+        await new Promise(r => setTimeout(r, 0));
+        expect(panel_like.restoring).toBe(true);
+
+        // The user applies their own sort over the live (natural) grid.
+        await panel_like.handle_set_sort({
+            type: 'setSort',
+            keys: [{ col_index: 1, direction: 'desc' }],
+            labels_on: true,
+        });
+
+        release!();
+        await p;
+
+        // User's sort applied + persisted; the superseded restore neither
+        // settled nor forgot the saved filter.
+        expect(panel_like.sort.keys[0].direction).toBe('desc');
+        expect(sort_set.length).toBe(1);
+        expect(filter_set).toEqual([]);
+        expect(posted.some(m => m.type === 'restoreSettled')).toBe(false);
+    });
+
+    it('a user filter does not inherit the restore\'s committed sort (Codex HIGH)', async () => {
+        const { panel_like, posted, filter_set } =
+            await make_restore_panel({
+                stored_sort: STORED_SORT,
+                stored_filter: STORED_FILTER,
+            });
+        // The restore commits the saved sort, then parks in the filter
+        // read (this is the window the bug lived in).
+        panel_like.compute_sort_permutation =
+            async () => new Uint32Array(10);
+        let release: (() => void) | null = null;
+        const my_gate = new Promise<void>(r => { release = r; });
+        let filter_calls = 0;
+        panel_like.compute_filter_indices = async () => {
+            if (filter_calls++ === 0) await my_gate;
+            return new Uint32Array([0, 1]);
+        };
+        panel_like.current_schema_hash = () => 'h';
+        panel_like.post_filter_status = () => undefined;
+        panel_like.post_filter_applied = () =>
+            posted.push({ type: 'filterApplied' });
+
+        const p = panel_like.send_metadata();
+        await new Promise(r => setTimeout(r, 0));
+        // Precondition: the restore has committed the sort in memory.
+        expect(panel_like.sort.keys.length).toBe(1);
+        expect(panel_like.permutation).not.toBeNull();
+
+        // The user applies their own filter, superseding the restore.
+        await panel_like.handle_set_filters({
+            type: 'setFilters',
+            entries: [{
+                id: 'u1',
+                col_index: 0,
+                predicate: { kind: 'isNotEmpty' },
+                enabled: true,
+                include_missing: false,
+            }],
+            labels_on: true,
+        });
+
+        release!();
+        await p;
+
+        // The committed restored sort is discarded — no hidden sort under
+        // the filter-only chip — and the restore does not settle.
+        expect(panel_like.sort.keys.length).toBe(0);
+        expect(panel_like.permutation).toBeNull();
+        expect(panel_like.filter.entries.length).toBe(1);
+        expect(filter_set.length).toBe(1);
+        expect(posted.some(m => m.type === 'restoreSettled')).toBe(false);
+    });
+});
+
+describe('dispose during restore (paint-first, finding #5)', () => {
+    it('aborts the in-flight restore reads before closing the file', async () => {
+        const { panel_like } = await make_restore_panel();
+        panel_like.restoring = true;
+        panel_like.restore_id = 0;
+        const my_ctrl = new AbortController();
+        panel_like.restore_abort = my_ctrl;
+        panel_like.disposables = [];
+        panel_like.dta_file = { close: () => undefined };
+        panel_like.panel = {
+            ...panel_like.panel,
+            dispose: () => undefined,
+        };
+        const my_gen_before = panel_like.generation;
+
+        panel_like.dispose();
+
+        expect(my_ctrl.signal.aborted).toBe(true);
+        expect(panel_like.restoring).toBe(false);
+        expect(panel_like.restore_abort).toBeNull();
+        expect(panel_like.generation).toBe(my_gen_before + 1);
+        expect(panel_like.disposed).toBe(true);
     });
 });

--- a/tests/unit/data-browser/row-request-tracker.test.ts
+++ b/tests/unit/data-browser/row-request-tracker.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test';
+import { RowRequestTracker } from '../../../client/src/data-browser/webview/row-request-tracker';
+
+describe('data-browser RowRequestTracker', () => {
+    it('rejects stale row responses after a page is cleared and re-requested', () => {
+        const tracker = new RowRequestTracker();
+
+        const first_request = tracker.track(0);
+        tracker.clear();
+        const second_request = tracker.track(0);
+
+        expect(tracker.accepts(0, first_request)).toBe(false);
+        expect(tracker.has_pending(0)).toBe(true);
+        expect(tracker.accepts(0, second_request)).toBe(true);
+        expect(tracker.has_pending(0)).toBe(false);
+    });
+});

--- a/tests/unit/data-browser/sort-intent.test.ts
+++ b/tests/unit/data-browser/sort-intent.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    build_pending_sort,
+    pending_sort_after_applied,
+    sort_applied_outcome,
+    sort_work_pending,
+    visible_sort_state,
+} from '../../../client/src/data-browser/webview/sort-intent';
+import type { SortState } from '../../../client/src/data-browser/types';
+
+const sort_state = (
+    cols: number[],
+    labels_on_when_sorted = true
+): SortState => ({
+    keys: cols.map(col_index => ({
+        col_index,
+        direction: 'asc' as const,
+    })),
+    labels_on_when_sorted,
+});
+
+describe('data-browser sort intent', () => {
+    it('shows the pending requested sort while the host computes it', () => {
+        const applied = sort_state([]);
+        const pending = sort_state([0]);
+
+        expect(visible_sort_state(applied, pending)).toBe(pending);
+    });
+
+    it('falls back to the applied sort when no request is pending', () => {
+        const applied = sort_state([1]);
+
+        expect(visible_sort_state(applied, null)).toBe(applied);
+    });
+
+    it('builds a pending sort from requested keys and label mode', () => {
+        expect(build_pending_sort([{
+            col_index: 2,
+            direction: 'desc',
+        }], false)).toEqual({
+            keys: [{ col_index: 2, direction: 'desc' }],
+            labels_on_when_sorted: false,
+        });
+    });
+
+    it('keeps a newer pending sort when an older sort applies', () => {
+        const pending = sort_state([0, 1]);
+
+        expect(
+            pending_sort_after_applied(sort_state([0]), pending)
+        ).toBe(pending);
+    });
+
+    it('clears pending sort once that exact sort applies', () => {
+        const pending = sort_state([0, 1]);
+
+        expect(
+            pending_sort_after_applied(sort_state([0, 1]), pending)
+        ).toBeNull();
+    });
+
+    it('treats a locally queued sort intent as pending work', () => {
+        expect(sort_work_pending(false, sort_state([0]))).toBe(true);
+        expect(sort_work_pending(true, null)).toBe(true);
+        expect(sort_work_pending(false, null)).toBe(false);
+    });
+
+    it('does not refetch rows when an older sort applies under a newer pending sort', () => {
+        const pending = sort_state([1]);
+
+        expect(sort_applied_outcome(sort_state([0]), pending))
+            .toEqual({
+                pending_sort: pending,
+                refetch_rows: false,
+            });
+    });
+
+    it('refetches rows once the pending sort applies', () => {
+        expect(sort_applied_outcome(sort_state([1]), sort_state([1])))
+            .toEqual({
+                pending_sort: null,
+                refetch_rows: true,
+            });
+    });
+});

--- a/tests/unit/data-browser/visible-cell-damage.test.ts
+++ b/tests/unit/data-browser/visible-cell-damage.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { visible_cell_damage } from '../../../client/src/data-browser/webview/visible-cell-damage';
+
+describe('data-browser visible_cell_damage', () => {
+    it('returns every visible cell clamped to the effective row count', () => {
+        expect(visible_cell_damage({
+            column_count: 3,
+            first_row: 4,
+            row_count: 4,
+            total_rows: 6,
+        })).toEqual([
+            { cell: [0, 4] },
+            { cell: [1, 4] },
+            { cell: [2, 4] },
+            { cell: [0, 5] },
+            { cell: [1, 5] },
+            { cell: [2, 5] },
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

Makes the data viewer's saved sort/filter restore **non-blocking** ("paint-first"). Previously, reopening a `.dta` reapplied the saved sort/filter *before* showing any data: `send_metadata_impl` awaited the restore column reads, so the grid stayed blank and frozen for the whole read.

This was measured on a 14.4M-row × 270-col, 12 GB file: each saved sort key / filter column requires a full scan of the data section (row-major layout means one column's values are smeared across every disk block, so reading one column reads the whole 12 GB ≈ **2.8 s**). A 2-key sort + 1 filter restore froze the grid for **~8 s**.

Now the grid paints in natural order immediately and the restore runs in the background (still chunked/cancellable), applying the sorted/filtered order when it finishes. The ~8 s of frozen blank screen becomes ~8 s of a **usable grid** with an honest "Applying your saved sort & filter…" status and a Skip control.

> Note: this removes the *blocking*, not the work — the restore still reads the same bytes. Cutting the read throughput itself (one disk scan for N columns instead of N) requires a new `read_columns` API in `@jbearak/dta-parser` (a published dependency); tracked as a follow-up.

## What changed

- **Host (`browser-panel.ts`):** `send_metadata_impl` is split into an open/metadata phase (posts `metadata` in natural order immediately; owns the "Failed to open" dialog) and a restore phase (reads in the background, then posts a new terminal `restoreSettled` message). Restore errors no longer masquerade as open failures.
- **Protocol (`types.ts`):** new `RestoreSettledMessage { restore_id, sort, filter, nobs_effective }` — carries the final order to switch to, with `restore_id` as an identity guard against stale lifecycles.
- **Webview (`use-row-loader.ts`, `app.tsx`):** handles `restoreSettled`; the restore banner (already a non-blocking toolbar row) now sits over a live grid; the real row count shows during restore; a shared `reset_pages_and_refetch_viewport` helper; an EMPTY/natural settle leaves already-painted rows untouched (no flicker).
- A user sort/filter applied during a background restore **supersedes** it (aborts the reads, discards not-yet-announced restored state, consumes the one-shot restore so a later reload can't resurrect it).

## Correctness

The restore lifecycle is concurrency-sensitive; the change went through several adversarial review rounds (Codex + `/code-review`), each fix landing with a regression test in `tests/unit/data-browser/restore-cancel.test.ts`. Hazards closed include: stale row-cache/generation on settle; superseding leaving an unannounced restored sort; `refresh`/`dispose` closing the file before aborting the restore; a racing Skip forgetting just-restored prefs; a settle-phase throw stranding the banner; reload dropping the effective filter count; and an EMPTY settle stranding blank viewport pages.

Intentional design decisions (reviewed, not bugs): a Skip that loses the race to a successful settle is dropped rather than forgetting just-restored prefs; a `forget` store-write failure is swallowed rather than shown as a wrong dialog; paint-first reads the viewport once in natural order then again in restored order.

## Testing

- `bun run test` (typecheck + tests): green (6222 pass, 0 fail).
- `bun run lint`: clean.
- New/updated unit tests cover the paint-first ordering, `restoreSettled`, supersede-during-restore, Skip racing settle, settle-phase throw, reload re-announcing the filter count, and settle invalidation gating.


https://claude.ai/code/session_01PyhB8VJs4YsL1FR7EovUMy
