### PR TITLE
[codex] Handle continued local macro assignments

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -484,7 +484,7 @@ export class StataParser {
       has_equals = true;
       this.advance();
     }
-    this.skipTrivia();
+    this.skipLeadingMacroValueTrivia();
 
     // Collect the rest of the line as the macro value (stop at comment or terminator)
     let value = prefixOp || ''; // If prefixOp exists and no = value follows, it signifies increment
@@ -2461,6 +2461,21 @@ export class StataParser {
   private skipTrivia(): void {
     while (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK') || this.check('CONTINUATION') || this.check('WHITESPACE')) {
       this.advance();
+    }
+  }
+
+  private skipLeadingMacroValueTrivia(): void {
+    while (!this.isAtEnd()) {
+      if (this.skipContinuation()) {
+        continue;
+      }
+
+      if (this.check('WHITESPACE') || this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK')) {
+        this.advance();
+        continue;
+      }
+
+      break;
     }
   }
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -2464,6 +2464,10 @@ export class StataParser {
     }
   }
 
+  // Stata 18 MP audit: `local x = ///` followed by `1 / 2` succeeds
+  // with `_rc == 0` and x == .5, while bare `local x =` errors with
+  // invalid syntax rc 198. Bridge continuations here before the missing
+  // RHS check, but leave true empty assignments diagnostic-worthy.
   private skipLeadingMacroValueTrivia(): void {
     while (!this.isAtEnd()) {
       if (this.skipContinuation()) {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -443,13 +443,13 @@ export class StataParser {
     const scopeToken = this.advance(); // consume 'local' or 'global'
     const scope = scopeToken.value as 'local' | 'global';
 
-    this.skipTrivia();
+    this.skipMacroDefinitionTrivia();
 
     // Handle prefix increment/decrement: local ++i or local --i
     let prefixOp: string | undefined;
     if (this.check('OPERATOR') && (this.peek().value === '++' || this.peek().value === '--')) {
       prefixOp = this.advance().value;
-      this.skipTrivia();
+      this.skipMacroDefinitionTrivia();
     }
 
     if (!this.check('WORD')) {
@@ -462,7 +462,7 @@ export class StataParser {
 
     // Check for suffix increment/decrement (likely mistake): local i++
     // This assigns "++" to the macro instead of incrementing it.
-    this.skipTrivia();
+    this.skipMacroDefinitionTrivia();
     if (!prefixOp && this.check('OPERATOR') && (this.peek().value === '++' || this.peek().value === '--')) {
       const suffixOp = this.peek().value;
       this.errors.push({
@@ -484,7 +484,7 @@ export class StataParser {
       has_equals = true;
       this.advance();
     }
-    this.skipLeadingMacroValueTrivia();
+    this.skipMacroDefinitionTrivia();
 
     // Collect the rest of the line as the macro value (stop at comment or terminator)
     let value = prefixOp || ''; // If prefixOp exists and no = value follows, it signifies increment
@@ -546,7 +546,7 @@ export class StataParser {
 
   private parse_extended_macro_def(scopeToken: Token, scope: 'local' | 'global', macroName: string): MacroDefNode {
     this.advance(); // consume colon
-    this.skipTrivia();
+    this.skipMacroDefinitionTrivia();
 
     if (!this.check('WORD')) {
       this.addError('Expected function name after colon', this.peek().range);
@@ -554,7 +554,7 @@ export class StataParser {
     }
 
     const function_name = this.advance().value;
-    this.skipLeadingMacroValueTrivia();
+    this.skipMacroDefinitionTrivia();
 
     // Collect function arguments.
     // IMPORTANT: Preserve the original token stream verbatim to avoid introducing
@@ -2475,13 +2475,18 @@ export class StataParser {
     }
   }
 
-  // Stata 18 MP audit: `local x = ///` followed by `1 / 2` succeeds
-  // with `_rc == 0` and x == .5, while bare `local x =` errors with
-  // invalid syntax rc 198. Bridge continuations here before the missing
-  // RHS check, but leave true empty assignments diagnostic-worthy. The
-  // extended `local x : <func> ///` path reuses this so a continuation
-  // after the function name does not truncate the arguments.
-  private skipLeadingMacroValueTrivia(): void {
+  // Skip trivia within a macro definition statement, bridging `///`
+  // continuations onto the next physical line (skipContinuation consumes
+  // the continuation token AND the following statement terminator).
+  //
+  // Stata 18 MP audit: `local x = ///` followed by `1 / 2` succeeds with
+  // `_rc == 0` and x == .5, while bare `local x =` errors with invalid
+  // syntax rc 198, so bridging here still leaves a truly empty assignment
+  // diagnostic-worthy. A `///` may appear at any point inside the
+  // statement (after `local`/`global`, after the name, after `=`, or
+  // after the extended `:` function), so every trivia-skipping step in
+  // macro-definition parsing uses this instead of plain skipTrivia().
+  private skipMacroDefinitionTrivia(): void {
     while (!this.isAtEnd()) {
       if (this.skipContinuation()) {
         continue;
@@ -2497,38 +2502,55 @@ export class StataParser {
   }
 
   /**
-   * Check if the next non-trivia token(s) look like a macro definition.
-   * Returns true if next token is WORD, or OPERATOR ++/-- followed by WORD.
+   * Advance a lookahead offset past trivia, bridging `///` continuations the
+   * same way skipMacroDefinitionTrivia does for the live cursor (a continuation
+   * also consumes the following statement terminator). Returns the offset of
+   * the next significant token (or the end-of-token offset).
    */
-  private looksLikeMacroDefinition(): boolean {
-    let offset = 1;
-    // Skip trivia tokens
+  private nextSignificantOffsetForMacroDef(offset: number): number {
     while (this.current + offset < this.tokens.length) {
       const token = this.tokens[this.current + offset];
-      if (token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK' || 
-          token.type === 'CONTINUATION' || token.type === 'WHITESPACE') {
+      if (token.type === 'CONTINUATION') {
+        offset++;
+        if (this.current + offset < this.tokens.length &&
+            this.tokens[this.current + offset].type === 'STATEMENT_TERMINATOR') {
+          offset++;
+        }
+        continue;
+      }
+      if (token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK' ||
+          token.type === 'WHITESPACE') {
         offset++;
         continue;
       }
-      // Found first non-trivia token
-      if (token.type === 'WORD') {
-        return true;
-      }
-      // Check for ++/-- prefix followed by WORD
-      if (token.type === 'OPERATOR' && (token.value === '++' || token.value === '--')) {
-        offset++;
-        // Skip trivia after operator
-        while (this.current + offset < this.tokens.length) {
-          const next_token = this.tokens[this.current + offset];
-          if (next_token.type === 'COMMENT_LINE' || next_token.type === 'COMMENT_BLOCK' || 
-              next_token.type === 'CONTINUATION' || next_token.type === 'WHITESPACE') {
-            offset++;
-            continue;
-          }
-          return next_token.type === 'WORD';
-        }
-      }
+      break;
+    }
+    return offset;
+  }
+
+  /**
+   * Check if the next non-trivia token(s) look like a macro definition.
+   * Returns true if next token is WORD, or OPERATOR ++/-- followed by WORD.
+   * `///` continuations between the scope keyword and the name are bridged.
+   */
+  private looksLikeMacroDefinition(): boolean {
+    let offset = this.nextSignificantOffsetForMacroDef(1);
+    if (this.current + offset >= this.tokens.length) {
       return false;
+    }
+
+    const token = this.tokens[this.current + offset];
+    // Found first non-trivia token
+    if (token.type === 'WORD') {
+      return true;
+    }
+    // Check for ++/-- prefix followed by WORD
+    if (token.type === 'OPERATOR' && (token.value === '++' || token.value === '--')) {
+      offset = this.nextSignificantOffsetForMacroDef(offset + 1);
+      if (this.current + offset >= this.tokens.length) {
+        return false;
+      }
+      return this.tokens[this.current + offset].type === 'WORD';
     }
     return false;
   }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -554,13 +554,24 @@ export class StataParser {
     }
 
     const function_name = this.advance().value;
-    this.skipTrivia();
+    this.skipLeadingMacroValueTrivia();
 
     // Collect function arguments.
     // IMPORTANT: Preserve the original token stream verbatim to avoid introducing
     // artificial token boundaries (e.g., turning "0Ea" into "0E a").
     const arg_tokens: Token[] = [];
-    while (!this.check('STATEMENT_TERMINATOR') && !this.isAtEnd() && !this.isTrivia()) {
+    while (!this.check('STATEMENT_TERMINATOR') && !this.isAtEnd()) {
+      // Bridge `///` continuations onto the next physical line, matching the
+      // standard `= ...` value path.
+      if (this.skipContinuation()) {
+        continue;
+      }
+
+      // Stop at comments (continuations are handled above).
+      if (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK')) {
+        break;
+      }
+
       const token = this.advance();
       arg_tokens.push(token);
     }
@@ -2467,7 +2478,9 @@ export class StataParser {
   // Stata 18 MP audit: `local x = ///` followed by `1 / 2` succeeds
   // with `_rc == 0` and x == .5, while bare `local x =` errors with
   // invalid syntax rc 198. Bridge continuations here before the missing
-  // RHS check, but leave true empty assignments diagnostic-worthy.
+  // RHS check, but leave true empty assignments diagnostic-worthy. The
+  // extended `local x : <func> ///` path reuses this so a continuation
+  // after the function name does not truncate the arguments.
   private skipLeadingMacroValueTrivia(): void {
     while (!this.isAtEnd()) {
       if (this.skipContinuation()) {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -266,6 +266,27 @@ describe('StataParser', () => {
       }
     });
 
+    test('should parse extended macro definition continued after colon function', () => {
+      const source = `local x : display ///
+    1 / 2`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(1);
+
+      const node = parseResult.ast.nodes[0];
+      expect(node.type).toBe('macro_def');
+
+      if (node.type === 'macro_def') {
+        expect(node.scope).toBe('local');
+        expect(node.name).toBe('x');
+        expect(node.extendedFunction?.name).toBe('display');
+        expect(node.extendedFunction?.args).toBe('1 / 2');
+        expect(node.range.end.line).toBe(1);
+      }
+    });
+
     test('should parse global macro definition', () => {
       const source = 'global path "/usr/local/stata"';
       const lexResult = lexer.tokenize(source);

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -287,6 +287,48 @@ describe('StataParser', () => {
       }
     });
 
+    test('should parse global macro assignment continued after equals', () => {
+      const source = `global x = ///
+    1 + 2`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(1);
+
+      const node = parseResult.ast.nodes[0];
+      expect(node.type).toBe('macro_def');
+
+      if (node.type === 'macro_def') {
+        expect(node.scope).toBe('global');
+        expect(node.name).toBe('x');
+        expect(node.hasEquals).toBe(true);
+        expect(node.value).toBe('1+2');
+        expect(node.range.end.line).toBe(1);
+      }
+    });
+
+    test('should parse macro assignment continued across stacked continuations', () => {
+      const source = `local x = ///
+    1 + ///
+    2`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(1);
+
+      const node = parseResult.ast.nodes[0];
+      expect(node.type).toBe('macro_def');
+
+      if (node.type === 'macro_def') {
+        expect(node.name).toBe('x');
+        expect(node.hasEquals).toBe(true);
+        expect(node.value).toBe('1+2');
+        expect(node.range.end.line).toBe(2);
+      }
+    });
+
     test('should parse global macro definition', () => {
       const source = 'global path "/usr/local/stata"';
       const lexResult = lexer.tokenize(source);

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -329,6 +329,63 @@ describe('StataParser', () => {
       }
     });
 
+    test('should parse macro assignment continued after the scope keyword', () => {
+      const source = `local ///
+    x = 1`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(1);
+
+      const node = parseResult.ast.nodes[0];
+      expect(node.type).toBe('macro_def');
+
+      if (node.type === 'macro_def') {
+        expect(node.name).toBe('x');
+        expect(node.hasEquals).toBe(true);
+        expect(node.value).toBe('1');
+      }
+    });
+
+    test('should parse macro assignment continued between name and equals', () => {
+      const source = `local x ///
+    = 1`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(1);
+
+      const node = parseResult.ast.nodes[0];
+      expect(node.type).toBe('macro_def');
+
+      if (node.type === 'macro_def') {
+        expect(node.name).toBe('x');
+        expect(node.hasEquals).toBe(true);
+        expect(node.value).toBe('1');
+      }
+    });
+
+    test('should parse extended macro definition continued after the colon', () => {
+      const source = `local x : ///
+    display 1 + 2`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(1);
+
+      const node = parseResult.ast.nodes[0];
+      expect(node.type).toBe('macro_def');
+
+      if (node.type === 'macro_def') {
+        expect(node.name).toBe('x');
+        expect(node.extendedFunction?.name).toBe('display');
+        expect(node.extendedFunction?.args).toBe('1 + 2');
+      }
+    });
+
     test('should parse global macro definition', () => {
       const source = 'global path "/usr/local/stata"';
       const lexResult = lexer.tokenize(source);

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -227,6 +227,45 @@ describe('StataParser', () => {
       }
     });
 
+    test('should parse local macro assignment continued after equals', () => {
+      const source = `local x = ///
+    1 / 2`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(1);
+
+      const node = parseResult.ast.nodes[0];
+      expect(node.type).toBe('macro_def');
+
+      if (node.type === 'macro_def') {
+        expect(node.scope).toBe('local');
+        expect(node.name).toBe('x');
+        expect(node.hasEquals).toBe(true);
+        expect(node.value).toBe('1/2');
+        expect(node.range.end.line).toBe(1);
+      }
+    });
+
+    test('should report missing expression for local macro assignment ending at equals', () => {
+      const source = 'local x =';
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors.map(error => error.message)).toContain('Missing expression after equals sign');
+      expect(parseResult.ast.nodes).toHaveLength(1);
+
+      const node = parseResult.ast.nodes[0];
+      expect(node.type).toBe('macro_def');
+
+      if (node.type === 'macro_def') {
+        expect(node.name).toBe('x');
+        expect(node.hasEquals).toBe(true);
+        expect(node.value).toBe('');
+      }
+    });
+
     test('should parse global macro definition', () => {
       const source = 'global path "/usr/local/stata"';
       const lexResult = lexer.tokenize(source);


### PR DESCRIPTION
## Summary

Fixes #243. Stata treats a `///` line continuation as joining the next
physical line into the same logical statement, but the parser dropped or
mis-parsed continuations inside `local`/`global` macro definitions. A
continuation can appear at any point in the statement, and every such
position is now handled.

## Root Cause

Macro-definition parsing skipped trivia with `skipTrivia()`, which
advances over a `CONTINUATION` token but leaves the following statement
terminator in place. The macro value/argument collectors (and the
`looksLikeMacroDefinition()` dispatcher) then stopped at that physical
newline, producing a false `Missing expression after equals sign`
diagnostic, truncated arguments, or a statement not recognized as a macro
definition at all.

## Fix

Route every trivia-skipping step in macro-definition parsing through a
shared `skipMacroDefinitionTrivia()` helper that bridges continuations
(consuming the continuation token **and** the following terminator) while
still skipping whitespace/comments. This covers continuations:

- after the `local`/`global` keyword (`local ///` ⏎ `x = 1`)
- after a prefix `++`/`--`
- between the macro name and `=` (`local x ///` ⏎ `= 1`)
- after `=` (`local x = ///` ⏎ `1 / 2`) — the original #243 case
- after the extended `:` and its function name (`local x : display ///` ⏎ `1 / 2`)

The dispatcher `looksLikeMacroDefinition()` was rewritten to bridge
continuations via a `nextSignificantOffsetForMacroDef()` lookahead so
`local ///` ⏎ `x = 1` is still recognized as a macro definition.

Bare `local x =` still reports the missing-expression diagnostic, and the
command fallback for patterns like `global \`global' = ...` is unchanged.

## Validation

- `bun run test` (typecheck + full suite, 6329 pass)
- `bun run lint`
- New parser tests cover each continuation position, stacked
  continuations, the global variant, and the preserved bare-`=`
  diagnostic.

## Review

Two consecutive clean rounds from both `/code-review` and a Codex
correctness review on the final diff; the review process surfaced the
sibling continuation sites (extended `:` path and the dispatcher) that the
original fix missed.
