### PR TITLE
Make command-path nav/completion inert in block comments (#241)

### DIFF
--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -978,6 +978,22 @@ export class CompletionProvider {
                 ? this.context_tracker.get_context_at_position(position)
                 : LanguageContext.STATA;
 
+            // A Stata `/* ... */` block comment is inert: it is commented-out
+            // code, so offer no completions — path, command, variable, or the
+            // macro/quote snippet completions the trigger handling below would
+            // otherwise add. Placed before the quote/backtick trigger branch so
+            // those are also suppressed. Line comments are unaffected.
+            //
+            // Restricted to STATA context: inside embedded Mata/Python the lexer
+            // can emit COMMENT_BLOCK for `/* */` that is actually part of an
+            // embedded string (e.g. a Python single-quoted string, where `'` is
+            // lexed as an operator), and macros are valid there. `require_tokens`
+            // keeps the imprecise tokenless heuristic from suppressing live code.
+            if (my_current_context === LanguageContext.STATA &&
+                is_cursor_in_block_comment(document, position, { require_tokens: true })) {
+                return [];
+            }
+
             // Detect completion context (sync)
             const context = detect_completion_context(document, position, undefined, this.command_db);
 

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -112,8 +112,13 @@ export class DefinitionProvider {
             return null;
         }
 
-        const my_context = context_tracker
-            ? context_tracker.get_context_at_position(position)
+        // Prefer the explicit argument, but fall back to the document's own
+        // tracker so the block-comment guard and embedded-macro path use the
+        // real context even when a caller omits the optional argument (the
+        // completion provider does the same).
+        const my_context_tracker = context_tracker ?? document.context_tracker;
+        const my_context = my_context_tracker
+            ? my_context_tracker.get_context_at_position(position)
             : LanguageContext.STATA;
 
         // A Stata `/* ... */` block comment is inert: a commented-out

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -112,30 +112,46 @@ export class DefinitionProvider {
             return null;
         }
 
+        const my_context = context_tracker
+            ? context_tracker.get_context_at_position(position)
+            : LanguageContext.STATA;
+
+        // A Stata `/* ... */` block comment is inert: a commented-out
+        // `do "child.do"` is never executed, so neither command-path navigation
+        // nor symbol go-to-def should fire from inside one. Line comments are
+        // unaffected — `@lsp-*` directive navigation still works there via the
+        // directive branch below, which already excludes block comments.
+        //
+        // Restricted to STATA context: inside embedded Mata/Python the lexer can
+        // emit COMMENT_BLOCK for `/* */` that is actually part of an embedded
+        // string (e.g. a Python single-quoted string, where `'` is lexed as an
+        // operator), and macros are valid there — those resolve via the embedded
+        // handler below. `require_tokens` keeps the imprecise tokenless heuristic
+        // from hiding live code.
+        if (my_context === LanguageContext.STATA &&
+            is_cursor_in_block_comment(document, position, { require_tokens: true })) {
+            return null;
+        }
+
         // File-path / directive resolution runs first so cross-file directives
         // like `@lsp-done-by` and `do "..."` work from every context — including
-        // inside embedded-language blocks and inside comments.
+        // inside embedded-language blocks and inside line comments.
         const file_definition = this.get_include_definition(document, position);
         if (file_definition) {
             return file_definition;
         }
 
-        // Check if we're in an embedded language context
-        if (context_tracker) {
-            const my_context = context_tracker.get_context_at_position(position);
-
-            // In embedded language context, only resolve macros, not programs
-            if (my_context !== LanguageContext.STATA) {
-                return await this.get_macro_definition_only(
-                    document,
-                    position,
-                    workspace_symbols,
-                    scope_resolver,
-                    workspace_indexer,
-                    cross_file_config,
-                    cancellation_token
-                );
-            }
+        // In embedded language context, only resolve macros, not programs
+        if (my_context !== LanguageContext.STATA) {
+            return await this.get_macro_definition_only(
+                document,
+                position,
+                workspace_symbols,
+                scope_resolver,
+                workspace_indexer,
+                cross_file_config,
+                cancellation_token
+            );
         }
 
         // Get the word at the cursor position
@@ -1482,13 +1498,15 @@ export class DefinitionProvider {
     /**
      * Handle navigation for "do", "run", "include" commands and @lsp-* directives.
      *
-     * `do`/`run`/`include` only match when they are the first non-whitespace
-     * token on the line, so command navigation does not trigger from inside
-     * comments. The `@lsp-*` regex is intentionally unanchored, which lets
-     * directives nested inside comments still resolve. We still only navigate
-     * when the cursor actually sits on the quoted path — otherwise clicking an
-     * unrelated word on a line like `// note: @lsp-do: "helper"` would also
-     * jump to helper.do.
+     * Callers gate this on block comments: `get_definition` returns early when
+     * the cursor is inside a block comment, so a commented-out `do "x"` never
+     * reaches here. Within line comments, `do`/`run`/`include` only match when
+     * they are the first non-whitespace token on the line, so command navigation
+     * does not trigger from a `//` or `*` line. The `@lsp-*` regex is
+     * intentionally unanchored, so directives nested in line comments resolve.
+     * We still only navigate when the cursor actually sits on the quoted path —
+     * otherwise clicking an unrelated word on a line like
+     * `// note: @lsp-do: "helper"` would also jump to helper.do.
      */
     private get_include_definition(document: DocumentState, position: Position): Definition | null {
         const line_text = get_line_text(document, position.line);

--- a/src/utils/comment-utils.ts
+++ b/src/utils/comment-utils.ts
@@ -39,8 +39,20 @@ function is_cursor_in_comment_from_tokens(tokens: Token[], position: Position): 
  * `//` / line-leading `*` line comment). Directives are inert inside block
  * comments, so providers use this to avoid resolving/completing a
  * directive-looking line that is actually block-commented out.
+ *
+ * With lexer tokens present, detection uses precise COMMENT_BLOCK ranges.
+ * Without them (a rare lexer error/timeout state) it falls back to a string
+ * heuristic that can misread `/*` inside strings or `//` comments. Callers that
+ * drive blanket suppression (returning nothing for a whole position) should pass
+ * `require_tokens: true` to opt out of that heuristic rather than risk hiding
+ * live code; callers that only suppress a narrow directive-looking line can rely
+ * on the best-effort fallback.
  */
-export function is_cursor_in_block_comment(document: DocumentState, position: Position): boolean {
+export function is_cursor_in_block_comment(
+    document: DocumentState,
+    position: Position,
+    options?: { require_tokens?: boolean }
+): boolean {
     if (document.tokens && document.tokens.length > 0) {
         for (const my_token of document.tokens) {
             // A block comment is always inert; a line comment is inert only when
@@ -49,11 +61,30 @@ export function is_cursor_in_block_comment(document: DocumentState, position: Po
             const is_block = my_token.type === 'COMMENT_BLOCK';
             const is_spanned_line = my_token.type === 'COMMENT_LINE' &&
                 my_token.range.end.line > my_token.range.start.line;
-            if ((is_block || is_spanned_line) &&
-                is_position_in_range(position, my_token.range)) {
-                return true;
+            if (is_block || is_spanned_line) {
+                if (is_position_in_range(position, my_token.range)) {
+                    return true;
+                }
+                // An unterminated `/* ... */` (a block, or a line-leading `*`
+                // that opened a block) runs to EOF with an exclusive token end,
+                // so a cursor typed at the very end of the buffer sits exactly
+                // on that end and would otherwise read as outside the comment.
+                // Treat that EOF end as inclusive so providers stay inert while
+                // the user is still typing the comment body. A terminated
+                // comment's value ends with `*/`, so it keeps exclusive-end
+                // behavior (e.g. the char immediately after an inline block).
+                if (!my_token.value.endsWith('*/') &&
+                    position.line === my_token.range.end.line &&
+                    position.character === my_token.range.end.character) {
+                    return true;
+                }
             }
         }
+        return false;
+    }
+
+    // No tokens: only the imprecise string heuristic is available.
+    if (options?.require_tokens) {
         return false;
     }
 

--- a/src/utils/comment-utils.ts
+++ b/src/utils/comment-utils.ts
@@ -54,7 +54,16 @@ export function is_cursor_in_block_comment(
     options?: { require_tokens?: boolean }
 ): boolean {
     if (document.tokens && document.tokens.length > 0) {
-        for (const my_token of document.tokens) {
+        // Prefer the line-bucketed index for an O(B) lookup (B = tokens spanning
+        // the cursor line) instead of scanning the whole token array on every
+        // completion/definition request. build_token_line_index buckets a token
+        // under every line it spans, so a multi-line block comment is found from
+        // any of its lines (including its EOF end line). Fall back to a full scan
+        // for documents built without the index (e.g. some test fixtures).
+        const the_candidates = document.token_line_index?.size
+            ? (document.token_line_index.get(position.line) ?? [])
+            : document.tokens;
+        for (const my_token of the_candidates) {
             // A block comment is always inert; a line comment is inert only when
             // the lexer spans it across lines (e.g. a line-leading `*` followed
             // by a block opener), matching block_comment_lines for the parser.

--- a/tests/unit/completion.test.ts
+++ b/tests/unit/completion.test.ts
@@ -18,6 +18,7 @@ import { DocumentState } from '../../src/document-store';
 import { SymbolTable, MacroSymbol, ProgramSymbol, VariableSymbol, ScalarSymbol, MatrixSymbol } from '../../src/types';
 import { ContextTracker } from '../../src/context-tracker';
 import { LanguageContext } from '../../src/context-tracker/types';
+import { StataLexer } from '../../src/lexer';
 
 /**
  * Helper to create a minimal document state for testing.
@@ -2117,5 +2118,112 @@ describe('Path completion preserves on-disk casing', () => {
         expect(the_labels).toContain('loadData.do');
         expect(the_labels).not.toContain('clean.do');
         expect(the_labels).not.toContain('loaddata.do');
+    });
+});
+
+// ─── Regression guard: completions inert inside block comments (#241) ──────────
+// A do/run/include path (and any other completion) inside a /* ... */ block
+// comment is commented-out code, so get_completions must return nothing. Tokens
+// are populated (the production path) so the token-based block-comment detector
+// is exercised, not just the string heuristic.
+describe('Completion inert inside block comments', () => {
+    let temp_dir: string;
+    let provider: CompletionProvider;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sight-block-comment-'));
+        fs.mkdirSync(path.join(temp_dir, '.git'));
+        fs.mkdirSync(path.join(temp_dir, 'Helpers'));
+        fs.writeFileSync(path.join(temp_dir, 'Helpers', 'Clean.do'), '');
+        fs.writeFileSync(path.join(temp_dir, 'Helpers', 'loadData.do'), '');
+        provider = new CompletionProvider(new CommandDatabase());
+    });
+
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    // Build a DocumentState with real lexer tokens so the token-based
+    // is_cursor_in_block_comment path runs.
+    function make_lexed_doc(content: string): DocumentState {
+        const tokens = new StataLexer().tokenize(content).tokens;
+        return {
+            uri: `file://${path.join(temp_dir, 'main.do')}`,
+            version: 1,
+            content,
+            tokens,
+            ast: null,
+            symbols: {
+                programs: new Map(),
+                localMacros: new Map(),
+                globalMacros: new Map(),
+                variables: new Map(),
+                scalars: new Map(),
+                matrices: new Map(),
+            },
+            diagnostics: [],
+            context_ranges: [],
+        } as unknown as DocumentState;
+    }
+
+    it('offers no command-path completions inside a closed block comment', async () => {
+        const content = '/*\ndo Helpers/C\n*/';
+        const doc = make_lexed_doc(content);
+        const position = Position.create(1, 'do Helpers/C'.length);
+
+        const completions = await provider.get_completions(doc, position);
+
+        expect(completions.length).toBe(0);
+    });
+
+    it('still offers command-path completions for the same line outside a block comment', async () => {
+        // Positive control: identical path line, not commented out.
+        const content = 'do Helpers/C';
+        const doc = make_lexed_doc(content);
+        const position = Position.create(0, content.length);
+
+        const completions = await provider.get_completions(doc, position);
+
+        const the_labels = completions.map(c => c.label);
+        expect(completions.length).toBeGreaterThan(0);
+        expect(the_labels).toContain('Clean.do');
+    });
+
+    it('offers no command-path completions inside an unterminated block comment at EOF', async () => {
+        const content = '/*\ndo Helpers/C';
+        const doc = make_lexed_doc(content);
+        const position = Position.create(1, 'do Helpers/C'.length);
+
+        const completions = await provider.get_completions(doc, position);
+
+        expect(completions.length).toBe(0);
+    });
+
+    it('offers no macro/quote-trigger completions inside a block comment', async () => {
+        // The backtick trigger path runs before the context switch; the early
+        // return must suppress it too.
+        const content = '/*\ndo `\n*/';
+        const doc = make_lexed_doc(content);
+        const position = Position.create(1, 'do `'.length);
+
+        const completions = await provider.get_completions(doc, position, '`');
+
+        expect(completions.length).toBe(0);
+    });
+
+    it('does not suppress completions when the document has no tokens', async () => {
+        // The early return is gated on having lexer tokens: without them (a rare
+        // lexer error/timeout state), the block-comment string heuristic is too
+        // unreliable to justify blanket suppression, so command-path completion
+        // still runs. Same content as the closed-block case, but tokenless.
+        const content = '/*\ndo Helpers/C\n*/';
+        const doc = make_lexed_doc(content);
+        (doc as unknown as { tokens: unknown[] }).tokens = [];
+        const position = Position.create(1, 'do Helpers/C'.length);
+
+        const completions = await provider.get_completions(doc, position);
+
+        // Not suppressed: command-path completion lists the on-disk file.
+        expect(completions.map(c => c.label)).toContain('Clean.do');
     });
 });

--- a/tests/unit/definition.test.ts
+++ b/tests/unit/definition.test.ts
@@ -1310,6 +1310,31 @@ describe('DefinitionProvider - Context-Aware Behavior', () => {
             expect(my_definition).toBeNull();
         });
 
+        it('does not suppress navigation when the document has no tokens', async () => {
+            // The block-comment guard uses require_tokens: true, so a document
+            // without lexer tokens (a rare lexer error/timeout state) must not be
+            // blanket-suppressed via the imprecise string heuristic — navigation
+            // still resolves. Same block-comment-looking content, but tokenless.
+            const child_path = path.join(temp_dir, 'child.do');
+            fs.writeFileSync(child_path, '// Child file');
+
+            const my_content = '/*\ndo "child.do"\n*/';
+            const my_doc = create_test_document(
+                my_content,
+                undefined,
+                URI.file(path.join(temp_dir, 'test.do')).toString()
+            );
+            (my_doc as unknown as { tokens: unknown[] }).tokens = [];
+
+            const my_definition = await definition_provider.get_definition(
+                my_doc,
+                { line: 1, character: 8 } // Position on "child.do"
+            );
+
+            expect(my_definition).not.toBeNull();
+            expect(my_definition?.uri).toContain('child.do');
+        });
+
         it('should not navigate to directive target when cursor is on a word outside the quoted path', async () => {
             const helper_path = path.join(temp_dir, 'helper.do');
             fs.writeFileSync(helper_path, '// Helper file');

--- a/tests/unit/definition.test.ts
+++ b/tests/unit/definition.test.ts
@@ -1243,6 +1243,73 @@ describe('DefinitionProvider - Context-Aware Behavior', () => {
             expect(my_definition).toBeNull();
         });
 
+        it('should not navigate a do command path inside a block comment', async () => {
+            // A commented-out `do "child.do"` is never executed by Stata, so
+            // go-to-definition must be inert inside the /* ... */ block (#241).
+            const child_path = path.join(temp_dir, 'child.do');
+            fs.writeFileSync(child_path, '// Child file');
+
+            const my_content = '/*\ndo "child.do"\n*/';
+            const my_doc = create_test_document(
+                my_content,
+                undefined,
+                URI.file(path.join(temp_dir, 'test.do')).toString()
+            );
+
+            const my_definition = await definition_provider.get_definition(
+                my_doc,
+                { line: 1, character: 8 } // Position on "child.do" inside block
+            );
+
+            expect(my_definition).toBeNull();
+        });
+
+        it('should still navigate the same do command path outside a block comment', async () => {
+            // Positive control for the block-comment gate above: identical line,
+            // not commented out, must still resolve.
+            const child_path = path.join(temp_dir, 'child.do');
+            fs.writeFileSync(child_path, '// Child file');
+
+            const my_content = 'do "child.do"';
+            const my_doc = create_test_document(
+                my_content,
+                undefined,
+                URI.file(path.join(temp_dir, 'test.do')).toString()
+            );
+
+            const my_definition = await definition_provider.get_definition(
+                my_doc,
+                { line: 0, character: 8 } // Position on "child.do"
+            );
+
+            expect(my_definition).not.toBeNull();
+            expect(my_definition?.uri).toContain('child.do');
+        });
+
+        it('should not navigate a do command path inside an unterminated block comment at EOF', async () => {
+            // Unterminated /* runs to EOF; the cursor sits at the exclusive token
+            // end, which is_cursor_in_block_comment must still treat as inside.
+            const child_path = path.join(temp_dir, 'child.do');
+            fs.writeFileSync(child_path, '// Child file');
+
+            const my_content = '/*\ndo "child.do"';
+            const my_doc = create_test_document(
+                my_content,
+                undefined,
+                URI.file(path.join(temp_dir, 'test.do')).toString()
+            );
+
+            // Cursor at the very end of the buffer (line 1, char 13) — the
+            // unterminated COMMENT_BLOCK's exclusive end, which the EOF-inclusive
+            // branch of is_cursor_in_block_comment must still treat as inside.
+            const my_definition = await definition_provider.get_definition(
+                my_doc,
+                { line: 1, character: 'do "child.do"'.length }
+            );
+
+            expect(my_definition).toBeNull();
+        });
+
         it('should not navigate to directive target when cursor is on a word outside the quoted path', async () => {
             const helper_path = path.join(temp_dir, 'helper.do');
             fs.writeFileSync(helper_path, '// Helper file');


### PR DESCRIPTION
## Summary

Fixes #241. Go-to-definition and path completion fired for a `do`/`run`/`include` **command path** sitting inside a `/* ... */` block comment, even though Stata never executes such a line. This completes the "block comments are inert" model that `chore/normalize-directives` (#239) applied to LSP *directives*, extending it to ordinary commented-out command paths.

```stata
/*
do "child.do"
*/
```

Before: cursor on `"child.do"` navigated to `child.do` and completion offered `command_path` entries. After: both are inert.

## What changed

- **`get_definition` / `get_completions`** now early-return (`null` / `[]`) when the cursor is inside a Stata block comment. This suppresses command-path navigation, path completion, **and** the quote/backtick *trigger* completions (which run before the context switch). Symbol go-to-def was already suppressed in comments; this adds the command-path and trigger paths.
- **Scoped to STATA language context, gated on lexer tokens** via `is_cursor_in_block_comment(document, position, { require_tokens: true })`:
  - *STATA-only*: inside embedded Mata/Python the lexer can emit `COMMENT_BLOCK` for `/* */` that is actually part of an embedded string (e.g. a Python single-quoted string, where `'` is lexed as an operator), and macros are valid there — so the blanket suppression must not apply. (Verified this preserves `main`'s embedded behavior exactly.)
  - *`require_tokens`*: avoids the imprecise tokenless string heuristic (a rare lexer-error state) blanket-suppressing live code. The policy lives in one place — a new optional param on `is_cursor_in_block_comment` — rather than duplicated at each call site.
- **`is_cursor_in_block_comment`** now treats an *unterminated* comment token's EOF end as inclusive, so completion stays inert while the user is still typing an unclosed `/* ...` block at the end of the buffer.

Line comments are unaffected: `@lsp-*` directive navigation still works in `//` and `*` comments via the existing directive branch.

## Out of scope (pre-existing, not regressed)

- `/* */ do "x"` — live code after a closed block comment on the same line stays navigable/completable (cursor isn't in the block comment).
- `#delimit ;` statement-boundary modeling.

## Testing

- New regression tests in `tests/unit/definition.test.ts` and `tests/unit/completion.test.ts`: closed block comment → inert, positive controls (live code still resolves), unterminated-block-at-EOF, trigger-completion suppression, and a token-gate test (tokenless docs are not blanket-suppressed).
- `bun run test` (typecheck + full suite): 6332 pass, 0 fail.
- `bun run lint`: clean.

Reviewed adversarially across multiple rounds (Codex + code-review) until two consecutive clean passes on the final diff.

https://claude.ai/code/session_01CaHgUCP4KC2gkNeWjKH4Um

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completions now stay hidden when the cursor is inside a `/* ... */` block comment.
  * Go-to-definition no longer jumps to file paths from commands placed inside block comments, including unterminated comments at the end of a file.
  * Block-comment detection is now more reliable, especially when lexer tokens are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->