### PR TITLE
chore/normalize directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Sight's sister project [Raven](https://github.com/jbearak/raven) implements a la
 - **Go-to-Definition**: Jump to definitions of local/global macros and programs across the workspace
 - **[Find References](docs/find-references.md)**: Locate every use of a macro, program, or variable across related files
 - **[Cross-file awareness](docs/cross-file.md)**: Symbol resolution across `do`/`include` chains with position-aware scope
-- **[Declaration directives](docs/declaration-directives.md)**: Suppress diagnostics for dynamically-created symbols (`# sight: local`, `# sight: global`; `@lsp-` remains an alias)
+- **[Declaration directives](docs/declaration-directives.md)**: Suppress diagnostics for dynamically-created symbols (`sight: local`, `sight: global`; `@lsp-` remains an alias)
 - **[Document Outline](docs/document-outline.md)**: Hierarchical code navigation with programs, macros, variables, and code sections
 - **Workspace Symbols**: Search for symbols across the entire workspace
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Sight's sister project [Raven](https://github.com/jbearak/raven) implements a la
 - **Go-to-Definition**: Jump to definitions of local/global macros and programs across the workspace
 - **[Find References](docs/find-references.md)**: Locate every use of a macro, program, or variable across related files
 - **[Cross-file awareness](docs/cross-file.md)**: Symbol resolution across `do`/`include` chains with position-aware scope
-- **[Declaration directives](docs/declaration-directives.md)**: Suppress diagnostics for dynamically-created symbols (`@lsp-local`, `@lsp-global`)
+- **[Declaration directives](docs/declaration-directives.md)**: Suppress diagnostics for dynamically-created symbols (`# sight: local`, `# sight: global`; `@lsp-` remains an alias)
 - **[Document Outline](docs/document-outline.md)**: Hierarchical code navigation with programs, macros, variables, and code sections
 - **Workspace Symbols**: Search for symbols across the entire workspace
 

--- a/client/package.json
+++ b/client/package.json
@@ -104,7 +104,7 @@
             "off"
           ],
           "default": "off",
-          "description": "[Experimental] Severity level for undefined variable references. Off by default since the LSP cannot statically determine which variables exist in your dataset. Use @lsp-variables directive to declare variables loaded from data files.",
+          "description": "[Experimental] Severity level for undefined variable references. Off by default since the LSP cannot statically determine which variables exist in your dataset. Use the # sight: variables directive to declare variables loaded from data files (@lsp-variables remains an alias).",
           "enumDescriptions": [
             "Show as error",
             "Show as warning",
@@ -356,7 +356,7 @@
           "default": "lsp",
           "description": "Set working directory before executing code",
           "enumDescriptions": [
-            "Use working directory from LSP (from @lsp-cd, @lsp-working-directory, @lsp-wd directives or inherited from parent files)",
+            "Use working directory from LSP (from # sight: cd, # sight: working-directory, # sight: wd directives or inherited from parent files; @lsp- remains an alias)",
             "Do not change working directory",
             "Change to the directory of the current file",
             "Change to the workspace root directory"

--- a/client/package.json
+++ b/client/package.json
@@ -104,7 +104,7 @@
             "off"
           ],
           "default": "off",
-          "description": "[Experimental] Severity level for undefined variable references. Off by default since the LSP cannot statically determine which variables exist in your dataset. Use the # sight: variables directive to declare variables loaded from data files (@lsp-variables remains an alias).",
+          "description": "[Experimental] Severity level for undefined variable references. Off by default since the LSP cannot statically determine which variables exist in your dataset. Use the sight: variables directive to declare variables loaded from data files (@lsp-variables remains an alias).",
           "enumDescriptions": [
             "Show as error",
             "Show as warning",
@@ -356,7 +356,7 @@
           "default": "lsp",
           "description": "Set working directory before executing code",
           "enumDescriptions": [
-            "Use working directory from LSP (from # sight: cd, # sight: working-directory, # sight: wd directives or inherited from parent files; @lsp- remains an alias)",
+            "Use working directory from LSP (from sight: cd, sight: working-directory, sight: wd directives or inherited from parent files; @lsp- remains an alias)",
             "Do not change working directory",
             "Change to the directory of the current file",
             "Change to the workspace root directory"

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -46,8 +46,9 @@ Globals, programs, scalars, and matrices defined in unrelated workspace
 files are not hidden. They appear at the bottom of the list with a
 `(out of scope — from <path>)` detail. Accepting one produces an
 undefined-symbol diagnostic — the cue to add a `do` / `run` / `include`
-statement or a cross-file directive (`@lsp-do`, `@lsp-done-by`,
-`@lsp-included-by`, …) to bring the symbol into scope.
+statement or a cross-file directive (`# sight: do`, `# sight: done-by`,
+`# sight: included-by`, …) to bring the symbol into scope. `@lsp-`
+spellings remain aliases.
 
 ### 4. Built-ins win over out-of-scope programs
 
@@ -72,7 +73,7 @@ analyses.
 
 ### Resolved-scope mode
 
-Active when the file has `@lsp-*` directives or auto-discovered
+Active when the file has `# sight:` / `@lsp-` directives or auto-discovered
 parents via the dependency graph. The in-scope set is the current
 file plus the call-site-filtered scope chain. Entries the resolver
 ruled out (after the call site, or excluded by `do` / `run`

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -46,8 +46,8 @@ Globals, programs, scalars, and matrices defined in unrelated workspace
 files are not hidden. They appear at the bottom of the list with a
 `(out of scope — from <path>)` detail. Accepting one produces an
 undefined-symbol diagnostic — the cue to add a `do` / `run` / `include`
-statement or a cross-file directive (`# sight: do`, `# sight: done-by`,
-`# sight: included-by`, …) to bring the symbol into scope. `@lsp-`
+statement or a cross-file directive (`sight: do`, `sight: done-by`,
+`sight: included-by`, …) to bring the symbol into scope. `@lsp-`
 spellings remain aliases.
 
 ### 4. Built-ins win over out-of-scope programs
@@ -73,7 +73,7 @@ analyses.
 
 ### Resolved-scope mode
 
-Active when the file has `# sight:` / `@lsp-` directives or auto-discovered
+Active when the file has `sight:` / `@lsp-` directives or auto-discovered
 parents via the dependency graph. The in-scope set is the current
 file plus the call-site-filtered scope chain. Entries the resolver
 ruled out (after the call site, or excluded by `do` / `run`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ local result: list file_global - other
 global file_global value
 ```
 
-**Global macros from other files** also produce warnings unless the LSP can determine the relationship. By default (`crossFile.backwardDependencies: "auto"`), the LSP scans the workspace at startup to discover which files call which, and automatically resolves parent–child symbol inheritance. It also follows `do`, `run`, and `include` commands within each file for forward resolution. For cases where auto-detection doesn't work (e.g., dynamic paths with macros), you can use explicit directives (`@lsp-done-by`, `@lsp-included-by`, `@lsp-do`, `@lsp-run`, `@lsp-include`). The workspace indexer provides globals for completions and go-to-definition, but does not suppress undefined macro warnings. See [Cross-File Awareness](cross-file.md) for details.
+**Global macros from other files** also produce warnings unless the LSP can determine the relationship. By default (`crossFile.backwardDependencies: "auto"`), the LSP scans the workspace at startup to discover which files call which, and automatically resolves parent–child symbol inheritance. It also follows `do`, `run`, and `include` commands within each file for forward resolution. For cases where auto-detection doesn't work (e.g., dynamic paths with macros), you can use explicit directives (`# sight: done-by`, `# sight: included-by`, `# sight: do`, `# sight: run`, `# sight: include`). The older `@lsp-` forms remain permanent aliases. The workspace indexer provides globals for completions and go-to-definition, but does not suppress undefined macro warnings. See [Cross-File Awareness](cross-file.md) for details.
 
 **First definition wins**: When a macro is defined multiple times, references before the first definition produce warnings, but references after the first definition do not (even if they appear before later redefinitions).
 
@@ -298,7 +298,7 @@ caseMismatch = "auto"
 | `crossFile.assumeCallSite`              | `"end"` \| `"start"` | `"end"`         | Where to assume call site when not specified and inference fails        |
 | `crossFile.diagnostics.missingFile`     | severity             | `"warning"`     | Severity for missing directive file diagnostics                         |
 | `crossFile.diagnostics.callSiteIdentification` | severity      | `"information"` | Severity for call site identification diagnostics                       |
-| `crossFile.diagnostics.caseMismatch`    | severity + `"auto"`  | `"auto"`        | Severity for case-only path mismatch diagnostics. `"auto"` maps to `information` on case-insensitive filesystems (macOS/Windows) and `warning` on case-sensitive ones (Linux/CI). Independent of `missingFile`; not suppressible via `@lsp-ignore` — silence with `"off"` or fix the path. |
+| `crossFile.diagnostics.caseMismatch`    | severity + `"auto"`  | `"auto"`        | Severity for case-only path mismatch diagnostics. `"auto"` maps to `information` on case-insensitive filesystems (macOS/Windows) and `warning` on case-sensitive ones (Linux/CI). Independent of `missingFile`; not suppressible via `# sight: ignore` — silence with `"off"` or fix the path. |
 
 Severity options: `"error"`, `"warning"`, `"information"`, `"off"` (alias:
 `"info"` for `"information"`). `crossFile.diagnostics.caseMismatch` also

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ local result: list file_global - other
 global file_global value
 ```
 
-**Global macros from other files** also produce warnings unless the LSP can determine the relationship. By default (`crossFile.backwardDependencies: "auto"`), the LSP scans the workspace at startup to discover which files call which, and automatically resolves parent–child symbol inheritance. It also follows `do`, `run`, and `include` commands within each file for forward resolution. For cases where auto-detection doesn't work (e.g., dynamic paths with macros), you can use explicit directives (`# sight: done-by`, `# sight: included-by`, `# sight: do`, `# sight: run`, `# sight: include`). The older `@lsp-` forms remain permanent aliases. The workspace indexer provides globals for completions and go-to-definition, but does not suppress undefined macro warnings. See [Cross-File Awareness](cross-file.md) for details.
+**Global macros from other files** also produce warnings unless the LSP can determine the relationship. By default (`crossFile.backwardDependencies: "auto"`), the LSP scans the workspace at startup to discover which files call which, and automatically resolves parent–child symbol inheritance. It also follows `do`, `run`, and `include` commands within each file for forward resolution. For cases where auto-detection doesn't work (e.g., dynamic paths with macros), you can use explicit directives (`sight: done-by`, `sight: included-by`, `sight: do`, `sight: run`, `sight: include`). The older `@lsp-` forms remain permanent aliases. The workspace indexer provides globals for completions and go-to-definition, but does not suppress undefined macro warnings. See [Cross-File Awareness](cross-file.md) for details.
 
 **First definition wins**: When a macro is defined multiple times, references before the first definition produce warnings, but references after the first definition do not (even if they appear before later redefinitions).
 
@@ -298,7 +298,7 @@ caseMismatch = "auto"
 | `crossFile.assumeCallSite`              | `"end"` \| `"start"` | `"end"`         | Where to assume call site when not specified and inference fails        |
 | `crossFile.diagnostics.missingFile`     | severity             | `"warning"`     | Severity for missing directive file diagnostics                         |
 | `crossFile.diagnostics.callSiteIdentification` | severity      | `"information"` | Severity for call site identification diagnostics                       |
-| `crossFile.diagnostics.caseMismatch`    | severity + `"auto"`  | `"auto"`        | Severity for case-only path mismatch diagnostics. `"auto"` maps to `information` on case-insensitive filesystems (macOS/Windows) and `warning` on case-sensitive ones (Linux/CI). Independent of `missingFile`; not suppressible via `# sight: ignore` — silence with `"off"` or fix the path. |
+| `crossFile.diagnostics.caseMismatch`    | severity + `"auto"`  | `"auto"`        | Severity for case-only path mismatch diagnostics. `"auto"` maps to `information` on case-insensitive filesystems (macOS/Windows) and `warning` on case-sensitive ones (Linux/CI). Independent of `missingFile`; not suppressible via `sight: ignore` — silence with `"off"` or fix the path. |
 
 Severity options: `"error"`, `"warning"`, `"information"`, `"off"` (alias:
 `"info"` for `"information"`). `crossFile.diagnostics.caseMismatch` also

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -45,7 +45,7 @@ go-to-definition all work across the two files with zero setup.
 
 - **Backward dependencies**: If `parent.do` calls `do "child.do"`, the LSP
   automatically makes the parent's symbols available in the child (equivalent
-  to adding `@lsp-done-by: "parent.do"` to the child's header).
+  to adding `// # sight: done-by: "parent.do"` to the child's header).
 - **Forward calls**: `do`, `run`, and `include` commands in the current file
   are also followed, making callee symbols available after the call site.
 
@@ -71,7 +71,7 @@ backwardDependencies = "explicit"
 ```
 
 In this mode the LSP will not auto-discover parent files — you must add
-`@lsp-done-by` or `@lsp-included-by` directives to each child file's header.
+`# sight: done-by` or `# sight: included-by` directives to each child file's header.
 
 **Per-file opt-out:** Even in auto mode, adding an explicit backward directive
 to a file's header causes the LSP to skip auto-discovery for that file and use
@@ -184,9 +184,12 @@ and follows them for scope resolution. Paths containing macro references (e.g.,
 For cases where auto-detection doesn't work, you can use explicit forward
 directives anywhere in a file's comments:
 
-- `@lsp-do: "path.do"` — Follow a `do` call (excludes locals)
-- `@lsp-run: "path.do"` — Follow a `run` call (excludes locals)
-- `@lsp-include: "path.do"` — Follow an `include` call (includes locals)
+- `# sight: do: "path.do"` — Follow a `do` call (excludes locals)
+- `# sight: run: "path.do"` — Follow a `run` call (excludes locals)
+- `# sight: include: "path.do"` — Follow an `include` call (includes locals)
+
+Use these inside Stata comments, for example `// # sight: do: "path.do"`.
+The older `@lsp-` prefix is a permanent alias (`// @lsp-do: "path.do"`).
 
 **Scope visibility:**
 
@@ -202,23 +205,23 @@ workspace), you can declare parent relationships explicitly.
 
 **Recommended (spec) syntax:**
 
-- `@lsp-done-by: "<path>"` — Parent calls this file via `do` (inherits
+- `# sight: done-by: "<path>"` — Parent calls this file via `do` (inherits
   globals, scalars, matrices, programs; **not** locals)
-- `@lsp-run-by: "<path>"` — Synonym for `@lsp-done-by`; use when the parent
+- `# sight: run-by: "<path>"` — Synonym for `# sight: done-by`; use when the parent
   calls via `run`
-- `@lsp-included-by: "<path>"` — Parent calls this file via `include`
+- `# sight: included-by: "<path>"` — Parent calls this file via `include`
   (inherits all symbols including locals)
 
 Notes:
 - Backward directives are only read from the **top of the file** (header).
   Parsing stops at the first line that is not a comment and not blank after
   trimming whitespace (so whitespace-only lines still count as blank). Forward
-  directives (`@lsp-do`, `@lsp-run`, `@lsp-include`) can appear anywhere in
+  directives (`# sight: do`, `# sight: run`, `# sight: include`) can appear anywhere in
   file comments.
 - The parser also accepts an alternative form without the colon and/or without
-  quotes (e.g. `// @lsp-done-by parent.do`), but the spec form above is
-  preferred.
-- `@lsp-run-by` and `@lsp-done-by` are functionally identical; use whichever
+  quotes (e.g. `// # sight: done-by parent.do`), but the spec form above is
+  preferred. The `@lsp-` forms remain permanent aliases.
+- `# sight: run-by` and `# sight: done-by` are functionally identical; use whichever
   matches the actual Stata command (`run` vs `do`) for semantic clarity.
 
 ## Working Directory
@@ -226,24 +229,24 @@ Notes:
 By default, the LSP resolves relative paths in `do`, `run`, and `include`
 commands relative to the script's containing directory. However, Stata scripts
 are often executed from a different working directory than where they reside.
-The `@lsp-working-directory` directive allows you to specify this working
+The `# sight: working-directory` directive allows you to specify this working
 directory context.
 
 **Directive Syntax:**
 
 ```stata
-// @lsp-working-directory: "/path/to/working/dir"
+// # sight: working-directory: "/path/to/working/dir"
 ```
 
 **Synonym Forms:**
 
 All of the following are equivalent:
-- `@lsp-working-directory`
-- `@lsp-working-dir`
-- `@lsp-current-directory`
-- `@lsp-current-dir`
-- `@lsp-cd`
-- `@lsp-wd`
+- `# sight: working-directory`
+- `# sight: working-dir`
+- `# sight: current-directory`
+- `# sight: current-dir`
+- `# sight: cd`
+- `# sight: wd`
 
 **Path Resolution:**
 
@@ -254,7 +257,7 @@ All of the following are equivalent:
 
 **Limitations:**
 - Filesystem-absolute paths (e.g. `/Users/alice/project/file.do`) are not
-  currently supported by `@lsp-working-directory` because leading `/` is
+  currently supported by `# sight: working-directory` because leading `/` is
   reserved for workspace-root-relative paths.
 
 **Examples:**
@@ -263,7 +266,7 @@ All of the following are equivalent:
 // Script in /project/scripts/analysis.do
 // Executed from /project (workspace root)
 
-// @lsp-working-directory: "/"
+// # sight: working-directory: "/"
 // Paths in do/run/include resolve relative to /project
 
 do "data/load_data.do"  // Resolves to /project/data/load_data.do
@@ -273,7 +276,7 @@ do "data/load_data.do"  // Resolves to /project/data/load_data.do
 // Script in /project/scripts/analysis.do
 // Executed from /project/data
 
-// @lsp-working-directory: "../data"
+// # sight: working-directory: "../data"
 // Paths resolve relative to /project/data
 
 do "clean.do"  // Resolves to /project/data/clean.do
@@ -281,7 +284,7 @@ do "clean.do"  // Resolves to /project/data/clean.do
 
 **Fallback Behavior:**
 
-When no `@lsp-working-directory` directive is present:
+When no `# sight: working-directory` directive is present:
 1. The LSP first tries to resolve paths relative to the script's containing
    directory
 2. If the file is not found, it tries resolving relative to the workspace root
@@ -296,8 +299,8 @@ When no `@lsp-working-directory` directive is present:
   used (with a warning)
 - The directive only affects path resolution for `do`, `run`, and `include`
   **commands in Stata code**
-- Other `@lsp-*` directives (`@lsp-do`, `@lsp-run`, `@lsp-include`,
-  `@lsp-done-by`, `@lsp-included-by`) always resolve paths relative to the
+- Other cross-file directives (`# sight: do`, `# sight: run`, `# sight: include`,
+  `# sight: done-by`, `# sight: included-by`) always resolve paths relative to the
   script's containing directory, unaffected by the working directory directive
 
 **Common Use Case:**
@@ -319,7 +322,7 @@ root:
 
 ```stata
 // scripts/analysis.do
-// @lsp-working-directory: "/"
+// # sight: working-directory: "/"
 do "data/load.do"  // Resolves to /project/data/load.do
 ```
 
@@ -346,7 +349,7 @@ directive when the parent already establishes the working directory context.
 ```text
 project/
 ├── scripts/
-│   ├── loop.do       # Has @lsp-cd: "../" (sets wd to project/)
+│   ├── loop.do       # Has # sight: cd: "../" (sets wd to project/)
 │   └── dhs/
 │       └── survey.do # Inherits working directory from loop.do
 └── data/
@@ -355,7 +358,7 @@ project/
 
 ```stata
 // scripts/loop.do
-// @lsp-cd: "../"
+// # sight: cd: "../"
 // Working directory is now project/ (parent of scripts/)
 global survey_list "dhs"
 foreach survey of global survey_list {
@@ -376,8 +379,8 @@ so paths in `survey.do` resolve relative to `project/` rather than
 
 ## Call Site Parameters
 
-Backward directives (`@lsp-done-by`, `@lsp-run-by`, `@lsp-included-by`) and
-forward call directives (`@lsp-do`, `@lsp-run`, `@lsp-include`) support
+Backward directives (`# sight: done-by`, `# sight: run-by`, `# sight: included-by`) and
+forward call directives (`# sight: do`, `# sight: run`, `# sight: include`) support
 optional call-site parameters. These parameters control the **effective call
 site line** used for call-site filtering and scope visibility.
 
@@ -482,19 +485,19 @@ save "$output_path/results.dta", replace
 ### Explicit Directives
 
 ```stata
-// @lsp-done-by: "setup.do"
+// # sight: done-by: "setup.do"
 local result `global_from_setup'
 ```
 
 ```stata
-// @lsp-included-by: "common.do"
+// # sight: included-by: "common.do"
 local shared_local `local_from_common'
 ```
 
 ### Line-Specific Directives
 
 ```stata
-// @lsp-done-by: "config.do" line=5
+// # sight: done-by: "config.do" line=5
 local data_path `root_path'  // Symbols on or before line 5 are available
 local other `undefined'      // This will still warn
 ```
@@ -502,7 +505,7 @@ local other `undefined'      // This will still warn
 ### Call Site Matching
 
 ```stata
-// @lsp-done-by: "orchestrator.do" match="do \"analysis.do\""
+// # sight: done-by: "orchestrator.do" match="do \"analysis.do\""
 local result `setup_global'  // Symbols before the do call are available
 ```
 
@@ -521,8 +524,8 @@ Rules:
 Example (same depth, lattermost wins):
 
 ```stata
-// @lsp-done-by: "analysis.do"
-// @lsp-done-by: "setup.do"
+// # sight: done-by: "analysis.do"
+// # sight: done-by: "setup.do"
 local path "$data_path"  // Uses definition from setup.do (lattermost)
 ```
 
@@ -541,7 +544,7 @@ the list reflects how Stata actually scopes each construct:
 
 - **Programs, scalars, matrices, and macros** — returned only for files that
   share a dependency-graph edge with the current file (ancestors or
-  descendants via `do`, `run`, `include`, or their `@lsp-*` directive
+  descendants via `do`, `run`, `include`, or their `# sight:` directive
   equivalents, transitively). Same-named symbols in unrelated modules are
   almost always coincidental, so they are omitted.
 - **Variables** — returned for the entire workspace. Stata variables are
@@ -570,7 +573,7 @@ cascade of false undefined-symbol warnings.
 ### Forward calls and directives
 
 For `do`, `run`, and `include` commands in Stata code — and for the
-explicit forward-call directives `@lsp-do`, `@lsp-run`, `@lsp-include`
+explicit forward-call directives `# sight: do`, `# sight: run`, `# sight: include`
 — the diagnostic message notes that Stata will not find the file on
 case-sensitive systems and shows the as-written path alongside the
 on-disk spelling. For example, `do helpers/clean` resolving on-disk
@@ -588,9 +591,9 @@ explicit directive), the range is the path token in the Stata source.
 
 ### Backward header directives
 
-For `@lsp-done-by`, `@lsp-run-by`, and `@lsp-included-by` directives in
+For `# sight: done-by`, `# sight: run-by`, and `# sight: included-by` directives in
 the file header, the LSP resolves paths relative to the **file's own
-containing directory** — no `@lsp-cd` / working-directory is applied
+containing directory** — no `# sight: cd` / working-directory is applied
 here and there is no workspace-root fallback (backward directives have
 never used them). The message makes no Stata-execution claim because
 backward directives are not Stata commands; it simply asks you to fix
@@ -632,8 +635,8 @@ Severity is controlled by `crossFile.diagnostics.caseMismatch` (see
 to `information` on a case-insensitive host (macOS/Windows) and
 `warning` on a case-sensitive host (Linux/CI), so the mismatch is quiet
 during local development but surfaces as a build warning in Linux CI.
-The diagnostic is **not** suppressible by `@lsp-ignore` or
-`@lsp-ignore-next`; silence it project-wide with `caseMismatch = "off"`
+The diagnostic is **not** suppressible by `# sight: ignore` or
+`# sight: ignore-next`; silence it project-wide with `caseMismatch = "off"`
 or by correcting the path casing.
 
 ## Call Site Diagnostics
@@ -651,7 +654,7 @@ an error:
   assumption (configurable via `assumeCallSite`). The diagnostic suggests using
   `line=` or `match=` parameters for explicit call site specification.
 
-- **done-by with include mismatch**: When you use `@lsp-done-by` but the
+- **done-by with include mismatch**: When you use `# sight: done-by` but the
   parent file actually uses `include`, the LSP informs you that full
   inheritance (including local macros) will occur.
 
@@ -659,7 +662,7 @@ an error:
 
 These diagnostics indicate potential issues that may affect your code:
 
-- **included-by with do/run mismatch**: When you use `@lsp-included-by` but
+- **included-by with do/run mismatch**: When you use `# sight: included-by` but
   the parent file uses `do` or `run`, local macros will NOT be inherited. This
   is a semantic issue that may cause undefined macro warnings.
 
@@ -673,7 +676,7 @@ These diagnostics indicate potential issues that may affect your code:
 
 - **line= invalid call statement**: When the specified `line=` points to a
   line that doesn't contain a `do`/`run`/`include` command or
-  `@lsp-do`/`@lsp-run`/`@lsp-include` directive.
+  `# sight: do`/`# sight: run`/`# sight: include` directive.
 
 - **match= not found**: When the specified `match=` string is not found in the
   parent file.
@@ -753,8 +756,8 @@ sibling in execution order — see
 `tests/integration/hub-heavy-sibling-visibility.test.ts`.
 
 **Interaction with a future per-file standalone opt-out.** A planned
-`@lsp-standalone` directive would let a file resolve its own diagnostics as if it
-had no parents (a *backward* concern). It does **not** introduce caller-dependence
+`# sight: standalone` directive would let a file resolve its own diagnostics as
+if it had no parents (a *backward* concern). It does **not** introduce caller-dependence
 into the *forward* closure: standalone can change the file's *inherited working
 directory* and the *effective call type* it is entered under, but both are inputs
 the closure already depends on (and would key on, were the closure cached).

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -45,7 +45,7 @@ go-to-definition all work across the two files with zero setup.
 
 - **Backward dependencies**: If `parent.do` calls `do "child.do"`, the LSP
   automatically makes the parent's symbols available in the child (equivalent
-  to adding `// # sight: done-by: "parent.do"` to the child's header).
+  to adding `// sight: done-by: "parent.do"` to the child's header).
 - **Forward calls**: `do`, `run`, and `include` commands in the current file
   are also followed, making callee symbols available after the call site.
 
@@ -71,7 +71,7 @@ backwardDependencies = "explicit"
 ```
 
 In this mode the LSP will not auto-discover parent files — you must add
-`# sight: done-by` or `# sight: included-by` directives to each child file's header.
+`sight: done-by` or `sight: included-by` directives to each child file's header.
 
 **Per-file opt-out:** Even in auto mode, adding an explicit backward directive
 to a file's header causes the LSP to skip auto-discovery for that file and use
@@ -184,11 +184,11 @@ and follows them for scope resolution. Paths containing macro references (e.g.,
 For cases where auto-detection doesn't work, you can use explicit forward
 directives anywhere in a file's comments:
 
-- `# sight: do: "path.do"` — Follow a `do` call (excludes locals)
-- `# sight: run: "path.do"` — Follow a `run` call (excludes locals)
-- `# sight: include: "path.do"` — Follow an `include` call (includes locals)
+- `sight: do: "path.do"` — Follow a `do` call (excludes locals)
+- `sight: run: "path.do"` — Follow a `run` call (excludes locals)
+- `sight: include: "path.do"` — Follow an `include` call (includes locals)
 
-Use these inside Stata comments, for example `// # sight: do: "path.do"`.
+Use these inside Stata comments, for example `// sight: do: "path.do"`.
 The older `@lsp-` prefix is a permanent alias (`// @lsp-do: "path.do"`).
 
 **Scope visibility:**
@@ -205,23 +205,23 @@ workspace), you can declare parent relationships explicitly.
 
 **Recommended (spec) syntax:**
 
-- `# sight: done-by: "<path>"` — Parent calls this file via `do` (inherits
+- `sight: done-by: "<path>"` — Parent calls this file via `do` (inherits
   globals, scalars, matrices, programs; **not** locals)
-- `# sight: run-by: "<path>"` — Synonym for `# sight: done-by`; use when the parent
+- `sight: run-by: "<path>"` — Synonym for `sight: done-by`; use when the parent
   calls via `run`
-- `# sight: included-by: "<path>"` — Parent calls this file via `include`
+- `sight: included-by: "<path>"` — Parent calls this file via `include`
   (inherits all symbols including locals)
 
 Notes:
 - Backward directives are only read from the **top of the file** (header).
   Parsing stops at the first line that is not a comment and not blank after
   trimming whitespace (so whitespace-only lines still count as blank). Forward
-  directives (`# sight: do`, `# sight: run`, `# sight: include`) can appear anywhere in
+  directives (`sight: do`, `sight: run`, `sight: include`) can appear anywhere in
   file comments.
 - The parser also accepts an alternative form without the colon and/or without
-  quotes (e.g. `// # sight: done-by parent.do`), but the spec form above is
+  quotes (e.g. `// sight: done-by parent.do`), but the spec form above is
   preferred. The `@lsp-` forms remain permanent aliases.
-- `# sight: run-by` and `# sight: done-by` are functionally identical; use whichever
+- `sight: run-by` and `sight: done-by` are functionally identical; use whichever
   matches the actual Stata command (`run` vs `do`) for semantic clarity.
 
 ## Working Directory
@@ -229,24 +229,24 @@ Notes:
 By default, the LSP resolves relative paths in `do`, `run`, and `include`
 commands relative to the script's containing directory. However, Stata scripts
 are often executed from a different working directory than where they reside.
-The `# sight: working-directory` directive allows you to specify this working
+The `sight: working-directory` directive allows you to specify this working
 directory context.
 
 **Directive Syntax:**
 
 ```stata
-// # sight: working-directory: "/path/to/working/dir"
+// sight: working-directory: "/path/to/working/dir"
 ```
 
 **Synonym Forms:**
 
 All of the following are equivalent:
-- `# sight: working-directory`
-- `# sight: working-dir`
-- `# sight: current-directory`
-- `# sight: current-dir`
-- `# sight: cd`
-- `# sight: wd`
+- `sight: working-directory`
+- `sight: working-dir`
+- `sight: current-directory`
+- `sight: current-dir`
+- `sight: cd`
+- `sight: wd`
 
 **Path Resolution:**
 
@@ -257,7 +257,7 @@ All of the following are equivalent:
 
 **Limitations:**
 - Filesystem-absolute paths (e.g. `/Users/alice/project/file.do`) are not
-  currently supported by `# sight: working-directory` because leading `/` is
+  currently supported by `sight: working-directory` because leading `/` is
   reserved for workspace-root-relative paths.
 
 **Examples:**
@@ -266,7 +266,7 @@ All of the following are equivalent:
 // Script in /project/scripts/analysis.do
 // Executed from /project (workspace root)
 
-// # sight: working-directory: "/"
+// sight: working-directory: "/"
 // Paths in do/run/include resolve relative to /project
 
 do "data/load_data.do"  // Resolves to /project/data/load_data.do
@@ -276,7 +276,7 @@ do "data/load_data.do"  // Resolves to /project/data/load_data.do
 // Script in /project/scripts/analysis.do
 // Executed from /project/data
 
-// # sight: working-directory: "../data"
+// sight: working-directory: "../data"
 // Paths resolve relative to /project/data
 
 do "clean.do"  // Resolves to /project/data/clean.do
@@ -284,7 +284,7 @@ do "clean.do"  // Resolves to /project/data/clean.do
 
 **Fallback Behavior:**
 
-When no `# sight: working-directory` directive is present:
+When no `sight: working-directory` directive is present:
 1. The LSP first tries to resolve paths relative to the script's containing
    directory
 2. If the file is not found, it tries resolving relative to the workspace root
@@ -299,8 +299,8 @@ When no `# sight: working-directory` directive is present:
   used (with a warning)
 - The directive only affects path resolution for `do`, `run`, and `include`
   **commands in Stata code**
-- Other cross-file directives (`# sight: do`, `# sight: run`, `# sight: include`,
-  `# sight: done-by`, `# sight: included-by`) always resolve paths relative to the
+- Other cross-file directives (`sight: do`, `sight: run`, `sight: include`,
+  `sight: done-by`, `sight: included-by`) always resolve paths relative to the
   script's containing directory, unaffected by the working directory directive
 
 **Common Use Case:**
@@ -322,7 +322,7 @@ root:
 
 ```stata
 // scripts/analysis.do
-// # sight: working-directory: "/"
+// sight: working-directory: "/"
 do "data/load.do"  // Resolves to /project/data/load.do
 ```
 
@@ -349,7 +349,7 @@ directive when the parent already establishes the working directory context.
 ```text
 project/
 ├── scripts/
-│   ├── loop.do       # Has # sight: cd: "../" (sets wd to project/)
+│   ├── loop.do       # Has sight: cd: "../" (sets wd to project/)
 │   └── dhs/
 │       └── survey.do # Inherits working directory from loop.do
 └── data/
@@ -358,7 +358,7 @@ project/
 
 ```stata
 // scripts/loop.do
-// # sight: cd: "../"
+// sight: cd: "../"
 // Working directory is now project/ (parent of scripts/)
 global survey_list "dhs"
 foreach survey of global survey_list {
@@ -379,8 +379,8 @@ so paths in `survey.do` resolve relative to `project/` rather than
 
 ## Call Site Parameters
 
-Backward directives (`# sight: done-by`, `# sight: run-by`, `# sight: included-by`) and
-forward call directives (`# sight: do`, `# sight: run`, `# sight: include`) support
+Backward directives (`sight: done-by`, `sight: run-by`, `sight: included-by`) and
+forward call directives (`sight: do`, `sight: run`, `sight: include`) support
 optional call-site parameters. These parameters control the **effective call
 site line** used for call-site filtering and scope visibility.
 
@@ -485,19 +485,19 @@ save "$output_path/results.dta", replace
 ### Explicit Directives
 
 ```stata
-// # sight: done-by: "setup.do"
+// sight: done-by: "setup.do"
 local result `global_from_setup'
 ```
 
 ```stata
-// # sight: included-by: "common.do"
+// sight: included-by: "common.do"
 local shared_local `local_from_common'
 ```
 
 ### Line-Specific Directives
 
 ```stata
-// # sight: done-by: "config.do" line=5
+// sight: done-by: "config.do" line=5
 local data_path `root_path'  // Symbols on or before line 5 are available
 local other `undefined'      // This will still warn
 ```
@@ -505,7 +505,7 @@ local other `undefined'      // This will still warn
 ### Call Site Matching
 
 ```stata
-// # sight: done-by: "orchestrator.do" match="do \"analysis.do\""
+// sight: done-by: "orchestrator.do" match="do \"analysis.do\""
 local result `setup_global'  // Symbols before the do call are available
 ```
 
@@ -524,8 +524,8 @@ Rules:
 Example (same depth, lattermost wins):
 
 ```stata
-// # sight: done-by: "analysis.do"
-// # sight: done-by: "setup.do"
+// sight: done-by: "analysis.do"
+// sight: done-by: "setup.do"
 local path "$data_path"  // Uses definition from setup.do (lattermost)
 ```
 
@@ -544,7 +544,7 @@ the list reflects how Stata actually scopes each construct:
 
 - **Programs, scalars, matrices, and macros** — returned only for files that
   share a dependency-graph edge with the current file (ancestors or
-  descendants via `do`, `run`, `include`, or their `# sight:` directive
+  descendants via `do`, `run`, `include`, or their `sight:` directive
   equivalents, transitively). Same-named symbols in unrelated modules are
   almost always coincidental, so they are omitted.
 - **Variables** — returned for the entire workspace. Stata variables are
@@ -573,7 +573,7 @@ cascade of false undefined-symbol warnings.
 ### Forward calls and directives
 
 For `do`, `run`, and `include` commands in Stata code — and for the
-explicit forward-call directives `# sight: do`, `# sight: run`, `# sight: include`
+explicit forward-call directives `sight: do`, `sight: run`, `sight: include`
 — the diagnostic message notes that Stata will not find the file on
 case-sensitive systems and shows the as-written path alongside the
 on-disk spelling. For example, `do helpers/clean` resolving on-disk
@@ -591,9 +591,9 @@ explicit directive), the range is the path token in the Stata source.
 
 ### Backward header directives
 
-For `# sight: done-by`, `# sight: run-by`, and `# sight: included-by` directives in
+For `sight: done-by`, `sight: run-by`, and `sight: included-by` directives in
 the file header, the LSP resolves paths relative to the **file's own
-containing directory** — no `# sight: cd` / working-directory is applied
+containing directory** — no `sight: cd` / working-directory is applied
 here and there is no workspace-root fallback (backward directives have
 never used them). The message makes no Stata-execution claim because
 backward directives are not Stata commands; it simply asks you to fix
@@ -635,8 +635,8 @@ Severity is controlled by `crossFile.diagnostics.caseMismatch` (see
 to `information` on a case-insensitive host (macOS/Windows) and
 `warning` on a case-sensitive host (Linux/CI), so the mismatch is quiet
 during local development but surfaces as a build warning in Linux CI.
-The diagnostic is **not** suppressible by `# sight: ignore` or
-`# sight: ignore-next`; silence it project-wide with `caseMismatch = "off"`
+The diagnostic is **not** suppressible by `sight: ignore` or
+`sight: ignore-next`; silence it project-wide with `caseMismatch = "off"`
 or by correcting the path casing.
 
 ## Call Site Diagnostics
@@ -654,7 +654,7 @@ an error:
   assumption (configurable via `assumeCallSite`). The diagnostic suggests using
   `line=` or `match=` parameters for explicit call site specification.
 
-- **done-by with include mismatch**: When you use `# sight: done-by` but the
+- **done-by with include mismatch**: When you use `sight: done-by` but the
   parent file actually uses `include`, the LSP informs you that full
   inheritance (including local macros) will occur.
 
@@ -662,7 +662,7 @@ an error:
 
 These diagnostics indicate potential issues that may affect your code:
 
-- **included-by with do/run mismatch**: When you use `# sight: included-by` but
+- **included-by with do/run mismatch**: When you use `sight: included-by` but
   the parent file uses `do` or `run`, local macros will NOT be inherited. This
   is a semantic issue that may cause undefined macro warnings.
 
@@ -676,7 +676,7 @@ These diagnostics indicate potential issues that may affect your code:
 
 - **line= invalid call statement**: When the specified `line=` points to a
   line that doesn't contain a `do`/`run`/`include` command or
-  `# sight: do`/`# sight: run`/`# sight: include` directive.
+  `sight: do`/`sight: run`/`sight: include` directive.
 
 - **match= not found**: When the specified `match=` string is not found in the
   parent file.
@@ -756,7 +756,7 @@ sibling in execution order — see
 `tests/integration/hub-heavy-sibling-visibility.test.ts`.
 
 **Interaction with a future per-file standalone opt-out.** A planned
-`# sight: standalone` directive would let a file resolve its own diagnostics as
+`sight: standalone` directive would let a file resolve its own diagnostics as
 if it had no parents (a *backward* concern). It does **not** introduce caller-dependence
 into the *forward* closure: standalone can change the file's *inherited working
 directory* and the *effective call type* it is entered under, but both are inputs

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -188,8 +188,10 @@ directives anywhere in a file's comments:
 - `sight: run: "path.do"` — Follow a `run` call (excludes locals)
 - `sight: include: "path.do"` — Follow an `include` call (includes locals)
 
-Use these inside Stata comments, for example `// sight: do: "path.do"`.
-The older `@lsp-` prefix is a permanent alias (`// @lsp-do: "path.do"`).
+Use these as standalone Stata line comments, for example
+`// sight: do: "path.do"` or `* sight: do: "path.do"`. Inline trailing
+comments and `/* ... */` block comments are not directive comments. The older
+`@lsp-` prefix is a permanent alias (`// @lsp-do: "path.do"`).
 
 **Scope visibility:**
 
@@ -216,8 +218,8 @@ Notes:
 - Backward directives are only read from the **top of the file** (header).
   Parsing stops at the first line that is not a comment and not blank after
   trimming whitespace (so whitespace-only lines still count as blank). Forward
-  directives (`sight: do`, `sight: run`, `sight: include`) can appear anywhere in
-  file comments.
+  directives (`sight: do`, `sight: run`, `sight: include`) can appear anywhere
+  as standalone `//` or line-leading `*` comment lines.
 - The parser also accepts an alternative form without the colon and/or without
   quotes (e.g. `// sight: done-by parent.do`), but the spec form above is
   preferred. The `@lsp-` forms remain permanent aliases.

--- a/docs/declaration-directives.md
+++ b/docs/declaration-directives.md
@@ -4,67 +4,70 @@
 
 You can suppress diagnostics on specific lines using comment directives:
 
-- `@lsp-ignore` - Suppresses all diagnostics on the same line
-- `@lsp-ignore-next` - Suppresses all diagnostics on the next line
+- `# sight: ignore` - Suppresses all diagnostics on the same line
+- `# sight: ignore-next` - Suppresses all diagnostics on the next line
+
+`# sight:` is the preferred directive prefix. It must appear inside a Stata
+comment, such as `// # sight: ...` or `* # sight: ...`. The older `@lsp-`
+forms remain permanent aliases, so `// @lsp-ignore` still works.
 
 ```stata
 // Suppress warning on the next line
-// @lsp-ignore-next
+// # sight: ignore-next
 local result `macro_from_program'
 
 // Suppress warning on the same line
-local result `macro_from_program'  // @lsp-ignore
+local result `macro_from_program'  // # sight: ignore
 ```
 
 <a id="what-the-lsp-can-detect"></a>
 
-This is useful when the LSP cannot automatically detect that a macro will be defined. The LSP can trace `do`/`run`/`include` calls to find macros defined in other files, and it can detect macros created by called programs when the macro name is fixed or set via a program option. In other situations, you can use `@lsp-ignore` or `@lsp-ignore-next` to suppress diagnostics for a specific line, or `@lsp-local` to declare the macro to the LSP.
+This is useful when the LSP cannot automatically detect that a macro will be defined. The LSP can trace `do`/`run`/`include` calls to find macros defined in other files, and it can detect macros created by called programs when the macro name is fixed or set via a program option. In other situations, you can use `# sight: ignore` or `# sight: ignore-next` to suppress diagnostics for a specific line, or `# sight: local` to declare the macro to the LSP.
 
 ## Declaring Symbols with Directives
 
 You can explicitly declare symbols to the LSP using declaration directives. These directives tell the LSP that a symbol should be considered defined from the point where the directive appears.
 
-*   **Locals and Globals**: The LSP **will** emit warnings (or errors, based on settings) if these macros are used but not defined. Use declaration directives (`@lsp-local`, `@lsp-global`) to suppress these warnings for macros defined dynamically.
-*   **Variables**: By default, the LSP does **not** emit warnings about undefined variables, since it cannot statically check what's in your datasets. This is an experimental feature - you can set `sight.diagnostics.severity.undefinedVariable` to a severity other than `"off"` (see [Configuration](configuration.md)) to enable checking, then use `@lsp-variables` to declare variables loaded from external data files.
-*   **Scalars, Matrices, and Programs**: You can declare these to the LSP (`@lsp-scalar`, `@lsp-matrix`, `@lsp-program`), but at present, the LSP does **not** emit warnings if it fails to find them in scope. Support for these directives is implemented to prepare code for future configurable strictness checks.
+*   **Locals and Globals**: The LSP **will** emit warnings (or errors, based on settings) if these macros are used but not defined. Use declaration directives (`# sight: local`, `# sight: global`) to suppress these warnings for macros defined dynamically.
+*   **Variables**: By default, the LSP does **not** emit warnings about undefined variables, since it cannot statically check what's in your datasets. This is an experimental feature - you can set `sight.diagnostics.severity.undefinedVariable` to a severity other than `"off"` (see [Configuration](configuration.md)) to enable checking, then use `# sight: variables` to declare variables loaded from external data files.
+*   **Scalars, Matrices, and Programs**: You can declare these to the LSP (`# sight: scalar`, `# sight: matrix`, `# sight: program`), but at present, the LSP does **not** emit warnings if it fails to find them in scope. Support for these directives is implemented to prepare code for future configurable strictness checks.
 
 **Available directives:**
 
 | Directive             | Purpose                 |
 | --------------------- | ----------------------- |
-| `@lsp-local <name>`   | Declares a local macro  |
-| `@lsp-global <name>`  | Declares a global macro |
-| `@lsp-variables <names>` | Declares variables (space-separated) |
-| `@lsp-scalar <name>`  | Declares a scalar       |
-| `@lsp-matrix <name>`  | Declares a matrix       |
-| `@lsp-program <name>` | Declares a program      |
+| `# sight: local <name>`   | Declares a local macro  |
+| `# sight: global <name>`  | Declares a global macro |
+| `# sight: variables <names>` | Declares variables (space-separated) |
+| `# sight: scalar <name>`  | Declares a scalar       |
+| `# sight: matrix <name>`  | Declares a matrix       |
+| `# sight: program <name>` | Declares a program      |
 
-**Important:** Each directive accepts exactly one argument (the symbol name). Multiple arguments will produce a warning.
-
-**Exception:** `@lsp-variables` accepts multiple space-separated variable names.
+Each declaration directive accepts one or more space-separated symbol names.
+`# sight: variables` likewise accepts one or more variable names.
 
 **Examples:**
 
 ```stata
 // Declare a local macro that will be created by a called program
-// @lsp-local result_from_program
+// # sight: local result_from_program
 do "compute_result.do"
 display `result_from_program'  // No warning - declared above
 
 // Declare a global macro set by external code
-* @lsp-global CONFIG_PATH
+* # sight: global CONFIG_PATH
 local path "$CONFIG_PATH"  // No warning
 
 // Declare a scalar (ready for future validation enhancements)
-// @lsp-scalar my_scalar
+// # sight: scalar my_scalar
 display scalar(my_scalar)
 
 // Declare a matrix
-// @lsp-matrix coefficients
+// # sight: matrix coefficients
 matrix list coefficients
 
 // Declare a program defined elsewhere
-// @lsp-program my_utility
+// # sight: program my_utility
 my_utility arg1 arg2
 ```
 

--- a/docs/declaration-directives.md
+++ b/docs/declaration-directives.md
@@ -4,14 +4,17 @@
 
 You can suppress diagnostics on specific lines using comment directives:
 
-- `sight: ignore` - Suppresses diagnostics on the next statement
-- `sight: ignore-next` - Also suppresses diagnostics on the next statement
+- `sight: ignore` - Suppresses diagnostics on the next statement when used on
+  its own comment line, or on the current statement when used as a trailing
+  `//` comment
+- `sight: ignore-next` - Suppresses diagnostics on the next statement
 
-`sight:` is the preferred directive prefix. It must appear inside a Stata
-line comment, on a line by itself, such as `// sight: ...` or `* sight: ...`.
-Block comments (`/* ... */`) and inline trailing comments do not carry
-directives. The older `@lsp-` forms remain permanent aliases, so
-`// @lsp-ignore` still works.
+`sight:` is the preferred directive prefix. Most directives must appear inside
+a Stata line comment, on a line by itself, such as `// sight: ...` or
+`* sight: ...`. `sight: ignore` may also appear as a trailing `//` comment for
+same-line suppression; `sight: ignore-next` always targets the next statement.
+Block comments (`/* ... */`) do not carry directives. The older `@lsp-` forms
+remain permanent aliases, so `// @lsp-ignore` still works.
 
 ```stata
 // Suppress warning on the next line
@@ -21,6 +24,13 @@ local result `macro_from_program'
 // Suppress warning on the next statement
 // sight: ignore
 local result `macro_from_program'
+
+// Suppress warning on this statement
+replace undefined_var = . // sight: ignore
+
+// Suppress warning on the following statement
+display "before" // sight: ignore-next
+replace undefined_var = .
 ```
 
 <a id="what-the-lsp-can-detect"></a>

--- a/docs/declaration-directives.md
+++ b/docs/declaration-directives.md
@@ -4,70 +4,70 @@
 
 You can suppress diagnostics on specific lines using comment directives:
 
-- `# sight: ignore` - Suppresses all diagnostics on the same line
-- `# sight: ignore-next` - Suppresses all diagnostics on the next line
+- `sight: ignore` - Suppresses all diagnostics on the same line
+- `sight: ignore-next` - Suppresses all diagnostics on the next line
 
-`# sight:` is the preferred directive prefix. It must appear inside a Stata
-comment, such as `// # sight: ...` or `* # sight: ...`. The older `@lsp-`
+`sight:` is the preferred directive prefix. It must appear inside a Stata
+comment, such as `// sight: ...` or `* sight: ...`. The older `@lsp-`
 forms remain permanent aliases, so `// @lsp-ignore` still works.
 
 ```stata
 // Suppress warning on the next line
-// # sight: ignore-next
+// sight: ignore-next
 local result `macro_from_program'
 
 // Suppress warning on the same line
-local result `macro_from_program'  // # sight: ignore
+local result `macro_from_program'  // sight: ignore
 ```
 
 <a id="what-the-lsp-can-detect"></a>
 
-This is useful when the LSP cannot automatically detect that a macro will be defined. The LSP can trace `do`/`run`/`include` calls to find macros defined in other files, and it can detect macros created by called programs when the macro name is fixed or set via a program option. In other situations, you can use `# sight: ignore` or `# sight: ignore-next` to suppress diagnostics for a specific line, or `# sight: local` to declare the macro to the LSP.
+This is useful when the LSP cannot automatically detect that a macro will be defined. The LSP can trace `do`/`run`/`include` calls to find macros defined in other files, and it can detect macros created by called programs when the macro name is fixed or set via a program option. In other situations, you can use `sight: ignore` or `sight: ignore-next` to suppress diagnostics for a specific line, or `sight: local` to declare the macro to the LSP.
 
 ## Declaring Symbols with Directives
 
 You can explicitly declare symbols to the LSP using declaration directives. These directives tell the LSP that a symbol should be considered defined from the point where the directive appears.
 
-*   **Locals and Globals**: The LSP **will** emit warnings (or errors, based on settings) if these macros are used but not defined. Use declaration directives (`# sight: local`, `# sight: global`) to suppress these warnings for macros defined dynamically.
-*   **Variables**: By default, the LSP does **not** emit warnings about undefined variables, since it cannot statically check what's in your datasets. This is an experimental feature - you can set `sight.diagnostics.severity.undefinedVariable` to a severity other than `"off"` (see [Configuration](configuration.md)) to enable checking, then use `# sight: variables` to declare variables loaded from external data files.
-*   **Scalars, Matrices, and Programs**: You can declare these to the LSP (`# sight: scalar`, `# sight: matrix`, `# sight: program`), but at present, the LSP does **not** emit warnings if it fails to find them in scope. Support for these directives is implemented to prepare code for future configurable strictness checks.
+*   **Locals and Globals**: The LSP **will** emit warnings (or errors, based on settings) if these macros are used but not defined. Use declaration directives (`sight: local`, `sight: global`) to suppress these warnings for macros defined dynamically.
+*   **Variables**: By default, the LSP does **not** emit warnings about undefined variables, since it cannot statically check what's in your datasets. This is an experimental feature - you can set `sight.diagnostics.severity.undefinedVariable` to a severity other than `"off"` (see [Configuration](configuration.md)) to enable checking, then use `sight: variables` to declare variables loaded from external data files.
+*   **Scalars, Matrices, and Programs**: You can declare these to the LSP (`sight: scalar`, `sight: matrix`, `sight: program`), but at present, the LSP does **not** emit warnings if it fails to find them in scope. Support for these directives is implemented to prepare code for future configurable strictness checks.
 
 **Available directives:**
 
 | Directive             | Purpose                 |
 | --------------------- | ----------------------- |
-| `# sight: local <name>`   | Declares a local macro  |
-| `# sight: global <name>`  | Declares a global macro |
-| `# sight: variables <names>` | Declares variables (space-separated) |
-| `# sight: scalar <name>`  | Declares a scalar       |
-| `# sight: matrix <name>`  | Declares a matrix       |
-| `# sight: program <name>` | Declares a program      |
+| `sight: local <name>`   | Declares a local macro  |
+| `sight: global <name>`  | Declares a global macro |
+| `sight: variables <names>` | Declares variables (space-separated) |
+| `sight: scalar <name>`  | Declares a scalar       |
+| `sight: matrix <name>`  | Declares a matrix       |
+| `sight: program <name>` | Declares a program      |
 
 Each declaration directive accepts one or more space-separated symbol names.
-`# sight: variables` likewise accepts one or more variable names.
+`sight: variables` likewise accepts one or more variable names.
 
 **Examples:**
 
 ```stata
 // Declare a local macro that will be created by a called program
-// # sight: local result_from_program
+// sight: local result_from_program
 do "compute_result.do"
 display `result_from_program'  // No warning - declared above
 
 // Declare a global macro set by external code
-* # sight: global CONFIG_PATH
+* sight: global CONFIG_PATH
 local path "$CONFIG_PATH"  // No warning
 
 // Declare a scalar (ready for future validation enhancements)
-// # sight: scalar my_scalar
+// sight: scalar my_scalar
 display scalar(my_scalar)
 
 // Declare a matrix
-// # sight: matrix coefficients
+// sight: matrix coefficients
 matrix list coefficients
 
 // Declare a program defined elsewhere
-// # sight: program my_utility
+// sight: program my_utility
 my_utility arg1 arg2
 ```
 

--- a/docs/declaration-directives.md
+++ b/docs/declaration-directives.md
@@ -4,20 +4,23 @@
 
 You can suppress diagnostics on specific lines using comment directives:
 
-- `sight: ignore` - Suppresses all diagnostics on the same line
-- `sight: ignore-next` - Suppresses all diagnostics on the next line
+- `sight: ignore` - Suppresses diagnostics on the next statement
+- `sight: ignore-next` - Also suppresses diagnostics on the next statement
 
 `sight:` is the preferred directive prefix. It must appear inside a Stata
-comment, such as `// sight: ...` or `* sight: ...`. The older `@lsp-`
-forms remain permanent aliases, so `// @lsp-ignore` still works.
+line comment, on a line by itself, such as `// sight: ...` or `* sight: ...`.
+Block comments (`/* ... */`) and inline trailing comments do not carry
+directives. The older `@lsp-` forms remain permanent aliases, so
+`// @lsp-ignore` still works.
 
 ```stata
 // Suppress warning on the next line
 // sight: ignore-next
 local result `macro_from_program'
 
-// Suppress warning on the same line
-local result `macro_from_program'  // sight: ignore
+// Suppress warning on the next statement
+// sight: ignore
+local result `macro_from_program'
 ```
 
 <a id="what-the-lsp-can-detect"></a>
@@ -75,7 +78,8 @@ my_utility arg1 arg2
 - Directives can appear anywhere in the file (not just in the header)
 - The declaration takes effect from the line where it appears through the end of the file
 - References to the symbol before the directive line will still produce warnings
-- Both `*` and `//` comment styles are supported
+- Directives must be standalone `//` or line-leading `*` comments
+- `/* ... */` block comments are not directive comments
 - Trailing whitespace after the symbol name is allowed
 
 **When to use declaration directives:**

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -12,8 +12,8 @@ tables below) and `source: "sight"`.
 
 ## Quick reference
 
-- **Silence one site** — add `// sight: ignore` on the offending line, or
-  `// sight: ignore-next` on the line above. Suppresses undefined-symbol
+- **Silence one site** — add `// sight: ignore` or
+  `// sight: ignore-next` on its own line above the offending statement. Suppresses undefined-symbol
   (`UNDEFINED_MACRO`, `UNDEFINED_VARIABLE`, `OUT_OF_SCOPE_SYMBOL`) and
   operator-style diagnostics on the targeted line. Lexer, parser /
   brace-style, and indentation diagnostics are not silenced this way —
@@ -219,13 +219,15 @@ Each severity key accepts `"error"`, `"warning"`, `"information"`,
 
 | Directive | Effect |
 |---|---|
-| `// sight: ignore` | Suppresses undefined-symbol and operator-style diagnostics on the same line. Does not silence lexer, parser / brace-style, or indentation diagnostics. |
-| `// sight: ignore-next` | Same effect as `sight: ignore`, but applied to the next non-trivia statement. |
+| `// sight: ignore` | Suppresses undefined-symbol and operator-style diagnostics on the next non-trivia statement. Does not silence lexer, parser / brace-style, or indentation diagnostics. |
+| `// sight: ignore-next` | Same effect as `sight: ignore`. |
 | `// sight: local name [name ...]` | Declares one or more local macros from the directive line forward. |
 | `// sight: global name [name ...]` | Same, for globals. |
 | `// sight: variables var [var ...]` | Declares variables (e.g., loaded from a `.dta` file). |
 | `// sight: scalar name`, `// sight: matrix name`, `// sight: program name` | Declares scalars, matrices, and programs respectively. |
 
+Directives must occupy their own `//` or line-leading `*` comment line. Inline
+trailing comments and `/* ... */` block comments are not directive comments.
 `@lsp-` spellings are permanent aliases for all directive forms above.
 
 Declaration directives are forward-only: they suppress warnings at and

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -13,11 +13,12 @@ tables below) and `source: "sight"`.
 ## Quick reference
 
 - **Silence one site** — add `// sight: ignore` or
-  `// sight: ignore-next` on its own line above the offending statement. Suppresses undefined-symbol
-  (`UNDEFINED_MACRO`, `UNDEFINED_VARIABLE`, `OUT_OF_SCOPE_SYMBOL`) and
-  operator-style diagnostics on the targeted line. Lexer, parser /
-  brace-style, and indentation diagnostics are not silenced this way —
-  fix lexer/parser issues at the source, or turn indentation off via
+  `// sight: ignore-next` on its own line above the offending statement, or
+  add `// sight: ignore` as a trailing comment on the offending line.
+  Suppresses undefined-symbol (`UNDEFINED_MACRO`, `UNDEFINED_VARIABLE`,
+  `OUT_OF_SCOPE_SYMBOL`) and operator-style diagnostics on the targeted line.
+  Lexer, parser / brace-style, and indentation diagnostics are not silenced
+  this way — fix lexer/parser issues at the source, or turn indentation off via
   `sight.diagnostics.indentation` (it ships off by default).
 - **Declare a symbol the analyzer can't see** — use
   [`sight: local`, `sight: global`, `sight: variables`, `sight: scalar`,
@@ -219,16 +220,19 @@ Each severity key accepts `"error"`, `"warning"`, `"information"`,
 
 | Directive | Effect |
 |---|---|
-| `// sight: ignore` | Suppresses undefined-symbol and operator-style diagnostics on the next non-trivia statement. Does not silence lexer, parser / brace-style, or indentation diagnostics. |
-| `// sight: ignore-next` | Same effect as `sight: ignore`. |
+| `// sight: ignore` | On its own comment line, suppresses undefined-symbol and operator-style diagnostics on the next non-trivia statement. As a trailing `//` comment, suppresses those diagnostics on the same line. Does not silence lexer, parser / brace-style, or indentation diagnostics. |
+| `// sight: ignore-next` | Suppresses undefined-symbol and operator-style diagnostics on the next non-trivia statement. It does not suppress diagnostics on its own source line. |
 | `// sight: local name [name ...]` | Declares one or more local macros from the directive line forward. |
 | `// sight: global name [name ...]` | Same, for globals. |
 | `// sight: variables var [var ...]` | Declares variables (e.g., loaded from a `.dta` file). |
 | `// sight: scalar name`, `// sight: matrix name`, `// sight: program name` | Declares scalars, matrices, and programs respectively. |
 
-Directives must occupy their own `//` or line-leading `*` comment line. Inline
-trailing comments and `/* ... */` block comments are not directive comments.
-`@lsp-` spellings are permanent aliases for all directive forms above.
+Directives other than `sight: ignore` and `sight: ignore-next` must occupy
+their own `//` or line-leading `*` comment line. `sight: ignore` may also be
+used as a trailing `//` comment for same-line suppression; `sight: ignore-next`
+always targets the following statement. `/* ... */` block comments are not
+directive comments. `@lsp-` spellings are permanent aliases for all directive
+forms above.
 
 Declaration directives are forward-only: they suppress warnings at and
 after the directive line, not earlier ones. See

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -12,21 +12,21 @@ tables below) and `source: "sight"`.
 
 ## Quick reference
 
-- **Silence one site** — add `// @lsp-ignore` on the offending line, or
-  `// @lsp-ignore-next` on the line above. Suppresses undefined-symbol
+- **Silence one site** — add `// # sight: ignore` on the offending line, or
+  `// # sight: ignore-next` on the line above. Suppresses undefined-symbol
   (`UNDEFINED_MACRO`, `UNDEFINED_VARIABLE`, `OUT_OF_SCOPE_SYMBOL`) and
   operator-style diagnostics on the targeted line. Lexer, parser /
   brace-style, and indentation diagnostics are not silenced this way —
   fix lexer/parser issues at the source, or turn indentation off via
   `sight.diagnostics.indentation` (it ships off by default).
 - **Declare a symbol the analyzer can't see** — use
-  [`@lsp-local`, `@lsp-global`, `@lsp-variables`, `@lsp-scalar`,
-  `@lsp-matrix`, `@lsp-program`](declaration-directives.md). Forward-only:
+  [`# sight: local`, `# sight: global`, `# sight: variables`, `# sight: scalar`,
+  `# sight: matrix`, `# sight: program`](declaration-directives.md). Forward-only:
   effective at and after the directive line.
 - **Bring a sibling file's symbols into scope** — usually nothing to do:
   Sight auto-discovers `do` / `run` / `include` relationships and
   inherits the parent's symbols. Add a header directive
-  (`@lsp-done-by`, `@lsp-included-by`) only when auto-discovery can't
+  (`# sight: done-by`, `# sight: included-by`) only when auto-discovery can't
   see the link — for example, when the path is built from macros. See
   [Cross-File Awareness](cross-file.md).
 - **Turn a category off globally** — set the matching severity to
@@ -120,14 +120,14 @@ via the `crossFile.diagnostics.*` keys in `sight.toml`.
 
 | Code | Name | Default | Severity key | Trigger |
 |---|---|---|---|---|
-| 7001 | `PATH_CASE_MISMATCH` | `auto` | `crossFile.diagnostics.caseMismatch` | A `do`/`run`/`include` command or cross-file directive (`@lsp-do`, `@lsp-run`, `@lsp-include`, `@lsp-done-by`, `@lsp-run-by`, `@lsp-included-by`) references a path that differs from the on-disk file by letter case only. The file is resolved and symbols are inherited normally; only the spelling is wrong. |
+| 7001 | `PATH_CASE_MISMATCH` | `auto` | `crossFile.diagnostics.caseMismatch` | A `do`/`run`/`include` command or cross-file directive (`# sight: do`, `# sight: run`, `# sight: include`, `# sight: done-by`, `# sight: run-by`, `# sight: included-by`) references a path that differs from the on-disk file by letter case only. The file is resolved and symbols are inherited normally; only the spelling is wrong. |
 
 ### `PATH_CASE_MISMATCH` (7001)
 
 **Trigger:** A static path in a `do`, `run`, or `include` command — or
-in a forward directive (`@lsp-do`, `@lsp-run`, `@lsp-include`) or
-backward header directive (`@lsp-done-by`, `@lsp-run-by`,
-`@lsp-included-by`) — resolves to an on-disk file that has different
+in a forward directive (`# sight: do`, `# sight: run`, `# sight: include`) or
+backward header directive (`# sight: done-by`, `# sight: run-by`,
+`# sight: included-by`) — resolves to an on-disk file that has different
 letter casing. The file is found and symbols are inherited (no
 undefined-symbol cascade), but the diagnostic asks you to fix the
 spelling.
@@ -142,8 +142,8 @@ Path "helpers/clean" does not match the file on disk
 filesystems (Linux). Update the path to match.
 ```
 
-**Backward message** (`@lsp-done-by`, `@lsp-run-by`,
-`@lsp-included-by`): backward directives are not Stata commands, so the
+**Backward message** (`# sight: done-by`, `# sight: run-by`,
+`# sight: included-by`): backward directives are not Stata commands, so the
 message makes no execution claim:
 
 ```text
@@ -156,7 +156,7 @@ filesystems (macOS/Windows), `warning` on case-sensitive ones (Linux /
 CI). This means the same code is quiet during local development on a Mac
 but surfaces as a build warning in Linux CI — the intended asymmetry.
 
-**Not suppressible** by `@lsp-ignore` or `@lsp-ignore-next`. Suppress
+**Not suppressible** by `# sight: ignore` or `# sight: ignore-next`. Suppress
 project-wide with `crossFile.diagnostics.caseMismatch = "off"`, or fix
 the path casing. Setting `crossFile.diagnostics.missingFile = "off"`
 does **not** silence this diagnostic — the two settings are independent.
@@ -209,22 +209,24 @@ Each severity key accepts `"error"`, `"warning"`, `"information"`,
   [Why undefined-variable is off by default](#why-undefined-variable-is-off-by-default).
 - `styleWarnings` currently gates `CONTINUATION_NO_SPACE` (1004).
 - Parse and brace-style diagnostics have no per-category control and
-  `@lsp-ignore` does not silence them — fix the underlying issue.
+  `# sight: ignore` does not silence them — fix the underlying issue.
 - Indentation diagnostics ship off; turn them on with the boolean
   `sight.diagnostics.indentation`. Both indentation codes emit at
-  `information` severity (there is no severity key), and `@lsp-ignore`
+  `information` severity (there is no severity key), and `# sight: ignore`
   does not silence individual sites.
 
 ## Suppressing diagnostics in source
 
 | Directive | Effect |
 |---|---|
-| `// @lsp-ignore` | Suppresses undefined-symbol and operator-style diagnostics on the same line. Does not silence lexer, parser / brace-style, or indentation diagnostics. |
-| `// @lsp-ignore-next` | Same effect as `@lsp-ignore`, but applied to the next non-trivia statement. |
-| `// @lsp-local name [name …]` | Declares one or more local macros from the directive line forward. |
-| `// @lsp-global name [name …]` | Same, for globals. |
-| `// @lsp-variables var [var …]` | Declares variables (e.g., loaded from a `.dta` file). |
-| `// @lsp-scalar name`, `// @lsp-matrix name`, `// @lsp-program name` | Declares scalars, matrices, and programs respectively. |
+| `// # sight: ignore` | Suppresses undefined-symbol and operator-style diagnostics on the same line. Does not silence lexer, parser / brace-style, or indentation diagnostics. |
+| `// # sight: ignore-next` | Same effect as `# sight: ignore`, but applied to the next non-trivia statement. |
+| `// # sight: local name [name ...]` | Declares one or more local macros from the directive line forward. |
+| `// # sight: global name [name ...]` | Same, for globals. |
+| `// # sight: variables var [var ...]` | Declares variables (e.g., loaded from a `.dta` file). |
+| `// # sight: scalar name`, `// # sight: matrix name`, `// # sight: program name` | Declares scalars, matrices, and programs respectively. |
+
+`@lsp-` spellings are permanent aliases for all directive forms above.
 
 Declaration directives are forward-only: they suppress warnings at and
 after the directive line, not earlier ones. See
@@ -234,8 +236,8 @@ syntax.
 For cross-file linkage (the usual reason a global appears "undefined"
 when it is defined in a sibling file), prefer the dependency-graph
 mechanism — Sight auto-discovers `do` / `run` / `include` chains and
-inherits the parent's symbols. Header directives (`@lsp-done-by`,
-`@lsp-included-by`) handle cases auto-discovery cannot, such as paths
+inherits the parent's symbols. Header directives (`# sight: done-by`,
+`# sight: included-by`) handle cases auto-discovery cannot, such as paths
 built from macros. See [Cross-File Awareness](cross-file.md).
 
 ## How scope is decided
@@ -250,7 +252,7 @@ holds:
      (programs, globals, scalars, matrices, variables).
    - `included-by` / `include` inherit all symbols, including local
      macros.
-3. **Declared by directive** (`@lsp-local`, `@lsp-global`, … ) on or
+3. **Declared by directive** (`# sight: local`, `# sight: global`, … ) on or
    before the reference line.
 
 Workspace indexing alone does **not** suppress diagnostics. A global
@@ -291,11 +293,11 @@ Sight recognizes a variable as defined when it sees one of:
 - `confirm variable` / `confirm var` — treated as an assertion that
   the variable exists; useful for declaring columns loaded from a
   dataset without disabling the diagnostic.
-- `@lsp-variables name [name …]` — manual declaration, forward-only.
+- `# sight: variables name [name …]` — manual declaration, forward-only.
 
 Variables loaded from `use`, `import`, or `merge` are **not**
 introspected — Sight does not read `.dta` files. If the diagnostic is
-on and you load data, declare the columns with `@lsp-variables` (or a
+on and you load data, declare the columns with `# sight: variables` (or a
 `confirm variable` line if you want a runtime assertion as well).
 
 ## Why undefined-variable is off by default
@@ -307,7 +309,7 @@ listed above, a name may legitimately come from a `use`, `import`, or
 is built from macros. Defaulting the diagnostic to `off` avoids
 drowning users in false positives. To opt in, set
 `sight.diagnostics.severity.undefinedVariable` to any non-`off` value
-and declare dynamically-loaded columns with `@lsp-variables` or
+and declare dynamically-loaded columns with `# sight: variables` or
 `confirm variable`.
 
 ## Relationship to completion

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -12,21 +12,21 @@ tables below) and `source: "sight"`.
 
 ## Quick reference
 
-- **Silence one site** — add `// # sight: ignore` on the offending line, or
-  `// # sight: ignore-next` on the line above. Suppresses undefined-symbol
+- **Silence one site** — add `// sight: ignore` on the offending line, or
+  `// sight: ignore-next` on the line above. Suppresses undefined-symbol
   (`UNDEFINED_MACRO`, `UNDEFINED_VARIABLE`, `OUT_OF_SCOPE_SYMBOL`) and
   operator-style diagnostics on the targeted line. Lexer, parser /
   brace-style, and indentation diagnostics are not silenced this way —
   fix lexer/parser issues at the source, or turn indentation off via
   `sight.diagnostics.indentation` (it ships off by default).
 - **Declare a symbol the analyzer can't see** — use
-  [`# sight: local`, `# sight: global`, `# sight: variables`, `# sight: scalar`,
-  `# sight: matrix`, `# sight: program`](declaration-directives.md). Forward-only:
+  [`sight: local`, `sight: global`, `sight: variables`, `sight: scalar`,
+  `sight: matrix`, `sight: program`](declaration-directives.md). Forward-only:
   effective at and after the directive line.
 - **Bring a sibling file's symbols into scope** — usually nothing to do:
   Sight auto-discovers `do` / `run` / `include` relationships and
   inherits the parent's symbols. Add a header directive
-  (`# sight: done-by`, `# sight: included-by`) only when auto-discovery can't
+  (`sight: done-by`, `sight: included-by`) only when auto-discovery can't
   see the link — for example, when the path is built from macros. See
   [Cross-File Awareness](cross-file.md).
 - **Turn a category off globally** — set the matching severity to
@@ -120,14 +120,14 @@ via the `crossFile.diagnostics.*` keys in `sight.toml`.
 
 | Code | Name | Default | Severity key | Trigger |
 |---|---|---|---|---|
-| 7001 | `PATH_CASE_MISMATCH` | `auto` | `crossFile.diagnostics.caseMismatch` | A `do`/`run`/`include` command or cross-file directive (`# sight: do`, `# sight: run`, `# sight: include`, `# sight: done-by`, `# sight: run-by`, `# sight: included-by`) references a path that differs from the on-disk file by letter case only. The file is resolved and symbols are inherited normally; only the spelling is wrong. |
+| 7001 | `PATH_CASE_MISMATCH` | `auto` | `crossFile.diagnostics.caseMismatch` | A `do`/`run`/`include` command or cross-file directive (`sight: do`, `sight: run`, `sight: include`, `sight: done-by`, `sight: run-by`, `sight: included-by`) references a path that differs from the on-disk file by letter case only. The file is resolved and symbols are inherited normally; only the spelling is wrong. |
 
 ### `PATH_CASE_MISMATCH` (7001)
 
 **Trigger:** A static path in a `do`, `run`, or `include` command — or
-in a forward directive (`# sight: do`, `# sight: run`, `# sight: include`) or
-backward header directive (`# sight: done-by`, `# sight: run-by`,
-`# sight: included-by`) — resolves to an on-disk file that has different
+in a forward directive (`sight: do`, `sight: run`, `sight: include`) or
+backward header directive (`sight: done-by`, `sight: run-by`,
+`sight: included-by`) — resolves to an on-disk file that has different
 letter casing. The file is found and symbols are inherited (no
 undefined-symbol cascade), but the diagnostic asks you to fix the
 spelling.
@@ -142,8 +142,8 @@ Path "helpers/clean" does not match the file on disk
 filesystems (Linux). Update the path to match.
 ```
 
-**Backward message** (`# sight: done-by`, `# sight: run-by`,
-`# sight: included-by`): backward directives are not Stata commands, so the
+**Backward message** (`sight: done-by`, `sight: run-by`,
+`sight: included-by`): backward directives are not Stata commands, so the
 message makes no execution claim:
 
 ```text
@@ -156,7 +156,7 @@ filesystems (macOS/Windows), `warning` on case-sensitive ones (Linux /
 CI). This means the same code is quiet during local development on a Mac
 but surfaces as a build warning in Linux CI — the intended asymmetry.
 
-**Not suppressible** by `# sight: ignore` or `# sight: ignore-next`. Suppress
+**Not suppressible** by `sight: ignore` or `sight: ignore-next`. Suppress
 project-wide with `crossFile.diagnostics.caseMismatch = "off"`, or fix
 the path casing. Setting `crossFile.diagnostics.missingFile = "off"`
 does **not** silence this diagnostic — the two settings are independent.
@@ -209,22 +209,22 @@ Each severity key accepts `"error"`, `"warning"`, `"information"`,
   [Why undefined-variable is off by default](#why-undefined-variable-is-off-by-default).
 - `styleWarnings` currently gates `CONTINUATION_NO_SPACE` (1004).
 - Parse and brace-style diagnostics have no per-category control and
-  `# sight: ignore` does not silence them — fix the underlying issue.
+  `sight: ignore` does not silence them — fix the underlying issue.
 - Indentation diagnostics ship off; turn them on with the boolean
   `sight.diagnostics.indentation`. Both indentation codes emit at
-  `information` severity (there is no severity key), and `# sight: ignore`
+  `information` severity (there is no severity key), and `sight: ignore`
   does not silence individual sites.
 
 ## Suppressing diagnostics in source
 
 | Directive | Effect |
 |---|---|
-| `// # sight: ignore` | Suppresses undefined-symbol and operator-style diagnostics on the same line. Does not silence lexer, parser / brace-style, or indentation diagnostics. |
-| `// # sight: ignore-next` | Same effect as `# sight: ignore`, but applied to the next non-trivia statement. |
-| `// # sight: local name [name ...]` | Declares one or more local macros from the directive line forward. |
-| `// # sight: global name [name ...]` | Same, for globals. |
-| `// # sight: variables var [var ...]` | Declares variables (e.g., loaded from a `.dta` file). |
-| `// # sight: scalar name`, `// # sight: matrix name`, `// # sight: program name` | Declares scalars, matrices, and programs respectively. |
+| `// sight: ignore` | Suppresses undefined-symbol and operator-style diagnostics on the same line. Does not silence lexer, parser / brace-style, or indentation diagnostics. |
+| `// sight: ignore-next` | Same effect as `sight: ignore`, but applied to the next non-trivia statement. |
+| `// sight: local name [name ...]` | Declares one or more local macros from the directive line forward. |
+| `// sight: global name [name ...]` | Same, for globals. |
+| `// sight: variables var [var ...]` | Declares variables (e.g., loaded from a `.dta` file). |
+| `// sight: scalar name`, `// sight: matrix name`, `// sight: program name` | Declares scalars, matrices, and programs respectively. |
 
 `@lsp-` spellings are permanent aliases for all directive forms above.
 
@@ -236,8 +236,8 @@ syntax.
 For cross-file linkage (the usual reason a global appears "undefined"
 when it is defined in a sibling file), prefer the dependency-graph
 mechanism — Sight auto-discovers `do` / `run` / `include` chains and
-inherits the parent's symbols. Header directives (`# sight: done-by`,
-`# sight: included-by`) handle cases auto-discovery cannot, such as paths
+inherits the parent's symbols. Header directives (`sight: done-by`,
+`sight: included-by`) handle cases auto-discovery cannot, such as paths
 built from macros. See [Cross-File Awareness](cross-file.md).
 
 ## How scope is decided
@@ -252,7 +252,7 @@ holds:
      (programs, globals, scalars, matrices, variables).
    - `included-by` / `include` inherit all symbols, including local
      macros.
-3. **Declared by directive** (`# sight: local`, `# sight: global`, … ) on or
+3. **Declared by directive** (`sight: local`, `sight: global`, … ) on or
    before the reference line.
 
 Workspace indexing alone does **not** suppress diagnostics. A global
@@ -293,11 +293,11 @@ Sight recognizes a variable as defined when it sees one of:
 - `confirm variable` / `confirm var` — treated as an assertion that
   the variable exists; useful for declaring columns loaded from a
   dataset without disabling the diagnostic.
-- `# sight: variables name [name …]` — manual declaration, forward-only.
+- `sight: variables name [name …]` — manual declaration, forward-only.
 
 Variables loaded from `use`, `import`, or `merge` are **not**
 introspected — Sight does not read `.dta` files. If the diagnostic is
-on and you load data, declare the columns with `# sight: variables` (or a
+on and you load data, declare the columns with `sight: variables` (or a
 `confirm variable` line if you want a runtime assertion as well).
 
 ## Why undefined-variable is off by default
@@ -309,7 +309,7 @@ listed above, a name may legitimately come from a `use`, `import`, or
 is built from macros. Defaulting the diagnostic to `off` avoids
 drowning users in false positives. To opt in, set
 `sight.diagnostics.severity.undefinedVariable` to any non-`off` value
-and declare dynamically-loaded columns with `# sight: variables` or
+and declare dynamically-loaded columns with `sight: variables` or
 `confirm variable`.
 
 ## Relationship to completion

--- a/docs/send-to-stata.md
+++ b/docs/send-to-stata.md
@@ -74,7 +74,7 @@ Control which directory Stata uses when executing your code:
 
 | Option | Description | When to Use |
 |--------|-------------|-------------|
-| **lsp** (default) | Uses working directory from LSP directives | Recommended - leverages `# sight: cd` or inherited from parent files |
+| **lsp** (default) | Uses working directory from LSP directives | Recommended - leverages `sight: cd` or inherited from parent files |
 | **none** | No directory change | When Stata's current directory is already correct |
 | **file** | Changes to current file's directory | For standalone scripts |
 | **workspace** | Changes to workspace root | For project-relative paths |
@@ -82,8 +82,8 @@ Control which directory Stata uses when executing your code:
 **Configuration**: `sight.sendToStata.workingDirectory`
 
 The **lsp** option reads the working directory from:
-- `# sight: cd`, `# sight: working-directory`, or `# sight: wd` directives in your file (`@lsp-` forms remain aliases)
-- Parent files via `# sight: done-by` or `# sight: included-by` directives (inherits working directory)
+- `sight: cd`, `sight: working-directory`, or `sight: wd` directives in your file (`@lsp-` forms remain aliases)
+- Parent files via `sight: done-by` or `sight: included-by` directives (inherits working directory)
 - Falls back to "none" if no LSP working directory is available
 
 When set to "none", manual CD commands appear in the toolbar menu for quick directory changes.

--- a/docs/send-to-stata.md
+++ b/docs/send-to-stata.md
@@ -74,7 +74,7 @@ Control which directory Stata uses when executing your code:
 
 | Option | Description | When to Use |
 |--------|-------------|-------------|
-| **lsp** (default) | Uses working directory from LSP directives | Recommended - leverages `@lsp-cd` or inherited from parent files |
+| **lsp** (default) | Uses working directory from LSP directives | Recommended - leverages `# sight: cd` or inherited from parent files |
 | **none** | No directory change | When Stata's current directory is already correct |
 | **file** | Changes to current file's directory | For standalone scripts |
 | **workspace** | Changes to workspace root | For project-relative paths |
@@ -82,8 +82,8 @@ Control which directory Stata uses when executing your code:
 **Configuration**: `sight.sendToStata.workingDirectory`
 
 The **lsp** option reads the working directory from:
-- `@lsp-cd`, `@lsp-working-directory`, or `@lsp-wd` directives in your file
-- Parent files via `@lsp-done-by` or `@lsp-included-by` directives (inherits working directory)
+- `# sight: cd`, `# sight: working-directory`, or `# sight: wd` directives in your file (`@lsp-` forms remain aliases)
+- Parent files via `# sight: done-by` or `# sight: included-by` directives (inherits working directory)
 - Falls back to "none" if no LSP working directory is available
 
 When set to "none", manual CD commands appear in the toolbar menu for quick directory changes.

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -1,5 +1,4 @@
 import { Range } from 'vscode-languageserver-textdocument';
-import { get_line_text, get_line_count, compute_line_offsets } from '../utils/line-utils';
 import {
     format_undefined_macro_message,
     format_undefined_variable_message,
@@ -30,8 +29,7 @@ import { DirectiveParser } from '../directive-parser';
 import { find_macro_creating_command, matches_option } from './macro-creating-commands';
 import { parse_option_argument, is_valid_identifier } from './option-argument-parser';
 import {
-    DECLARATION_DIRECTIVE_KEYWORDS,
-    DIRECTIVE_PREFIX_PATTERN,
+    DECLARATION_DIRECTIVE_PATTERN,
     VARIABLES_DIRECTIVE_PATTERN,
     has_ignore_directive,
     has_ignore_next_directive,
@@ -283,18 +281,20 @@ export class SemanticAnalyzer {
         // This avoids issues with multi-line block comments causing line number mismatches
         this.parse_declaration_directives_from_tokens(tokens, symbols);
         
-        // Process other directives (ignore, variables)
+        // Process other directives (ignore, variables). Like declaration
+        // directives, these are only honored in standalone `//` / line-leading
+        // `*` comments; `/* ... */` block comments do not carry directives.
         for (let i = 0; i < tokens.length; i++) {
             const token = tokens[i];
-            
-            if (token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK') {
+
+            if (token.type === 'COMMENT_LINE') {
                 const token_content = token.value.trim();
                 const is_standalone_comment = this.is_standalone_comment_token(tokens, i);
 
                 if (has_ignore_directive(token_content)) {
                     if (is_standalone_comment) {
                         this.ignore_next_non_trivia_line(tokens, i);
-                    } else if (token.type === 'COMMENT_LINE') {
+                    } else {
                         this.config.ignored_lines.add(token.range.start.line);
                     }
                 }
@@ -341,48 +341,26 @@ export class SemanticAnalyzer {
      * when reconstructing content for the directive parser.
      */
     private parse_declaration_directives_from_tokens(tokens: Token[], symbols?: SymbolTable): void {
-        // Pattern to match declaration directives (captures all remaining text)
-        const DECLARATION_PATTERN = new RegExp(
-            `${DIRECTIVE_PREFIX_PATTERN}(${DECLARATION_DIRECTIVE_KEYWORDS}):?\\s+(.+)\\s*$`
-        );
-
         for (let i = 0; i < tokens.length; i++) {
             const token = tokens[i];
-            if (token.type !== 'COMMENT_LINE' && token.type !== 'COMMENT_BLOCK') {
+            // Directives live only in standalone `//` / line-leading `*`
+            // comments. `/* ... */` block comments do not carry directives
+            // (see docs/declaration-directives.md), so a directive-looking line
+            // nested inside a block comment must stay inert.
+            if (token.type !== 'COMMENT_LINE') {
                 continue;
             }
             if (!this.is_standalone_comment_token(tokens, i)) {
                 continue;
             }
 
-            const token_content = token.value;
-
-            // For block comments, check each line separately
-            if (token.type === 'COMMENT_BLOCK') {
-                const my_doc = { content: token_content, line_offsets: compute_line_offsets(token_content) };
-                const my_line_count = get_line_count(my_doc);
-                for (let line_offset = 0; line_offset < my_line_count; line_offset++) {
-                    const my_line = get_line_text(my_doc, line_offset);
-                    const my_match = my_line.match(DECLARATION_PATTERN);
-                    if (my_match) {
-                        const my_type = my_match[1] as 'local' | 'global' | 'scalar' | 'matrix' | 'program';
-                        const the_names = my_match[2].split(/\s+/).filter(n => n.length > 0);
-                        const my_actual_line = token.range.start.line + line_offset;
-                        for (const my_name of the_names) {
-                            this.register_declaration_directive(my_type, my_name, my_actual_line, symbols);
-                        }
-                    }
-                }
-            } else {
-                // Line comment - check the whole content
-                const my_match = token_content.match(DECLARATION_PATTERN);
-                if (my_match) {
-                    const my_type = my_match[1] as 'local' | 'global' | 'scalar' | 'matrix' | 'program';
-                    const the_names = my_match[2].split(/\s+/).filter(n => n.length > 0);
-                    const my_actual_line = token.range.start.line;
-                    for (const my_name of the_names) {
-                        this.register_declaration_directive(my_type, my_name, my_actual_line, symbols);
-                    }
+            const my_match = token.value.match(DECLARATION_DIRECTIVE_PATTERN);
+            if (my_match) {
+                const my_type = my_match[1] as 'local' | 'global' | 'scalar' | 'matrix' | 'program';
+                const the_names = my_match[2].split(/\s+/).filter(n => n.length > 0);
+                const my_actual_line = token.range.start.line;
+                for (const my_name of the_names) {
+                    this.register_declaration_directive(my_type, my_name, my_actual_line, symbols);
                 }
             }
         }

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -32,6 +32,7 @@ import { parse_option_argument, is_valid_identifier } from './option-argument-pa
 import {
     DECLARATION_DIRECTIVE_KEYWORDS,
     DIRECTIVE_PREFIX_PATTERN,
+    VARIABLES_DIRECTIVE_PATTERN,
     has_ignore_directive,
     has_ignore_next_directive,
 } from '../utils/directives';
@@ -306,9 +307,7 @@ export class SemanticAnalyzer {
                     }
                 }
                 // Check for @lsp-variables directive
-                const variables_match = token_content.match(
-                    new RegExp(`${DIRECTIVE_PREFIX_PATTERN}variables:?\\s+(.+)\\s*$`)
-                );
+                const variables_match = token_content.match(VARIABLES_DIRECTIVE_PATTERN);
                 if (variables_match) {
                     const var_names = variables_match[1].split(/\s+/).filter(v => v.length > 0);
                     for (const var_name of var_names) {
@@ -513,9 +512,7 @@ export class SemanticAnalyzer {
         }
 
         // Check for @lsp-variables directive
-        const variables_match = content.match(
-            new RegExp(`${DIRECTIVE_PREFIX_PATTERN}variables:?\\s+(.+)\\s*$`)
-        );
+        const variables_match = content.match(VARIABLES_DIRECTIVE_PATTERN);
         if (variables_match) {
             const var_names = variables_match[1].split(/\s+/).filter(v => v.length > 0);
             for (const var_name of var_names) {

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -286,11 +286,12 @@ export class SemanticAnalyzer {
         for (let i = 0; i < tokens.length; i++) {
             const token = tokens[i];
             
-            if (token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK') {
+            if ((token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK') &&
+                this.is_standalone_comment_token(tokens, i)) {
                 const token_content = token.value.trim();
 
-                // Check for ignore-next directive (ignores next line)
-                if (has_ignore_next_directive(token_content)) {
+                // Standalone ignore directives target the next non-trivia token.
+                if (has_ignore_directive(token_content) || has_ignore_next_directive(token_content)) {
                     // Find the next non-trivia token's line
                     for (let j = i + 1; j < tokens.length; j++) {
                         const next_token = tokens[j];
@@ -304,14 +305,9 @@ export class SemanticAnalyzer {
                         }
                     }
                 }
-                // Check for ignore directive (ignores same line)
-                else if (has_ignore_directive(token_content)) {
-                    this.config.ignored_lines.add(token.range.start.line);
-                }
-
                 // Check for @lsp-variables directive
                 const variables_match = token_content.match(
-                    new RegExp(`${DIRECTIVE_PREFIX_PATTERN}variables:?\\s+(.+)`)
+                    new RegExp(`${DIRECTIVE_PREFIX_PATTERN}variables:?\\s+(.+)\\s*$`)
                 );
                 if (variables_match) {
                     const var_names = variables_match[1].split(/\s+/).filter(v => v.length > 0);
@@ -334,11 +330,15 @@ export class SemanticAnalyzer {
     private parse_declaration_directives_from_tokens(tokens: Token[], symbols?: SymbolTable): void {
         // Pattern to match declaration directives (captures all remaining text)
         const DECLARATION_PATTERN = new RegExp(
-            `${DIRECTIVE_PREFIX_PATTERN}(${DECLARATION_DIRECTIVE_KEYWORDS}):?\\s+(.+)`
+            `${DIRECTIVE_PREFIX_PATTERN}(${DECLARATION_DIRECTIVE_KEYWORDS}):?\\s+(.+)\\s*$`
         );
 
-        for (const token of tokens) {
+        for (let i = 0; i < tokens.length; i++) {
+            const token = tokens[i];
             if (token.type !== 'COMMENT_LINE' && token.type !== 'COMMENT_BLOCK') {
+                continue;
+            }
+            if (!this.is_standalone_comment_token(tokens, i)) {
                 continue;
             }
 
@@ -490,13 +490,6 @@ export class SemanticAnalyzer {
             }
         }
 
-        // Check trailing trivia
-        if (this.has_trivia(node) && node.trailingTrivia) {
-            for (const trivia of node.trailingTrivia) {
-                this.parse_directive(trivia, node);
-            }
-        }
-
         // Recurse into nested nodes
         if (node.type === 'program') {
             for (const child of node.body) {
@@ -512,8 +505,8 @@ export class SemanticAnalyzer {
     private parse_directive(trivia: TriviaNode, following_node: StataNode): void {
         const content = trivia.content.trim();
 
-        // Check for ignore-next directive
-        if (has_ignore_next_directive(content)) {
+        // Standalone ignore directives target the following node.
+        if (has_ignore_directive(content) || has_ignore_next_directive(content)) {
             // Ignore the line of the following node
             const line_to_ignore = following_node.range.start.line;
             this.config.ignored_lines.add(line_to_ignore);
@@ -521,7 +514,7 @@ export class SemanticAnalyzer {
 
         // Check for @lsp-variables directive
         const variables_match = content.match(
-            new RegExp(`${DIRECTIVE_PREFIX_PATTERN}variables:?\\s+(.+)`)
+            new RegExp(`${DIRECTIVE_PREFIX_PATTERN}variables:?\\s+(.+)\\s*$`)
         );
         if (variables_match) {
             const var_names = variables_match[1].split(/\s+/).filter(v => v.length > 0);
@@ -529,6 +522,23 @@ export class SemanticAnalyzer {
                 this.config.declared_variables.add(var_name);
             }
         }
+    }
+
+    private is_standalone_comment_token(tokens: Token[], comment_index: number): boolean {
+        const comment = tokens[comment_index];
+        const line = comment.range.start.line;
+
+        for (let i = comment_index - 1; i >= 0; i--) {
+            const token = tokens[i];
+            if (token.range.start.line !== line) {
+                break;
+            }
+            if (token.type !== 'WHITESPACE') {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -287,25 +287,25 @@ export class SemanticAnalyzer {
         for (let i = 0; i < tokens.length; i++) {
             const token = tokens[i];
             
-            if ((token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK') &&
-                this.is_standalone_comment_token(tokens, i)) {
+            if (token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK') {
                 const token_content = token.value.trim();
+                const is_standalone_comment = this.is_standalone_comment_token(tokens, i);
 
-                // Standalone ignore directives target the next non-trivia token.
-                if (has_ignore_directive(token_content) || has_ignore_next_directive(token_content)) {
-                    // Find the next non-trivia token's line
-                    for (let j = i + 1; j < tokens.length; j++) {
-                        const next_token = tokens[j];
-                        if (next_token.type !== 'WHITESPACE' && 
-                            next_token.type !== 'COMMENT_LINE' && 
-                            next_token.type !== 'COMMENT_BLOCK' &&
-                            next_token.type !== 'CONTINUATION' &&
-                            next_token.type !== 'STATEMENT_TERMINATOR') {
-                            this.config.ignored_lines.add(next_token.range.start.line);
-                            break;
-                        }
+                if (has_ignore_directive(token_content)) {
+                    if (is_standalone_comment) {
+                        this.ignore_next_non_trivia_line(tokens, i);
+                    } else if (token.type === 'COMMENT_LINE') {
+                        this.config.ignored_lines.add(token.range.start.line);
                     }
                 }
+                if (has_ignore_next_directive(token_content)) {
+                    this.ignore_next_non_trivia_line(tokens, i);
+                }
+
+                if (!is_standalone_comment) {
+                    continue;
+                }
+
                 // Check for @lsp-variables directive
                 const variables_match = token_content.match(VARIABLES_DIRECTIVE_PATTERN);
                 if (variables_match) {
@@ -314,6 +314,20 @@ export class SemanticAnalyzer {
                         this.config.declared_variables.add(var_name);
                     }
                 }
+            }
+        }
+    }
+
+    private ignore_next_non_trivia_line(tokens: Token[], directive_index: number): void {
+        for (let j = directive_index + 1; j < tokens.length; j++) {
+            const next_token = tokens[j];
+            if (next_token.type !== 'WHITESPACE' &&
+                next_token.type !== 'COMMENT_LINE' &&
+                next_token.type !== 'COMMENT_BLOCK' &&
+                next_token.type !== 'CONTINUATION' &&
+                next_token.type !== 'STATEMENT_TERMINATOR') {
+                this.config.ignored_lines.add(next_token.range.start.line);
+                break;
             }
         }
     }

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -29,6 +29,12 @@ import {
 import { DirectiveParser } from '../directive-parser';
 import { find_macro_creating_command, matches_option } from './macro-creating-commands';
 import { parse_option_argument, is_valid_identifier } from './option-argument-parser';
+import {
+    DECLARATION_DIRECTIVE_KEYWORDS,
+    DIRECTIVE_PREFIX_PATTERN,
+    has_ignore_directive,
+    has_ignore_next_directive,
+} from '../utils/directives';
 
 // Diagnostic interface for semantic errors
 export interface SemanticDiagnostic {
@@ -283,8 +289,8 @@ export class SemanticAnalyzer {
             if (token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK') {
                 const token_content = token.value.trim();
 
-                // Check for @lsp-ignore-next directive (ignores next line)
-                if (token_content.includes('@lsp-ignore-next')) {
+                // Check for ignore-next directive (ignores next line)
+                if (has_ignore_next_directive(token_content)) {
                     // Find the next non-trivia token's line
                     for (let j = i + 1; j < tokens.length; j++) {
                         const next_token = tokens[j];
@@ -298,13 +304,15 @@ export class SemanticAnalyzer {
                         }
                     }
                 }
-                // Check for @lsp-ignore directive (ignores same line)
-                else if (token_content.includes('@lsp-ignore')) {
+                // Check for ignore directive (ignores same line)
+                else if (has_ignore_directive(token_content)) {
                     this.config.ignored_lines.add(token.range.start.line);
                 }
 
                 // Check for @lsp-variables directive
-                const variables_match = token_content.match(/@lsp-variables\s+(.+)/);
+                const variables_match = token_content.match(
+                    new RegExp(`${DIRECTIVE_PREFIX_PATTERN}variables:?\\s+(.+)`)
+                );
                 if (variables_match) {
                     const var_names = variables_match[1].split(/\s+/).filter(v => v.length > 0);
                     for (const var_name of var_names) {
@@ -325,7 +333,9 @@ export class SemanticAnalyzer {
      */
     private parse_declaration_directives_from_tokens(tokens: Token[], symbols?: SymbolTable): void {
         // Pattern to match declaration directives (captures all remaining text)
-        const DECLARATION_PATTERN = /@lsp-(local|global|scalar|matrix|program)\s+(.+)/;
+        const DECLARATION_PATTERN = new RegExp(
+            `${DIRECTIVE_PREFIX_PATTERN}(${DECLARATION_DIRECTIVE_KEYWORDS}):?\\s+(.+)`
+        );
 
         for (const token of tokens) {
             if (token.type !== 'COMMENT_LINE' && token.type !== 'COMMENT_BLOCK') {
@@ -502,15 +512,17 @@ export class SemanticAnalyzer {
     private parse_directive(trivia: TriviaNode, following_node: StataNode): void {
         const content = trivia.content.trim();
 
-        // Check for @lsp-ignore-next directive
-        if (content.includes('@lsp-ignore-next')) {
+        // Check for ignore-next directive
+        if (has_ignore_next_directive(content)) {
             // Ignore the line of the following node
             const line_to_ignore = following_node.range.start.line;
             this.config.ignored_lines.add(line_to_ignore);
         }
 
         // Check for @lsp-variables directive
-        const variables_match = content.match(/@lsp-variables\s+(.+)/);
+        const variables_match = content.match(
+            new RegExp(`${DIRECTIVE_PREFIX_PATTERN}variables:?\\s+(.+)`)
+        );
         if (variables_match) {
             const var_names = variables_match[1].split(/\s+/).filter(v => v.length > 0);
             for (const var_name of var_names) {

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -250,7 +250,7 @@ export class DirectiveParser {
         the_diagnostics.push(...declaration_result.diagnostics);
 
         // Parse forward call directives from the entire file
-        const forward_call_result = this.parse_forward_call_directives(content, file_uri);
+        const forward_call_result = this.parse_forward_call_directives(content, file_uri, tokens);
         the_diagnostics.push(...forward_call_result.diagnostics);
 
         // Emit warning if multiple working directory directives were found

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -37,27 +37,23 @@ import {
 // Accept both spec form with colon (@lsp-done-by:) and legacy form without colon.
 // Accept both quoted and unquoted paths.
 // @lsp-run-by is a synonym for @lsp-done-by (semantic clarity for files called via `run` command)
-// These patterns match only the directive head (keyword + path). They do NOT
-// anchor to end-of-line or capture a trailing params group: an unanchored
-// `@lsp-...` prefix combined with a trailing `(?:\s+(.*))?$` triggers a
-// CodeQL polynomial-ReDoS finding (each `@lsp-` start position can drive an
-// O(n) scan to `$`). Any call-site params after the path are extracted by
-// slicing the remainder of the line (see parse()/parse_forward_call_directives).
+const CALL_SITE_PARAMS_PATTERN = String.raw`((?:\s+(?:line=\d+|match="[^"]+"))*)\s*$`;
+
 const DIRECTIVE_PATTERN = make_directive_pattern(
     BACKWARD_DIRECTIVE_KEYWORDS,
-    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))`,
+    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))${CALL_SITE_PARAMS_PATTERN}`,
 );
 
 const FORWARD_CALL_DIRECTIVE_PATTERN = make_directive_pattern(
     FORWARD_DIRECTIVE_KEYWORDS,
-    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))`,
+    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))${CALL_SITE_PARAMS_PATTERN}`,
 );
 
 // Pattern for working directory directive with all synonyms
 // Matches: @lsp-working-directory, @lsp-working-dir, @lsp-current-directory, @lsp-current-dir, @lsp-cd, @lsp-wd
 const WORKING_DIR_DIRECTIVE_PATTERN = make_directive_pattern(
     WORKING_DIR_DIRECTIVE_KEYWORDS,
-    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))$`,
+    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))\s*$`,
 );
 
 const PARAM_LINE = /line=(\d+)/;
@@ -81,7 +77,7 @@ const DO_INCLUDE_PATTERN = build_do_include_pattern('capture');
 // Shared pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments.
 const CALL_DIRECTIVE_PATTERN = make_directive_pattern(
     FORWARD_DIRECTIVE_KEYWORDS,
-    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))`,
+    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))${CALL_SITE_PARAMS_PATTERN}`,
 );
 
 function looks_like_unquoted_path_token(token: string): boolean {
@@ -173,7 +169,6 @@ export class DirectiveParser {
                 continue;
             }
 
-            // Allow directives to appear anywhere in the comment line
             const my_match = my_trimmed.match(DIRECTIVE_PATTERN);
             if (my_match) {
                 // Map 'run-by' to 'done-by' (synonym for semantic clarity)
@@ -182,9 +177,7 @@ export class DirectiveParser {
                 const my_quoted_path = my_match[2] as string | undefined;
                 const my_unquoted_path = my_match[3] as string | undefined;
                 const my_raw_path = (my_quoted_path || my_unquoted_path) as string;
-                const my_params = my_trimmed
-                    .slice((my_match.index ?? 0) + my_match[0].length)
-                    .trim();
+                const my_params = my_match[4]?.trim() ?? '';
 
                 // If the path is unquoted, require that it resembles a path token.
                 // This keeps malformed cases like "@lsp-done-by missing-quotes" from being
@@ -221,7 +214,7 @@ export class DirectiveParser {
                     call_site: my_call_site,
                     range: my_range,
                 });
-            } else if (/(?:@lsp-|(?:^|\/\/|\*)\s*sight:\s*)(?:done-by|run-by|included-by)/.test(my_trimmed)) {
+            } else if (make_directive_pattern(BACKWARD_DIRECTIVE_KEYWORDS, String.raw`:?`).test(my_trimmed)) {
                 // Malformed directive
                 the_diagnostics.push({
                     message: 'Malformed directive. Expected: ' +
@@ -289,7 +282,7 @@ export class DirectiveParser {
             const my_trimmed = my_line.trim();
 
             if ((my_trimmed.startsWith('*') || my_trimmed.startsWith('//')) &&
-                has_ignore_next_directive(my_trimmed)) {
+                (has_ignore_directive(my_trimmed) || has_ignore_next_directive(my_trimmed))) {
                 // Mark the next non-blank, non-comment line as ignored
                 for (let j = i + 1; j < line_count; j++) {
                     const next_trimmed = get_line_text(doc, j).trim();
@@ -321,12 +314,7 @@ export class DirectiveParser {
 
             const my_match = my_trimmed.match(FORWARD_CALL_DIRECTIVE_PATTERN);
             if (my_match) {
-                // Check if this line should be ignored
-                // @lsp-ignore on same line
-                if (has_ignore_directive(my_trimmed) && !has_ignore_next_directive(my_trimmed)) {
-                    continue;
-                }
-                // @lsp-ignore-next from preceding line
+                // @lsp-ignore/@lsp-ignore-next from preceding directive line
                 if (ignored_next_lines.has(i)) {
                     continue;
                 }
@@ -335,9 +323,7 @@ export class DirectiveParser {
                 const my_quoted_path = my_match[2];
                 const my_unquoted_path = my_match[3];
                 const my_raw_path = my_quoted_path || my_unquoted_path;
-                const my_params = my_trimmed
-                    .slice((my_match.index ?? 0) + my_match[0].length)
-                    .trim();
+                const my_params = my_match[4]?.trim() ?? '';
 
                 if (!my_raw_path) {
                     the_diagnostics.push({

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -25,10 +25,7 @@ import {
     DocumentLike,
 } from '../utils/line-utils';
 import { build_do_include_pattern } from '../utils/stata-call-patterns';
-import {
-    block_comment_lines_from_tokens,
-    block_comment_lines_from_content,
-} from '../utils/block-comment-utils';
+import { block_comment_lines } from '../utils/block-comment-utils';
 import {
     BACKWARD_DIRECTIVE_KEYWORDS,
     FORWARD_DIRECTIVE_KEYWORDS,
@@ -124,7 +121,7 @@ export class DirectiveParser {
      * Parse directives from file content.
      * Stops at first non-comment, non-blank line.
      */
-    parse(content: string, file_uri: string): DirectiveParseResult {
+    parse(content: string, file_uri: string, tokens?: Token[]): DirectiveParseResult {
         const doc: DocumentLike = { content, line_offsets: compute_line_offsets(content) };
         const line_count = get_line_count(doc);
         const the_directives: Directive[] = [];
@@ -249,7 +246,7 @@ export class DirectiveParser {
         }
 
         // Parse declaration directives from the entire file (not just header)
-        const declaration_result = this.parse_declaration_directives(content, file_uri);
+        const declaration_result = this.parse_declaration_directives(content, file_uri, tokens);
         the_diagnostics.push(...declaration_result.diagnostics);
 
         // Parse forward call directives from the entire file
@@ -295,17 +292,15 @@ export class DirectiveParser {
         const the_forward_calls: ForwardCallDirective[] = [];
         const the_diagnostics: DirectiveDiagnostic[] = [];
 
-        // Lines inside `/* ... */` block comments do not carry directives.
-        const block_comment_lines = tokens
-            ? block_comment_lines_from_tokens(tokens)
-            : block_comment_lines_from_content(content);
+        // Lines whose leading text is inside a block comment carry no directives.
+        const block_lines = block_comment_lines(content, tokens);
 
         // Track lines to ignore from @lsp-ignore-next
         const ignored_next_lines = new Set<number>();
 
         // First pass: find @lsp-ignore-next directives
         for (let i = 0; i < line_count; i++) {
-            if (block_comment_lines.has(i)) {
+            if (block_lines.has(i)) {
                 continue;
             }
             const my_line = get_line_text(doc, i);
@@ -315,6 +310,9 @@ export class DirectiveParser {
                 (has_ignore_directive(my_trimmed) || has_ignore_next_directive(my_trimmed))) {
                 // Mark the next non-blank, non-comment line as ignored
                 for (let j = i + 1; j < line_count; j++) {
+                    if (block_lines.has(j)) {
+                        continue; // block-commented-out line is not a target
+                    }
                     const next_trimmed = get_line_text(doc, j).trim();
                     if (next_trimmed !== '' &&
                         !next_trimmed.startsWith('*') &&
@@ -334,7 +332,7 @@ export class DirectiveParser {
         }
 
         for (let i = 0; i < line_count; i++) {
-            if (block_comment_lines.has(i)) {
+            if (block_lines.has(i)) {
                 continue;
             }
             const my_line = get_line_text(doc, i);
@@ -437,18 +435,19 @@ export class DirectiveParser {
      */
     parse_declaration_directives(
         content: string,
-        _file_uri: string
+        _file_uri: string,
+        tokens?: Token[]
     ): { declarations: DeclarationDirective[]; diagnostics: DirectiveDiagnostic[] } {
         const doc: DocumentLike = { content, line_offsets: compute_line_offsets(content) };
         const line_count = get_line_count(doc);
         const the_declarations: DeclarationDirective[] = [];
         const the_diagnostics: DirectiveDiagnostic[] = [];
 
-        // Lines inside `/* ... */` block comments do not carry directives.
-        const block_comment_lines = block_comment_lines_from_content(content);
+        // Lines whose leading text is inside a block comment carry no directives.
+        const block_lines = block_comment_lines(content, tokens);
 
         for (let i = 0; i < line_count; i++) {
-            if (block_comment_lines.has(i)) {
+            if (block_lines.has(i)) {
                 continue;
             }
             const my_line = get_line_text(doc, i);
@@ -632,11 +631,11 @@ export class DirectiveParser {
             ? child_basename.slice(0, -3).toLowerCase()
             : child_basename.toLowerCase();
 
-        // Code and directives inside `/* ... */` block comments are inert.
-        const block_comment_lines = block_comment_lines_from_content(parent_content);
+        // Code and directives whose leading text is inside a block comment are inert.
+        const block_lines = block_comment_lines(parent_content);
 
         for (let i = 0; i < line_count; i++) {
-            if (block_comment_lines.has(i)) {
+            if (block_lines.has(i)) {
                 continue;
             }
             const my_line = get_line_text(doc, i);
@@ -713,11 +712,11 @@ export class DirectiveParser {
             ? child_basename.slice(0, -3).toLowerCase()
             : child_basename.toLowerCase();
 
-        // Code and directives inside `/* ... */` block comments are inert.
-        const block_comment_lines = block_comment_lines_from_content(parent_content);
+        // Code and directives whose leading text is inside a block comment are inert.
+        const block_lines = block_comment_lines(parent_content);
 
         for (let i = 0; i < line_count; i++) {
-            if (block_comment_lines.has(i)) {
+            if (block_lines.has(i)) {
                 continue;
             }
             const my_line = get_line_text(doc, i);
@@ -811,11 +810,11 @@ export class DirectiveParser {
             ? child_basename.slice(0, -3).toLowerCase()
             : child_basename.toLowerCase();
 
-        // Code and directives inside `/* ... */` block comments are inert.
-        const block_comment_lines = block_comment_lines_from_content(parent_content);
+        // Code and directives whose leading text is inside a block comment are inert.
+        const block_lines = block_comment_lines(parent_content);
 
         for (let i = 0; i < line_count; i++) {
-            if (block_comment_lines.has(i)) {
+            if (block_lines.has(i)) {
                 continue;
             }
             const my_line = get_line_text(doc, i);

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -192,7 +192,7 @@ export class DirectiveParser {
                 if (!my_quoted_path && my_unquoted_path && !looks_like_unquoted_path_token(my_unquoted_path)) {
                     the_diagnostics.push({
                         message: 'Malformed directive. Expected: ' +
-                            '// # sight: done-by: "path.do" or // # sight: run-by: "path.do" or // # sight: included-by: "path.do"',
+                            '// sight: done-by: "path.do" or // sight: run-by: "path.do" or // sight: included-by: "path.do"',
                         range: {
                             start: { line: i, character: 0 },
                             end: { line: i, character: my_line.length },
@@ -221,11 +221,11 @@ export class DirectiveParser {
                     call_site: my_call_site,
                     range: my_range,
                 });
-            } else if (/(?:@lsp-|#\s*sight:\s*)(?:done-by|run-by|included-by)/.test(my_trimmed)) {
+            } else if (/(?:@lsp-|(?:^|\/\/|\*)\s*sight:\s*)(?:done-by|run-by|included-by)/.test(my_trimmed)) {
                 // Malformed directive
                 the_diagnostics.push({
                     message: 'Malformed directive. Expected: ' +
-                        '// # sight: done-by "path" or // # sight: run-by "path" or // # sight: included-by "path"',
+                        '// sight: done-by "path" or // sight: run-by "path" or // sight: included-by "path"',
                     range: {
                         start: { line: i, character: 0 },
                         end: { line: i, character: my_line.length },
@@ -353,7 +353,7 @@ export class DirectiveParser {
                 if (!my_quoted_path && my_unquoted_path && !looks_like_unquoted_path_token(my_unquoted_path)) {
                     the_diagnostics.push({
                         message: 'Malformed directive. Expected: ' +
-                            '// # sight: do: "path.do" or // # sight: run: "path.do" or // # sight: include: "path.do"',
+                            '// sight: do: "path.do" or // sight: run: "path.do" or // sight: include: "path.do"',
                         range: { start: { line: i, character: 0 }, end: { line: i, character: my_line.length } },
                         severity: 'warning',
                     });

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -29,6 +29,7 @@ import {
     FORWARD_DIRECTIVE_KEYWORDS,
     WORKING_DIR_DIRECTIVE_KEYWORDS,
     DECLARATION_DIRECTIVE_KEYWORDS,
+    CALL_SITE_PARAMS_FRAGMENT,
     make_directive_pattern,
     has_ignore_directive,
     has_ignore_next_directive,
@@ -37,7 +38,9 @@ import {
 // Accept both spec form with colon (@lsp-done-by:) and legacy form without colon.
 // Accept both quoted and unquoted paths.
 // @lsp-run-by is a synonym for @lsp-done-by (semantic clarity for files called via `run` command)
-const CALL_SITE_PARAMS_PATTERN = String.raw`((?:\s+(?:line=\d+|match="[^"]+"))*)\s*$`;
+// Capture group wraps the shared params fragment so callers can read the raw
+// param tail from the match (e.g. `my_match[4]`).
+const CALL_SITE_PARAMS_PATTERN = String.raw`(${CALL_SITE_PARAMS_FRAGMENT})\s*$`;
 
 const DIRECTIVE_PATTERN = make_directive_pattern(
     BACKWARD_DIRECTIVE_KEYWORDS,
@@ -65,7 +68,9 @@ const WORKING_DIR_DIRECTIVE_PATTERN = make_directive_pattern(
 );
 
 const PARAM_LINE = /line=(\d+)/;
-const PARAM_MATCH = /match="([^"]+)"/;
+// Capture the `match=` string body, allowing an escaped quote `\"` so
+// `match="do \"x\""` yields the raw value `do \"x\"` (unescaped in parse_call_site).
+const PARAM_MATCH = /match="((?:\\"|[^"])*)"/;
 
 // Pattern to match declaration directives: @lsp-(local|global|scalar|matrix|program)
 // Captures: [1] = directive type. The declared names (rest of line) are sliced
@@ -475,7 +480,10 @@ export class DirectiveParser {
     private parse_call_site(params: string): CallSite | undefined {
         const my_match_result = params.match(PARAM_MATCH);
         if (my_match_result) {
-            return { type: 'match', value: my_match_result[1] };
+            // Unescape `\"` so `match="do \"x\""` searches the parent for the
+            // literal text `do "x"`. Lone backslashes are left untouched.
+            const my_value = my_match_result[1].replace(/\\"/g, '"');
+            return { type: 'match', value: my_value };
         }
 
         const my_line_result = params.match(PARAM_LINE);

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -62,6 +62,15 @@ const FORWARD_CALL_DIRECTIVE_PATTERN = make_directive_pattern(
     String.raw`:?\s+(?:"([^"]+)"|([^\s]+))${CALL_SITE_PARAMS_PATTERN}`,
 );
 
+// Detects a standalone forward-directive head (keyword present but the full
+// FORWARD_CALL_DIRECTIVE_PATTERN did not match) so the parser can report it as
+// malformed, mirroring BACKWARD_DIRECTIVE_HEAD_PATTERN. The `(?=\s|$)` lookahead
+// keeps the keyword a whole word so `// sight: doctor` is not treated as `do`.
+const FORWARD_CALL_DIRECTIVE_HEAD_PATTERN = make_directive_pattern(
+    FORWARD_DIRECTIVE_KEYWORDS,
+    String.raw`:?(?=\s|$)`,
+);
+
 // Pattern for working directory directive with all synonyms
 // Matches: @lsp-working-directory, @lsp-working-dir, @lsp-current-directory, @lsp-current-dir, @lsp-cd, @lsp-wd
 const WORKING_DIR_DIRECTIVE_PATTERN = make_directive_pattern(
@@ -416,6 +425,18 @@ export class DirectiveParser {
                     call_site_line: my_call_site_line,
                     call_site: my_call_site,
                     range: my_range,
+                });
+            } else if (!ignored_next_lines.has(i) &&
+                FORWARD_CALL_DIRECTIVE_HEAD_PATTERN.test(my_trimmed)) {
+                // Forward-directive head present but the full directive did not
+                // parse (e.g. missing path or empty match=""). Report it as
+                // malformed, mirroring backward directives, so the user is not
+                // left guessing why the directive was silently ignored.
+                the_diagnostics.push({
+                    message: 'Malformed directive. Expected: ' +
+                        '// sight: do: "path.do" or // sight: run: "path.do" or // sight: include: "path.do"',
+                    range: { start: { line: i, character: 0 }, end: { line: i, character: my_line.length } },
+                    severity: 'warning',
                 });
             }
         }

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -51,10 +51,12 @@ const DIRECTIVE_PATTERN = make_directive_pattern(
 
 // Detects a standalone backward-directive head (keyword present but the full
 // DIRECTIVE_PATTERN did not match) so the parser can report it as malformed.
-// Hoisted to module scope so it is not recompiled on every header line.
+// Hoisted to module scope so it is not recompiled on every header line. The
+// `(?=:|\s|$)` boundary keeps the keyword whole — it matches `done-by:"x"`
+// (no space) and `done-by` alone, but not words like `done-bytes`.
 const BACKWARD_DIRECTIVE_HEAD_PATTERN = make_directive_pattern(
     BACKWARD_DIRECTIVE_KEYWORDS,
-    String.raw`:?`,
+    String.raw`(?=:|\s|$)`,
 );
 
 const FORWARD_CALL_DIRECTIVE_PATTERN = make_directive_pattern(
@@ -64,11 +66,12 @@ const FORWARD_CALL_DIRECTIVE_PATTERN = make_directive_pattern(
 
 // Detects a standalone forward-directive head (keyword present but the full
 // FORWARD_CALL_DIRECTIVE_PATTERN did not match) so the parser can report it as
-// malformed, mirroring BACKWARD_DIRECTIVE_HEAD_PATTERN. The `(?=\s|$)` lookahead
-// keeps the keyword a whole word so `// sight: doctor` is not treated as `do`.
+// malformed, mirroring BACKWARD_DIRECTIVE_HEAD_PATTERN. The `(?=:|\s|$)` boundary
+// keeps the keyword whole: it matches `do:"x"` (no space) and `do` alone, but
+// not words like `doctor`.
 const FORWARD_CALL_DIRECTIVE_HEAD_PATTERN = make_directive_pattern(
     FORWARD_DIRECTIVE_KEYWORDS,
-    String.raw`:?(?=\s|$)`,
+    String.raw`(?=:|\s|$)`,
 );
 
 // Pattern for working directory directive with all synonyms

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -16,6 +16,7 @@ import {
     DeclarationDirective,
     ForwardCallDirective,
     WorkingDirectoryDirective,
+    Token,
 } from '../types';
 import {
     get_line_text,
@@ -24,6 +25,10 @@ import {
     DocumentLike,
 } from '../utils/line-utils';
 import { build_do_include_pattern } from '../utils/stata-call-patterns';
+import {
+    block_comment_lines_from_tokens,
+    block_comment_lines_from_content,
+} from '../utils/block-comment-utils';
 import {
     BACKWARD_DIRECTIVE_KEYWORDS,
     FORWARD_DIRECTIVE_KEYWORDS,
@@ -282,18 +287,27 @@ export class DirectiveParser {
      */
     parse_forward_call_directives(
         content: string,
-        _file_uri: string
+        _file_uri: string,
+        tokens?: Token[]
     ): { forward_calls: ForwardCallDirective[]; diagnostics: DirectiveDiagnostic[] } {
         const doc: DocumentLike = { content, line_offsets: compute_line_offsets(content) };
         const line_count = get_line_count(doc);
         const the_forward_calls: ForwardCallDirective[] = [];
         const the_diagnostics: DirectiveDiagnostic[] = [];
 
+        // Lines inside `/* ... */` block comments do not carry directives.
+        const block_comment_lines = tokens
+            ? block_comment_lines_from_tokens(tokens)
+            : block_comment_lines_from_content(content);
+
         // Track lines to ignore from @lsp-ignore-next
         const ignored_next_lines = new Set<number>();
 
         // First pass: find @lsp-ignore-next directives
         for (let i = 0; i < line_count; i++) {
+            if (block_comment_lines.has(i)) {
+                continue;
+            }
             const my_line = get_line_text(doc, i);
             const my_trimmed = my_line.trim();
 
@@ -320,6 +334,9 @@ export class DirectiveParser {
         }
 
         for (let i = 0; i < line_count; i++) {
+            if (block_comment_lines.has(i)) {
+                continue;
+            }
             const my_line = get_line_text(doc, i);
             const my_trimmed = my_line.trim();
 
@@ -427,7 +444,13 @@ export class DirectiveParser {
         const the_declarations: DeclarationDirective[] = [];
         const the_diagnostics: DirectiveDiagnostic[] = [];
 
+        // Lines inside `/* ... */` block comments do not carry directives.
+        const block_comment_lines = block_comment_lines_from_content(content);
+
         for (let i = 0; i < line_count; i++) {
+            if (block_comment_lines.has(i)) {
+                continue;
+            }
             const my_line = get_line_text(doc, i);
             const my_trimmed = my_line.trim();
 
@@ -609,7 +632,13 @@ export class DirectiveParser {
             ? child_basename.slice(0, -3).toLowerCase()
             : child_basename.toLowerCase();
 
+        // Code and directives inside `/* ... */` block comments are inert.
+        const block_comment_lines = block_comment_lines_from_content(parent_content);
+
         for (let i = 0; i < line_count; i++) {
+            if (block_comment_lines.has(i)) {
+                continue;
+            }
             const my_line = get_line_text(doc, i);
             const my_trimmed = my_line.trim();
 
@@ -684,7 +713,13 @@ export class DirectiveParser {
             ? child_basename.slice(0, -3).toLowerCase()
             : child_basename.toLowerCase();
 
+        // Code and directives inside `/* ... */` block comments are inert.
+        const block_comment_lines = block_comment_lines_from_content(parent_content);
+
         for (let i = 0; i < line_count; i++) {
+            if (block_comment_lines.has(i)) {
+                continue;
+            }
             const my_line = get_line_text(doc, i);
             const my_trimmed = my_line.trim();
 
@@ -776,7 +811,13 @@ export class DirectiveParser {
             ? child_basename.slice(0, -3).toLowerCase()
             : child_basename.toLowerCase();
 
+        // Code and directives inside `/* ... */` block comments are inert.
+        const block_comment_lines = block_comment_lines_from_content(parent_content);
+
         for (let i = 0; i < line_count; i++) {
+            if (block_comment_lines.has(i)) {
+                continue;
+            }
             const my_line = get_line_text(doc, i);
             const my_trimmed = my_line.trim();
 

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -24,6 +24,15 @@ import {
     DocumentLike,
 } from '../utils/line-utils';
 import { build_do_include_pattern } from '../utils/stata-call-patterns';
+import {
+    BACKWARD_DIRECTIVE_KEYWORDS,
+    FORWARD_DIRECTIVE_KEYWORDS,
+    WORKING_DIR_DIRECTIVE_KEYWORDS,
+    DECLARATION_DIRECTIVE_KEYWORDS,
+    make_directive_pattern,
+    has_ignore_directive,
+    has_ignore_next_directive,
+} from '../utils/directives';
 
 // Accept both spec form with colon (@lsp-done-by:) and legacy form without colon.
 // Accept both quoted and unquoted paths.
@@ -34,13 +43,22 @@ import { build_do_include_pattern } from '../utils/stata-call-patterns';
 // CodeQL polynomial-ReDoS finding (each `@lsp-` start position can drive an
 // O(n) scan to `$`). Any call-site params after the path are extracted by
 // slicing the remainder of the line (see parse()/parse_forward_call_directives).
-const DIRECTIVE_PATTERN = /@lsp-(done-by|run-by|included-by):?\s+(?:"([^"]+)"|([^\s]+))/;
+const DIRECTIVE_PATTERN = make_directive_pattern(
+    BACKWARD_DIRECTIVE_KEYWORDS,
+    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))`,
+);
 
-const FORWARD_CALL_DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+(?:"([^"]+)"|([^\s]+))/;
+const FORWARD_CALL_DIRECTIVE_PATTERN = make_directive_pattern(
+    FORWARD_DIRECTIVE_KEYWORDS,
+    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))`,
+);
 
 // Pattern for working directory directive with all synonyms
 // Matches: @lsp-working-directory, @lsp-working-dir, @lsp-current-directory, @lsp-current-dir, @lsp-cd, @lsp-wd
-const WORKING_DIR_DIRECTIVE_PATTERN = /@lsp-(working-directory|working-dir|current-directory|current-dir|cd|wd):?\s+(?:"([^"]+)"|([^\s]+))$/;
+const WORKING_DIR_DIRECTIVE_PATTERN = make_directive_pattern(
+    WORKING_DIR_DIRECTIVE_KEYWORDS,
+    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))$`,
+);
 
 const PARAM_LINE = /line=(\d+)/;
 const PARAM_MATCH = /match="([^"]+)"/;
@@ -50,7 +68,10 @@ const PARAM_MATCH = /match="([^"]+)"/;
 // from the remainder after the match. A `(?=\s|$)` lookahead keeps the keyword a
 // whole word (so `@lsp-localx` is not matched) without a trailing `.*$` group,
 // which would otherwise trigger a CodeQL polynomial-ReDoS finding.
-const DECLARATION_DIRECTIVE_PATTERN = /@lsp-(local|global|scalar|matrix|program)(?=\s|$)/;
+const DECLARATION_DIRECTIVE_PATTERN = make_directive_pattern(
+    DECLARATION_DIRECTIVE_KEYWORDS,
+    String.raw`:?(?=\s|$)`,
+);
 
 // Shared pattern to match do/include/run statements with optional prefix commands.
 // Prefix alternatives live in utils/stata-call-patterns so this pattern and the
@@ -58,7 +79,10 @@ const DECLARATION_DIRECTIVE_PATTERN = /@lsp-(local|global|scalar|matrix|program)
 const DO_INCLUDE_PATTERN = build_do_include_pattern('capture');
 
 // Shared pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments.
-const CALL_DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+(?:"([^"]+)"|([^\s]+))/;
+const CALL_DIRECTIVE_PATTERN = make_directive_pattern(
+    FORWARD_DIRECTIVE_KEYWORDS,
+    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))`,
+);
 
 function looks_like_unquoted_path_token(token: string): boolean {
     // Heuristic for valid unquoted paths:
@@ -168,7 +192,7 @@ export class DirectiveParser {
                 if (!my_quoted_path && my_unquoted_path && !looks_like_unquoted_path_token(my_unquoted_path)) {
                     the_diagnostics.push({
                         message: 'Malformed directive. Expected: ' +
-                            '// @lsp-done-by: "path.do" or // @lsp-run-by: "path.do" or // @lsp-included-by: "path.do"',
+                            '// # sight: done-by: "path.do" or // # sight: run-by: "path.do" or // # sight: included-by: "path.do"',
                         range: {
                             start: { line: i, character: 0 },
                             end: { line: i, character: my_line.length },
@@ -197,13 +221,11 @@ export class DirectiveParser {
                     call_site: my_call_site,
                     range: my_range,
                 });
-            } else if (my_trimmed.includes('@lsp-done-by') ||
-                       my_trimmed.includes('@lsp-run-by') ||
-                       my_trimmed.includes('@lsp-included-by')) {
+            } else if (/(?:@lsp-|#\s*sight:\s*)(?:done-by|run-by|included-by)/.test(my_trimmed)) {
                 // Malformed directive
                 the_diagnostics.push({
                     message: 'Malformed directive. Expected: ' +
-                        '// @lsp-done-by "path" or // @lsp-run-by "path" or // @lsp-included-by "path"',
+                        '// # sight: done-by "path" or // # sight: run-by "path" or // # sight: included-by "path"',
                     range: {
                         start: { line: i, character: 0 },
                         end: { line: i, character: my_line.length },
@@ -267,7 +289,7 @@ export class DirectiveParser {
             const my_trimmed = my_line.trim();
 
             if ((my_trimmed.startsWith('*') || my_trimmed.startsWith('//')) &&
-                my_trimmed.includes('@lsp-ignore-next')) {
+                has_ignore_next_directive(my_trimmed)) {
                 // Mark the next non-blank, non-comment line as ignored
                 for (let j = i + 1; j < line_count; j++) {
                     const next_trimmed = get_line_text(doc, j).trim();
@@ -301,7 +323,7 @@ export class DirectiveParser {
             if (my_match) {
                 // Check if this line should be ignored
                 // @lsp-ignore on same line
-                if (my_trimmed.includes('@lsp-ignore') && !my_trimmed.includes('@lsp-ignore-next')) {
+                if (has_ignore_directive(my_trimmed) && !has_ignore_next_directive(my_trimmed)) {
                     continue;
                 }
                 // @lsp-ignore-next from preceding line
@@ -331,7 +353,7 @@ export class DirectiveParser {
                 if (!my_quoted_path && my_unquoted_path && !looks_like_unquoted_path_token(my_unquoted_path)) {
                     the_diagnostics.push({
                         message: 'Malformed directive. Expected: ' +
-                            '// @lsp-do: "path.do" or // @lsp-run: "path.do" or // @lsp-include: "path.do"',
+                            '// # sight: do: "path.do" or // # sight: run: "path.do" or // # sight: include: "path.do"',
                         range: { start: { line: i, character: 0 }, end: { line: i, character: my_line.length } },
                         severity: 'warning',
                     });

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -144,7 +144,13 @@ export class DirectiveParser {
         let working_directory: WorkingDirectoryDirective | undefined;
         let working_dir_count = 0;
 
+        // Continuation lines of multi-line comments carry no directives.
+        const block_lines = block_comment_lines(content, tokens);
+
         for (let i = 0; i < line_count; i++) {
+            if (block_lines.has(i)) {
+                continue;
+            }
             const my_line = get_line_text(doc, i);
             const my_trimmed = my_line.trim();
 

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -68,16 +68,18 @@ const WORKING_DIR_DIRECTIVE_PATTERN = make_directive_pattern(
 );
 
 const PARAM_LINE = /line=(\d+)/;
-// Capture the `match=` string body, allowing an escaped quote `\"` so
+// Capture the non-empty `match=` string body, allowing an escaped quote `\"` so
 // `match="do \"x\""` yields the raw value `do \"x\"` (unescaped in parse_call_site).
-const PARAM_MATCH = /match="((?:\\"|[^"])*)"/;
+const PARAM_MATCH = /match="((?:\\"|[^"])+)"/;
 
-// Pattern to match declaration directives: @lsp-(local|global|scalar|matrix|program)
+// Head pattern to match declaration directives: @lsp-(local|global|scalar|matrix|program)
 // Captures: [1] = directive type. The declared names (rest of line) are sliced
 // from the remainder after the match. A `(?=\s|$)` lookahead keeps the keyword a
 // whole word (so `@lsp-localx` is not matched) without a trailing `.*$` group,
-// which would otherwise trigger a CodeQL polynomial-ReDoS finding.
-const DECLARATION_DIRECTIVE_PATTERN = make_directive_pattern(
+// which would otherwise trigger a CodeQL polynomial-ReDoS finding. Named
+// `_HEAD_` (cf. BACKWARD_DIRECTIVE_HEAD_PATTERN) to distinguish it from the
+// name-capturing DECLARATION_DIRECTIVE_PATTERN exported by utils/directives.ts.
+const DECLARATION_DIRECTIVE_HEAD_PATTERN = make_directive_pattern(
     DECLARATION_DIRECTIVE_KEYWORDS,
     String.raw`:?(?=\s|$)`,
 );
@@ -435,7 +437,7 @@ export class DirectiveParser {
             }
 
             // Check for declaration directive pattern
-            const my_match = my_trimmed.match(DECLARATION_DIRECTIVE_PATTERN);
+            const my_match = my_trimmed.match(DECLARATION_DIRECTIVE_HEAD_PATTERN);
             if (my_match) {
                 const my_type = my_match[1] as 'local' | 'global' | 'scalar' | 'matrix' | 'program';
                 const my_rest = my_trimmed

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -44,6 +44,14 @@ const DIRECTIVE_PATTERN = make_directive_pattern(
     String.raw`:?\s+(?:"([^"]+)"|([^\s]+))${CALL_SITE_PARAMS_PATTERN}`,
 );
 
+// Detects a standalone backward-directive head (keyword present but the full
+// DIRECTIVE_PATTERN did not match) so the parser can report it as malformed.
+// Hoisted to module scope so it is not recompiled on every header line.
+const BACKWARD_DIRECTIVE_HEAD_PATTERN = make_directive_pattern(
+    BACKWARD_DIRECTIVE_KEYWORDS,
+    String.raw`:?`,
+);
+
 const FORWARD_CALL_DIRECTIVE_PATTERN = make_directive_pattern(
     FORWARD_DIRECTIVE_KEYWORDS,
     String.raw`:?\s+(?:"([^"]+)"|([^\s]+))${CALL_SITE_PARAMS_PATTERN}`,
@@ -214,7 +222,7 @@ export class DirectiveParser {
                     call_site: my_call_site,
                     range: my_range,
                 });
-            } else if (make_directive_pattern(BACKWARD_DIRECTIVE_KEYWORDS, String.raw`:?`).test(my_trimmed)) {
+            } else if (BACKWARD_DIRECTIVE_HEAD_PATTERN.test(my_trimmed)) {
                 // Malformed directive
                 the_diagnostics.push({
                     message: 'Malformed directive. Expected: ' +
@@ -257,7 +265,8 @@ export class DirectiveParser {
     /**
      * Parse forward call directives from entire file content.
      * Scans the entire file for @lsp-do, @lsp-run, @lsp-include directives.
-     * Respects @lsp-ignore (same line) and @lsp-ignore-next (preceding line).
+     * Respects standalone @lsp-ignore / @lsp-ignore-next comment lines, which
+     * suppress the next statement.
      *
      * @param content - The file content to parse
      * @param _file_uri - The URI of the file (unused; kept for parity

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -790,7 +790,11 @@ export class DocumentStore {
     let all_forward_calls = analyze_result.result!.forward_calls;
     try {
       const directive_parser = new DirectiveParser();
-      const directive_result = directive_parser.parse_forward_call_directives(content, uri);
+      const directive_result = directive_parser.parse_forward_call_directives(
+        content,
+        uri,
+        lex_result.result!.tokens
+      );
       const directive_forward_calls: ForwardCall[] = directive_result.forward_calls.map(d => ({
         type: d.type,
         raw_path: d.raw_path,

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -683,7 +683,7 @@ export class DocumentStore {
     const directive_parser = new DirectiveParser();
     let resolved_working_directory: string | undefined;
     try {
-      const directive_result = directive_parser.parse(content, uri);
+      const directive_result = directive_parser.parse(content, uri, lex_result.result!.tokens);
 
       if (this.scope_resolver) {
         this.scope_resolver.sync_backward_directive_dependencies(

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -539,6 +539,8 @@ export class WorkspaceIndexer {
                 parseResult.ast,
                 file_uri,
                 undefined,
+                undefined,
+                lexResult.tokens,
             );
 
             // Resolve effective working directory: own @lsp-cd / @lsp-wd

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -47,6 +47,7 @@ import {
 import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 import { isPathDirective, isFileCommand, hasStataExtension } from '../utils/file-path-utils';
 import { DIRECTIVE_BODY_PREFIX_PATTERN } from '../utils/directives';
+import { is_cursor_in_block_comment } from '../utils/comment-utils';
 import { classify_entry_sync } from '../utils/symlink-aware-entry';
 import { logger } from '../utils/logger';
 import * as fs from 'fs';
@@ -181,9 +182,10 @@ export function detect_completion_context(
         return extended_macro_context;
     }
 
-    // Check for directive path context (e.g., @lsp-done-by:)
+    // Check for directive path context (e.g., @lsp-done-by:). Directives are
+    // inert inside `/* ... */` block comments, so skip block-commented lines.
     const directive_context = detect_directive_context(text_before_cursor);
-    if (directive_context) {
+    if (directive_context && !is_cursor_in_block_comment(document, position)) {
         return directive_context;
     }
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -61,6 +61,16 @@ import {
 import { get_line_text, get_line_count } from '../utils/line-utils';
 import { format_help_link } from '../utils/help-link';
 
+// Directive at the start of its own comment line, applied to the comment body
+// after the `//`/`*` marker has been stripped. Capture group 1 is the
+// directive name, group 2 the remaining path text. Compiled once at module
+// load rather than on every completion request (see the "RegExp in Loops"
+// guidance in CLAUDE.md); it carries no global flag, so it holds no
+// `lastIndex` state and is safe to share across calls.
+const DIRECTIVE_PATH_CONTEXT_PATTERN = new RegExp(
+    `^\\s*(${DIRECTIVE_BODY_PREFIX_PATTERN}[a-zA-Z-]+)\\s*:?\\s*(.*)$`
+);
+
 /**
  * Map ForwardCallSite.effective_type to directive_type for ranking.
  * 'include' -> 'included-by', else 'done-by'
@@ -424,8 +434,7 @@ function detect_directive_context(text_before_cursor: string): CompletionContext
     const comment_content = comment_match[2];
     
     // Look for a directive at the start of its own comment line.
-    const directive_pattern = new RegExp(`^\\s*(${DIRECTIVE_BODY_PREFIX_PATTERN}[a-zA-Z-]+)\\s*:?\\s*(.*)$`);
-    const directive_match = comment_content.match(directive_pattern);
+    const directive_match = comment_content.match(DIRECTIVE_PATH_CONTEXT_PATTERN);
     
     if (directive_match) {
         const directive = directive_match[1];

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -46,7 +46,7 @@ import {
 } from '../scope-resolver';
 import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 import { isPathDirective, isFileCommand, hasStataExtension } from '../utils/file-path-utils';
-import { DIRECTIVE_PREFIX_PATTERN } from '../utils/directives';
+import { DIRECTIVE_BODY_PREFIX_PATTERN } from '../utils/directives';
 import { classify_entry_sync } from '../utils/symlink-aware-entry';
 import { logger } from '../utils/logger';
 import * as fs from 'fs';
@@ -423,8 +423,8 @@ function detect_directive_context(text_before_cursor: string): CompletionContext
     
     const comment_content = comment_match[2];
     
-    // Look for @lsp-* directive pattern
-    const directive_pattern = new RegExp(`(${DIRECTIVE_PREFIX_PATTERN}[a-zA-Z-]+)\\s*:?\\s*(.*)$`);
+    // Look for a directive at the start of its own comment line.
+    const directive_pattern = new RegExp(`^\\s*(${DIRECTIVE_BODY_PREFIX_PATTERN}[a-zA-Z-]+)\\s*:?\\s*(.*)$`);
     const directive_match = comment_content.match(directive_pattern);
     
     if (directive_match) {

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -46,6 +46,7 @@ import {
 } from '../scope-resolver';
 import { create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 import { isPathDirective, isFileCommand, hasStataExtension } from '../utils/file-path-utils';
+import { DIRECTIVE_PREFIX_PATTERN } from '../utils/directives';
 import { classify_entry_sync } from '../utils/symlink-aware-entry';
 import { logger } from '../utils/logger';
 import * as fs from 'fs';
@@ -423,7 +424,7 @@ function detect_directive_context(text_before_cursor: string): CompletionContext
     const comment_content = comment_match[2];
     
     // Look for @lsp-* directive pattern
-    const directive_pattern = /(@lsp-[a-zA-Z-]+)\s*:\s*(.*)$/;
+    const directive_pattern = new RegExp(`(${DIRECTIVE_PREFIX_PATTERN}[a-zA-Z-]+)\\s*:?\\s*(.*)$`);
     const directive_match = comment_content.match(directive_pattern);
     
     if (directive_match) {

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -55,6 +55,16 @@ import {
     DIRECTIVE_PREFIX_PATTERN,
 } from '../utils/directives';
 
+// Path-bearing directive line (`done-by`/`run-by`/`included-by`/`do`/`run`/
+// `include`) with an optional quoted or bare path and trailing call-site
+// params. Compiled once at module load rather than per definition request
+// (see the "RegExp in Loops" guidance in CLAUDE.md). It carries no global
+// flag, so it holds no `lastIndex` state and is safe to share across calls.
+const PATH_BEARING_DIRECTIVE_PATTERN = new RegExp(
+    `${DIRECTIVE_PREFIX_PATTERN}(${BACKWARD_DIRECTIVE_KEYWORDS}|${FORWARD_DIRECTIVE_KEYWORDS})` +
+    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))(?:\s+(?:line=\d+|match="[^"]+"))*\s*$`
+);
+
 /**
  * Definition Provider class.
  */
@@ -1505,12 +1515,7 @@ export class DefinitionProvider {
 
         // Check for path-bearing directives. These are only directives inside
         // Stata comments; bare `sight:` text is ordinary invalid Stata code.
-        const directive_match = line_text.match(
-            new RegExp(
-                `${DIRECTIVE_PREFIX_PATTERN}(${BACKWARD_DIRECTIVE_KEYWORDS}|${FORWARD_DIRECTIVE_KEYWORDS})` +
-                String.raw`:?\s+(?:"([^"]+)"|([^\s]+))(?:\s+(?:line=\d+|match="[^"]+"))*\s*$`
-            )
-        );
+        const directive_match = line_text.match(PATH_BEARING_DIRECTIVE_PATTERN);
         if (directive_match && is_cursor_in_comment(document, position)) {
             const quoted_path = directive_match[2];
             const unquoted_path = directive_match[3];

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -1508,7 +1508,7 @@ export class DefinitionProvider {
         const directive_match = line_text.match(
             new RegExp(
                 `${DIRECTIVE_PREFIX_PATTERN}(${BACKWARD_DIRECTIVE_KEYWORDS}|${FORWARD_DIRECTIVE_KEYWORDS})` +
-                String.raw`:?\s+(?:"([^"]+)"|([^\s]+))`
+                String.raw`:?\s+(?:"([^"]+)"|([^\s]+))(?:\s+(?:line=\d+|match="[^"]+"))*\s*$`
             )
         );
         if (directive_match && is_cursor_in_comment(document, position)) {
@@ -1517,11 +1517,14 @@ export class DefinitionProvider {
             const file_path = quoted_path || unquoted_path;
             const match_start = directive_match.index!;
 
-            // The match ends at the path (including the closing quote when
-            // quoted), so compute the span from the end. This is insensitive to
-            // whether the directive used `@lsp-` or `sight:`.
-            const path_start = match_start + directive_match[0].length -
-                file_path.length - (quoted_path ? 1 : 0);
+            const keyword_start = directive_match[0].indexOf(directive_match[1]);
+            const path_literal = quoted_path ? `"${file_path}"` : file_path;
+            const path_literal_start = directive_match[0].indexOf(
+                path_literal,
+                keyword_start + directive_match[1].length
+            );
+            if (path_literal_start < 0) return null;
+            const path_start = match_start + path_literal_start + (quoted_path ? 1 : 0);
             const path_end = path_start + file_path.length;
             if (position.character >= path_start &&
                 position.character <= path_end) {

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -1504,7 +1504,7 @@ export class DefinitionProvider {
         }
 
         // Check for path-bearing directives. These are only directives inside
-        // Stata comments; bare `# sight:` text is ordinary invalid Stata code.
+        // Stata comments; bare `sight:` text is ordinary invalid Stata code.
         const directive_match = line_text.match(
             new RegExp(
                 `${DIRECTIVE_PREFIX_PATTERN}(${BACKWARD_DIRECTIVE_KEYWORDS}|${FORWARD_DIRECTIVE_KEYWORDS})` +
@@ -1519,7 +1519,7 @@ export class DefinitionProvider {
 
             // The match ends at the path (including the closing quote when
             // quoted), so compute the span from the end. This is insensitive to
-            // whether the directive used `@lsp-` or `# sight:`.
+            // whether the directive used `@lsp-` or `sight:`.
             const path_start = match_start + directive_match[0].length -
                 file_path.length - (quoted_path ? 1 : 0);
             const path_end = path_start + file_path.length;

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -48,7 +48,7 @@ import * as path from 'path';
 import { URI } from 'vscode-uri';
 import { resolve_path_rich } from '../utils/file-path-utils';
 import { get_line_text } from '../utils/line-utils';
-import { is_cursor_in_comment } from '../utils/comment-utils';
+import { is_cursor_in_comment, is_cursor_in_block_comment } from '../utils/comment-utils';
 import {
     BACKWARD_DIRECTIVE_KEYWORDS,
     FORWARD_DIRECTIVE_KEYWORDS,
@@ -1517,7 +1517,9 @@ export class DefinitionProvider {
         // Check for path-bearing directives. These are only directives inside
         // Stata comments; bare `sight:` text is ordinary invalid Stata code.
         const directive_match = line_text.match(PATH_BEARING_DIRECTIVE_PATTERN);
-        if (directive_match && is_cursor_in_comment(document, position)) {
+        if (directive_match &&
+            is_cursor_in_comment(document, position) &&
+            !is_cursor_in_block_comment(document, position)) {
             const quoted_path = directive_match[2];
             const unquoted_path = directive_match[3];
             const file_path = quoted_path || unquoted_path;

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -49,6 +49,11 @@ import { URI } from 'vscode-uri';
 import { resolve_path_rich } from '../utils/file-path-utils';
 import { get_line_text } from '../utils/line-utils';
 import { is_cursor_in_comment } from '../utils/comment-utils';
+import {
+    BACKWARD_DIRECTIVE_KEYWORDS,
+    FORWARD_DIRECTIVE_KEYWORDS,
+    DIRECTIVE_PREFIX_PATTERN,
+} from '../utils/directives';
 
 /**
  * Definition Provider class.
@@ -1498,28 +1503,25 @@ export class DefinitionProvider {
             }
         }
 
-        // Check for @lsp-* directives
-        const directive_match = line_text.match(/@lsp-(done-by|included-by|do|run|include):?\s+(?:"([^"]+)"|([^\s]+))/);
-        if (directive_match) {
+        // Check for path-bearing directives. These are only directives inside
+        // Stata comments; bare `# sight:` text is ordinary invalid Stata code.
+        const directive_match = line_text.match(
+            new RegExp(
+                `${DIRECTIVE_PREFIX_PATTERN}(${BACKWARD_DIRECTIVE_KEYWORDS}|${FORWARD_DIRECTIVE_KEYWORDS})` +
+                String.raw`:?\s+(?:"([^"]+)"|([^\s]+))`
+            )
+        );
+        if (directive_match && is_cursor_in_comment(document, position)) {
             const quoted_path = directive_match[2];
             const unquoted_path = directive_match[3];
             const file_path = quoted_path || unquoted_path;
             const match_start = directive_match.index!;
 
-            // Locate the path span by walking past the `@lsp-<keyword>:?\s+`
-            // prefix rather than working backward from `match[0].length`. This
-            // stays correct when the path is a substring of the directive
-            // keyword (e.g. `@lsp-do: "do"`) AND when the regex is later
-            // broadened to capture trailing parameters like `line=5` or
-            // `match="..."` in `match[0]`.
-            const DIRECTIVE_PREFIX = '@lsp-';
-            let cursor = match_start + DIRECTIVE_PREFIX.length + directive_match[1].length;
-            if (line_text[cursor] === ':') cursor++;
-            while (cursor < line_text.length && /\s/.test(line_text[cursor])) {
-                cursor++;
-            }
-            if (quoted_path) cursor++; // skip opening quote
-            const path_start = cursor;
+            // The match ends at the path (including the closing quote when
+            // quoted), so compute the span from the end. This is insensitive to
+            // whether the directive used `@lsp-` or `# sight:`.
+            const path_start = match_start + directive_match[0].length -
+                file_path.length - (quoted_path ? 1 : 0);
             const path_end = path_start + file_path.length;
             if (position.character >= path_start &&
                 position.character <= path_end) {

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -53,6 +53,7 @@ import {
     BACKWARD_DIRECTIVE_KEYWORDS,
     FORWARD_DIRECTIVE_KEYWORDS,
     DIRECTIVE_PREFIX_PATTERN,
+    CALL_SITE_PARAMS_FRAGMENT,
 } from '../utils/directives';
 
 // Path-bearing directive line (`done-by`/`run-by`/`included-by`/`do`/`run`/
@@ -62,7 +63,7 @@ import {
 // flag, so it holds no `lastIndex` state and is safe to share across calls.
 const PATH_BEARING_DIRECTIVE_PATTERN = new RegExp(
     `${DIRECTIVE_PREFIX_PATTERN}(${BACKWARD_DIRECTIVE_KEYWORDS}|${FORWARD_DIRECTIVE_KEYWORDS})` +
-    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))(?:\s+(?:line=\d+|match="[^"]+"))*\s*$`
+    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))` + CALL_SITE_PARAMS_FRAGMENT + String.raw`\s*$`
 );
 
 /**

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -28,7 +28,11 @@ import {
 } from '../utils/out-of-scope-message';
 import { undefined_symbol_data_fields } from '../utils/undefined-symbol-diagnostic';
 import { host_is_case_sensitive } from '../utils/file-path-utils';
-import { has_ignore_directive, has_ignore_next_directive } from '../utils/directives';
+import {
+    has_ignore_directive,
+    has_ignore_next_directive,
+    has_trailing_ignore_directive,
+} from '../utils/directives';
 import { IndentationDiagnosticAnalyzer } from './indentation-diagnostics';
 import { OperatorSequenceAnalyzer } from './operator-sequence-diagnostics';
 import { MixedLogicalOperatorAnalyzer } from './mixed-logical-diagnostics';
@@ -740,14 +744,22 @@ export class DiagnosticsProvider {
             return true;
         }
         
-        // Fallback for tests or synthetic document states that did not run the analyzer.
+        // Fallback for tests or synthetic document states that did not run the
+        // analyzer (real documents use the tokenized `ignored_lines` above).
+        // Same-line trailing `// sight: ignore` on the diagnostic line.
+        const current_line = get_line_text(document, diagnostic_line);
+        if (has_trailing_ignore_directive(current_line)) {
+            return true;
+        }
+        // Standalone `// sight: ignore` / `// sight: ignore-next` on the
+        // preceding line targets this (next) statement.
         if (diagnostic_line > 0) {
             const previous_line = get_line_text(document, diagnostic_line - 1);
             if (has_ignore_directive(previous_line) || has_ignore_next_directive(previous_line)) {
                 return true;
             }
         }
-        
+
         return false;
     }
 

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -28,6 +28,7 @@ import {
 } from '../utils/out-of-scope-message';
 import { undefined_symbol_data_fields } from '../utils/undefined-symbol-diagnostic';
 import { host_is_case_sensitive } from '../utils/file-path-utils';
+import { has_ignore_directive, has_ignore_next_directive } from '../utils/directives';
 import { IndentationDiagnosticAnalyzer } from './indentation-diagnostics';
 import { OperatorSequenceAnalyzer } from './operator-sequence-diagnostics';
 import { MixedLogicalOperatorAnalyzer } from './mixed-logical-diagnostics';
@@ -736,18 +737,18 @@ export class DiagnosticsProvider {
         const diagnostic_line = diagnostic_range.start.line;
         const line_count = get_line_count(document);
         
-        // Check current line for @lsp-ignore
+        // Check current line for ignore directive
         if (diagnostic_line < line_count) {
             const current_line = get_line_text(document, diagnostic_line);
-            if (current_line.includes('// @lsp-ignore')) {
+            if (has_ignore_directive(current_line)) {
                 return true;
             }
         }
         
-        // Check previous line for @lsp-ignore-next
+        // Check previous line for ignore-next directive
         if (diagnostic_line > 0) {
             const previous_line = get_line_text(document, diagnostic_line - 1);
-            if (previous_line.includes('// @lsp-ignore-next')) {
+            if (has_ignore_next_directive(previous_line)) {
                 return true;
             }
         }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -735,20 +735,15 @@ export class DiagnosticsProvider {
         diagnostic_range: Range
     ): boolean {
         const diagnostic_line = diagnostic_range.start.line;
-        const line_count = get_line_count(document);
-        
-        // Check current line for ignore directive
-        if (diagnostic_line < line_count) {
-            const current_line = get_line_text(document, diagnostic_line);
-            if (has_ignore_directive(current_line)) {
-                return true;
-            }
+
+        if (document.ignored_lines?.has(diagnostic_line)) {
+            return true;
         }
         
-        // Check previous line for ignore-next directive
+        // Fallback for tests or synthetic document states that did not run the analyzer.
         if (diagnostic_line > 0) {
             const previous_line = get_line_text(document, diagnostic_line - 1);
-            if (has_ignore_next_directive(previous_line)) {
+            if (has_ignore_directive(previous_line) || has_ignore_next_directive(previous_line)) {
                 return true;
             }
         }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -743,9 +743,17 @@ export class DiagnosticsProvider {
         if (document.ignored_lines?.has(diagnostic_line)) {
             return true;
         }
-        
-        // Fallback for tests or synthetic document states that did not run the
-        // analyzer (real documents use the tokenized `ignored_lines` above).
+
+        // Raw-line fallback ONLY for synthetic/error document states that never
+        // ran the tokenized analyzer (no tokens). Documents that were lexed have
+        // an authoritative `ignored_lines` above, computed from comment tokens
+        // that correctly distinguish a real `// sight: ignore` from one that
+        // merely appears inside a `/* ... */` block comment; the raw-line regexes
+        // below cannot make that distinction, so applying them to real documents
+        // would over-suppress.
+        if (document.tokens && document.tokens.length > 0) {
+            return false;
+        }
         // Same-line trailing `// sight: ignore` on the diagnostic line.
         const current_line = get_line_text(document, diagnostic_line);
         if (has_trailing_ignore_directive(current_line)) {

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -526,7 +526,7 @@ export class ScopeResolver {
     ): void {
         if (directive_type === 'included-by' && detected_call_type !== 'include') {
             diagnostics.push({
-                message: `Directive # sight: included-by used but caller uses ${detected_call_type} (not include). Local macros will not be inherited.`,
+                message: `Directive sight: included-by used but caller uses ${detected_call_type} (not include). Local macros will not be inherited.`,
                 range,
                 severity: 'warning',
                 source: {
@@ -555,7 +555,7 @@ export class ScopeResolver {
             const call_site_severity = config.diagnostics?.call_site_identification ?? 'information';
             if (call_site_severity !== 'off') {
                 diagnostics.push({
-                    message: `Directive # sight: done-by used but caller uses include. Full inheritance (including local macros) will occur.`,
+                    message: `Directive sight: done-by used but caller uses include. Full inheritance (including local macros) will occur.`,
                     range,
                     severity: call_site_severity,
                     source: {
@@ -623,7 +623,7 @@ export class ScopeResolver {
                     the_group.find((d) => d.type === 'included-by')?.range ?? the_group[0].range;
                 diagnostics.push({
                     message:
-                        'Both # sight: done-by and # sight: included-by reference the same parent; ' +
+                        'Both sight: done-by and sight: included-by reference the same parent; ' +
                         'treating as included-by (full inheritance).',
                     range: my_range,
                     severity: 'warning',

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -2080,7 +2080,7 @@ export class ScopeResolver {
         // calls as resolution context; the analyzer no longer resolves paths.
         const my_analysis = this.analyzer.analyze(my_parse_result.ast, uri, undefined, {
             working_directory: effective_working_directory,
-        });
+        }, my_lex_result.tokens);
 
         // Combine forward calls from commands and directives.
         // Stamp caller_uri and working_directory on directive calls so every

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -53,6 +53,10 @@ import {
     is_resolvable_static_call,
     type RichResolveFs,
 } from '../utils/file-path-utils';
+import {
+    FORWARD_DIRECTIVE_KEYWORDS,
+    make_directive_pattern,
+} from '../utils/directives';
 
 export {
     get_visible_symbols_at,
@@ -76,8 +80,11 @@ const DEFAULT_CONFIG: ScopeResolverConfig = {
 // state to reset between calls.
 const DO_INCLUDE_PATTERN = build_do_include_pattern('prefix');
 
-// Pattern to match @lsp-do, @lsp-run, @lsp-include directives in comment lines.
-const DIRECTIVE_PATTERN = /@lsp-(do|run|include):?\s+/;
+// Pattern to match forward directives in comment lines.
+const DIRECTIVE_PATTERN = make_directive_pattern(
+    FORWARD_DIRECTIVE_KEYWORDS,
+    String.raw`:?\s+`,
+);
 
 /**
  * Build a Partial<ScopeResolverConfig> with undefined values filtered out.
@@ -519,7 +526,7 @@ export class ScopeResolver {
     ): void {
         if (directive_type === 'included-by' && detected_call_type !== 'include') {
             diagnostics.push({
-                message: `Directive @lsp-included-by used but caller uses ${detected_call_type} (not include). Local macros will not be inherited.`,
+                message: `Directive # sight: included-by used but caller uses ${detected_call_type} (not include). Local macros will not be inherited.`,
                 range,
                 severity: 'warning',
                 source: {
@@ -548,7 +555,7 @@ export class ScopeResolver {
             const call_site_severity = config.diagnostics?.call_site_identification ?? 'information';
             if (call_site_severity !== 'off') {
                 diagnostics.push({
-                    message: `Directive @lsp-done-by used but caller uses include. Full inheritance (including local macros) will occur.`,
+                    message: `Directive # sight: done-by used but caller uses include. Full inheritance (including local macros) will occur.`,
                     range,
                     severity: call_site_severity,
                     source: {
@@ -616,7 +623,7 @@ export class ScopeResolver {
                     the_group.find((d) => d.type === 'included-by')?.range ?? the_group[0].range;
                 diagnostics.push({
                     message:
-                        'Both @lsp-done-by and @lsp-included-by reference the same parent; ' +
+                        'Both # sight: done-by and # sight: included-by reference the same parent; ' +
                         'treating as included-by (full inheritance).',
                     range: my_range,
                     severity: 'warning',
@@ -1732,7 +1739,7 @@ export class ScopeResolver {
 
                         if (!call_validation) {
                             diagnostics.push({
-                                message: `Specified line=${my_directive.call_site.value} does not contain a do/run/include command or @lsp-do/run/include directive.`,
+                                message: `Specified line=${my_directive.call_site.value} does not contain a do/run/include command or forward directive.`,
                                 range: my_directive.range,
                                 severity: 'warning',
                                 source: {

--- a/src/utils/block-comment-utils.ts
+++ b/src/utils/block-comment-utils.ts
@@ -1,16 +1,20 @@
 /**
- * Block-comment line detection.
+ * Multi-line comment continuation detection.
  *
  * LSP directives are honored only in standalone `//` or line-leading `*` line
- * comments; Stata block comments do not carry directives (see
- * docs/declaration-directives.md). The raw-line directive scanners in the
- * directive parser recognize a line as a directive (or a `do`/`include` call)
- * from its leading text, which would also match a line nested inside a
- * multi-line block comment. This helper reports the lines whose FIRST
- * non-whitespace character lies inside a block comment, so those scanners can
- * skip block-commented-out lines while still seeing real code that merely has a
- * trailing block comment (a `do "child.do"` line followed by an inline block
- * comment is still a real call).
+ * comments; a line whose content is actually *inside* a comment that opened on
+ * an earlier line carries no directive (see docs/declaration-directives.md).
+ * The raw-line directive scanners in the directive parser recognize a line as a
+ * directive from its leading text, which would also match a line nested inside a
+ * multi-line comment. This helper reports the CONTINUATION lines of multi-line
+ * comments — both Stata block comments and a line comment that the lexer spans
+ * across lines (such as a line-leading star followed by a block-comment opener)
+ * — so those scanners skip them, matching the token-based analyzer.
+ *
+ * A comment's own opening line is never reported, so a real `// sight: ...`
+ * directive on its own line still parses; and a real code line that merely has a
+ * trailing inline block comment (its leading text is not inside the comment) is
+ * not reported either.
  */
 
 import { Token } from '../types';
@@ -18,18 +22,23 @@ import { StataLexer } from '../lexer';
 import { compute_line_offsets, get_line_text, get_line_count } from './line-utils';
 
 /**
- * Line indices (0-based) whose first non-whitespace character is inside a Stata
- * block comment. `tokens` should be the lexer tokens for `content`; when
- * omitted, `content` is lexed.
+ * Line indices (0-based) whose first non-whitespace character is inside a
+ * multi-line comment that opened on an earlier line. `tokens` should be the
+ * lexer tokens for `content`; when omitted, `content` is lexed.
  */
 export function block_comment_lines(content: string, tokens?: Token[]): Set<number> {
     const the_tokens = tokens ?? new StataLexer().tokenize(content).tokens;
-    const the_block_ranges = the_tokens
-        .filter(my_token => my_token.type === 'COMMENT_BLOCK')
+    // Only multi-line comments have continuation lines to skip. A single-line
+    // comment (the common `// sight: ...` directive, or an inline `/* */`)
+    // never hides a directive on a later line.
+    const the_comment_ranges = the_tokens
+        .filter(my_token =>
+            (my_token.type === 'COMMENT_BLOCK' || my_token.type === 'COMMENT_LINE') &&
+            my_token.range.end.line > my_token.range.start.line)
         .map(my_token => my_token.range);
 
     const the_lines = new Set<number>();
-    if (the_block_ranges.length === 0) {
+    if (the_comment_ranges.length === 0) {
         return the_lines;
     }
 
@@ -41,12 +50,15 @@ export function block_comment_lines(content: string, tokens?: Token[]): Set<numb
         if (my_col < 0) {
             continue; // blank line
         }
-        for (const my_range of the_block_ranges) {
-            const after_start = my_line > my_range.start.line ||
-                (my_line === my_range.start.line && my_col >= my_range.start.character);
+        for (const my_range of the_comment_ranges) {
+            // Only continuation lines (the comment opened on an earlier line)
+            // count; the opening line may legitimately start a directive.
+            if (my_range.start.line >= my_line) {
+                continue;
+            }
             const before_end = my_line < my_range.end.line ||
                 (my_line === my_range.end.line && my_col < my_range.end.character);
-            if (after_start && before_end) {
+            if (before_end) {
                 the_lines.add(my_line);
                 break;
             }

--- a/src/utils/block-comment-utils.ts
+++ b/src/utils/block-comment-utils.ts
@@ -23,14 +23,20 @@ import { compute_line_offsets, get_line_text, get_line_count } from './line-util
 
 /**
  * Line indices (0-based) whose first non-whitespace character is inside a
- * multi-line comment that opened on an earlier line. `tokens` should be the
- * lexer tokens for `content`; when omitted, `content` is lexed.
+ * multi-line comment token. `tokens` should be the lexer tokens for `content`;
+ * when omitted, `content` is lexed.
+ *
+ * Only multi-line comments are considered: a single-line comment (the common
+ * `// sight: ...` directive, or an inline block comment) never hides a
+ * directive, so it is excluded and a real directive on its own line still
+ * parses. Anchoring on the line's first non-whitespace character means a real
+ * code line with a trailing multi-line comment opener (code, then a block
+ * opener) is NOT marked — its leading text is the code, not the comment — while
+ * a comment opener whose leading text is itself the comment (a bare block
+ * opener, or a line-leading-star span) IS marked.
  */
 export function block_comment_lines(content: string, tokens?: Token[]): Set<number> {
     const the_tokens = tokens ?? new StataLexer().tokenize(content).tokens;
-    // Only multi-line comments have continuation lines to skip. A single-line
-    // comment (the common `// sight: ...` directive, or an inline `/* */`)
-    // never hides a directive on a later line.
     const the_comment_ranges = the_tokens
         .filter(my_token =>
             (my_token.type === 'COMMENT_BLOCK' || my_token.type === 'COMMENT_LINE') &&
@@ -51,14 +57,11 @@ export function block_comment_lines(content: string, tokens?: Token[]): Set<numb
             continue; // blank line
         }
         for (const my_range of the_comment_ranges) {
-            // Only continuation lines (the comment opened on an earlier line)
-            // count; the opening line may legitimately start a directive.
-            if (my_range.start.line >= my_line) {
-                continue;
-            }
+            const after_start = my_line > my_range.start.line ||
+                (my_line === my_range.start.line && my_col >= my_range.start.character);
             const before_end = my_line < my_range.end.line ||
                 (my_line === my_range.end.line && my_col < my_range.end.character);
-            if (before_end) {
+            if (after_start && before_end) {
                 the_lines.add(my_line);
                 break;
             }

--- a/src/utils/block-comment-utils.ts
+++ b/src/utils/block-comment-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Block-comment line detection.
+ *
+ * LSP directives are honored only in standalone `//` or line-leading `*` line
+ * comments; Stata block comments do not carry directives (see
+ * docs/declaration-directives.md). The raw-line directive scanners in the
+ * directive parser recognize a line as a directive when its trimmed text starts
+ * with `//` or `*`, which also matches `//`/`*` lines nested inside a multi-line
+ * block comment. These helpers identify the lines covered by a block comment so
+ * those scanners can skip them, matching the token-based analyzer.
+ */
+
+import { Token } from '../types';
+import { StataLexer } from '../lexer';
+
+/**
+ * Line indices (0-based) covered by a Stata block comment, derived from
+ * already-lexed tokens.
+ */
+export function block_comment_lines_from_tokens(tokens: Token[]): Set<number> {
+    const the_lines = new Set<number>();
+    for (const my_token of tokens) {
+        if (my_token.type === 'COMMENT_BLOCK') {
+            for (let my_line = my_token.range.start.line;
+                my_line <= my_token.range.end.line;
+                my_line++) {
+                the_lines.add(my_line);
+            }
+        }
+    }
+    return the_lines;
+}
+
+/**
+ * Line indices (0-based) covered by a Stata block comment in `content`.
+ * Lexes the content; callers that already hold tokens should use
+ * `block_comment_lines_from_tokens` instead.
+ */
+export function block_comment_lines_from_content(content: string): Set<number> {
+    const { tokens } = new StataLexer().tokenize(content);
+    return block_comment_lines_from_tokens(tokens);
+}

--- a/src/utils/block-comment-utils.ts
+++ b/src/utils/block-comment-utils.ts
@@ -4,39 +4,53 @@
  * LSP directives are honored only in standalone `//` or line-leading `*` line
  * comments; Stata block comments do not carry directives (see
  * docs/declaration-directives.md). The raw-line directive scanners in the
- * directive parser recognize a line as a directive when its trimmed text starts
- * with `//` or `*`, which also matches `//`/`*` lines nested inside a multi-line
- * block comment. These helpers identify the lines covered by a block comment so
- * those scanners can skip them, matching the token-based analyzer.
+ * directive parser recognize a line as a directive (or a `do`/`include` call)
+ * from its leading text, which would also match a line nested inside a
+ * multi-line block comment. This helper reports the lines whose FIRST
+ * non-whitespace character lies inside a block comment, so those scanners can
+ * skip block-commented-out lines while still seeing real code that merely has a
+ * trailing block comment (a `do "child.do"` line followed by an inline block
+ * comment is still a real call).
  */
 
 import { Token } from '../types';
 import { StataLexer } from '../lexer';
+import { compute_line_offsets, get_line_text, get_line_count } from './line-utils';
 
 /**
- * Line indices (0-based) covered by a Stata block comment, derived from
- * already-lexed tokens.
+ * Line indices (0-based) whose first non-whitespace character is inside a Stata
+ * block comment. `tokens` should be the lexer tokens for `content`; when
+ * omitted, `content` is lexed.
  */
-export function block_comment_lines_from_tokens(tokens: Token[]): Set<number> {
+export function block_comment_lines(content: string, tokens?: Token[]): Set<number> {
+    const the_tokens = tokens ?? new StataLexer().tokenize(content).tokens;
+    const the_block_ranges = the_tokens
+        .filter(my_token => my_token.type === 'COMMENT_BLOCK')
+        .map(my_token => my_token.range);
+
     const the_lines = new Set<number>();
-    for (const my_token of tokens) {
-        if (my_token.type === 'COMMENT_BLOCK') {
-            for (let my_line = my_token.range.start.line;
-                my_line <= my_token.range.end.line;
-                my_line++) {
+    if (the_block_ranges.length === 0) {
+        return the_lines;
+    }
+
+    const doc = { content, line_offsets: compute_line_offsets(content) };
+    const line_count = get_line_count(doc);
+    for (let my_line = 0; my_line < line_count; my_line++) {
+        const my_text = get_line_text(doc, my_line);
+        const my_col = my_text.search(/\S/);
+        if (my_col < 0) {
+            continue; // blank line
+        }
+        for (const my_range of the_block_ranges) {
+            const after_start = my_line > my_range.start.line ||
+                (my_line === my_range.start.line && my_col >= my_range.start.character);
+            const before_end = my_line < my_range.end.line ||
+                (my_line === my_range.end.line && my_col < my_range.end.character);
+            if (after_start && before_end) {
                 the_lines.add(my_line);
+                break;
             }
         }
     }
     return the_lines;
-}
-
-/**
- * Line indices (0-based) covered by a Stata block comment in `content`.
- * Lexes the content; callers that already hold tokens should use
- * `block_comment_lines_from_tokens` instead.
- */
-export function block_comment_lines_from_content(content: string): Set<number> {
-    const { tokens } = new StataLexer().tokenize(content);
-    return block_comment_lines_from_tokens(tokens);
 }

--- a/src/utils/block-comment-utils.ts
+++ b/src/utils/block-comment-utils.ts
@@ -26,21 +26,22 @@ import { compute_line_offsets, get_line_text, get_line_count } from './line-util
  * multi-line comment token. `tokens` should be the lexer tokens for `content`;
  * when omitted, `content` is lexed.
  *
- * Only multi-line comments are considered: a single-line comment (the common
- * `// sight: ...` directive, or an inline block comment) never hides a
- * directive, so it is excluded and a real directive on its own line still
- * parses. Anchoring on the line's first non-whitespace character means a real
- * code line with a trailing multi-line comment opener (code, then a block
- * opener) is NOT marked — its leading text is the code, not the comment — while
- * a comment opener whose leading text is itself the comment (a bare block
- * opener, or a line-leading-star span) IS marked.
+ * Considered comments are block comments (any — a block comment is never a
+ * directive) and line comments the lexer spans across lines. A single-line
+ * line comment (the common `// sight: ...` directive) is excluded so a real
+ * directive on its own line still parses. Anchoring on the line's first
+ * non-whitespace character means a real code line with a trailing block comment
+ * (code, then a block opener) is NOT marked — its leading text is the code, not
+ * the comment — while a comment whose leading text is itself the comment (a bare
+ * block comment, or a line-leading-star span) IS marked.
  */
 export function block_comment_lines(content: string, tokens?: Token[]): Set<number> {
     const the_tokens = tokens ?? new StataLexer().tokenize(content).tokens;
     const the_comment_ranges = the_tokens
         .filter(my_token =>
-            (my_token.type === 'COMMENT_BLOCK' || my_token.type === 'COMMENT_LINE') &&
-            my_token.range.end.line > my_token.range.start.line)
+            my_token.type === 'COMMENT_BLOCK' ||
+            (my_token.type === 'COMMENT_LINE' &&
+                my_token.range.end.line > my_token.range.start.line))
         .map(my_token => my_token.range);
 
     const the_lines = new Set<number>();

--- a/src/utils/comment-utils.ts
+++ b/src/utils/comment-utils.ts
@@ -34,6 +34,26 @@ function is_cursor_in_comment_from_tokens(tokens: Token[], position: Position): 
     return false;
 }
 
+/**
+ * True when the position falls inside a Stata block comment specifically (not a
+ * `//` / line-leading `*` line comment). Directives are inert inside block
+ * comments, so providers use this to avoid resolving/completing a
+ * directive-looking line that is actually block-commented out.
+ */
+export function is_cursor_in_block_comment(document: DocumentState, position: Position): boolean {
+    if (document.tokens && document.tokens.length > 0) {
+        for (const my_token of document.tokens) {
+            if (my_token.type === 'COMMENT_BLOCK' &&
+                is_position_in_range(position, my_token.range)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    return is_in_block_comment(document.content, position);
+}
+
 function is_cursor_in_comment_heuristic(content: string, position: Position): boolean {
     const doc = { content, line_offsets: compute_line_offsets(content) };
     const current_line = get_line_text(doc, position.line);

--- a/src/utils/comment-utils.ts
+++ b/src/utils/comment-utils.ts
@@ -43,7 +43,13 @@ function is_cursor_in_comment_from_tokens(tokens: Token[], position: Position): 
 export function is_cursor_in_block_comment(document: DocumentState, position: Position): boolean {
     if (document.tokens && document.tokens.length > 0) {
         for (const my_token of document.tokens) {
-            if (my_token.type === 'COMMENT_BLOCK' &&
+            // A block comment is always inert; a line comment is inert only when
+            // the lexer spans it across lines (e.g. a line-leading `*` followed
+            // by a block opener), matching block_comment_lines for the parser.
+            const is_block = my_token.type === 'COMMENT_BLOCK';
+            const is_spanned_line = my_token.type === 'COMMENT_LINE' &&
+                my_token.range.end.line > my_token.range.start.line;
+            if ((is_block || is_spanned_line) &&
                 is_position_in_range(position, my_token.range)) {
                 return true;
             }

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -26,14 +26,28 @@ export function make_directive_pattern(
     return new RegExp(`${DIRECTIVE_PREFIX_PATTERN}(${keywords})${suffix}`, flags);
 }
 
+// These probes run once per line/token during analysis and diagnostics, so the
+// regexes are compiled once at module load rather than on every call (see the
+// "RegExp in Loops" guidance in CLAUDE.md). None carry the global flag, so they
+// hold no `lastIndex` state and are safe to share across calls.
+const DIRECTIVE_PREFIX_REGEX = new RegExp(DIRECTIVE_PREFIX_PATTERN);
+const IGNORE_DIRECTIVE_REGEX = new RegExp(`${DIRECTIVE_PREFIX_PATTERN}ignore:?\\s*$`);
+const IGNORE_NEXT_DIRECTIVE_REGEX = new RegExp(`${DIRECTIVE_PREFIX_PATTERN}ignore-next:?\\s*$`);
+
+// Shared compiled pattern for `@lsp-variables` / `sight: variables` declarations.
+// Capture group 1 is the space-separated variable list.
+export const VARIABLES_DIRECTIVE_PATTERN = new RegExp(
+    `${DIRECTIVE_PREFIX_PATTERN}variables:?\\s+(.+)\\s*$`,
+);
+
 export function has_directive_prefix(text: string): boolean {
-    return new RegExp(DIRECTIVE_PREFIX_PATTERN).test(text);
+    return DIRECTIVE_PREFIX_REGEX.test(text);
 }
 
 export function has_ignore_directive(text: string): boolean {
-    return new RegExp(`${DIRECTIVE_PREFIX_PATTERN}ignore:?\\s*$`).test(text);
+    return IGNORE_DIRECTIVE_REGEX.test(text);
 }
 
 export function has_ignore_next_directive(text: string): boolean {
-    return new RegExp(`${DIRECTIVE_PREFIX_PATTERN}ignore-next:?\\s*$`).test(text);
+    return IGNORE_NEXT_DIRECTIVE_REGEX.test(text);
 }

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -16,13 +16,14 @@ export const FORWARD_DIRECTIVE_KEYWORDS = 'do|run|include';
 export const BACKWARD_DIRECTIVE_KEYWORDS = 'done-by|run-by|included-by';
 
 // Trailing call-site parameters for path-bearing directives: zero or more
-// `line=<n>` / `match="<string>"` params. A `match=` string may embed an
-// escaped quote `\"` (the documented form is `match="do \"analysis.do\""`); a
-// `\` is only special directly before a `"`, so lone backslashes (e.g. Windows
-// paths) stay literal. Non-capturing so it can be embedded in patterns with
-// their own capture groups.
+// `line=<n>` / `match="<string>"` params. A `match=` string must be non-empty
+// (an empty `match=""` matches every line, so it is treated as malformed, as on
+// `main`) and may embed an escaped quote `\"` (the documented form is
+// `match="do \"analysis.do\""`); a `\` is only special directly before a `"`, so
+// lone backslashes (e.g. Windows paths) stay literal. Non-capturing so it can be
+// embedded in patterns with their own capture groups.
 export const CALL_SITE_PARAMS_FRAGMENT =
-    String.raw`(?:\s+(?:line=\d+|match="(?:\\"|[^"])*"))*`;
+    String.raw`(?:\s+(?:line=\d+|match="(?:\\"|[^"])+"))*`;
 export const WORKING_DIR_DIRECTIVE_KEYWORDS =
     'working-directory|working-dir|current-directory|current-dir|cd|wd';
 export const DECLARATION_DIRECTIVE_KEYWORDS =

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared directive prefix handling.
+ *
+ * `# sight:` is the canonical user-facing directive namespace. In Stata files
+ * it still appears inside a Stata comment (`// # sight: ...` or `* # sight: ...`).
+ * The older `@lsp-` prefix remains a permanent alias.
+ */
+
+export const DIRECTIVE_PREFIX_PATTERN = String.raw`(?:@lsp-|#\s*sight:\s*)`;
+
+export const FORWARD_DIRECTIVE_KEYWORDS = 'do|run|include';
+export const BACKWARD_DIRECTIVE_KEYWORDS = 'done-by|run-by|included-by';
+export const WORKING_DIR_DIRECTIVE_KEYWORDS =
+    'working-directory|working-dir|current-directory|current-dir|cd|wd';
+export const DECLARATION_DIRECTIVE_KEYWORDS =
+    'local|global|scalar|matrix|program';
+
+export type DirectivePrefix = '@lsp-' | '# sight:';
+
+export function make_directive_pattern(
+    keywords: string,
+    suffix: string,
+    flags?: string,
+): RegExp {
+    return new RegExp(`${DIRECTIVE_PREFIX_PATTERN}(${keywords})${suffix}`, flags);
+}
+
+export function has_directive_prefix(text: string): boolean {
+    return /@lsp-|#\s*sight:\s*/.test(text);
+}
+
+export function has_ignore_directive(text: string): boolean {
+    return /@lsp-ignore(?!-next)(?=\s|$|[:])|#\s*sight:\s*ignore(?!-next)(?=\s|$|[:])/.test(
+        comment_region(text),
+    );
+}
+
+export function has_ignore_next_directive(text: string): boolean {
+    return /@lsp-ignore-next(?=\s|$|[:])|#\s*sight:\s*ignore-next(?=\s|$|[:])/.test(
+        comment_region(text),
+    );
+}
+
+function comment_region(text: string): string {
+    const trimmed = text.trimStart();
+    if (trimmed.startsWith('*') || trimmed.startsWith('//') || trimmed.startsWith('/*')) {
+        return trimmed;
+    }
+
+    const slash_comment = text.indexOf('//');
+    if (slash_comment >= 0) return text.slice(slash_comment);
+
+    return '';
+}

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -14,6 +14,15 @@ export const DIRECTIVE_PREFIX_PATTERN = String.raw`^\s*(?://|\*)\s*${DIRECTIVE_B
 
 export const FORWARD_DIRECTIVE_KEYWORDS = 'do|run|include';
 export const BACKWARD_DIRECTIVE_KEYWORDS = 'done-by|run-by|included-by';
+
+// Trailing call-site parameters for path-bearing directives: zero or more
+// `line=<n>` / `match="<string>"` params. A `match=` string may embed an
+// escaped quote `\"` (the documented form is `match="do \"analysis.do\""`); a
+// `\` is only special directly before a `"`, so lone backslashes (e.g. Windows
+// paths) stay literal. Non-capturing so it can be embedded in patterns with
+// their own capture groups.
+export const CALL_SITE_PARAMS_FRAGMENT =
+    String.raw`(?:\s+(?:line=\d+|match="(?:\\"|[^"])*"))*`;
 export const WORKING_DIR_DIRECTIVE_KEYWORDS =
     'working-directory|working-dir|current-directory|current-dir|cd|wd';
 export const DECLARATION_DIRECTIVE_KEYWORDS =

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -1,9 +1,12 @@
 /**
  * Shared directive prefix handling.
  *
- * `sight:` is the canonical user-facing directive namespace. Directives must
- * occupy their own Stata line-comment line (`// sight: ...` or `* sight: ...`).
- * The older `@lsp-` prefix remains a permanent alias with the same line shape.
+ * `sight:` is the canonical user-facing directive namespace. Most directives
+ * must occupy their own Stata line-comment line (`// sight: ...` or
+ * `* sight: ...`). `ignore` may also appear as a trailing `//` comment to
+ * suppress diagnostics on that same source line; `ignore-next` always targets
+ * the next non-trivia statement. The older `@lsp-` prefix remains a permanent
+ * alias with the same line shape.
  */
 
 export const DIRECTIVE_BODY_PREFIX_PATTERN = String.raw`(?:@lsp-|sight:\s*)`;

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -70,6 +70,19 @@ export function has_ignore_directive(text: string): boolean {
     return IGNORE_DIRECTIVE_REGEX.test(text);
 }
 
+// Matches a trailing `// sight: ignore` (or `// @lsp-ignore`) on a full source
+// line, i.e. NOT anchored to the start of the line, so it recognizes a same-line
+// suppression comment after code (`gen x = 1 // sight: ignore`). `ignore-next`
+// is excluded by the trailing `$`. Used by the diagnostics fallback for
+// synthetic documents that never ran the tokenized analyzer pass.
+const TRAILING_IGNORE_DIRECTIVE_REGEX = new RegExp(
+    `//\\s*${DIRECTIVE_BODY_PREFIX_PATTERN}ignore:?\\s*$`,
+);
+
+export function has_trailing_ignore_directive(text: string): boolean {
+    return TRAILING_IGNORE_DIRECTIVE_REGEX.test(text);
+}
+
 export function has_ignore_next_directive(text: string): boolean {
     return IGNORE_NEXT_DIRECTIVE_REGEX.test(text);
 }

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -43,6 +43,15 @@ export const VARIABLES_DIRECTIVE_PATTERN = new RegExp(
     `${DIRECTIVE_PREFIX_PATTERN}variables:?\\s+(.+)\\s*$`,
 );
 
+// Shared compiled pattern for declaration directives (`local`/`global`/
+// `scalar`/`matrix`/`program`). Capture group 1 is the keyword, group 2 the
+// space-separated name list. Like the probes above it requires a `//` or
+// line-leading `*` comment prefix, so it never matches text inside a
+// `/* ... */` block comment.
+export const DECLARATION_DIRECTIVE_PATTERN = new RegExp(
+    `${DIRECTIVE_PREFIX_PATTERN}(${DECLARATION_DIRECTIVE_KEYWORDS}):?\\s+(.+)\\s*$`,
+);
+
 export function has_directive_prefix(text: string): boolean {
     return DIRECTIVE_PREFIX_REGEX.test(text);
 }

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -1,12 +1,12 @@
 /**
  * Shared directive prefix handling.
  *
- * `# sight:` is the canonical user-facing directive namespace. In Stata files
- * it still appears inside a Stata comment (`// # sight: ...` or `* # sight: ...`).
+ * `sight:` is the canonical user-facing directive namespace. In Stata files
+ * it appears inside a Stata comment (`// sight: ...` or `* sight: ...`).
  * The older `@lsp-` prefix remains a permanent alias.
  */
 
-export const DIRECTIVE_PREFIX_PATTERN = String.raw`(?:@lsp-|#\s*sight:\s*)`;
+export const DIRECTIVE_PREFIX_PATTERN = String.raw`(?:@lsp-|(?:^|//|\*)\s*sight:\s*)`;
 
 export const FORWARD_DIRECTIVE_KEYWORDS = 'do|run|include';
 export const BACKWARD_DIRECTIVE_KEYWORDS = 'done-by|run-by|included-by';
@@ -15,7 +15,7 @@ export const WORKING_DIR_DIRECTIVE_KEYWORDS =
 export const DECLARATION_DIRECTIVE_KEYWORDS =
     'local|global|scalar|matrix|program';
 
-export type DirectivePrefix = '@lsp-' | '# sight:';
+export type DirectivePrefix = '@lsp-' | 'sight:';
 
 export function make_directive_pattern(
     keywords: string,
@@ -26,17 +26,17 @@ export function make_directive_pattern(
 }
 
 export function has_directive_prefix(text: string): boolean {
-    return /@lsp-|#\s*sight:\s*/.test(text);
+    return /@lsp-|(?:^|\/\/|\*)\s*sight:\s*/.test(text);
 }
 
 export function has_ignore_directive(text: string): boolean {
-    return /@lsp-ignore(?!-next)(?=\s|$|[:])|#\s*sight:\s*ignore(?!-next)(?=\s|$|[:])/.test(
+    return /@lsp-ignore(?!-next)(?=\s|$|[:])|(?:^|\/\/|\*)\s*sight:\s*ignore(?!-next)(?=\s|$|[:])/.test(
         comment_region(text),
     );
 }
 
 export function has_ignore_next_directive(text: string): boolean {
-    return /@lsp-ignore-next(?=\s|$|[:])|#\s*sight:\s*ignore-next(?=\s|$|[:])/.test(
+    return /@lsp-ignore-next(?=\s|$|[:])|(?:^|\/\/|\*)\s*sight:\s*ignore-next(?=\s|$|[:])/.test(
         comment_region(text),
     );
 }

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -1,12 +1,13 @@
 /**
  * Shared directive prefix handling.
  *
- * `sight:` is the canonical user-facing directive namespace. In Stata files
- * it appears inside a Stata comment (`// sight: ...` or `* sight: ...`).
- * The older `@lsp-` prefix remains a permanent alias.
+ * `sight:` is the canonical user-facing directive namespace. Directives must
+ * occupy their own Stata line-comment line (`// sight: ...` or `* sight: ...`).
+ * The older `@lsp-` prefix remains a permanent alias with the same line shape.
  */
 
-export const DIRECTIVE_PREFIX_PATTERN = String.raw`(?:@lsp-|(?:^|//|\*)\s*sight:\s*)`;
+export const DIRECTIVE_BODY_PREFIX_PATTERN = String.raw`(?:@lsp-|sight:\s*)`;
+export const DIRECTIVE_PREFIX_PATTERN = String.raw`^\s*(?://|\*)\s*${DIRECTIVE_BODY_PREFIX_PATTERN}`;
 
 export const FORWARD_DIRECTIVE_KEYWORDS = 'do|run|include';
 export const BACKWARD_DIRECTIVE_KEYWORDS = 'done-by|run-by|included-by';
@@ -26,29 +27,13 @@ export function make_directive_pattern(
 }
 
 export function has_directive_prefix(text: string): boolean {
-    return /@lsp-|(?:^|\/\/|\*)\s*sight:\s*/.test(text);
+    return new RegExp(DIRECTIVE_PREFIX_PATTERN).test(text);
 }
 
 export function has_ignore_directive(text: string): boolean {
-    return /@lsp-ignore(?!-next)(?=\s|$|[:])|(?:^|\/\/|\*)\s*sight:\s*ignore(?!-next)(?=\s|$|[:])/.test(
-        comment_region(text),
-    );
+    return new RegExp(`${DIRECTIVE_PREFIX_PATTERN}ignore:?\\s*$`).test(text);
 }
 
 export function has_ignore_next_directive(text: string): boolean {
-    return /@lsp-ignore-next(?=\s|$|[:])|(?:^|\/\/|\*)\s*sight:\s*ignore-next(?=\s|$|[:])/.test(
-        comment_region(text),
-    );
-}
-
-function comment_region(text: string): string {
-    const trimmed = text.trimStart();
-    if (trimmed.startsWith('*') || trimmed.startsWith('//') || trimmed.startsWith('/*')) {
-        return trimmed;
-    }
-
-    const slash_comment = text.indexOf('//');
-    if (slash_comment >= 0) return text.slice(slash_comment);
-
-    return '';
+    return new RegExp(`${DIRECTIVE_PREFIX_PATTERN}ignore-next:?\\s*$`).test(text);
 }

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -20,6 +20,7 @@ export const FILE_COMMANDS = new Set([
 // LSP directives that accept file paths
 export const PATH_DIRECTIVES = new Set([
   '@lsp-done-by',
+  '@lsp-run-by',
   '@lsp-included-by', 
   '@lsp-do',
   '@lsp-run',
@@ -50,7 +51,8 @@ export function isFileCommand(command: string): boolean {
  * Check if a directive accepts file paths
  */
 export function isPathDirective(directive: string): boolean {
-  return PATH_DIRECTIVES.has(directive.toLowerCase());
+  const normalized = directive.trim().toLowerCase().replace(/^#\s*sight:\s*/, '@lsp-');
+  return PATH_DIRECTIVES.has(normalized);
 }
 
 /**

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -48,11 +48,15 @@ export function isFileCommand(command: string): boolean {
 }
 
 /**
- * Check if a directive accepts file paths
+ * Check if a directive accepts file paths.
+ *
+ * Case-sensitive on the keyword: the directive parser matches keywords
+ * case-sensitively (lowercase only), so completion must not offer directive
+ * path completion for a form the parser would silently ignore (e.g. `sight: Do`).
+ * Only the canonical `sight:` prefix is rewritten to its `@lsp-` alias.
  */
 export function isPathDirective(directive: string): boolean {
-  const normalized = directive.trim().toLowerCase()
-    .replace(/^sight:\s*/, '@lsp-');
+  const normalized = directive.trim().replace(/^sight:\s*/, '@lsp-');
   return PATH_DIRECTIVES.has(normalized);
 }
 

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -51,7 +51,8 @@ export function isFileCommand(command: string): boolean {
  * Check if a directive accepts file paths
  */
 export function isPathDirective(directive: string): boolean {
-  const normalized = directive.trim().toLowerCase().replace(/^#\s*sight:\s*/, '@lsp-');
+  const normalized = directive.trim().toLowerCase()
+    .replace(/^sight:\s*/, '@lsp-');
   return PATH_DIRECTIVES.has(normalized);
 }
 

--- a/tests/integration/callee-revalidation.test.ts
+++ b/tests/integration/callee-revalidation.test.ts
@@ -207,7 +207,7 @@ local result = 1
 
             // Check that a mismatch warning was generated
             const mismatch_warnings = resolved_scope.diagnostics.filter(d =>
-                d.message.includes('Directive # sight: included-by used but caller uses do')
+                d.message.includes('Directive sight: included-by used but caller uses do')
             );
             expect(mismatch_warnings.length).toBe(1);
             expect(mismatch_warnings[0].severity).toBe('warning');
@@ -232,7 +232,7 @@ local result = 1
 
             // Check that a mismatch warning was generated via text inference
             const mismatch_warnings = resolved_scope.diagnostics.filter(d =>
-                d.message.includes('Directive # sight: included-by used but caller uses do (not include)')
+                d.message.includes('Directive sight: included-by used but caller uses do (not include)')
             );
             expect(mismatch_warnings.length).toBe(1);
             expect(mismatch_warnings[0].severity).toBe('warning');

--- a/tests/integration/callee-revalidation.test.ts
+++ b/tests/integration/callee-revalidation.test.ts
@@ -207,7 +207,7 @@ local result = 1
 
             // Check that a mismatch warning was generated
             const mismatch_warnings = resolved_scope.diagnostics.filter(d =>
-                d.message.includes('Directive @lsp-included-by used but caller uses do')
+                d.message.includes('Directive # sight: included-by used but caller uses do')
             );
             expect(mismatch_warnings.length).toBe(1);
             expect(mismatch_warnings[0].severity).toBe('warning');
@@ -232,7 +232,7 @@ local result = 1
 
             // Check that a mismatch warning was generated via text inference
             const mismatch_warnings = resolved_scope.diagnostics.filter(d =>
-                d.message.includes('Directive @lsp-included-by used but caller uses do (not include)')
+                d.message.includes('Directive # sight: included-by used but caller uses do (not include)')
             );
             expect(mismatch_warnings.length).toBe(1);
             expect(mismatch_warnings[0].severity).toBe('warning');

--- a/tests/integration/comprehensive-fixes.test.ts
+++ b/tests/integration/comprehensive-fixes.test.ts
@@ -396,7 +396,8 @@ program define main_program
 end
 
 // Test diagnostics with suppression
-local undefined_test \`nonexistent_macro'  // @lsp-ignore
+// @lsp-ignore
+local undefined_test \`nonexistent_macro'
 `;
 
             const main_path = write_file('main.do', main_content);
@@ -422,7 +423,7 @@ local undefined_test \`nonexistent_macro'  // @lsp-ignore
             const document = create_document_state(main_content);
             const diagnostics = await diagnostics_provider.get_diagnostics(document, config);
             const suppressed_diags = diagnostics.filter(
-                d => d.range.start.line === 9 && d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                d => d.range.start.line === 10 && d.code === StataDiagnosticCode.UNDEFINED_MACRO
             );
             expect(suppressed_diags).toHaveLength(0); // Should be suppressed by @lsp-ignore
 

--- a/tests/integration/cross-file-awareness.test.ts
+++ b/tests/integration/cross-file-awareness.test.ts
@@ -348,7 +348,7 @@ describe('Cross-File Awareness Integration', () => {
 
             // Should warn about conflicting directives
             const conflict_warning = resolved_scope.diagnostics.find((d) =>
-                d.message.includes('Both # sight: done-by and # sight: included-by')
+                d.message.includes('Both sight: done-by and sight: included-by')
             );
             expect(conflict_warning).toBeDefined();
         });

--- a/tests/integration/cross-file-awareness.test.ts
+++ b/tests/integration/cross-file-awareness.test.ts
@@ -348,7 +348,7 @@ describe('Cross-File Awareness Integration', () => {
 
             // Should warn about conflicting directives
             const conflict_warning = resolved_scope.diagnostics.find((d) =>
-                d.message.includes('Both @lsp-done-by and @lsp-included-by')
+                d.message.includes('Both # sight: done-by and # sight: included-by')
             );
             expect(conflict_warning).toBeDefined();
         });

--- a/tests/integration/out-of-scope-diagnostic-cleanup.test.ts
+++ b/tests/integration/out-of-scope-diagnostic-cleanup.test.ts
@@ -225,11 +225,12 @@ describe('Out-of-scope diagnostic cleanup integration', () => {
         ).toBe(false);
     });
 
-    it('suppresses same-line ignore rewrites for same-file, backward, and forward cases', async () => {
+    it('suppresses standalone ignore rewrites for same-file, backward, and forward cases', async () => {
         const same_file_diags = await diagnose_target(
             'same_file_ignore.do',
             [
-                'display `same_file_macro\' // @lsp-ignore',
+                '// @lsp-ignore',
+                'display `same_file_macro\'',
                 'local same_file_macro "value"',
             ].join('\n'),
         );
@@ -245,7 +246,8 @@ describe('Out-of-scope diagnostic cleanup integration', () => {
             'backward_ignore_child.do',
             [
                 '// @lsp-done-by "backward_ignore_parent.do"',
-                'display $after_global // @lsp-ignore',
+                '// @lsp-ignore',
+                'display $after_global',
             ].join('\n'),
             [
                 {
@@ -269,7 +271,8 @@ describe('Out-of-scope diagnostic cleanup integration', () => {
             'forward_ignore_main.do',
             [
                 'do "forward_ignore_child.do"',
-                'display `forward_macro\' // @lsp-ignore',
+                '// @lsp-ignore',
+                'display `forward_macro\'',
             ].join('\n'),
             [
                 {

--- a/tests/property/declaration-directive-parsing.prop.test.ts
+++ b/tests/property/declaration-directive-parsing.prop.test.ts
@@ -277,6 +277,8 @@ gen x = 1`;
                 ['global', 'config'],
                 ['scalar', 'my_scalar'],
             ]);
+            // Alias-equivalence: canonical `sight:` forms parse without warnings.
+            expect(result.diagnostics.length).toBe(0);
         });
     });
 });

--- a/tests/property/declaration-directive-parsing.prop.test.ts
+++ b/tests/property/declaration-directive-parsing.prop.test.ts
@@ -264,5 +264,19 @@ gen x = 1`;
             expect(result.declaration_directives.length).toBe(1);
             expect(result.declaration_directives[0].type).toBe('local');
         });
+
+        test('canonical # sight declaration directives parse like @lsp aliases', () => {
+            const content = `// # sight: local myvar
+* # sight: global config
+// # sight: scalar: my_scalar`;
+
+            const result = parser.parse(content, 'file:///test.do');
+
+            expect(result.declaration_directives.map(d => [d.type, d.name])).toEqual([
+                ['local', 'myvar'],
+                ['global', 'config'],
+                ['scalar', 'my_scalar'],
+            ]);
+        });
     });
 });

--- a/tests/property/declaration-directive-parsing.prop.test.ts
+++ b/tests/property/declaration-directive-parsing.prop.test.ts
@@ -265,10 +265,10 @@ gen x = 1`;
             expect(result.declaration_directives[0].type).toBe('local');
         });
 
-        test('canonical # sight declaration directives parse like @lsp aliases', () => {
-            const content = `// # sight: local myvar
-* # sight: global config
-// # sight: scalar: my_scalar`;
+        test('canonical sight declaration directives parse like aliases', () => {
+            const content = `// sight: local myvar
+* sight: global config
+// sight: scalar: my_scalar`;
 
             const result = parser.parse(content, 'file:///test.do');
 

--- a/tests/property/diagnostic-suppression.test.ts
+++ b/tests/property/diagnostic-suppression.test.ts
@@ -58,14 +58,14 @@ describe('Diagnostic Suppression Property Tests', () => {
     });
 
     /**
-     * Property: @lsp-ignore suppresses diagnostics on same line
+     * Property: @lsp-ignore suppresses diagnostics on following statement
      */
-    it('should suppress undefined macro diagnostics with @lsp-ignore on same line', async () => {
+    it('should suppress undefined macro diagnostics with standalone @lsp-ignore', async () => {
         await fc.assert(
             fc.asyncProperty(
                 arbitrary_non_reserved_identifier(),
                 async (macro_name: string) => {
-                    const content = `local result \`${macro_name}' // @lsp-ignore`;
+                    const content = `// @lsp-ignore\nlocal result \`${macro_name}'`;
                     const my_document = create_document_state(content);
                     
                     const the_diagnostics = await my_diagnostics_provider.get_diagnostics(
@@ -123,7 +123,7 @@ describe('Diagnostic Suppression Property Tests', () => {
                 fc.constantFrom('@lsp-ignore', '@lsp-ignore-next'),
                 async (var_name: string, suppress_type: string) => {
                     const content = suppress_type === '@lsp-ignore'
-                        ? `summarize ${var_name} // @lsp-ignore`
+                        ? `// @lsp-ignore\nsummarize ${var_name}`
                         : `// @lsp-ignore-next\nsummarize ${var_name}`;
                     
                     const my_document = create_document_state(content);
@@ -184,7 +184,7 @@ describe('Diagnostic Suppression Property Tests', () => {
                 async (macro1: string, macro2: string) => {
                     fc.pre(macro1 !== macro2); // Ensure different macro names
                     
-                    const content = `local result1 \`${macro1}' // @lsp-ignore\nlocal result2 \`${macro2}'`;
+                    const content = `// @lsp-ignore\nlocal result1 \`${macro1}'\nlocal result2 \`${macro2}'`;
                     const my_document = create_document_state(content);
                     
                     const the_diagnostics = await my_diagnostics_provider.get_diagnostics(
@@ -198,7 +198,7 @@ describe('Diagnostic Suppression Property Tests', () => {
                     );
                     
                     return undefined_macro_diags.length === 1 &&
-                           undefined_macro_diags[0].range.start.line === 1; // Second line (0-indexed)
+                           undefined_macro_diags[0].range.start.line === 2; // Third line (0-indexed)
                 }
             ),
             { numRuns: 50 }
@@ -344,7 +344,7 @@ describe('Diagnostic Suppression Property Tests', () => {
                 fc.constantFrom('@lsp-ignore', '@lsp-ignore-next'),
                 async (macro_name: string, suppress_type: string) => {
                     const suppressed_content = suppress_type === '@lsp-ignore'
-                        ? `display \`${macro_name}' // @lsp-ignore\nlocal ${macro_name} value`
+                        ? `// @lsp-ignore\ndisplay \`${macro_name}'\nlocal ${macro_name} value`
                         : `// @lsp-ignore-next\ndisplay \`${macro_name}'\nlocal ${macro_name} value`;
                     const control_content = `display \`${macro_name}'\nlocal ${macro_name} value`;
 

--- a/tests/property/directive-call-site-diagnostics.prop.test.ts
+++ b/tests/property/directive-call-site-diagnostics.prop.test.ts
@@ -235,7 +235,13 @@ describe('Directive Call Site Diagnostics Property Tests', () => {
         test('emits warning when match= string is not found', async () => {
             await fc.assert(
                 fc.asyncProperty(
-                    fc.string({ minLength: 5, maxLength: 20 }).filter(s => !s.includes('\n') && !s.includes('"')),
+                    // `match=` supports `\"` escaped quotes, so a `\` directly
+                    // before the closing quote is an escape, not a literal.
+                    // Exclude trailing backslashes (and `"`/newlines) so the
+                    // generated value is an unambiguous, plain search string.
+                    fc.string({ minLength: 5, maxLength: 20 }).filter(
+                        s => !s.includes('\n') && !s.includes('"') && !s.endsWith('\\')
+                    ),
                     async (match_string) => {
                         // Create parent file without the match string
                         const parent_content = `local x = 1\ndo "other.do"\nlocal z = 3`;

--- a/tests/property/directive-path-completion.prop.test.ts
+++ b/tests/property/directive-path-completion.prop.test.ts
@@ -122,13 +122,13 @@ describe('Directive Path Completion Property Tests', () => {
     );
   });
 
-  it('should detect canonical # sight directive path contexts', () => {
+  it('should detect canonical sight directive path contexts', () => {
     fc.assert(
       fc.property(
         fc.constantFrom('done-by', 'run-by', 'included-by', 'do', 'run', 'include', 'wd', 'cd'),
         arbitrary_partial_path(),
         (my_keyword, my_partial_path) => {
-          const my_directive = `# sight: ${my_keyword}`;
+          const my_directive = `sight: ${my_keyword}`;
           const my_line = `// ${my_directive}: ${my_partial_path}`;
           const my_document = create_mock_document(my_line);
           const my_position = Position.create(0, my_line.length);

--- a/tests/property/directive-path-completion.prop.test.ts
+++ b/tests/property/directive-path-completion.prop.test.ts
@@ -122,6 +122,30 @@ describe('Directive Path Completion Property Tests', () => {
     );
   });
 
+  it('should detect canonical # sight directive path contexts', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom('done-by', 'run-by', 'included-by', 'do', 'run', 'include', 'wd', 'cd'),
+        arbitrary_partial_path(),
+        (my_keyword, my_partial_path) => {
+          const my_directive = `# sight: ${my_keyword}`;
+          const my_line = `// ${my_directive}: ${my_partial_path}`;
+          const my_document = create_mock_document(my_line);
+          const my_position = Position.create(0, my_line.length);
+
+          const my_context = detect_completion_context(my_document, my_position);
+
+          expect(my_context.type).toBe('directive_path');
+          if (my_context.type === 'directive_path') {
+            expect(my_context.directive).toBe(my_directive);
+            expect(my_context.partial_path).toBe(my_partial_path);
+          }
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
   /**
    * Property 7: Stata File Filtering
    * Directive path completions should prioritize Stata file extensions.

--- a/tests/property/directive-path-completion.prop.test.ts
+++ b/tests/property/directive-path-completion.prop.test.ts
@@ -3,7 +3,23 @@ import * as fc from 'fast-check';
 import { detect_completion_context } from '../../src/providers/completion';
 import { DocumentState } from '../../src/document-store';
 import { Position } from 'vscode-languageserver';
-import { PATH_DIRECTIVES, STATA_FILE_EXTENSIONS } from '../../src/utils/file-path-utils';
+import { PATH_DIRECTIVES, STATA_FILE_EXTENSIONS, isPathDirective } from '../../src/utils/file-path-utils';
+
+describe('isPathDirective case-sensitivity', () => {
+  it('accepts canonical lowercase directive keywords', () => {
+    expect(isPathDirective('sight: do')).toBe(true);
+    expect(isPathDirective('sight: done-by')).toBe(true);
+    expect(isPathDirective('@lsp-include')).toBe(true);
+  });
+
+  it('rejects uppercase keywords the parser would ignore', () => {
+    // The directive parser matches keywords case-sensitively, so completion
+    // must not offer path completion for forms it would silently drop.
+    expect(isPathDirective('sight: Do')).toBe(false);
+    expect(isPathDirective('sight: Done-By')).toBe(false);
+    expect(isPathDirective('@lsp-Do')).toBe(false);
+  });
+});
 
 /**
  * Property tests for directive path completion functionality.

--- a/tests/property/operator-sequence-diagnostics.prop.test.ts
+++ b/tests/property/operator-sequence-diagnostics.prop.test.ts
@@ -1745,21 +1745,20 @@ describe('Embedded Context Suppression Property Tests', () => {
 /**
  * Feature: malformed-operator-diagnostics, Property 7: Directive suppression
  *
- * For any malformed operator pair on a line annotated with `@lsp-ignore` (same line)
- * or targeted by `@lsp-ignore-next` (preceding comment line), the analyzer should
+ * For any malformed operator pair targeted by a preceding standalone
+ * `@lsp-ignore` or `@lsp-ignore-next` comment line, the analyzer should
  * emit zero diagnostics for that pair.
  *
  * Validates: Requirements 7.1, 7.2
  */
 describe('Directive Suppression Property Tests', () => {
     /**
-     * Property 7: @lsp-ignore suppresses malformed operator diagnostics on same line
+     * Property 7: @lsp-ignore suppresses malformed operator diagnostics on the following statement
      *
-     * For any malformed operator pair on a line with `@lsp-ignore` comment
-     * (in any comment style: //, *, or block comments), the analyzer should emit zero
-     * operator sequence diagnostics.
+     * For any malformed operator pair targeted by a standalone `@lsp-ignore`
+     * comment line, the analyzer should emit zero operator sequence diagnostics.
      */
-    test('@lsp-ignore suppresses malformed operator diagnostics on same line', () => {
+    test('@lsp-ignore suppresses malformed operator diagnostics on following statement', () => {
         // Define all malformed pairs (both suggestible and invalid)
         const MALFORMED_PAIRS: Array<{ first: string; second: string }> = [
             // Suggestible pairs
@@ -1791,13 +1790,7 @@ describe('Directive Suppression Property Tests', () => {
         // Generator for malformed pairs
         const arbitrary_malformed_pair = fc.constantFrom(...MALFORMED_PAIRS);
 
-        // Generator for comment styles for @lsp-ignore (inline comments)
-        // Note: * comment style cannot be used inline (must be at start of line)
-        // so we test // and /* */ for inline @lsp-ignore
-        const arbitrary_inline_comment_style = fc.constantFrom(
-            '//',     // Slash-slash comment
-            '/* */',  // Block comment
-        );
+        const arbitrary_comment_style = fc.constantFrom('//', '*');
 
         // Default config with default severities
         const my_config: StataLSPConfig = {
@@ -1843,19 +1836,13 @@ describe('Directive Suppression Property Tests', () => {
         fc.assert(
             fc.property(
                 arbitrary_malformed_pair,
-                arbitrary_inline_comment_style,
+                arbitrary_comment_style,
                 arbitrary_identifier(),
                 arbitrary_identifier(),
                 (my_pair, my_comment_style, my_lhs, my_rhs) => {
-                    // Build source with the malformed pair and @lsp-ignore on same line
-                    let my_source: string;
-                    if (my_comment_style === '/* */') {
-                        // Block comment style
-                        my_source = `display ${my_lhs} ${my_pair.first} ${my_pair.second} ${my_rhs} /* @lsp-ignore */`;
-                    } else {
-                        // Slash-slash comment style
-                        my_source = `display ${my_lhs} ${my_pair.first} ${my_pair.second} ${my_rhs} // @lsp-ignore`;
-                    }
+                    const my_source =
+                        `${my_comment_style} @lsp-ignore\n` +
+                        `display ${my_lhs} ${my_pair.first} ${my_pair.second} ${my_rhs}`;
 
                     // Create document state (tokenizes, parses, analyzes)
                     const my_doc_state = create_document_state(my_source);
@@ -1870,7 +1857,7 @@ describe('Directive Suppression Property Tests', () => {
                             my_d.code === StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
                     );
 
-                    // Should emit zero diagnostics because the line has @lsp-ignore
+                    // Should emit zero diagnostics because the preceding line has @lsp-ignore
                     expect(my_operator_diagnostics).toHaveLength(0);
 
                     return true;
@@ -1884,7 +1871,7 @@ describe('Directive Suppression Property Tests', () => {
      * Property 7: @lsp-ignore-next suppresses malformed operator diagnostics on next line
      *
      * For any malformed operator pair on a line targeted by `@lsp-ignore-next`
-     * in a preceding comment (in any comment style: //, *, or block comments), the analyzer
+     * in a preceding // or * comment line, the analyzer
      * should emit zero operator sequence diagnostics.
      */
     test('@lsp-ignore-next suppresses malformed operator diagnostics on next line', () => {
@@ -1919,11 +1906,9 @@ describe('Directive Suppression Property Tests', () => {
         // Generator for malformed pairs
         const arbitrary_malformed_pair = fc.constantFrom(...MALFORMED_PAIRS);
 
-        // Generator for comment styles for @lsp-ignore-next (all three styles)
         const arbitrary_comment_style = fc.constantFrom(
             '//',     // Slash-slash comment
             '*',      // Star comment (at start of line)
-            '/* */',  // Block comment
         );
 
         // Default config with default severities
@@ -1976,16 +1961,8 @@ describe('Directive Suppression Property Tests', () => {
                 (my_pair, my_comment_style, my_lhs, my_rhs) => {
                     // Build source with @lsp-ignore-next on previous line
                     let my_source: string;
-                    if (my_comment_style === '*') {
-                        // Star comment must be at start of line
-                        my_source = `* @lsp-ignore-next\ndisplay ${my_lhs} ${my_pair.first} ${my_pair.second} ${my_rhs}`;
-                    } else if (my_comment_style === '/* */') {
-                        // Block comment style
-                        my_source = `/* @lsp-ignore-next */\ndisplay ${my_lhs} ${my_pair.first} ${my_pair.second} ${my_rhs}`;
-                    } else {
-                        // Slash-slash comment
-                        my_source = `// @lsp-ignore-next\ndisplay ${my_lhs} ${my_pair.first} ${my_pair.second} ${my_rhs}`;
-                    }
+                    my_source = `${my_comment_style} @lsp-ignore-next\n` +
+                        `display ${my_lhs} ${my_pair.first} ${my_pair.second} ${my_rhs}`;
 
                     // Create document state (tokenizes, parses, analyzes)
                     const my_doc_state = create_document_state(my_source);

--- a/tests/property/run-by-parsing-equivalence.prop.test.ts
+++ b/tests/property/run-by-parsing-equivalence.prop.test.ts
@@ -195,6 +195,6 @@ describe('Property 6: @lsp-run-by Parsing Equivalence', () => {
         expect(result.directives.length).toBe(0);
         expect(result.diagnostics.length).toBe(1);
         expect(result.diagnostics[0].severity).toBe('warning');
-        expect(result.diagnostics[0].message).toContain('# sight: run-by');
+        expect(result.diagnostics[0].message).toContain('sight: run-by');
     });
 });

--- a/tests/property/run-by-parsing-equivalence.prop.test.ts
+++ b/tests/property/run-by-parsing-equivalence.prop.test.ts
@@ -195,6 +195,6 @@ describe('Property 6: @lsp-run-by Parsing Equivalence', () => {
         expect(result.directives.length).toBe(0);
         expect(result.diagnostics.length).toBe(1);
         expect(result.diagnostics[0].severity).toBe('warning');
-        expect(result.diagnostics[0].message).toContain('@lsp-run-by');
+        expect(result.diagnostics[0].message).toContain('# sight: run-by');
     });
 });

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -570,9 +570,10 @@ display \`undefined_macro'
             expect(undefined_diags.length).toBe(0);
         });
 
-        it('should suppress diagnostics with @lsp-ignore on same line', () => {
+        it('should suppress diagnostics with standalone @lsp-ignore', () => {
             const result = analyze(`
-display \`undefined_macro' // @lsp-ignore
+// @lsp-ignore
+display \`undefined_macro'
 `, { undefined_macro_enabled: true });
             
             const undefined_diags = result.diagnostics.filter(
@@ -582,15 +583,16 @@ display \`undefined_macro' // @lsp-ignore
         });
 
         it('should suppress diagnostics with canonical sight ignore directives', () => {
-            const same_line = analyze(`
-display \`undefined_macro' // sight: ignore
+            const ignore = analyze(`
+// sight: ignore
+display \`undefined_macro'
 `, { undefined_macro_enabled: true });
             const next_line = analyze(`
 // sight: ignore-next
 display \`undefined_macro'
 `, { undefined_macro_enabled: true });
 
-            expect(same_line.diagnostics.filter(
+            expect(ignore.diagnostics.filter(
                 d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
             ).length).toBe(0);
             expect(next_line.diagnostics.filter(
@@ -604,6 +606,7 @@ display \`undefined_macro' * sight: ignore
 display \`another_macro' // sight: ignoreme
 sight: ignore-next
 display \`hash_prefixed_macro' // # sight: ignore
+display \`inline_macro' // sight: ignore
 display \`bare_directive_macro'
 `, { undefined_macro_enabled: true });
 
@@ -613,6 +616,7 @@ display \`bare_directive_macro'
             expect(undefined_diags.some(d => d.message.includes('undefined_macro'))).toBe(true);
             expect(undefined_diags.some(d => d.message.includes('another_macro'))).toBe(true);
             expect(undefined_diags.some(d => d.message.includes('hash_prefixed_macro'))).toBe(true);
+            expect(undefined_diags.some(d => d.message.includes('inline_macro'))).toBe(true);
             expect(undefined_diags.some(d => d.message.includes('bare_directive_macro'))).toBe(true);
         });
 

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -600,13 +600,36 @@ display \`undefined_macro'
             ).length).toBe(0);
         });
 
+        it('should suppress diagnostics with inline sight ignore comments', () => {
+            const ignore = analyze(`
+display \`inline_macro' // sight: ignore
+`, { undefined_macro_enabled: true });
+
+            const undefined_diags = ignore.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(undefined_diags.some(d => d.message.includes('inline_macro'))).toBe(false);
+        });
+
+        it('should apply inline sight ignore-next to the following statement', () => {
+            const ignore = analyze(`
+display \`current_macro' // sight: ignore-next
+display \`next_macro'
+`, { undefined_macro_enabled: true });
+
+            const undefined_diags = ignore.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(undefined_diags.some(d => d.message.includes('current_macro'))).toBe(true);
+            expect(undefined_diags.some(d => d.message.includes('next_macro'))).toBe(false);
+        });
+
         it('should not suppress diagnostics for sight lookalikes in code', () => {
             const result = analyze(`
 display \`undefined_macro' * sight: ignore
 display \`another_macro' // sight: ignoreme
 sight: ignore-next
 display \`hash_prefixed_macro' // # sight: ignore
-display \`inline_macro' // sight: ignore
 display \`bare_directive_macro'
 `, { undefined_macro_enabled: true });
 
@@ -616,7 +639,6 @@ display \`bare_directive_macro'
             expect(undefined_diags.some(d => d.message.includes('undefined_macro'))).toBe(true);
             expect(undefined_diags.some(d => d.message.includes('another_macro'))).toBe(true);
             expect(undefined_diags.some(d => d.message.includes('hash_prefixed_macro'))).toBe(true);
-            expect(undefined_diags.some(d => d.message.includes('inline_macro'))).toBe(true);
             expect(undefined_diags.some(d => d.message.includes('bare_directive_macro'))).toBe(true);
         });
 

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -581,6 +581,37 @@ display \`undefined_macro' // @lsp-ignore
             expect(undefined_diags.length).toBe(0);
         });
 
+        it('should suppress diagnostics with canonical # sight ignore directives', () => {
+            const same_line = analyze(`
+display \`undefined_macro' // # sight: ignore
+`, { undefined_macro_enabled: true });
+            const next_line = analyze(`
+// # sight: ignore-next
+display \`undefined_macro'
+`, { undefined_macro_enabled: true });
+
+            expect(same_line.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            ).length).toBe(0);
+            expect(next_line.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            ).length).toBe(0);
+        });
+
+        it('should not suppress diagnostics for # sight lookalikes in code', () => {
+            const result = analyze(`
+display \`undefined_macro' * # sight: ignore
+display \`another_macro' // # sight: ignoreme
+# sight: ignore-next
+display \`bare_directive_macro'
+`, { undefined_macro_enabled: true });
+
+            const undefined_diags = result.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(undefined_diags.length).toBeGreaterThan(0);
+        });
+
         it('should declare variables with @lsp-variables', () => {
             const result = analyze(`
 // @lsp-variables age income status
@@ -593,6 +624,34 @@ summarize age income
                      (d.message.includes('age') || d.message.includes('income'))
             );
             expect(var_diags.length).toBe(0);
+        });
+
+        it('should declare variables with canonical # sight directives', () => {
+            const result = analyze(`
+// # sight: variables age income
+summarize age income
+`, {
+                undefined_variable_enabled: true,
+            });
+
+            const declared_var_diags = result.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_VARIABLE &&
+                    (d.message.includes('age') || d.message.includes('income'))
+            );
+            expect(declared_var_diags.length).toBe(0);
+        });
+
+        it('should declare local macros with canonical # sight directives', () => {
+            const result = analyze(`
+// # sight: local dynamic_macro
+display \`dynamic_macro'
+`, {
+                undefined_macro_enabled: true,
+            });
+
+            expect(result.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            ).length).toBe(0);
         });
     });
 

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -581,12 +581,12 @@ display \`undefined_macro' // @lsp-ignore
             expect(undefined_diags.length).toBe(0);
         });
 
-        it('should suppress diagnostics with canonical # sight ignore directives', () => {
+        it('should suppress diagnostics with canonical sight ignore directives', () => {
             const same_line = analyze(`
-display \`undefined_macro' // # sight: ignore
+display \`undefined_macro' // sight: ignore
 `, { undefined_macro_enabled: true });
             const next_line = analyze(`
-// # sight: ignore-next
+// sight: ignore-next
 display \`undefined_macro'
 `, { undefined_macro_enabled: true });
 
@@ -598,18 +598,22 @@ display \`undefined_macro'
             ).length).toBe(0);
         });
 
-        it('should not suppress diagnostics for # sight lookalikes in code', () => {
+        it('should not suppress diagnostics for sight lookalikes in code', () => {
             const result = analyze(`
-display \`undefined_macro' * # sight: ignore
-display \`another_macro' // # sight: ignoreme
-# sight: ignore-next
+display \`undefined_macro' * sight: ignore
+display \`another_macro' // sight: ignoreme
+sight: ignore-next
+display \`hash_prefixed_macro' // # sight: ignore
 display \`bare_directive_macro'
 `, { undefined_macro_enabled: true });
 
             const undefined_diags = result.diagnostics.filter(
                 d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
             );
-            expect(undefined_diags.length).toBeGreaterThan(0);
+            expect(undefined_diags.some(d => d.message.includes('undefined_macro'))).toBe(true);
+            expect(undefined_diags.some(d => d.message.includes('another_macro'))).toBe(true);
+            expect(undefined_diags.some(d => d.message.includes('hash_prefixed_macro'))).toBe(true);
+            expect(undefined_diags.some(d => d.message.includes('bare_directive_macro'))).toBe(true);
         });
 
         it('should declare variables with @lsp-variables', () => {
@@ -626,9 +630,9 @@ summarize age income
             expect(var_diags.length).toBe(0);
         });
 
-        it('should declare variables with canonical # sight directives', () => {
+        it('should declare variables with canonical sight directives', () => {
             const result = analyze(`
-// # sight: variables age income
+// sight: variables age income
 summarize age income
 `, {
                 undefined_variable_enabled: true,
@@ -641,9 +645,9 @@ summarize age income
             expect(declared_var_diags.length).toBe(0);
         });
 
-        it('should declare local macros with canonical # sight directives', () => {
+        it('should declare local macros with canonical sight directives', () => {
             const result = analyze(`
-// # sight: local dynamic_macro
+// sight: local dynamic_macro
 display \`dynamic_macro'
 `, {
                 undefined_macro_enabled: true,

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -683,6 +683,56 @@ display \`dynamic_macro'
                 d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
             ).length).toBe(0);
         });
+
+        it('should NOT honor declaration directives nested in block comments', () => {
+            // `/* ... */` block comments do not carry directives, even when an
+            // interior line is itself shaped like a `//` or `*` comment.
+            const slash_nested = analyze(`
+/*
+// sight: local fake_macro
+*/
+display \`fake_macro'
+`, { undefined_macro_enabled: true });
+            const star_nested = analyze(`
+/*
+ * sight: local fake_macro
+ */
+display \`fake_macro'
+`, { undefined_macro_enabled: true });
+
+            expect(slash_nested.diagnostics.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('fake_macro')
+            )).toBe(true);
+            expect(star_nested.diagnostics.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('fake_macro')
+            )).toBe(true);
+        });
+
+        it('should NOT honor sight variables/ignore directives nested in block comments', () => {
+            const vars_nested = analyze(`
+/*
+// sight: variables age income
+*/
+summarize age income
+`, { undefined_variable_enabled: true });
+            const ignore_nested = analyze(`
+/*
+// sight: ignore-next
+*/
+display \`block_ignored_macro'
+`, { undefined_macro_enabled: true });
+
+            expect(vars_nested.diagnostics.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_VARIABLE &&
+                    (d.message.includes('age') || d.message.includes('income'))
+            )).toBe(true);
+            expect(ignore_nested.diagnostics.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('block_ignored_macro')
+            )).toBe(true);
+        });
     });
 
     describe('token macro forward reference detection', () => {

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -924,10 +924,17 @@ args single_arg
 
         it('should mark static path as static', () => {
             const result = analyze('do "static.do"');
-            
+
             expect(result.forward_calls.length).toBe(1);
             expect(result.forward_calls[0].is_static).toBe(true);
             expect(result.forward_calls[0].raw_path).toBe('static.do');
+        });
+
+        it('should suppress a forward call on a line with a trailing sight: ignore', () => {
+            // Requires the tokenized ignore pass; callers that pass tokens
+            // (DocumentStore, indexer, scope-resolver) must all honor this.
+            const result = analyze('do "child.do" // sight: ignore');
+            expect(result.forward_calls.length).toBe(0);
         });
 
         it('should mark path with embedded local macro as non-static', () => {

--- a/tests/unit/definition.test.ts
+++ b/tests/unit/definition.test.ts
@@ -1268,7 +1268,7 @@ describe('DefinitionProvider - Context-Aware Behavior', () => {
             expect(my_definition).toBeNull();
         });
 
-        it('should still navigate to directive target when cursor is on the quoted path', async () => {
+        it('should not navigate to directive target when the directive is embedded in prose', async () => {
             const helper_path = path.join(temp_dir, 'helper.do');
             fs.writeFileSync(helper_path, '// Helper file');
 
@@ -1288,10 +1288,7 @@ describe('DefinitionProvider - Context-Aware Behavior', () => {
                 context_tracker
             );
 
-            expect(my_definition).not.toBeNull();
-            expect(my_definition).not.toBeInstanceOf(Array);
-            const single = my_definition as { uri: string };
-            expect(single.uri).toContain('helper');
+            expect(my_definition).toBeNull();
         });
 
         // Regression tests: parameterized @lsp-* directives (line=, match="...")

--- a/tests/unit/definition.test.ts
+++ b/tests/unit/definition.test.ts
@@ -1146,11 +1146,11 @@ describe('DefinitionProvider - Context-Aware Behavior', () => {
             expect(my_definition?.uri).toContain('helper');
         });
 
-        it('should resolve canonical # sight directive paths with .do fallback', async () => {
+        it('should resolve canonical sight directive paths with .do fallback', async () => {
             const helper_path = path.join(temp_dir, 'helper.do');
             fs.writeFileSync(helper_path, '// Helper file');
 
-            const my_content = '// # sight: do: "helper"';
+            const my_content = '// sight: do: "helper"';
             const my_doc = create_test_document(my_content, undefined, URI.file(path.join(temp_dir, 'test.do')).toString());
 
             const my_definition = await definition_provider.get_definition(
@@ -1162,16 +1162,31 @@ describe('DefinitionProvider - Context-Aware Behavior', () => {
             expect(my_definition?.uri).toContain('helper');
         });
 
-        it('should not resolve bare # sight directive paths outside comments', async () => {
+        it('should not resolve bare sight directive paths outside comments', async () => {
             const helper_path = path.join(temp_dir, 'helper.do');
             fs.writeFileSync(helper_path, '// Helper file');
 
-            const my_content = '# sight: do: "helper"';
+            const my_content = 'sight: do: "helper"';
             const my_doc = create_test_document(my_content, undefined, URI.file(path.join(temp_dir, 'test.do')).toString());
 
             const my_definition = await definition_provider.get_definition(
                 my_doc,
                 { line: 0, character: 15 }
+            );
+
+            expect(my_definition).toBeNull();
+        });
+
+        it('should not resolve # sight directive paths', async () => {
+            const helper_path = path.join(temp_dir, 'helper.do');
+            fs.writeFileSync(helper_path, '// Helper file');
+
+            const my_content = '// # sight: do: "helper"';
+            const my_doc = create_test_document(my_content, undefined, URI.file(path.join(temp_dir, 'test.do')).toString());
+
+            const my_definition = await definition_provider.get_definition(
+                my_doc,
+                { line: 0, character: 19 }
             );
 
             expect(my_definition).toBeNull();

--- a/tests/unit/definition.test.ts
+++ b/tests/unit/definition.test.ts
@@ -1159,7 +1159,7 @@ describe('DefinitionProvider - Context-Aware Behavior', () => {
             );
 
             expect(my_definition).not.toBeNull();
-            expect(my_definition?.uri).toContain('helper');
+            expect(my_definition?.uri).toBe(URI.file(helper_path).toString());
         });
 
         it('should not resolve bare sight directive paths outside comments', async () => {

--- a/tests/unit/definition.test.ts
+++ b/tests/unit/definition.test.ts
@@ -1146,6 +1146,37 @@ describe('DefinitionProvider - Context-Aware Behavior', () => {
             expect(my_definition?.uri).toContain('helper');
         });
 
+        it('should resolve canonical # sight directive paths with .do fallback', async () => {
+            const helper_path = path.join(temp_dir, 'helper.do');
+            fs.writeFileSync(helper_path, '// Helper file');
+
+            const my_content = '// # sight: do: "helper"';
+            const my_doc = create_test_document(my_content, undefined, URI.file(path.join(temp_dir, 'test.do')).toString());
+
+            const my_definition = await definition_provider.get_definition(
+                my_doc,
+                { line: 0, character: 17 }
+            );
+
+            expect(my_definition).not.toBeNull();
+            expect(my_definition?.uri).toContain('helper');
+        });
+
+        it('should not resolve bare # sight directive paths outside comments', async () => {
+            const helper_path = path.join(temp_dir, 'helper.do');
+            fs.writeFileSync(helper_path, '// Helper file');
+
+            const my_content = '# sight: do: "helper"';
+            const my_doc = create_test_document(my_content, undefined, URI.file(path.join(temp_dir, 'test.do')).toString());
+
+            const my_definition = await definition_provider.get_definition(
+                my_doc,
+                { line: 0, character: 15 }
+            );
+
+            expect(my_definition).toBeNull();
+        });
+
         it('should resolve @lsp-do directive inside a mata block', async () => {
             const helper_path = path.join(temp_dir, 'helper.do');
             fs.writeFileSync(helper_path, '// Helper file');

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -1293,8 +1293,11 @@ display \`result'
             }
         });
 
-        it('should suppress backward-path rewrites with @lsp-ignore', async () => {
-            const content = "display `country_name' // @lsp-ignore";
+        it('should suppress backward-path rewrites with standalone @lsp-ignore', async () => {
+            const content = [
+                '// @lsp-ignore',
+                "display `country_name'",
+            ].join('\n');
             const document = create_real_document_state(content);
 
             const resolved_scope = {
@@ -2207,5 +2210,4 @@ display \`result'
         });
     });
 });
-
 

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -134,6 +134,15 @@ gen x = 1`;
             expect(result.directives.length).toBe(0);
         });
 
+        test('does not flag a non-directive word starting with a backward keyword', () => {
+            // `done-bytes` begins with `done-by` but is not a directive.
+            const content = '// sight: done-bytes are not a directive\ngen x = 1';
+            const result = parser.parse(content, 'file:///test.do');
+
+            expect(result.directives.length).toBe(0);
+            expect(result.diagnostics.some(d => d.message.includes('Malformed'))).toBe(false);
+        });
+
         test('does not honor // or * directives nested in multi-line block comments', () => {
             // A `//` or `*` line inside a /* ... */ block is block-commented out,
             // so the directive must stay inert across all scanners.
@@ -329,6 +338,14 @@ gen x = 1`;
 
             expect(result.forward_calls?.length ?? 0).toBe(0);
             expect(result.diagnostics.length).toBe(0);
+        });
+
+        test('reports a forward directive with no space after the colon as malformed', () => {
+            const content = '// sight: do:"setup.do"\ngen x = 1';
+            const result = parser.parse_forward_call_directives(content, 'file:///test.do');
+
+            expect(result.forward_calls?.length ?? 0).toBe(0);
+            expect(result.diagnostics.some(d => d.message.includes('Malformed directive'))).toBe(true);
         });
 
         test('accepts canonical sight forward directives', () => {

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -218,6 +218,26 @@ gen x = 1`;
             expect(parser.parse_forward_call_directives(content, 'file:///t.do').forward_calls.length).toBe(0);
         });
 
+        test('ignore-next skips a single-line block comment to reach the next directive', () => {
+            const content = [
+                '// sight: ignore-next',
+                '/* block */',
+                '// sight: do: "child.do"',
+            ].join('\n');
+            expect(parser.parse_forward_call_directives(content, 'file:///t.do').forward_calls.length).toBe(0);
+        });
+
+        test('a single-line block comment does not stop header directive parsing', () => {
+            const content = [
+                '/* header */',
+                '// sight: done-by: "parent.do"',
+                'gen x = 1',
+            ].join('\n');
+            const result = parser.parse(content, 'file:///t.do');
+            expect(result.directives.length).toBe(1);
+            expect(result.directives[0].type).toBe('done-by');
+        });
+
         test('does not infer a call site from a do statement inside a block comment', () => {
             const blocked = 'clear\n/*\ndo "child.do"\n*/\ngen z = 1';
             const real = 'clear\ndo "child.do"\ngen z = 1';

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -317,6 +317,15 @@ gen x = 1`;
             expect(line).toBe(1);
         });
 
+        test('empty match="" does not resolve to a line-0 match call site', () => {
+            // An empty match string matches every line; it must not become an
+            // explicit call site (which would silently resolve to line 0).
+            const content = '// sight: done-by: "parent.do" match=""\nlocal y 1';
+            const result = parser.parse(content, 'file:///child.do');
+
+            expect(result.directives.some(d => d.call_site?.type === 'match')).toBe(false);
+        });
+
         test('forward directive with escaped quotes in match= is recognized', () => {
             // The match= target line exists in this file, so the call site
             // resolves with no diagnostics.

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -120,14 +120,18 @@ gen x = 1`;
         });
 
         test('does not parse bare sight prefix as a Stata comment', () => {
-            const content = 'sight: done-by "parent.do"\ngen x = 1';
+            // Use the canonical `done-by:` body so the test isolates the prefix
+            // rule (bare `sight:` is not a comment) rather than body syntax.
+            const content = 'sight: done-by: "parent.do"\ngen x = 1';
             const result = parser.parse(content, 'file:///test.do');
 
             expect(result.directives.length).toBe(0);
         });
 
         test('does not parse # sight as a directive prefix', () => {
-            const content = '// # sight: done-by "parent.do"\ngen x = 1';
+            // Canonical `done-by:` body isolates the prefix rule (`# sight:` is
+            // not a recognized directive prefix).
+            const content = '// # sight: done-by: "parent.do"\ngen x = 1';
             const result = parser.parse(content, 'file:///test.do');
 
             expect(result.directives.length).toBe(0);

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -91,9 +91,9 @@ describe('DirectiveParser', () => {
             expect(result.directives[0].type).toBe('done-by');
         });
 
-        test('parses canonical # sight prefix in Stata comments', () => {
-            const content = `// # sight: done-by: "parent.do"
-* # sight: included-by utils.do
+        test('parses canonical sight prefix in Stata comments', () => {
+            const content = `// sight: done-by: "parent.do"
+* sight: included-by utils.do
 gen x = 1`;
             const result = parser.parse(content, 'file:///test.do');
 
@@ -104,15 +104,22 @@ gen x = 1`;
             expect(result.directives[1].raw_path).toBe('utils.do');
         });
 
-        test('does not parse bare # sight prefix as a Stata comment', () => {
-            const content = '# sight: done-by "parent.do"\ngen x = 1';
+        test('does not parse bare sight prefix as a Stata comment', () => {
+            const content = 'sight: done-by "parent.do"\ngen x = 1';
             const result = parser.parse(content, 'file:///test.do');
 
             expect(result.directives.length).toBe(0);
         });
 
-        test('parses canonical # sight working-directory directives', () => {
-            const content = '// # sight: wd: "../data"\ngen x = 1';
+        test('does not parse # sight as a directive prefix', () => {
+            const content = '// # sight: done-by "parent.do"\ngen x = 1';
+            const result = parser.parse(content, 'file:///test.do');
+
+            expect(result.directives.length).toBe(0);
+        });
+
+        test('parses canonical sight working-directory directives', () => {
+            const content = '// sight: wd: "../data"\ngen x = 1';
             const result = parser.parse(content, 'file:///project/scripts/test.do');
 
             expect(result.working_directory?.path).toBe('../data');
@@ -258,8 +265,8 @@ gen x = 1`;
             expect(result.forward_calls![0].call_site_line).toBe(4); // 0-indexed
         });
 
-        test('accepts canonical # sight forward directives', () => {
-            const content = '// # sight: include: "callee.do" line=5\ngen x = 1';
+        test('accepts canonical sight forward directives', () => {
+            const content = '// sight: include: "callee.do" line=5\ngen x = 1';
             const result = parser.parse(content, 'file:///test.do');
 
             expect(result.forward_calls?.length ?? 0).toBe(1);

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -193,6 +193,31 @@ gen x = 1`;
             expect(parser.parse_declaration_directives(spanning, 'file:///t.do').declarations.length).toBe(0);
         });
 
+        test('does not honor a directive on the opening line of a line-spanning comment', () => {
+            // `* sight: local fake /*` opens a comment span; the directive-looking
+            // opening line is part of the comment and must be inert.
+            const span_opener = [
+                '* sight: local fake /*',
+                '// sight: local inner',
+                '*/',
+                "display `fake'",
+            ].join('\n');
+            expect(parser.parse_declaration_directives(span_opener, 'file:///t.do').declarations.length).toBe(0);
+        });
+
+        test('ignore-next skips a block comment to reach the next directive', () => {
+            const content = [
+                '// sight: ignore-next',
+                '/*',
+                'note',
+                '*/',
+                '// sight: do: "child.do"',
+            ].join('\n');
+            // The block comment is trivia; ignore-next targets the do directive,
+            // so no forward call is registered.
+            expect(parser.parse_forward_call_directives(content, 'file:///t.do').forward_calls.length).toBe(0);
+        });
+
         test('does not infer a call site from a do statement inside a block comment', () => {
             const blocked = 'clear\n/*\ndo "child.do"\n*/\ngen z = 1';
             const real = 'clear\ndo "child.do"\ngen z = 1';

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -175,6 +175,24 @@ gen x = 1`;
             expect(r_star_decl.declarations.length).toBe(0);
         });
 
+        test('does not honor directives inside a line-spanning comment (* /* ... */)', () => {
+            // A line-leading `*` followed by a block opener makes the lexer span
+            // a single line comment across the lines; directives on the interior
+            // lines are inert, consistent with the analyzer.
+            const spanning = [
+                '* /*',
+                '// sight: done-by: "parent.do"',
+                '// sight: include: "setup.do"',
+                '// sight: local fake',
+                '*/',
+                'gen x = 1',
+            ].join('\n');
+
+            expect(parser.parse(spanning, 'file:///t.do').directives.length).toBe(0);
+            expect(parser.parse_forward_call_directives(spanning, 'file:///t.do').forward_calls.length).toBe(0);
+            expect(parser.parse_declaration_directives(spanning, 'file:///t.do').declarations.length).toBe(0);
+        });
+
         test('does not infer a call site from a do statement inside a block comment', () => {
             const blocked = 'clear\n/*\ndo "child.do"\n*/\ngen z = 1';
             const real = 'clear\ndo "child.do"\ngen z = 1';

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -134,6 +134,31 @@ gen x = 1`;
             expect(result.directives.length).toBe(0);
         });
 
+        test('does not honor // or * directives nested in multi-line block comments', () => {
+            // A `//` or `*` line inside a /* ... */ block is block-commented out,
+            // so the directive must stay inert across all scanners.
+            const slash = '/*\n// sight: include: "setup.do"\n// sight: local fake\n*/\ngen x = 1';
+            const star = '/*\n * sight: do: "setup.do"\n * sight: local fake\n */\ngen x = 1';
+
+            const r_slash = parser.parse_forward_call_directives(slash, 'file:///t.do');
+            const r_slash_decl = parser.parse_declaration_directives(slash, 'file:///t.do');
+            const r_star = parser.parse_forward_call_directives(star, 'file:///t.do');
+            const r_star_decl = parser.parse_declaration_directives(star, 'file:///t.do');
+
+            expect(r_slash.forward_calls.length).toBe(0);
+            expect(r_slash_decl.declarations.length).toBe(0);
+            expect(r_star.forward_calls.length).toBe(0);
+            expect(r_star_decl.declarations.length).toBe(0);
+        });
+
+        test('does not infer a call site from a do statement inside a block comment', () => {
+            const blocked = 'clear\n/*\ndo "child.do"\n*/\ngen z = 1';
+            const real = 'clear\ndo "child.do"\ngen z = 1';
+
+            expect(parser.infer_call_site_for_file(blocked, 'child.do')).toBeUndefined();
+            expect(parser.infer_call_site_for_file(real, 'child.do')).toBe(1);
+        });
+
         test('parses canonical sight working-directory directives', () => {
             const content = '// sight: wd: "../data"\ngen x = 1';
             const result = parser.parse(content, 'file:///project/scripts/test.do');

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -313,6 +313,24 @@ gen x = 1`;
             expect(result.forward_calls![0].call_site_line).toBe(4); // 0-indexed
         });
 
+        test('reports a forward directive head with empty match="" as malformed', () => {
+            // Parity with backward directives: a forward-directive head that does
+            // not fully parse should warn rather than be silently dropped.
+            const content = '// sight: do: "setup.do" match=""\ngen x = 1';
+            const result = parser.parse_forward_call_directives(content, 'file:///test.do');
+
+            expect(result.forward_calls?.length ?? 0).toBe(0);
+            expect(result.diagnostics.some(d => d.message.includes('Malformed directive'))).toBe(true);
+        });
+
+        test('does not flag a non-directive word starting with a keyword', () => {
+            const content = '// sight: doctor notes here\ngen x = 1';
+            const result = parser.parse_forward_call_directives(content, 'file:///test.do');
+
+            expect(result.forward_calls?.length ?? 0).toBe(0);
+            expect(result.diagnostics.length).toBe(0);
+        });
+
         test('accepts canonical sight forward directives', () => {
             const content = '// sight: include: "callee.do" line=5\ngen x = 1';
             const result = parser.parse(content, 'file:///test.do');

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -291,6 +291,45 @@ gen x = 1`;
             expect(result.forward_calls![0].call_site_line).toBe(4);
         });
     });
+
+    describe('Call-site match= with escaped quotes', () => {
+        const parser = new DirectiveParser();
+
+        test('backward directive with escaped quotes in match= is recognized (docs/cross-file.md)', () => {
+            // Documented form: match="do \"analysis.do\""
+            const content =
+                '// sight: done-by: "orchestrator.do" match="do \\"analysis.do\\""\nlocal x 1';
+            const result = parser.parse(content, 'file:///child.do');
+
+            expect(result.directives.length).toBe(1);
+            expect(result.directives[0].raw_path).toBe('orchestrator.do');
+            // The captured value is unescaped so it matches the literal parent text.
+            expect(result.directives[0].call_site).toEqual({
+                type: 'match',
+                value: 'do "analysis.do"',
+            });
+            expect(result.diagnostics.length).toBe(0);
+        });
+
+        test('escaped match= value resolves against parent content', () => {
+            const parent = ['clear', 'do "analysis.do"', 'gen z = 1'].join('\n');
+            const line = parser.find_match_line(parent, 'do "analysis.do"');
+            expect(line).toBe(1);
+        });
+
+        test('forward directive with escaped quotes in match= is recognized', () => {
+            // The match= target line exists in this file, so the call site
+            // resolves with no diagnostics.
+            const content =
+                '// sight: do: "callee.do" match="do \\"inner.do\\""\ndo "inner.do"\ngen x = 1';
+            const result = parser.parse(content, 'file:///test.do');
+
+            expect(result.forward_calls?.length ?? 0).toBe(1);
+            expect(result.forward_calls![0].raw_path).toBe('callee.do');
+            expect(result.forward_calls![0].call_site_line).toBe(1);
+            expect(result.diagnostics.length).toBe(0);
+        });
+    });
 });
 
 

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -159,6 +159,13 @@ gen x = 1`;
             expect(parser.infer_call_site_for_file(real, 'child.do')).toBe(1);
         });
 
+        test('still infers a call site for a real do with a trailing block comment', () => {
+            // Only lines whose leading text is inside a block comment are inert;
+            // a real `do` followed by an inline block comment is a real call.
+            const trailing = 'clear\ndo "child.do" /* run the child */\ngen z = 1';
+            expect(parser.infer_call_site_for_file(trailing, 'child.do')).toBe(1);
+        });
+
         test('parses canonical sight working-directory directives', () => {
             const content = '// sight: wd: "../data"\ngen x = 1';
             const result = parser.parse(content, 'file:///project/scripts/test.do');

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -90,6 +90,34 @@ describe('DirectiveParser', () => {
             expect(result.directives.length).toBe(1);
             expect(result.directives[0].type).toBe('done-by');
         });
+
+        test('parses canonical # sight prefix in Stata comments', () => {
+            const content = `// # sight: done-by: "parent.do"
+* # sight: included-by utils.do
+gen x = 1`;
+            const result = parser.parse(content, 'file:///test.do');
+
+            expect(result.directives.length).toBe(2);
+            expect(result.directives[0].type).toBe('done-by');
+            expect(result.directives[0].raw_path).toBe('parent.do');
+            expect(result.directives[1].type).toBe('included-by');
+            expect(result.directives[1].raw_path).toBe('utils.do');
+        });
+
+        test('does not parse bare # sight prefix as a Stata comment', () => {
+            const content = '# sight: done-by "parent.do"\ngen x = 1';
+            const result = parser.parse(content, 'file:///test.do');
+
+            expect(result.directives.length).toBe(0);
+        });
+
+        test('parses canonical # sight working-directory directives', () => {
+            const content = '// # sight: wd: "../data"\ngen x = 1';
+            const result = parser.parse(content, 'file:///project/scripts/test.do');
+
+            expect(result.working_directory?.path).toBe('../data');
+            expect(result.working_directory?.directive_form).toBe('wd');
+        });
     });
 
     describe('.do Extension Fallback', () => {
@@ -228,6 +256,16 @@ gen x = 1`;
             expect(result.forward_calls?.length ?? 0).toBe(1);
             expect(result.forward_calls![0].raw_path).toBe('callee.do');
             expect(result.forward_calls![0].call_site_line).toBe(4); // 0-indexed
+        });
+
+        test('accepts canonical # sight forward directives', () => {
+            const content = '// # sight: include: "callee.do" line=5\ngen x = 1';
+            const result = parser.parse(content, 'file:///test.do');
+
+            expect(result.forward_calls?.length ?? 0).toBe(1);
+            expect(result.forward_calls![0].type).toBe('include');
+            expect(result.forward_calls![0].raw_path).toBe('callee.do');
+            expect(result.forward_calls![0].call_site_line).toBe(4);
         });
     });
 });

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -1,5 +1,20 @@
 import { describe, test, expect } from 'bun:test';
 import { DirectiveParser } from '../../src/directive-parser';
+import { has_trailing_ignore_directive } from '../../src/utils/directives';
+
+describe('has_trailing_ignore_directive', () => {
+    test('matches a trailing same-line ignore comment (both prefixes)', () => {
+        expect(has_trailing_ignore_directive('gen x = 1 // sight: ignore')).toBe(true);
+        expect(has_trailing_ignore_directive('gen x = 1 // @lsp-ignore')).toBe(true);
+    });
+
+    test('does not match ignore-next or non-ignore lines', () => {
+        // ignore-next targets the next statement, not the same line.
+        expect(has_trailing_ignore_directive('gen x = 1 // sight: ignore-next')).toBe(false);
+        expect(has_trailing_ignore_directive('gen x = 1 // a normal comment')).toBe(false);
+        expect(has_trailing_ignore_directive('gen x = 1')).toBe(false);
+    });
+});
 
 describe('DirectiveParser', () => {
     test('resolve_path normalizes Windows-style separators for relative paths', () => {

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -118,6 +118,22 @@ gen x = 1`;
             expect(result.directives.length).toBe(0);
         });
 
+        test('does not parse directives embedded in prose comments', () => {
+            const content = `// note sight: done-by: "parent.do"
+* note @lsp-included-by: "utils.do"
+gen x = 1`;
+            const result = parser.parse(content, 'file:///test.do');
+
+            expect(result.directives.length).toBe(0);
+        });
+
+        test('does not parse directives from block comments', () => {
+            const content = '/* sight: done-by: "parent.do" */\ngen x = 1';
+            const result = parser.parse(content, 'file:///test.do');
+
+            expect(result.directives.length).toBe(0);
+        });
+
         test('parses canonical sight working-directory directives', () => {
             const content = '// sight: wd: "../data"\ngen x = 1';
             const result = parser.parse(content, 'file:///project/scripts/test.do');

--- a/tests/unit/explicit-call-site-mismatch.test.ts
+++ b/tests/unit/explicit-call-site-mismatch.test.ts
@@ -41,7 +41,7 @@ describe('Call-site mismatch diagnostics with explicit call sites', () => {
         const result = await resolver.resolve(URI.file(child_path).toString(), child_content);
 
         const mismatch_warning = result.diagnostics.find(
-            (d) => d.severity === 'warning' && d.message.includes('@lsp-included-by')
+            (d) => d.severity === 'warning' && d.message.includes('# sight: included-by')
         );
         expect(mismatch_warning).toBeDefined();
     });
@@ -70,7 +70,7 @@ describe('Call-site mismatch diagnostics with explicit call sites', () => {
         );
 
         const done_by_include_info = result.diagnostics.find(
-            (d) => d.message.includes('@lsp-done-by') && d.message.includes('include')
+            (d) => d.message.includes('# sight: done-by') && d.message.includes('include')
         );
         expect(done_by_include_info).toBeUndefined();
     });

--- a/tests/unit/explicit-call-site-mismatch.test.ts
+++ b/tests/unit/explicit-call-site-mismatch.test.ts
@@ -41,7 +41,7 @@ describe('Call-site mismatch diagnostics with explicit call sites', () => {
         const result = await resolver.resolve(URI.file(child_path).toString(), child_content);
 
         const mismatch_warning = result.diagnostics.find(
-            (d) => d.severity === 'warning' && d.message.includes('# sight: included-by')
+            (d) => d.severity === 'warning' && d.message.includes('sight: included-by')
         );
         expect(mismatch_warning).toBeDefined();
     });
@@ -70,7 +70,7 @@ describe('Call-site mismatch diagnostics with explicit call sites', () => {
         );
 
         const done_by_include_info = result.diagnostics.find(
-            (d) => d.message.includes('# sight: done-by') && d.message.includes('include')
+            (d) => d.message.includes('sight: done-by') && d.message.includes('include')
         );
         expect(done_by_include_info).toBeUndefined();
     });

--- a/tests/unit/mixed-logical-diagnostics.test.ts
+++ b/tests/unit/mixed-logical-diagnostics.test.ts
@@ -419,6 +419,15 @@ describe('MixedLogicalOperatorAnalyzer Unit Tests', () => {
             );
             expect(mixed).toHaveLength(0);
         });
+
+        it('inline sight ignore suppresses diagnostic on the same line', () => {
+            const doc = create_document_state('display x & y | z // sight: ignore');
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const mixed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+            expect(mixed).toHaveLength(0);
+        });
     });
 
     describe('Continuation Lines', () => {

--- a/tests/unit/mixed-logical-diagnostics.test.ts
+++ b/tests/unit/mixed-logical-diagnostics.test.ts
@@ -400,8 +400,8 @@ describe('MixedLogicalOperatorAnalyzer Unit Tests', () => {
     });
 
     describe('@lsp-ignore Suppression', () => {
-        it('@lsp-ignore suppresses diagnostic on same line', () => {
-            const doc = create_document_state('display x & y | z // @lsp-ignore');
+        it('@lsp-ignore suppresses diagnostic on the following statement', () => {
+            const doc = create_document_state('// @lsp-ignore\ndisplay x & y | z');
             const diagnostics = analyzer.analyze(doc, default_config);
             const mixed = diagnostics.filter(
                 d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS


### PR DESCRIPTION
- **Prefer # sight directive prefix**
- **Use sight directive prefix for Stata comments**
- **Require standalone directive comment lines**
- **Hoist directive regexes out of per-line/token loops**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the newer `sight:` directive names across documentation and editor settings, while keeping the older `@lsp-` forms as aliases.
  * Improved directive handling for comments, including clearer support for standalone ignore directives and declaration directives.

* **Bug Fixes**
  * Refined diagnostics and definition navigation so directive-based file links and suppression behavior work more consistently.
  * Updated warning messages and examples to match the current directive syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->