### PR TITLE
Publish Sight to npm with trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,6 @@ jobs:
           VERSION_PATTERN+='(-[0-9A-Za-z.-]+)?$'
           sight --version | grep -E "$VERSION_PATTERN"
           sight --help | grep 'static analyzer and language server for Stata'
-          sight-language-server --version | grep -E "$VERSION_PATTERN"
       - name: Test LSP stdio startup
         shell: bash
         run: bun scripts/smoke-stdio-startup.ts sight

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,16 +22,19 @@ concurrency:
   group: release-publish-${{ inputs.tag }}
   cancel-in-progress: false
 
-# Needs actions:read to find/download build artifacts, contents:write to
-# create the GitHub release, and id-token:write for npm Trusted Publishing.
+# Default to read-only permissions. The publish job requests the write scopes
+# it needs for GitHub Releases and npm Trusted Publishing.
 permissions:
   actions: read
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
 
     # IMPORTANT: configure this Environment in GitHub with required reviewers.
     # npm Trusted Publishing binds to this exact workflow + environment and
@@ -128,7 +131,7 @@ jobs:
           fi
 
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
 
       - name: Publish to npm
         run: npm publish --ignore-scripts --access public

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -22,18 +22,20 @@ concurrency:
   group: release-publish-${{ inputs.tag }}
   cancel-in-progress: false
 
-# Needs actions:read to find/download build artifacts, and contents:write to
-# create the GitHub release.
+# Needs actions:read to find/download build artifacts, contents:write to
+# create the GitHub release, and id-token:write for npm Trusted Publishing.
 permissions:
   actions: read
   contents: write
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
-    # IMPORTANT: configure this Environment in GitHub with required reviewers,
-    # and store publish tokens as *environment secrets*.
+    # IMPORTANT: configure this Environment in GitHub with required reviewers.
+    # npm Trusted Publishing binds to this exact workflow + environment and
+    # uses OIDC, so no long-lived NPM_TOKEN secret is required.
     environment: release
 
     steps:
@@ -88,6 +90,8 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          registry-url: https://registry.npmjs.org
 
       - name: Download build artifacts
         shell: bash
@@ -122,6 +126,12 @@ jobs:
           if ls client/*.vsix.sha256 >/dev/null 2>&1; then
             (cd client && sha256sum -c *.vsix.sha256)
           fi
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Publish to npm
+        run: npm publish --ignore-scripts --access public
 
       - name: Publish to VS Code Marketplace
         if: ${{ inputs.publish_vscode }}

--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@ scripts/
 .test-cache-monotonicity/
 .tmp/
 .kiro/
+.gitattributes
 *.test.ts
 *.test.js
 tsconfig.json
@@ -29,7 +30,14 @@ client/
 # Documentation and config (keep README, LICENSE)
 AGENTS.md
 COMMENT_NORMALIZATION.md
+DEVELOPMENT.md
+docs/
+examples/
+Formula/
+specs/
+stata/
 setup.sh
+eslint.config.js
 *.json
 !package.json
 *.do

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,6 +41,13 @@ To install the VSIX manually in VS Code:
 
 The LSP server can be built as a standalone binary for use with coding agents (like Kiro CLI), CI/CD pipelines, and editors other than VS Code.
 
+For the published npm package:
+
+```bash
+npm install -g @jbearak/sight
+sight --version
+```
+
 ### CLI Flags
 
 | Flag | Short | Description |

--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ npm install -g @jbearak/sight
 sight --help
 ```
 
+### From Homebrew (macOS, Apple Silicon)
+
+```bash
+brew install jbearak/sight/sight
+sight --help
+```
+
+Installs the prebuilt `sight` CLI from the
+[`jbearak/sight`](https://github.com/jbearak/homebrew-sight) tap. Apple Silicon
+macOS only.
+
 ### Other Methods
 
 - **Standalone CLI / Build from Source**: See [Standalone Installation](docs/standalone-installation.md)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ Execute code in Stata directly from the editor.
 
 > **Note:** If you have other extensions installed that provide Stata syntax highlighting (e.g., `stata-enhanced` or `stata-language`), disable them to use Sight's syntax highlighting.
 
+### From npm
+
+For command-line use or editors that connect to an external LSP server:
+
+```bash
+npm install -g @jbearak/sight
+sight --help
+```
+
 ### Other Methods
 
 - **Standalone CLI / Build from Source**: See [Standalone Installation](docs/standalone-installation.md)

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 0,
   "workspaces": {
     "": {
-      "name": "stata-lsp",
+      "name": "@jbearak/sight",
       "dependencies": {
         "@jbearak/dta-parser": "^0.3.0",
         "smol-toml": "^1.6.1",

--- a/docs/standalone-installation.md
+++ b/docs/standalone-installation.md
@@ -2,8 +2,18 @@
 
 In addition to the VS Code extension, you can install the standalone tool to
 use the LSP directly with other editors (e.g., vim, neovim, and emacs) or in
-CI/CD. To do this, either download a release binary or
+CI/CD. To do this, install from npm, download a release binary, or
 [build from source](#build-from-source).
+
+## npm
+
+```bash
+npm install -g @jbearak/sight
+sight --help
+```
+
+The npm package installs the `sight` command. Configure LSP clients to run
+`sight --stdio`.
 
 ## Release Binary
 
@@ -55,22 +65,7 @@ If `sight` is not found after this, add `%USERPROFILE%\bin` to your user
 `Path`.
 
 Existing editor configs that still call `sight-language-server` should be
-updated to `sight --stdio`. If you need temporary compatibility while updating
-those configs on macOS or Linux, add a legacy alias:
-
-```bash
-test ! -e ~/bin/sight-language-server || {
-  echo "~/bin/sight-language-server already exists; update configs to sight"
-  exit 1
-}
-ln -s ~/bin/sight ~/bin/sight-language-server
-```
-
-On Windows, copy the executable instead:
-
-```powershell
-Copy-Item "$HOME\bin\sight.exe" "$HOME\bin\sight-language-server.exe"
-```
+updated to `sight --stdio`.
 
 After installation, the `sight` command should be available globally. Use it
 with:

--- a/docs/standalone-installation.md
+++ b/docs/standalone-installation.md
@@ -2,8 +2,8 @@
 
 In addition to the VS Code extension, you can install the standalone tool to
 use the LSP directly with other editors (e.g., vim, neovim, and emacs) or in
-CI/CD. To do this, install from npm, download a release binary, or
-[build from source](#build-from-source).
+CI/CD. To do this, install from npm, install from Homebrew (macOS, Apple
+Silicon), download a release binary, or [build from source](#build-from-source).
 
 ## npm
 
@@ -14,6 +14,17 @@ sight --help
 
 The npm package installs the `sight` command. Configure LSP clients to run
 `sight --stdio`.
+
+## Homebrew (macOS, Apple Silicon)
+
+```bash
+brew install jbearak/sight/sight
+sight --help
+```
+
+Installs the prebuilt `sight` CLI from the
+[`jbearak/sight`](https://github.com/jbearak/homebrew-sight) tap. Apple Silicon
+macOS only. Configure LSP clients to run `sight --stdio`.
 
 ## Release Binary
 

--- a/docs/superpowers/plans/2026-06-28-npm-trusted-publishing.md
+++ b/docs/superpowers/plans/2026-06-28-npm-trusted-publishing.md
@@ -10,6 +10,8 @@
 
 ---
 
+## Tasks
+
 ### Task 1: Lock Package Bin Contract
 
 **Files:**
@@ -78,7 +80,7 @@ Use the existing binary-command workflow guard tests to ensure CI no longer refe
 
 - [ ] **Step 2: Implement workflow**
 
-Grant `id-token: write`, pass `registry-url` to setup, upgrade npm, and publish with `npm publish --ignore-scripts --access public`.
+Grant `id-token: write` on the publish job, pass `registry-url` to setup, install a pinned Trusted Publishing-capable npm CLI, and publish with `npm publish --ignore-scripts --access public`.
 
 - [ ] **Step 3: Update release script messaging**
 

--- a/docs/superpowers/plans/2026-06-28-npm-trusted-publishing.md
+++ b/docs/superpowers/plans/2026-06-28-npm-trusted-publishing.md
@@ -1,0 +1,136 @@
+# NPM Trusted Publishing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish Sight as `@jbearak/sight` via npm Trusted Publishing with one public npm command, `sight`, while cleaning up the old `sight-language-server` alias from source installs.
+
+**Architecture:** Keep Sight's existing two-stage release pipeline and add npm publishing to `release-publish.yml`, where the GitHub release and registry publishing already happen. Change package metadata and installer helpers so `sight` is the only installed command, while uninstall/install still remove Sight-owned stale legacy aliases.
+
+**Tech Stack:** Bun, TypeScript, npm, GitHub Actions, npm Trusted Publishing/OIDC.
+
+---
+
+### Task 1: Lock Package Bin Contract
+
+**Files:**
+- Modify: `tests/unit/binary-command-name.test.ts`
+- Modify: `package.json`
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Write failing tests**
+
+Add assertions that the root package name is `@jbearak/sight`, the `bin` map contains only `sight`, and CI no longer smoke-tests the legacy alias.
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test ./tests/unit/binary-command-name.test.ts`
+
+Expected before implementation: failure because `package.json` is still named `sight-language-server` and still exports the legacy bin.
+
+- [ ] **Step 3: Implement metadata and CI changes**
+
+Change `package.json` name/bin fields and remove the CI alias check.
+
+- [ ] **Step 4: Re-run test**
+
+Run: `bun test ./tests/unit/binary-command-name.test.ts`
+
+Expected after implementation: pass for package-contract assertions.
+
+### Task 2: Remove Legacy Source Install Alias
+
+**Files:**
+- Modify: `scripts/binary-names.ts`
+- Modify: `scripts/install.ts`
+- Modify: `scripts/uninstall.ts`
+- Modify: `tests/unit/binary-command-name.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Update install-name tests so `get_binary_names_to_install()` returns only `sight`, and add stale-alias cleanup tests showing source install/uninstall remove a Sight-owned `sight-language-server`.
+
+- [ ] **Step 2: Run tests**
+
+Run: `bun test ./tests/unit/binary-command-name.test.ts`
+
+Expected before implementation: failure because source install still writes both names.
+
+- [ ] **Step 3: Implement installer cleanup**
+
+Make install targets primary-only. Add separate stale legacy alias cleanup paths for install and uninstall, protected by existing ownership checks.
+
+- [ ] **Step 4: Re-run tests**
+
+Run: `bun test ./tests/unit/binary-command-name.test.ts`
+
+Expected after implementation: pass.
+
+### Task 3: Wire NPM Trusted Publishing
+
+**Files:**
+- Modify: `.github/workflows/release-publish.yml`
+- Modify: `.github/actions/setup/action.yml` only if needed
+- Modify: `scripts/release.ts`
+
+- [ ] **Step 1: Add workflow assertions if covered by existing tests**
+
+Use the existing binary-command workflow guard tests to ensure CI no longer references the old alias.
+
+- [ ] **Step 2: Implement workflow**
+
+Grant `id-token: write`, pass `registry-url` to setup, upgrade npm, and publish with `npm publish --ignore-scripts --access public`.
+
+- [ ] **Step 3: Update release script messaging**
+
+Mention npm as a release channel and `npm install -g @jbearak/sight` as an install test.
+
+### Task 4: Update Docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/standalone-installation.md`
+- Modify: `DEVELOPMENT.md` if it references npm install or old alias
+
+- [ ] **Step 1: Remove old-alias instructions**
+
+Delete guidance to create `sight-language-server` symlinks/copies. Add npm install as a standalone option.
+
+- [ ] **Step 2: Sweep references**
+
+Run: `rg -n "sight-language-server|@jbearak/sight|npm install -g" README.md docs DEVELOPMENT.md package.json .github scripts tests src`
+
+Expected: legacy alias remains only where it is intentionally tested as stale cleanup or accepted as an invocation-compatibility path.
+
+### Task 5: Verify Package Shape
+
+**Files:**
+- No source edits unless verification reveals a bug.
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+
+```bash
+bun test ./tests/unit/binary-command-name.test.ts
+bun test ./tests/integration/binary-invocation.test.ts
+bun test ./tests/unit/smoke-stdio-startup.test.ts
+```
+
+- [ ] **Step 2: Run package build checks**
+
+Run:
+
+```bash
+bun run build:npm
+npm pack --dry-run
+```
+
+- [ ] **Step 3: Run broader gate if practical**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Run `bun run test` and `bun run lint` if time permits.

--- a/docs/superpowers/specs/2026-06-28-npm-trusted-publishing-design.md
+++ b/docs/superpowers/specs/2026-06-28-npm-trusted-publishing-design.md
@@ -41,10 +41,10 @@ Publishing from `release-publish.yml` keeps npm aligned with the same approved r
 
 The publish job will:
 
-- grant `id-token: write` for npm Trusted Publishing;
+- grant `id-token: write` on the publish job for npm Trusted Publishing;
 - use the existing `release` environment;
 - configure npm with `registry-url: https://registry.npmjs.org`;
-- upgrade npm to a Trusted Publishing-capable version before publish;
+- install a pinned Trusted Publishing-capable npm CLI before publish;
 - publish with `npm publish --ignore-scripts --access public`.
 
 One-time npm setup:

--- a/docs/superpowers/specs/2026-06-28-npm-trusted-publishing-design.md
+++ b/docs/superpowers/specs/2026-06-28-npm-trusted-publishing-design.md
@@ -1,0 +1,101 @@
+# NPM Trusted Publishing for Sight
+
+## Goal
+
+Publish Sight to npm as `@jbearak/sight` automatically during the existing release flow, using npm Trusted Publishing rather than a long-lived `NPM_TOKEN`.
+
+The npm package should expose one command, `sight`. The old `sight-language-server` npm bin should not ship.
+
+## Precedents
+
+`jbearak/dta-parser` uses npm Trusted Publishing with GitHub Actions OIDC: the workflow has `id-token: write`, runs through the `release` environment, validates tag/package version alignment, and publishes with `npm publish --ignore-scripts --access public`.
+
+Raven provides the local cleanup precedent: it has one canonical executable name and its install scripts remove previously installed files before copying the new binary, including cleanup of old hand-installed binaries so they do not shadow the current install on `PATH`.
+
+## Design
+
+### Package metadata
+
+Rename the root package from `sight-language-server` to `@jbearak/sight`.
+
+Keep only this npm bin:
+
+```json
+{
+  "bin": {
+    "sight": "dist/sight-server.js"
+  }
+}
+```
+
+The bundled executable remains `dist/sight-server.js`; the CLI banner and primary command remain `sight`.
+
+### Release workflow
+
+Add npm publishing to `.github/workflows/release-publish.yml`, because Sight already has a two-stage release pipeline:
+
+1. `release-build.yml` verifies, builds, packages, smoke-tests, assembles artifacts, and triggers `release-publish.yml`.
+2. `release-publish.yml` validates the tag, downloads the exact build artifacts, publishes external channels, creates the GitHub release, and bumps Homebrew.
+
+Publishing from `release-publish.yml` keeps npm aligned with the same approved release artifact set instead of creating a second tag-triggered publish path.
+
+The publish job will:
+
+- grant `id-token: write` for npm Trusted Publishing;
+- use the existing `release` environment;
+- configure npm with `registry-url: https://registry.npmjs.org`;
+- upgrade npm to a Trusted Publishing-capable version before publish;
+- publish with `npm publish --ignore-scripts --access public`.
+
+One-time npm setup:
+
+- package: `@jbearak/sight`;
+- owner/repo: `jbearak/sight`;
+- workflow filename: `release-publish.yml`;
+- environment: `release`.
+
+### Build artifact and tarball safety
+
+The release build already runs `bun run build:npm`, validates `dist/sight-server.js --version`, and smoke-tests the bundled server. CI already runs `npm pack --dry-run` and global installation tests.
+
+Update those checks so they assert only the `sight` command after `npm install -g .`. Do not assert or preserve the `sight-language-server` alias.
+
+Keep `.npmignore` focused so the npm package contains the package manifest, README/license material, and the bundled server, not source, tests, scripts, client extension files, or binary artifacts.
+
+### Legacy alias cleanup
+
+Apply the Raven lesson beyond npm metadata:
+
+- source installation should install only `~/bin/sight`;
+- source installation should remove a Sight-owned stale `~/bin/sight-language-server` or `~/bin/sight-language-server.exe` when present;
+- source uninstallation should remove the old alias if it is Sight-owned, so users who previously installed from source are cleaned up;
+- documentation should stop recommending symlinking/copying `sight-language-server`;
+- tests should lock in the single-command package contract and stale-alias cleanup behavior.
+
+Do not change Stata language behavior or LSP protocol behavior.
+
+## Validation
+
+Run:
+
+```bash
+bun run typecheck
+bun test ./tests/unit/binary-command-name.test.ts
+bun test ./tests/integration/binary-invocation.test.ts
+bun test ./tests/unit/smoke-stdio-startup.test.ts
+bun run build:npm
+npm pack --dry-run
+```
+
+If time permits, also run the full CI-equivalent gate:
+
+```bash
+bun run test
+bun run lint
+```
+
+## Risks
+
+Trusted Publishing requires npm-side configuration before the first release. If that is missing, the release workflow will fail at the npm publish step after build validation but before publishing npm.
+
+Removing the old bin is intentionally breaking for users who installed only through npm and call `sight-language-server`. The desired contract is one command, `sight`; docs and installer cleanup should make that explicit.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "A static analyzer and language server for the Stata statistical programming language",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jbearak/sight.git"
+    "url": "git+https://github.com/jbearak/sight.git"
   },
   "bugs": {
     "url": "https://github.com/jbearak/sight/issues"
@@ -27,8 +27,8 @@
     "build:npm": "bun run build:bundle && npm run validate:npm",
     "validate:npm": "node dist/sight-server.js --version && echo 'NPM build validation passed'",
     "prepublishOnly": "npm run build:npm",
-    "publish:npm": "npm publish --ignore-scripts --access public",
-    "publish:dry-run": "npm publish --dry-run --access public",
+    "publish:npm": "npm run build:npm && npm publish --ignore-scripts --access public",
+    "publish:dry-run": "npm run build:npm && npm publish --dry-run --ignore-scripts --access public",
     "install:binary": "bun scripts/install.ts",
     "uninstall:binary": "bun scripts/uninstall.ts",
     "watch": "tsc --watch",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,22 @@
 {
-  "name": "sight-language-server",
+  "name": "@jbearak/sight",
   "version": "0.8.4",
   "type": "module",
   "workspaces": [
     "client"
   ],
-  "description": "Language Server Protocol implementation for Stata",
+  "description": "A static analyzer and language server for the Stata statistical programming language",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jbearak/sight.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jbearak/sight/issues"
+  },
+  "homepage": "https://github.com/jbearak/sight#readme",
   "main": "dist/sight-server.js",
   "bin": {
-    "sight": "dist/sight-server.js",
-    "sight-language-server": "dist/sight-server.js"
+    "sight": "dist/sight-server.js"
   },
   "scripts": {
     "build": "tsc && cp -r src/command-database/caches dist/command-database/ && bun run build:bundle && cd client && npm run compile && npm run copy-server && cd ..",
@@ -20,8 +27,8 @@
     "build:npm": "bun run build:bundle && npm run validate:npm",
     "validate:npm": "node dist/sight-server.js --version && echo 'NPM build validation passed'",
     "prepublishOnly": "npm run build:npm",
-    "publish:npm": "npm publish",
-    "publish:dry-run": "npm publish --dry-run",
+    "publish:npm": "npm publish --ignore-scripts --access public",
+    "publish:dry-run": "npm publish --dry-run --access public",
     "install:binary": "bun scripts/install.ts",
     "uninstall:binary": "bun scripts/uninstall.ts",
     "watch": "tsc --watch",

--- a/scripts/binary-names.ts
+++ b/scripts/binary-names.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 import {
     LEGACY_BINARY_NAME,
     PRIMARY_BINARY_NAME,
+    WINDOWS_SHIM_EXTENSIONS,
 } from '../src/cli-binary-names';
 
 export {
@@ -80,7 +81,7 @@ export function get_binary_shadow_paths_to_check(
     }
 
     const the_base_names = [PRIMARY_BINARY_NAME];
-    const the_extensions = ['', '.cmd', '.bat', '.ps1'];
+    const the_extensions = WINDOWS_SHIM_EXTENSIONS;
 
     return the_base_names.flatMap((my_binary_name) =>
         the_extensions.map((my_extension) => join(
@@ -104,12 +105,13 @@ export function get_legacy_binary_paths_to_cleanup(
         return [join(user_bin_path, legacy_binary_name)];
     }
 
+    // On Windows, reclaim the platform .exe plus the bare legacy name and every
+    // npm command-shim extension.
     return [
         join(user_bin_path, legacy_binary_name),
-        join(user_bin_path, LEGACY_BINARY_NAME),
-        join(user_bin_path, `${LEGACY_BINARY_NAME}.cmd`),
-        join(user_bin_path, `${LEGACY_BINARY_NAME}.bat`),
-        join(user_bin_path, `${LEGACY_BINARY_NAME}.ps1`),
+        ...WINDOWS_SHIM_EXTENSIONS.map((my_extension) =>
+            join(user_bin_path, `${LEGACY_BINARY_NAME}${my_extension}`)
+        ),
     ];
 }
 

--- a/scripts/binary-names.ts
+++ b/scripts/binary-names.ts
@@ -41,10 +41,7 @@ export function get_legacy_binary_name(
 export function get_binary_names_to_install(
     platform: NodeJS.Platform = process.platform
 ): string[] {
-    return [
-        get_binary_name(platform),
-        get_legacy_binary_name(platform),
-    ];
+    return [get_binary_name(platform)];
 }
 
 /**
@@ -53,7 +50,10 @@ export function get_binary_names_to_install(
 export function get_binary_names_to_uninstall(
     platform: NodeJS.Platform = process.platform
 ): string[] {
-    return get_binary_names_to_install(platform);
+    return [
+        get_binary_name(platform),
+        get_legacy_binary_name(platform),
+    ];
 }
 
 /**
@@ -79,10 +79,7 @@ export function get_binary_shadow_paths_to_check(
         return [];
     }
 
-    const the_base_names = [
-        PRIMARY_BINARY_NAME,
-        LEGACY_BINARY_NAME,
-    ];
+    const the_base_names = [PRIMARY_BINARY_NAME];
     const the_extensions = ['', '.cmd', '.bat', '.ps1'];
 
     return the_base_names.flatMap((my_binary_name) =>
@@ -91,6 +88,29 @@ export function get_binary_shadow_paths_to_check(
             `${my_binary_name}${my_extension}`
         ))
     );
+}
+
+/**
+ * Get stale legacy command paths that source install should remove when they
+ * are Sight-owned.
+ */
+export function get_legacy_binary_paths_to_cleanup(
+    user_bin_path: string,
+    platform: NodeJS.Platform = process.platform
+): string[] {
+    const legacy_binary_name = get_legacy_binary_name(platform);
+
+    if (platform !== 'win32') {
+        return [join(user_bin_path, legacy_binary_name)];
+    }
+
+    return [
+        join(user_bin_path, legacy_binary_name),
+        join(user_bin_path, LEGACY_BINARY_NAME),
+        join(user_bin_path, `${LEGACY_BINARY_NAME}.cmd`),
+        join(user_bin_path, `${LEGACY_BINARY_NAME}.bat`),
+        join(user_bin_path, `${LEGACY_BINARY_NAME}.ps1`),
+    ];
 }
 
 /**

--- a/scripts/binary-ownership.ts
+++ b/scripts/binary-ownership.ts
@@ -10,6 +10,7 @@ import { extname } from 'path';
 import {
     CLI_DESCRIPTION,
     PRIMARY_BINARY_NAME,
+    WINDOWS_SHIM_EXTENSIONS,
 } from '../src/cli-binary-names';
 
 const BUNDLED_SERVER_ENTRYPOINT = 'sight-server.js';
@@ -41,7 +42,7 @@ function has_sight_npm_shim_content(
 ): boolean {
     const extension = extname(binary_path).toLowerCase();
     const the_allowed_extensions = platform === 'win32'
-        ? ['', '.cmd', '.bat', '.ps1']
+        ? WINDOWS_SHIM_EXTENSIONS
         : [''];
 
     if (!the_allowed_extensions.includes(extension)) {

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -2,7 +2,8 @@
 /**
  * Install script for the Sight LSP binary.
  * 
- * Copies the platform binary to ~/bin/sight and the legacy alias.
+ * Copies the platform binary to ~/bin/sight.
+ * Removes Sight-owned stale legacy aliases from earlier installs.
  * Provides PATH setup instructions after install.
  * 
  * Usage:
@@ -23,6 +24,7 @@ import {
 import { detect_platform } from './build-binary';
 import {
     get_binary_shadow_paths_to_check,
+    get_legacy_binary_paths_to_cleanup,
     get_binary_paths_to_install,
 } from './binary-names';
 import { ensure_sight_binary_target } from './binary-ownership';
@@ -108,7 +110,35 @@ function ensure_existing_target_is_replaceable(
 }
 
 /**
- * Copy the source binary to every supported command name.
+ * Remove stale legacy command names when they are owned by Sight.
+ */
+function remove_stale_legacy_aliases(
+    user_bin_path: string,
+    platform: NodeJS.Platform,
+    check_existing_target: ExistingTargetChecker
+): void {
+    for (const my_target_path of get_legacy_binary_paths_to_cleanup(
+        user_bin_path,
+        platform
+    )) {
+        const my_target = get_existing_target(my_target_path);
+
+        if (!my_target.exists_or_is_symlink || !existsSync(my_target.path)) {
+            continue;
+        }
+
+        try {
+            check_existing_target(my_target.path, platform);
+        } catch {
+            continue;
+        }
+
+        unlinkSync(my_target.path);
+    }
+}
+
+/**
+ * Copy the source binary to the supported command name.
  */
 export function install_binary_files(
     source_path: string,
@@ -155,6 +185,12 @@ export function install_binary_files(
     for (const my_target_path of the_target_paths) {
         copyFileSync(source_path, my_target_path);
     }
+
+    remove_stale_legacy_aliases(
+        user_bin_path,
+        platform,
+        check_existing_target
+    );
 
     return the_target_paths;
 }
@@ -230,7 +266,7 @@ function detect_shell(): string {
 }
 
 /**
- * Install the Sight binary to ~/bin command names.
+ * Install the Sight binary to ~/bin.
  */
 async function install(): Promise<InstallResult> {
     // Detect platform
@@ -284,7 +320,7 @@ async function install(): Promise<InstallResult> {
         }
     }
 
-    // Copy the binary to the primary command and legacy alias.
+    // Copy the binary to the primary command and remove stale legacy aliases.
     let the_target_paths: string[] = [];
     try {
         the_target_paths = install_binary_files(source_path, user_bin);

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -133,7 +133,17 @@ function remove_stale_legacy_aliases(
             continue;
         }
 
-        unlinkSync(my_target.path);
+        // Cleanup is best-effort: the primary command is already installed, so
+        // a failed unlink (locked file, EPERM/EACCES) must not fail an install
+        // that has otherwise succeeded.
+        try {
+            unlinkSync(my_target.path);
+        } catch (error) {
+            console.warn(
+                `Warning: could not remove stale legacy alias ` +
+                `${my_target.path}: ${error}`
+            );
+        }
     }
 }
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -92,6 +92,7 @@ This script will:
 
 Distribution Channels:
 🚀 GitHub Releases        - Direct binary downloads
+📦 npm                    - Published as @jbearak/sight
 🎨 VS Code Marketplace    - Published only when RELEASE_PUBLISH_VSCODE=true
 🌐 OpenVSX Registry       - Published only when RELEASE_PUBLISH_VSCODE=true
 
@@ -146,11 +147,13 @@ async function main(): Promise<void> {
 
 What happens next:
 1. 🚀 GitHub Action builds all artifacts and creates release
-2. 📦 If RELEASE_PUBLISH_VSCODE=true, it publishes extension registry artifacts
+2. 📦 The publish workflow publishes @jbearak/sight to npm with Trusted Publishing
+3. 🎨 If RELEASE_PUBLISH_VSCODE=true, it publishes extension registry artifacts
 
 Next steps:
 1. Check GitHub Actions: https://github.com/jbearak/sight/actions
 2. Once release is created, test installations:
+   - npm: npm install -g @jbearak/sight && sight --version
    - VS Code: Search for "jbearak.sight" in Extensions
    - Standalone: Download the matching sight-* release binary
 `);

--- a/src/cli-binary-names.ts
+++ b/src/cli-binary-names.ts
@@ -4,6 +4,15 @@
 
 export const PRIMARY_BINARY_NAME = 'sight';
 export const LEGACY_BINARY_NAME = 'sight-language-server';
+// Windows command-shim extensions npm writes for a `bin` entry, plus the bare
+// (extension-less) name. Shared by install shadow checks, legacy-alias cleanup,
+// and Sight-ownership shim detection so the set cannot drift between them.
+export const WINDOWS_SHIM_EXTENSIONS: readonly string[] = [
+    '',
+    '.cmd',
+    '.bat',
+    '.ps1',
+];
 // Version-less tagline. The help banner composes this with the version
 // (`sight <version>, <description>`); keeping it version-less lets it double as
 // a stable identity marker for compiled binaries across releases.

--- a/tests/unit/binary-command-name.test.ts
+++ b/tests/unit/binary-command-name.test.ts
@@ -435,17 +435,20 @@ function expect_step_before(
 }
 
 describe('binary command name', () => {
-    it('uses the shipped bundle for package main and npm executables', () => {
+    it('uses the shipped bundle for package main and the npm executable', () => {
         const package_json_path = join(__dirname, '../../package.json');
         const package_content = JSON.parse(
             readFileSync(package_json_path, 'utf8')
         );
 
+        expect(package_content.name).toBe('@jbearak/sight');
+        expect(package_content.description).toBe(
+            'A static analyzer and language server for the Stata statistical programming language'
+        );
         expect(package_content.main).toBe('dist/sight-server.js');
         expect(package_content.main).toBe(package_content.bin.sight);
         expect(package_content.bin).toEqual({
             sight: 'dist/sight-server.js',
-            'sight-language-server': 'dist/sight-server.js',
         });
     });
 
@@ -580,7 +583,7 @@ describe('binary command name', () => {
         }
     });
 
-    it('source install writes primary and legacy command names', () => {
+    it('source install writes only the primary command name', () => {
         const temp_root = make_temp_dir();
         const source_path = join(temp_root, 'source-binary');
         const user_bin_path = join(temp_root, 'bin');
@@ -600,19 +603,17 @@ describe('binary command name', () => {
             );
 
             expect(the_target_paths.map((target_path) => basename(target_path)))
-                .toEqual(['sight', 'sight-language-server']);
+                .toEqual(['sight']);
             expect(readFileSync(join(user_bin_path, 'sight'), 'utf8'))
                 .toBe('new-binary');
-            expect(readFileSync(
-                join(user_bin_path, 'sight-language-server'),
-                'utf8'
-            )).toBe('new-binary');
+            expect(existsSync(join(user_bin_path, 'sight-language-server')))
+                .toBe(false);
         } finally {
             rmSync(temp_root, { recursive: true, force: true });
         }
     });
 
-    it('source install replaces legacy source-installed native binary', () => {
+    it('source install removes legacy source-installed native binary', () => {
         const temp_root = make_temp_dir();
         const source_path = join(temp_root, 'source-binary');
         const user_bin_path = join(temp_root, 'bin');
@@ -627,7 +628,7 @@ describe('binary command name', () => {
 
             expect(readFileSync(join(user_bin_path, 'sight'), 'utf8'))
                 .toBe('new-binary');
-            expect(readFileSync(legacy_path, 'utf8')).toBe('new-binary');
+            expect(existsSync(legacy_path)).toBe(false);
         } finally {
             rmSync(temp_root, { recursive: true, force: true });
         }
@@ -686,7 +687,7 @@ describe('binary command name', () => {
         }
     });
 
-    it('source install validates all targets before replacing symlinks', () => {
+    it('source install leaves unrelated legacy aliases during cleanup', () => {
         if (process.platform === 'win32') {
             return;
         }
@@ -705,15 +706,17 @@ describe('binary command name', () => {
             symlinkSync(managed_path, existing_sight_path);
             write_version_script(legacy_path, 'other 1.0.0');
 
-            expect(() => install_binary_files(
+            const the_target_paths = install_binary_files(
                 source_path,
                 user_bin_path,
                 'linux'
-            )).toThrow(/Refusing to overwrite/);
+            );
 
-            expect(lstatSync(existing_sight_path).isSymbolicLink()).toBe(true);
+            expect(the_target_paths.map((target_path) => basename(target_path)))
+                .toEqual(['sight']);
+            expect(lstatSync(existing_sight_path).isSymbolicLink()).toBe(false);
             expect(readFileSync(existing_sight_path, 'utf8'))
-                .toContain(CLI_DESCRIPTION);
+                .toBe('new-binary');
             expect(readFileSync(legacy_path, 'utf8'))
                 .toContain('other 1.0.0');
         } finally {
@@ -776,7 +779,7 @@ describe('binary command name', () => {
         }
     });
 
-    it('source install refuses to overwrite unrelated legacy alias', () => {
+    it('source install leaves unrelated legacy alias in place', () => {
         const temp_root = make_temp_dir();
         const source_path = join(temp_root, 'source-binary');
         const user_bin_path = join(temp_root, 'bin');
@@ -787,13 +790,16 @@ describe('binary command name', () => {
             mkdirSync(user_bin_path, { recursive: true });
             write_version_script(legacy_path, 'other 1.0.0');
 
-            expect(() => install_binary_files(
+            const the_target_paths = install_binary_files(
                 source_path,
                 user_bin_path,
                 'linux'
-            )).toThrow(/Refusing to overwrite/);
+            );
 
-            expect(existsSync(join(user_bin_path, 'sight'))).toBe(false);
+            expect(the_target_paths.map((target_path) => basename(target_path)))
+                .toEqual(['sight']);
+            expect(readFileSync(join(user_bin_path, 'sight'), 'utf8'))
+                .toBe('new-binary');
             expect(readFileSync(legacy_path, 'utf8'))
                 .toContain('other 1.0.0');
         } finally {
@@ -934,7 +940,7 @@ describe('binary command name', () => {
         }
     });
 
-    it('source install writes Windows primary and legacy command names', () => {
+    it('source install writes only the Windows primary command name', () => {
         const temp_root = make_temp_dir();
         const source_path = join(temp_root, 'source-binary.exe');
         const user_bin_path = join(temp_root, 'bin');
@@ -950,13 +956,12 @@ describe('binary command name', () => {
             );
 
             expect(the_target_paths.map((target_path) => basename(target_path)))
-                .toEqual(['sight.exe', 'sight-language-server.exe']);
+                .toEqual(['sight.exe']);
             expect(readFileSync(join(user_bin_path, 'sight.exe'), 'utf8'))
                 .toBe('new-binary');
-            expect(readFileSync(
-                join(user_bin_path, 'sight-language-server.exe'),
-                'utf8'
-            )).toBe('new-binary');
+            expect(existsSync(
+                join(user_bin_path, 'sight-language-server.exe')
+            )).toBe(false);
         } finally {
             rmSync(temp_root, { recursive: true, force: true });
         }
@@ -1130,19 +1135,10 @@ describe('binary command name', () => {
         )).toBe(true);
     });
 
-    it('tracks primary and legacy source-install names', () => {
-        expect(get_binary_names_to_install('darwin')).toEqual([
-            'sight',
-            'sight-language-server',
-        ]);
-        expect(get_binary_names_to_install('linux')).toEqual([
-            'sight',
-            'sight-language-server',
-        ]);
-        expect(get_binary_names_to_install('win32')).toEqual([
-            'sight.exe',
-            'sight-language-server.exe',
-        ]);
+    it('tracks primary source-install names and legacy cleanup names', () => {
+        expect(get_binary_names_to_install('darwin')).toEqual(['sight']);
+        expect(get_binary_names_to_install('linux')).toEqual(['sight']);
+        expect(get_binary_names_to_install('win32')).toEqual(['sight.exe']);
         expect(get_binary_shadow_paths_to_check('/bin', 'win32').map(
             (target_path) => basename(target_path)
         )).toEqual([
@@ -1150,10 +1146,6 @@ describe('binary command name', () => {
             'sight.cmd',
             'sight.bat',
             'sight.ps1',
-            'sight-language-server',
-            'sight-language-server.cmd',
-            'sight-language-server.bat',
-            'sight-language-server.ps1',
         ]);
         expect(get_binary_shadow_paths_to_check('/bin', 'linux')).toEqual([]);
 
@@ -1208,7 +1200,7 @@ describe('binary command name', () => {
         expect(workflow_content).toMatch(
             /sight --help \| grep 'static analyzer and language server for Stata'/
         );
-        expect(workflow_content).toContain(
+        expect(workflow_content).not.toContain(
             'sight-language-server --version | grep -E "$VERSION_PATTERN"'
         );
         expect_workflow_runs_stdio_smoke_helper(
@@ -1454,6 +1446,28 @@ describe('binary command name', () => {
 
         expect(workflow_content).toContain('actions: read');
         expect(workflow_content).toContain('contents: write');
+        expect(workflow_content).toContain('id-token: write');
+        expect(workflow_content).toContain(
+            'registry-url: https://registry.npmjs.org'
+        );
+        expect(workflow_content).toContain(
+            'npm install -g npm@latest'
+        );
+        expect(workflow_content).toContain(
+            'npm publish --ignore-scripts --access public'
+        );
+        expect_step_before(
+            workflow_content,
+            'publish',
+            'Verify checksums',
+            'Publish to npm'
+        );
+        expect_step_before(
+            workflow_content,
+            'publish',
+            'Publish to npm',
+            'Create GitHub Release'
+        );
         expect(workflow_content).toContain(
             'build_run_id:'
         );

--- a/tests/unit/binary-command-name.test.ts
+++ b/tests/unit/binary-command-name.test.ts
@@ -445,11 +445,20 @@ describe('binary command name', () => {
         expect(package_content.description).toBe(
             'A static analyzer and language server for the Stata statistical programming language'
         );
+        expect(package_content.repository.url).toBe(
+            'git+https://github.com/jbearak/sight.git'
+        );
         expect(package_content.main).toBe('dist/sight-server.js');
         expect(package_content.main).toBe(package_content.bin.sight);
         expect(package_content.bin).toEqual({
             sight: 'dist/sight-server.js',
         });
+        expect(package_content.scripts['publish:npm']).toBe(
+            'npm run build:npm && npm publish --ignore-scripts --access public'
+        );
+        expect(package_content.scripts['publish:dry-run']).toBe(
+            'npm run build:npm && npm publish --dry-run --ignore-scripts --access public'
+        );
     });
 
     it('uses shared command names for supported platforms', () => {
@@ -1444,6 +1453,25 @@ describe('binary command name', () => {
         );
         const workflow_content = readFileSync(workflow_path, 'utf8');
 
+        const workflow_header = workflow_content.split('\njobs:\n')[0];
+        expect(workflow_header).toContain(
+            'permissions:\n' +
+            '  actions: read\n' +
+            '  contents: read'
+        );
+        expect(workflow_header).not.toContain('contents: write');
+        expect(workflow_header).not.toContain('id-token: write');
+
+        const publish_job = get_workflow_job_block(
+            workflow_content,
+            'publish'
+        );
+        expect(publish_job).toContain(
+            'permissions:\n' +
+            '      actions: read\n' +
+            '      contents: write\n' +
+            '      id-token: write'
+        );
         expect(workflow_content).toContain('actions: read');
         expect(workflow_content).toContain('contents: write');
         expect(workflow_content).toContain('id-token: write');
@@ -1451,8 +1479,9 @@ describe('binary command name', () => {
             'registry-url: https://registry.npmjs.org'
         );
         expect(workflow_content).toContain(
-            'npm install -g npm@latest'
+            'npm install -g npm@11.5.1'
         );
+        expect(workflow_content).not.toContain('npm@latest');
         expect(workflow_content).toContain(
             'npm publish --ignore-scripts --access public'
         );


### PR DESCRIPTION
## Summary
- Rename the npm package to `@jbearak/sight` and expose only the `sight` bin.
- Add npm Trusted Publishing to `release-publish.yml` via OIDC, npm registry setup, and `npm publish --ignore-scripts --access public`.
- Remove npm/CI use of the old `sight-language-server` alias while cleaning up Sight-owned stale source-install aliases.
- Update install/release docs and tighten npm tarball contents.

## Test Plan
- [x] `bun test ./tests/unit/binary-command-name.test.ts`
- [x] `bun test ./tests/integration/binary-invocation.test.ts`
- [x] `bun test ./tests/unit/smoke-stdio-startup.test.ts`
- [x] `bun run build:npm`
- [x] `npm_config_cache=/tmp/sight-npm-cache npm pack --dry-run`
- [x] temporary `npm install -g . --prefix <tmp>` creates only `bin/sight`; `sight --version` prints `sight 0.8.4`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run lint`

## Manual follow-up
Configure npm Trusted Publishing for package `@jbearak/sight` with GitHub Actions publisher `jbearak/sight`, workflow `release-publish.yml`, environment `release`, allowed action `npm publish`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added npm-based installation and publishing support for the package.
  * The distributed package now exposes only the primary `sight` command.

* **Bug Fixes**
  * Installation now removes stale legacy command aliases when present.
  * Command checks and release validation now focus on the supported `sight` entry point.

* **Documentation**
  * Updated installation guides and release notes to include npm setup and usage.
  * Clarified the expected command for editor and CLI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->