### PR TITLE
Suppress diagnostics inside nested block comments (#244)

### DIFF
--- a/.kiro/specs/block-comment-indentation-false-positive/design.md
+++ b/.kiro/specs/block-comment-indentation-false-positive/design.md
@@ -175,7 +175,7 @@ No new data models are required. The implementation uses a `Set<number>` to trac
 
 ### Property 3: Nested delimiter handling
 
-*For any* block comment containing `/*` sequences within its content, the `IndentationDiagnosticAnalyzer` should correctly identify the block comment as ending at the first `*/` (since Stata doesn't support nested block comments).
+*For any* block comment containing nested `/*` sequences within its content, the `IndentationDiagnosticAnalyzer` should track comment depth and identify the block comment as ending only at the matching `*/` (Stata block comments nest, matching the lexer and TextMate grammar).
 
 **Validates: Requirements 2.3**
 

--- a/src/context-tracker/index.ts
+++ b/src/context-tracker/index.ts
@@ -17,10 +17,11 @@ const CONTEXT_TRIVIA_TOKEN_TYPES: Set<TokenType> = new Set([
   'COMMENT_BLOCK',
   'CONTINUATION',
   'WHITESPACE',
-  // The newline / `;` that ends a line is a separator, not live code. It
-  // matters here because the terminator after a comment's closing `*/`
-  // starts on that closing line (e.g. `program define foo */`), and must
-  // not make an otherwise fully-commented line look like live code.
+  // The newline / `;` that ends a line is a separator, not live
+  // code. It matters here because the terminator after a comment's
+  // closing `*/` starts on that closing line (e.g.
+  // `program define foo */`), and must not make an otherwise
+  // fully-commented line look like live code.
   'STATEMENT_TERMINATOR',
   'EOF',
 ]);
@@ -59,12 +60,13 @@ export class ContextTracker implements IContextTracker {
       this.document_content = document_content;
     }
 
-    // Pre-compute the lines that sit inside multi-line block comments so
-    // the raw-line block-structure validations can skip them. Derived from
-    // the same tokens, so nested block comments are handled by the lexer.
-    // A line that also carries a live code token (e.g. `/* c */ end`, where
-    // the comment closes mid-line) must still be scanned, so drop any line
-    // that has a non-trivia token starting on it.
+    // Pre-compute the lines that sit inside multi-line block comments
+    // so the raw-line block-structure validations can skip them.
+    // Derived from the same tokens, so nested block comments are
+    // handled by the lexer. A line that also carries a live code token
+    // (e.g. `/* c */ end`, where the comment closes mid-line) must
+    // still be scanned, so drop any line that has a non-trivia token
+    // starting on it.
     const my_comment_lines = block_comment_lines(this.document_content, tokens);
     for (const my_token of tokens) {
       if (!CONTEXT_TRIVIA_TOKEN_TYPES.has(my_token.type)) {
@@ -515,8 +517,8 @@ export class ContextTracker implements IContextTracker {
     const my_line_count = get_line_count(doc);
     
     for (let my_line_number = 0; my_line_number < my_line_count; my_line_number++) {
-      // Lines inside a multi-line block comment are not live code, so they
-      // neither open nor close program/embedded blocks.
+      // Lines inside a multi-line block comment are not live code, so
+      // they neither open nor close program/embedded blocks.
       if (this.block_comment_continuation_lines.has(my_line_number)) {
         continue;
       }

--- a/src/context-tracker/index.ts
+++ b/src/context-tracker/index.ts
@@ -5,8 +5,25 @@ import {
   ContextDiagnostic,
   IContextTracker,
 } from './types';
-import { ContextErrorCode, Token } from '../types';
+import { ContextErrorCode, Token, TokenType } from '../types';
 import { get_line_text, get_line_count, compute_line_offsets } from '../utils/line-utils';
+import { block_comment_lines } from '../utils/block-comment-utils';
+
+// Token types that carry no live code. A line whose only tokens are
+// these (and that the lexer placed inside a block comment) is safe to
+// skip in the raw-line block-structure scans.
+const CONTEXT_TRIVIA_TOKEN_TYPES: Set<TokenType> = new Set([
+  'COMMENT_LINE',
+  'COMMENT_BLOCK',
+  'CONTINUATION',
+  'WHITESPACE',
+  // The newline / `;` that ends a line is a separator, not live code. It
+  // matters here because the terminator after a comment's closing `*/`
+  // starts on that closing line (e.g. `program define foo */`), and must
+  // not make an otherwise fully-commented line look like live code.
+  'STATEMENT_TERMINATOR',
+  'EOF',
+]);
 
 /**
  * Context Tracker maintains language context state during parsing.
@@ -19,6 +36,11 @@ export class ContextTracker implements IContextTracker {
   private context_stack: LanguageContext[] = [LanguageContext.STATA];
   private document_content: string = '';
   private diagnostics: ContextDiagnostic[] = [];
+  // Lines (0-based) that are entirely inside a multi-line block comment
+  // (leading text commented, no live code token). The raw-line block-
+  // structure scans below skip these so commented-out `end`/`program`/
+  // `mata` lines do not produce spurious diagnostics.
+  private block_comment_continuation_lines: Set<number> = new Set();
 
   /**
    * Initialize context tracker from tokens instead of raw content.
@@ -36,7 +58,21 @@ export class ContextTracker implements IContextTracker {
     if (document_content !== undefined) {
       this.document_content = document_content;
     }
-    
+
+    // Pre-compute the lines that sit inside multi-line block comments so
+    // the raw-line block-structure validations can skip them. Derived from
+    // the same tokens, so nested block comments are handled by the lexer.
+    // A line that also carries a live code token (e.g. `/* c */ end`, where
+    // the comment closes mid-line) must still be scanned, so drop any line
+    // that has a non-trivia token starting on it.
+    const my_comment_lines = block_comment_lines(this.document_content, tokens);
+    for (const my_token of tokens) {
+      if (!CONTEXT_TRIVIA_TOKEN_TYPES.has(my_token.type)) {
+        my_comment_lines.delete(my_token.range.start.line);
+      }
+    }
+    this.block_comment_continuation_lines = my_comment_lines;
+
     // Extract context ranges from tokens
     // Tokens already have position information (range) and type information
     // that can be used to detect context blocks
@@ -312,6 +348,10 @@ export class ContextTracker implements IContextTracker {
     const my_valid_end_lines = this.find_valid_end_lines(my_doc);
 
     for (let my_line_number = 0; my_line_number < my_line_count; my_line_number++) {
+      // Lines inside a multi-line block comment are not live code
+      if (this.block_comment_continuation_lines.has(my_line_number)) {
+        continue;
+      }
       const my_line = get_line_text(my_doc, my_line_number);
       const my_code_part = this.extract_code_before_comment(my_line);
       const my_code_trimmed = my_code_part.trim();
@@ -475,6 +515,11 @@ export class ContextTracker implements IContextTracker {
     const my_line_count = get_line_count(doc);
     
     for (let my_line_number = 0; my_line_number < my_line_count; my_line_number++) {
+      // Lines inside a multi-line block comment are not live code, so they
+      // neither open nor close program/embedded blocks.
+      if (this.block_comment_continuation_lines.has(my_line_number)) {
+        continue;
+      }
       const my_line = get_line_text(doc, my_line_number);
       const my_code_part = this.extract_code_before_comment(my_line);
       const my_code_trimmed = my_code_part.trim();
@@ -816,6 +861,11 @@ export class ContextTracker implements IContextTracker {
 
     // Search forward from start_line for a likely end position
     for (let my_i = start_line + 1; my_i < my_line_count; my_i++) {
+      // Skip lines inside a multi-line block comment - a commented-out
+      // `end`/`mata`/`python` is not a real recovery point.
+      if (this.block_comment_continuation_lines.has(my_i)) {
+        continue;
+      }
       const my_line = get_line_text(my_doc, my_i);
       const my_code_part = this.extract_code_before_comment(my_line);
       const my_code_trimmed = my_code_part.trim();

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -224,15 +224,23 @@ export class StataLexer {
         return true;
       }
       
-      // Check for /* block comment */
-      if (my_char === '/' && my_pos + 1 < this.source.length && 
+      // Check for /* block comment */ (nestable, matching
+      // consumeBlockCommentBody)
+      if (my_char === '/' && my_pos + 1 < this.source.length &&
           this.source[my_pos + 1] === '*') {
-        // Skip the block comment
-        my_pos += 2; // Skip /*
-        while (my_pos + 1 < this.source.length) {
+        // Skip the (possibly nested) block comment, tracking depth
+        my_pos += 2; // Skip the opening /*
+        let my_depth = 1;
+        while (my_pos + 1 < this.source.length && my_depth > 0) {
+          if (this.source[my_pos] === '/' && this.source[my_pos + 1] === '*') {
+            my_depth++;
+            my_pos += 2; // Skip nested /*
+            continue;
+          }
           if (this.source[my_pos] === '*' && this.source[my_pos + 1] === '/') {
+            my_depth--;
             my_pos += 2; // Skip */
-            break;
+            continue;
           }
           if (this.source[my_pos] === '\n') {
             // Block comment spans to next line - treat as block mode
@@ -240,9 +248,9 @@ export class StataLexer {
           }
           my_pos++;
         }
-        // If we exited the loop without finding */, we reached EOF or near-EOF
-        // Treat unclosed block comment as block mode
-        if (my_pos + 1 >= this.source.length) {
+        // If still open, we reached EOF or near-EOF; treat an unclosed
+        // block comment as block mode
+        if (my_depth > 0) {
           return true;
         }
         continue;

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -755,15 +755,7 @@ export class StataLexer {
         this.advance(); // consume /
         this.advance(); // consume *
 
-        // Scan until */ or EOF (like scanBlockComment)
-        while (!this.isAtEnd()) {
-          if (this.peek() === '*' && this.peekNext() === '/') {
-            this.advance(); // consume *
-            this.advance(); // consume /
-            break;
-          }
-          this.advance();
-        }
+        this.consumeBlockCommentBody();
 
         // Only warn when /* causes multi-line comment behavior
         // (i.e., */ is on a different line, or unclosed and spans lines)
@@ -820,15 +812,7 @@ export class StataLexer {
   }
 
   private scanBlockComment(startLine: number, startColumn: number): Token {
-    // Consume until */
-    while (!this.isAtEnd()) {
-      if (this.peek() === '*' && this.peekNext() === '/') {
-        this.advance(); // consume *
-        this.advance(); // consume /
-        break;
-      }
-      this.advance();
-    }
+    this.consumeBlockCommentBody();
 
     const value = this.source.substring(this.position_to_offset(startLine, startColumn), this.position);
     return {
@@ -836,6 +820,28 @@ export class StataLexer {
       value,
       range: this.makeRange(startLine, startColumn, this.line, this.column),
     };
+  }
+
+  private consumeBlockCommentBody(): void {
+    let depth = 1;
+
+    while (!this.isAtEnd() && depth > 0) {
+      if (this.peek() === '/' && this.peekNext() === '*') {
+        this.advance(); // consume /
+        this.advance(); // consume *
+        depth++;
+        continue;
+      }
+
+      if (this.peek() === '*' && this.peekNext() === '/') {
+        this.advance(); // consume *
+        this.advance(); // consume /
+        depth--;
+        continue;
+      }
+
+      this.advance();
+    }
   }
 
   private scanDelimitDirective(startLine: number, startColumn: number): Token {

--- a/src/providers/indentation-diagnostics.ts
+++ b/src/providers/indentation-diagnostics.ts
@@ -257,34 +257,31 @@ export class IndentationDiagnosticAnalyzer {
    * - It is entirely within an open block comment
    * - It contains the closing delimiter (from start of line to that point)
    * 
-   * Note: Stata doesn't support nested block comments, so the first
-   * closing delimiter ends the comment regardless of any opening
-   * sequences inside.
+   * Nested block openers increase comment depth, matching the lexer and
+   * TextMate grammar.
    */
   compute_block_comment_lines(lines: string[]): Set<number> {
     const block_comment_lines = new Set<number>();
-    let in_block_comment = false;
+    let block_comment_depth = 0;
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       let j = 0;
 
       while (j < line.length) {
-        if (!in_block_comment) {
-          // Look for /* (with bounds check for j + 1)
-          if (j + 1 < line.length && line[j] === '/' && line[j + 1] === '*') {
-            in_block_comment = true;
-            block_comment_lines.add(i);
-            j += 2;
-            continue;
-          }
-        } else {
+        if (j + 1 < line.length && line[j] === '/' && line[j + 1] === '*') {
+          block_comment_depth++;
+          block_comment_lines.add(i);
+          j += 2;
+          continue;
+        }
+
+        if (block_comment_depth > 0) {
           // Already in block comment - this line is inside
           block_comment_lines.add(i);
 
-          // Look for */ (with bounds check for j + 1)
           if (j + 1 < line.length && line[j] === '*' && line[j + 1] === '/') {
-            in_block_comment = false;
+            block_comment_depth--;
             j += 2;
             continue;
           }
@@ -293,7 +290,7 @@ export class IndentationDiagnosticAnalyzer {
       }
 
       // If we're still in a block comment at end of line, mark this line
-      if (in_block_comment) {
+      if (block_comment_depth > 0) {
         block_comment_lines.add(i);
       }
     }

--- a/src/providers/indentation-diagnostics.ts
+++ b/src/providers/indentation-diagnostics.ts
@@ -21,8 +21,11 @@ export class IndentationDiagnosticAnalyzer {
     // Get Stata-only ranges (exclude embedded language blocks)
     const stataRanges = this.getStataRanges(document);
     
-    // Compute block comment lines to exclude from indentation checks
-    const block_comment_lines = this.compute_block_comment_lines(lines);
+    // Compute block comment lines to exclude from indentation checks.
+    // Prefer the lexer tokens so `/*` inside strings/code is not
+    // mistaken for a comment opener; fall back to a raw scan when
+    // tokens are absent.
+    const block_comment_lines = this.compute_block_comment_lines(lines, document.tokens);
     
     // Compute continuation lines from tokens for efficient lookup
     const continuation_lines = document.tokens 
@@ -259,8 +262,18 @@ export class IndentationDiagnosticAnalyzer {
    * 
    * Nested block openers increase comment depth, matching the lexer and
    * TextMate grammar.
+   *
+   * When `tokens` are supplied, the lines are derived from the lexer's
+   * COMMENT_BLOCK token ranges, which already exclude `/*` sequences
+   * that appear inside string literals or other code. Without tokens, a
+   * raw text scan is used as a fallback (it cannot tell a real opener
+   * from one inside a string).
    */
-  compute_block_comment_lines(lines: string[]): Set<number> {
+  compute_block_comment_lines(lines: string[], tokens?: Token[]): Set<number> {
+    if (tokens && tokens.length > 0) {
+      return this.block_comment_lines_from_tokens(tokens);
+    }
+
     const block_comment_lines = new Set<number>();
     let block_comment_depth = 0;
 
@@ -296,6 +309,39 @@ export class IndentationDiagnosticAnalyzer {
     }
 
     return block_comment_lines;
+  }
+
+  /**
+   * Derive the set of block-comment lines from the lexer's comment
+   * tokens. A COMMENT_BLOCK token already spans its full (possibly
+   * nested) extent, and a line-leading `*` comment that absorbs an
+   * unclosed `/*` becomes a COMMENT_LINE token spanning several lines;
+   * both put their covered lines inside a comment. `/*` inside strings
+   * or code never produces a comment token, so it is correctly ignored.
+   * Single-line `//` / `*` comments are excluded (handled elsewhere).
+   */
+  private block_comment_lines_from_tokens(tokens: Token[]): Set<number> {
+    const the_block_comment_lines = new Set<number>();
+
+    for (const my_token of tokens) {
+      const my_spans_lines =
+        my_token.range.end.line > my_token.range.start.line;
+      const my_is_multiline_comment =
+        my_token.type === 'COMMENT_BLOCK' ||
+        (my_token.type === 'COMMENT_LINE' && my_spans_lines);
+      if (!my_is_multiline_comment) {
+        continue;
+      }
+      for (
+        let my_line = my_token.range.start.line;
+        my_line <= my_token.range.end.line;
+        my_line++
+      ) {
+        the_block_comment_lines.add(my_line);
+      }
+    }
+
+    return the_block_comment_lines;
   }
 
   /**

--- a/tests/property/block-comment-indentation-exclusion.prop.test.ts
+++ b/tests/property/block-comment-indentation-exclusion.prop.test.ts
@@ -17,6 +17,7 @@ import { IndentationDiagnosticAnalyzer } from '../../src/providers/indentation-d
 import { DocumentState } from '../../src/document-store';
 import { ContextTracker } from '../../src/context-tracker';
 import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
+import { create_document_state } from './helpers/document-utils';
 
 /**
  * Create a minimal DocumentState for indentation analysis.
@@ -96,6 +97,53 @@ describe('Block Comment Indentation Exclusion Property Tests', () => {
             d => d.code === StataDiagnosticCode.MISSING_INDENTATION &&
                 d.range.start.line === 5
         )).toBe(true);
+    });
+
+    it('does not treat /* inside a string literal as a block comment', () => {
+        // The `/*` sequences live inside a string, not a comment, so
+        // no line is inside a block comment and the unindented live
+        // `display` must still be flagged. Uses a fully-lexed document
+        // so the analyzer takes the token-aware path.
+        const my_source = [
+            'display "/* outer /* inner */"',
+            'if 1 {',
+            'display "live and not indented"',
+            '}',
+        ].join('\n');
+        const my_document = create_document_state(my_source);
+        const my_diagnostics = analyzer.analyze(my_document, config);
+        const my_block_comment_lines = analyzer.compute_block_comment_lines(
+            my_source.split('\n'),
+            my_document.tokens
+        );
+
+        expect(my_block_comment_lines.size).toBe(0);
+        expect(my_diagnostics.some(
+            d => d.code === StataDiagnosticCode.MISSING_INDENTATION &&
+                d.range.start.line === 2
+        )).toBe(true);
+    });
+
+    it('excludes lines inside a multi-line star-led comment span', () => {
+        // A line-leading `*` comment that absorbs an unclosed `/*` is
+        // lexed as one multi-line COMMENT_LINE token; its inside lines
+        // must be excluded from indentation checks too.
+        const my_source = [
+            'if 1 {',
+            '* /* outer',
+            'display "commented and not indented"',
+            '*/',
+            '}',
+        ].join('\n');
+        const my_document = create_document_state(my_source);
+        const my_diagnostics = analyzer.analyze(my_document, config);
+        const my_block_comment_lines = analyzer.compute_block_comment_lines(
+            my_source.split('\n'),
+            my_document.tokens
+        );
+
+        expect(my_block_comment_lines.has(2)).toBe(true);
+        expect(my_diagnostics.some(d => d.range.start.line === 2)).toBe(false);
     });
 
     // Generator for random block comment content lines (without /* or */)

--- a/tests/property/block-comment-indentation-exclusion.prop.test.ts
+++ b/tests/property/block-comment-indentation-exclusion.prop.test.ts
@@ -75,6 +75,29 @@ const config: StataLSPConfig = {
 describe('Block Comment Indentation Exclusion Property Tests', () => {
     const analyzer = new IndentationDiagnosticAnalyzer();
 
+    it('excludes lines between an inner block close and the outer block close', () => {
+        const my_source = [
+            '/* outer',
+            '/* inner */',
+            'display "commented but not indented"',
+            '*/',
+            'if 1 {',
+            'display "live and not indented"',
+            '}',
+        ].join('\n');
+        const my_document = create_document_for_indentation(my_source);
+        const my_diagnostics = analyzer.analyze(my_document, config);
+        const my_block_comment_lines = analyzer.compute_block_comment_lines(my_source.split('\n'));
+
+        expect(my_block_comment_lines.has(2)).toBe(true);
+        expect(my_block_comment_lines.has(4)).toBe(false);
+        expect(my_diagnostics.some(d => d.range.start.line === 2)).toBe(false);
+        expect(my_diagnostics.some(
+            d => d.code === StataDiagnosticCode.MISSING_INDENTATION &&
+                d.range.start.line === 5
+        )).toBe(true);
+    });
+
     // Generator for random block comment content lines (without /* or */)
     const arbitrary_comment_line = fc.oneof(
         // Line starting with asterisk (common style)

--- a/tests/unit/context-tracker.test.ts
+++ b/tests/unit/context-tracker.test.ts
@@ -435,10 +435,11 @@ end`;
     });
 
     test('should treat a commented program on the closing comment line as not live', () => {
-      // `program define foo */` is the line that closes the block comment,
-      // so the program definition is commented out. The terminator after
-      // `*/` starts on this line, so it must not make the line look live;
-      // the following `end` is then a real orphan and must be flagged.
+      // `program define foo */` is the line that closes the block
+      // comment, so the program definition is commented out. The
+      // terminator after `*/` starts on this line, so it must not make
+      // the line look live; the following `end` is then a real orphan
+      // and must be flagged.
       const my_source = `/*
 program define foo */
 end`;

--- a/tests/unit/context-tracker.test.ts
+++ b/tests/unit/context-tracker.test.ts
@@ -388,6 +388,82 @@ end // close mata block`;
       expect(my_ranges).toHaveLength(1);
       expect(my_ranges[0].end_delimiter?.command).toBe('end');
     });
+
+    test('should not flag an orphan end inside a block comment', () => {
+      const my_source = `/* outer
+end
+*/
+display "live"`;
+
+      init_tracker_from_source(tracker, my_source);
+      const my_diagnostics = tracker.validate_context_structure();
+
+      expect(my_diagnostics.some(
+        my_d => my_d.code === ContextErrorCode.UNEXPECTED_END
+      )).toBe(false);
+    });
+
+    test('should not flag an orphan end inside a nested block comment', () => {
+      const my_source = `/* outer
+/* inner */
+end
+*/
+display "live"`;
+
+      init_tracker_from_source(tracker, my_source);
+      const my_diagnostics = tracker.validate_context_structure();
+
+      expect(my_diagnostics.some(
+        my_d => my_d.code === ContextErrorCode.UNEXPECTED_END
+      )).toBe(false);
+    });
+
+    test('should still flag a live orphan end after a block comment', () => {
+      const my_source = `/* program foo
+end
+*/
+end`;
+
+      init_tracker_from_source(tracker, my_source);
+      const my_diagnostics = tracker.validate_context_structure();
+
+      const my_orphan = my_diagnostics.find(
+        my_d => my_d.code === ContextErrorCode.UNEXPECTED_END
+      );
+      expect(my_orphan).toBeDefined();
+      expect(my_orphan?.range.start.line).toBe(3);
+    });
+
+    test('should treat a commented program on the closing comment line as not live', () => {
+      // `program define foo */` is the line that closes the block comment,
+      // so the program definition is commented out. The terminator after
+      // `*/` starts on this line, so it must not make the line look live;
+      // the following `end` is then a real orphan and must be flagged.
+      const my_source = `/*
+program define foo */
+end`;
+
+      init_tracker_from_source(tracker, my_source);
+      const my_diagnostics = tracker.validate_context_structure();
+
+      const my_orphan = my_diagnostics.find(
+        my_d => my_d.code === ContextErrorCode.UNEXPECTED_END
+      );
+      expect(my_orphan).toBeDefined();
+      expect(my_orphan?.range.start.line).toBe(2);
+    });
+
+    test('should not flag "end mata"/"end python" inside a block comment', () => {
+      const my_source = `/* outer
+end mata
+end python
+*/`;
+
+      init_tracker_from_source(tracker, my_source);
+      const my_diagnostics = tracker.validate_context_structure();
+
+      expect(my_diagnostics).toHaveLength(0);
+    });
   });
 
   describe('edge case handling - malformed blocks', () => {

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -242,6 +242,30 @@ describe('DiagnosticsProvider', () => {
             expect(macro_diagnostic).toBeUndefined();
         });
 
+        it('should suppress undefined macro diagnostics inside nested block comments', async () => {
+            const document = create_real_document_state([
+                '/* MM: outer comment starts',
+                '/* inner comment */',
+                'display `commented_macro\'',
+                '*/',
+                'display `live_macro\'',
+            ].join('\n'));
+            const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG);
+
+            const commented_macro = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('commented_macro')
+            );
+            expect(commented_macro).toBeUndefined();
+
+            const live_macro = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('live_macro')
+            );
+            expect(live_macro).toBeDefined();
+            expect(live_macro?.range.start.line).toBe(4);
+        });
+
         it('should respect severity configuration for undefined macros', async () => {
             const document = create_document_state('display `undefined\'\n');
             
@@ -2210,4 +2234,3 @@ display \`result'
         });
     });
 });
-

--- a/tests/unit/lexer.test.ts
+++ b/tests/unit/lexer.test.ts
@@ -283,10 +283,10 @@ describe('StataLexer', () => {
       expect(commentToken?.range.end.line).toBe(3);
       expect(commentToken?.value).toContain('display `commented_macro\'');
 
-      const macroTokens = result.tokens.filter(t => t.type === 'MACRO_REF_LOCAL');
-      expect(macroTokens).toHaveLength(1);
-      expect(macroTokens[0].value).toBe('`live_macro\'');
-      expect(macroTokens[0].range.start.line).toBe(4);
+      const the_macro_tokens = result.tokens.filter(t => t.type === 'MACRO_REF_LOCAL');
+      expect(the_macro_tokens).toHaveLength(1);
+      expect(the_macro_tokens[0].value).toBe('`live_macro\'');
+      expect(the_macro_tokens[0].range.start.line).toBe(4);
     });
   });
 
@@ -334,6 +334,21 @@ describe('StataLexer', () => {
       const mata_token = result.tokens.find(t => t.type === 'MATA_INLINE');
       expect(mata_token).toBeDefined();
       expect(mata_token?.value).toBe('mata:');
+    });
+
+    test('should treat mata: followed by a closed nested block comment as block start', () => {
+      // The whole line after the colon is a comment (nested), so this is a
+      // block start, not an inline expression. Requires depth-counted
+      // block-comment scanning in the mata:/python: lookahead.
+      const source = 'mata: /* outer /* inner */ still outer */\nmatrix A = (1, 2)';
+      const result = lexer.tokenize(source);
+
+      expect(result.errors).toHaveLength(0);
+      const mata_start = result.tokens.find(t => t.type === 'MATA_START');
+      expect(mata_start).toBeDefined();
+      expect(mata_start?.value).toBe('mata:');
+      const mata_inline = result.tokens.find(t => t.type === 'MATA_INLINE');
+      expect(mata_inline).toBeUndefined();
     });
 
     test('should recognize python block start', () => {

--- a/tests/unit/lexer.test.ts
+++ b/tests/unit/lexer.test.ts
@@ -337,9 +337,9 @@ describe('StataLexer', () => {
     });
 
     test('should treat mata: followed by a closed nested block comment as block start', () => {
-      // The whole line after the colon is a comment (nested), so this is a
-      // block start, not an inline expression. Requires depth-counted
-      // block-comment scanning in the mata:/python: lookahead.
+      // The whole line after the colon is a comment (nested), so this
+      // is a block start, not an inline expression. Requires depth-
+      // counted block-comment scanning in the mata:/python: lookahead.
       const source = 'mata: /* outer /* inner */ still outer */\nmatrix A = (1, 2)';
       const result = lexer.tokenize(source);
 

--- a/tests/unit/lexer.test.ts
+++ b/tests/unit/lexer.test.ts
@@ -264,6 +264,30 @@ describe('StataLexer', () => {
       expect(commentToken).toBeDefined();
       expect(commentToken?.value).toBe('/* block comment */');
     });
+
+    test('should keep outer block comment active across nested block comment', () => {
+      const source = [
+        '/* outer',
+        '/* inner */',
+        'display `commented_macro\'',
+        '*/',
+        'display `live_macro\'',
+      ].join('\n');
+      const result = lexer.tokenize(source);
+
+      expect(result.errors).toHaveLength(0);
+
+      const commentToken = result.tokens.find(t => t.type === 'COMMENT_BLOCK');
+      expect(commentToken).toBeDefined();
+      expect(commentToken?.range.start.line).toBe(0);
+      expect(commentToken?.range.end.line).toBe(3);
+      expect(commentToken?.value).toContain('display `commented_macro\'');
+
+      const macroTokens = result.tokens.filter(t => t.type === 'MACRO_REF_LOCAL');
+      expect(macroTokens).toHaveLength(1);
+      expect(macroTokens[0].value).toBe('`live_macro\'');
+      expect(macroTokens[0].range.start.line).toBe(4);
+    });
   });
 
   describe('statement terminators', () => {


### PR DESCRIPTION
## Summary

Fixes #244. Stata `/* */` block comments nest, but Sight treated the first
`*/` as the end of the outermost comment, so code inside a nested block
comment was analyzed as live and produced spurious diagnostics (e.g.
`` `v226' is not defined ``).

This makes block-comment nesting depth-aware across the pipeline and ensures
diagnostics are suppressed for lines genuinely inside a (possibly nested)
block comment — the issue's "undefined-local **or other code diagnostics**"
expected behavior.

## Changes

- **Lexer** (`src/lexer/index.ts`): `consumeBlockCommentBody()` counts nesting
  depth so a `COMMENT_BLOCK` token spans the full nested extent. The
  `mata:`/`python:` inline-vs-block lookahead
  (`is_only_whitespace_or_comment_until_newline`) is also depth-aware, so a
  closed nested comment on the colon line is recognized as block mode.
- **Indentation diagnostics** (`src/providers/indentation-diagnostics.ts`):
  `compute_block_comment_lines()` derives comment lines from the lexer's
  `COMMENT_BLOCK` and multi-line `COMMENT_LINE` token ranges when tokens are
  available, so `/*` inside string literals or code is not miscounted (a raw
  depth-scan remains as a fallback).
- **Context tracker** (`src/context-tracker/index.ts`): the raw-line
  block-structure scans (`validate_end_delimiters`, `find_valid_end_lines`,
  `attempt_recovery_from_unclosed_block`) skip lines entirely inside a
  multi-line block comment, so a commented-out `end`/`program`/`mata` no longer
  emits a spurious "Unexpected end" or unbalances block tracking; lines that
  carry live code (e.g. `/* c */ end`) are still scanned.

## Testing

- `bun run typecheck`, `bun test` (6346 pass, 0 fail), and `bun run lint` all pass.
- Added unit/property tests for: nested-comment lexing, `mata:` lookahead with a
  nested comment, undefined-macro suppression in nested comments, orphan-`end`
  suppression inside (nested) comments, the commented-`program`-on-the-closing-
  line case, `/*` inside a string literal, and multi-line star-led comment spans.

https://claude.ai/code/session_01EgxDcYi39TpqfoHYcaPDHF