### PR TITLE
Align scope-resolver call-site validation with the directive parser (#240)

### DIFF
--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -25,7 +25,11 @@ import {
     DocumentLike,
 } from '../utils/line-utils';
 import { build_do_include_pattern } from '../utils/stata-call-patterns';
-import { block_comment_lines } from '../utils/block-comment-utils';
+import {
+    block_comment_lines,
+    block_comment_ranges,
+    position_in_block_comment,
+} from '../utils/block-comment-utils';
 import {
     BACKWARD_DIRECTIVE_KEYWORDS,
     FORWARD_DIRECTIVE_KEYWORDS,
@@ -98,16 +102,16 @@ const DECLARATION_DIRECTIVE_HEAD_PATTERN = make_directive_pattern(
     String.raw`:?(?=\s|$)`,
 );
 
-// Shared pattern to match do/include/run statements with optional prefix commands.
-// Prefix alternatives live in utils/stata-call-patterns so this pattern and the
-// prefix-only variant in scope-resolver stay in lockstep.
+// Shared pattern to match do/include/run statements with optional prefix
+// commands, capturing the called path. Prefix alternatives live in
+// utils/stata-call-patterns. The scope-resolver classifies call lines via
+// classify_call_line() in this module, so there is no separate copy to keep in
+// lockstep.
 const DO_INCLUDE_PATTERN = build_do_include_pattern('capture');
 
-// Shared pattern to match @lsp-do, @lsp-run, @lsp-include directives in comments.
-const CALL_DIRECTIVE_PATTERN = make_directive_pattern(
-    FORWARD_DIRECTIVE_KEYWORDS,
-    String.raw`:?\s+(?:"([^"]+)"|([^\s]+))${CALL_SITE_PARAMS_PATTERN}`,
-);
+// Forward-call directives (@lsp-do/run/include, sight: do/run/include) in
+// comments are matched with FORWARD_CALL_DIRECTIVE_PATTERN above; the inference
+// scanners and classify_call_line share that single constant.
 
 function looks_like_unquoted_path_token(token: string): boolean {
     // Heuristic for valid unquoted paths:
@@ -407,8 +411,10 @@ export class DirectiveParser {
                     // line= is 1-indexed in directive, convert to 0-indexed and clamp
                     my_call_site_line = Math.max(0, my_call_site.value - 1);
                 } else if (my_call_site?.type === 'match' && typeof my_call_site.value === 'string') {
-                    // Search current file content for match string
-                    const match_line = this.find_match_line(content, my_call_site.value);
+                    // Search current file content for match string (reuse the
+                    // already-lexed tokens for block-comment span detection).
+                    const match_line = this.find_match_line(
+                        content, my_call_site.value, block_comment_ranges(content, tokens));
                     if (match_line !== undefined) {
                         my_call_site_line = match_line;
                     } else {
@@ -614,15 +620,80 @@ export class DirectiveParser {
      */
     find_match_line(
         parent_content: string,
-        match_string: string
+        match_string: string,
+        block_ranges?: Range[]
     ): number | undefined {
         const doc: DocumentLike = { content: parent_content, line_offsets: compute_line_offsets(parent_content) };
         const line_count = get_line_count(doc);
+        // A match= occurrence inside a /* ... */ block comment is inert in Stata,
+        // so it must never become a call site. find_match_line does an unanchored
+        // substring search, so it checks the POSITION of each occurrence (not the
+        // whole line): an inline comment like `display 1 /* do "x" */` must not
+        // match, while a real `do "x"` after a `*/` on the same line must. Callers
+        // that already computed the ranges can pass them to avoid re-lexing.
+        const the_block_ranges = block_ranges ?? block_comment_ranges(parent_content);
         for (let i = 0; i < line_count; i++) {
-            if (get_line_text(doc, i).includes(match_string)) {
-                return i; // 0-indexed line number
+            const my_text = get_line_text(doc, i);
+            // `my_from <= length` bounds the scan: for an empty match_string,
+            // indexOf('') returns my_from up to the line length and then clamps,
+            // so without this bound the loop would never terminate.
+            let my_from = 0;
+            while (my_from <= my_text.length) {
+                const my_col = my_text.indexOf(match_string, my_from);
+                if (my_col < 0) {
+                    break;
+                }
+                if (!position_in_block_comment(i, my_col, the_block_ranges)) {
+                    return i; // first non-block-commented occurrence
+                }
+                my_from = my_col + 1; // a later occurrence on this line may be live
             }
         }
+        return undefined;
+    }
+
+    /**
+     * Classify a single line as a do/run/include call statement, applying the
+     * SAME validation as the directive scanners: a real command must carry a
+     * path; a forward directive must carry a valid path plus a well-formed
+     * line=/match= tail. Returns the call type, or undefined.
+     *
+     * Does NOT consider block comments — callers must first skip lines inside
+     * a /* ... *\/ block (see block_comment_lines), since this operates on a
+     * single line with no surrounding context.
+     */
+    classify_call_line(
+        line_content: string
+    ): 'do' | 'run' | 'include' | undefined {
+        const my_trimmed = line_content.trim();
+
+        // Real do/include/run command — require a path (capture variant),
+        // matching infer_call_type_for_file / find_all_call_sites_for_file.
+        const command_match = my_trimmed.match(DO_INCLUDE_PATTERN);
+        if (command_match) {
+            const my_path = command_match[2] || command_match[3];
+            if (my_path) {
+                return command_match[1] as 'do' | 'run' | 'include';
+            }
+        }
+
+        // Forward directive in a comment line — full validation (path required
+        // plus a well-formed param tail, rejecting param-like unquoted tokens),
+        // matching parse_forward_call_directives.
+        if (my_trimmed.startsWith('*') || my_trimmed.startsWith('//')) {
+            const directive_match = my_trimmed.match(FORWARD_CALL_DIRECTIVE_PATTERN);
+            if (directive_match) {
+                const my_quoted_path = directive_match[2];
+                const my_unquoted_path = directive_match[3];
+                const my_path = my_quoted_path || my_unquoted_path;
+                if (my_path &&
+                    (my_quoted_path ||
+                        looks_like_unquoted_path_token(my_unquoted_path))) {
+                    return directive_match[1] as 'do' | 'run' | 'include';
+                }
+            }
+        }
+
         return undefined;
     }
 
@@ -697,13 +768,19 @@ export class DirectiveParser {
 
             // Also check for @lsp-do, @lsp-run, @lsp-include directives in comment lines
             if (my_trimmed.startsWith('*') || my_trimmed.startsWith('//')) {
-                const directive_match = my_trimmed.match(CALL_DIRECTIVE_PATTERN);
+                const directive_match = my_trimmed.match(FORWARD_CALL_DIRECTIVE_PATTERN);
                 if (directive_match) {
                     const my_quoted_path = directive_match[2];
                     const my_unquoted_path = directive_match[3];
                     const my_target_path = my_quoted_path || my_unquoted_path;
 
-                    if (my_target_path) {
+                    // Reject param-like unquoted tokens (line=.../match=...),
+                    // matching parse_forward_call_directives, so a directive like
+                    // `// sight: do line=5` is not mis-read as a call to a
+                    // pathologically-named child such as `line=5.do`.
+                    if (my_target_path &&
+                        (my_quoted_path ||
+                            looks_like_unquoted_path_token(my_unquoted_path))) {
                         const my_target_basename = path.basename(my_target_path);
                         const my_target_without_ext = my_target_basename.toLowerCase().endsWith('.do')
                             ? my_target_basename.slice(0, -3).toLowerCase()
@@ -779,14 +856,20 @@ export class DirectiveParser {
 
             // Also check for @lsp-do, @lsp-run, @lsp-include directives in comment lines
             if (my_trimmed.startsWith('*') || my_trimmed.startsWith('//')) {
-                const directive_match = my_trimmed.match(CALL_DIRECTIVE_PATTERN);
+                const directive_match = my_trimmed.match(FORWARD_CALL_DIRECTIVE_PATTERN);
                 if (directive_match) {
                     const my_call_type = directive_match[1] as 'do' | 'run' | 'include';
                     const my_quoted_path = directive_match[2];
                     const my_unquoted_path = directive_match[3];
                     const my_target_path = my_quoted_path || my_unquoted_path;
 
-                    if (my_target_path) {
+                    // Reject param-like unquoted tokens (line=.../match=...),
+                    // matching parse_forward_call_directives, so a directive like
+                    // `// sight: do line=5` is not mis-read as a call to a
+                    // pathologically-named child such as `line=5.do`.
+                    if (my_target_path &&
+                        (my_quoted_path ||
+                            looks_like_unquoted_path_token(my_unquoted_path))) {
                         const my_target_basename = path.basename(my_target_path);
                         const my_target_without_ext = my_target_basename.toLowerCase().endsWith('.do')
                             ? my_target_basename.slice(0, -3).toLowerCase()
@@ -877,14 +960,20 @@ export class DirectiveParser {
 
             // Also check for @lsp-do, @lsp-run, @lsp-include directives in comment lines
             if (my_trimmed.startsWith('*') || my_trimmed.startsWith('//')) {
-                const directive_match = my_trimmed.match(CALL_DIRECTIVE_PATTERN);
+                const directive_match = my_trimmed.match(FORWARD_CALL_DIRECTIVE_PATTERN);
                 if (directive_match) {
                     const my_call_type = directive_match[1] as 'do' | 'run' | 'include';
                     const my_quoted_path = directive_match[2];
                     const my_unquoted_path = directive_match[3];
                     const my_target_path = my_quoted_path || my_unquoted_path;
 
-                    if (my_target_path) {
+                    // Reject param-like unquoted tokens (line=.../match=...),
+                    // matching parse_forward_call_directives, so a directive like
+                    // `// sight: do line=5` is not mis-read as a call to a
+                    // pathologically-named child such as `line=5.do`.
+                    if (my_target_path &&
+                        (my_quoted_path ||
+                            looks_like_unquoted_path_token(my_unquoted_path))) {
                         const my_target_basename = path.basename(my_target_path);
                         const my_target_without_ext = my_target_basename.toLowerCase().endsWith('.do')
                             ? my_target_basename.slice(0, -3).toLowerCase()

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -316,6 +316,9 @@ export class DirectiveParser {
 
         // Lines whose leading text is inside a block comment carry no directives.
         const block_lines = block_comment_lines(content, tokens);
+        // Block-comment spans for match= occurrence checks, computed lazily once
+        // and reused across all match= directives in this file.
+        let the_block_ranges: Range[] | undefined;
 
         // Track lines to ignore from @lsp-ignore-next
         const ignored_next_lines = new Set<number>();
@@ -413,8 +416,11 @@ export class DirectiveParser {
                 } else if (my_call_site?.type === 'match' && typeof my_call_site.value === 'string') {
                     // Search current file content for match string (reuse the
                     // already-lexed tokens for block-comment span detection).
+                    if (the_block_ranges === undefined) {
+                        the_block_ranges = block_comment_ranges(content, tokens);
+                    }
                     const match_line = this.find_match_line(
-                        content, my_call_site.value, block_comment_ranges(content, tokens));
+                        content, my_call_site.value, the_block_ranges);
                     if (match_line !== undefined) {
                         my_call_site_line = match_line;
                     } else {

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -45,7 +45,6 @@ import {
     get_workspace_root_for_uri,
     get_workspace_root_for_path,
 } from '../utils/workspace-roots';
-import { build_do_include_pattern } from '../utils/stata-call-patterns';
 import {
     resolve_path_rich,
     resolve_forward_call_rich,
@@ -54,9 +53,9 @@ import {
     type RichResolveFs,
 } from '../utils/file-path-utils';
 import {
-    FORWARD_DIRECTIVE_KEYWORDS,
-    make_directive_pattern,
-} from '../utils/directives';
+    block_comment_ranges,
+    position_in_block_comment,
+} from '../utils/block-comment-utils';
 
 export {
     get_visible_symbols_at,
@@ -72,19 +71,6 @@ const DEFAULT_CONFIG: ScopeResolverConfig = {
     max_forward_depth: 10,
     max_chain_depth: 20,
 };
-
-// Pattern to match do/include/run commands with optional prefix commands.
-// Prefix alternatives live in utils/stata-call-patterns so this pattern and the
-// path-capturing variant in directive-parser stay in lockstep. Built once at
-// module load; neither pattern uses the `g` flag, so there is no `lastIndex`
-// state to reset between calls.
-const DO_INCLUDE_PATTERN = build_do_include_pattern('prefix');
-
-// Pattern to match forward directives in comment lines.
-const DIRECTIVE_PATTERN = make_directive_pattern(
-    FORWARD_DIRECTIVE_KEYWORDS,
-    String.raw`:?\s+`,
-);
 
 /**
  * Build a Partial<ScopeResolverConfig> with undefined values filtered out.
@@ -463,29 +449,40 @@ export class ScopeResolver {
     }
 
     /**
-     * Check if a line contains a valid call statement (do/run/include command or @lsp-do/run/include directive).
-     * @param line_content - The content of the line to check
-     * @returns The detected call_type, or undefined if no call found
+     * Check if a given parent line is a valid call statement (do/run/include
+     * command or @lsp-do/run/include forward directive).
+     *
+     * Delegates to DirectiveParser.classify_call_line so validation matches the
+     * directive parser exactly (path required; forward directives need a
+     * well-formed line=/match= tail and a non-param-like unquoted path). A line
+     * whose leading text is inside a block comment is inert in Stata and is
+     * never a call statement.
+     *
+     * @param parent_content - Full content of the parent file
+     * @param line_number - 0-indexed line to check
+     * @param block_ranges - Block-comment spans in the parent file
+     * @returns The detected call_type, or undefined if no valid call found
      */
-    private validate_call_statement(line_content: string): 'do' | 'run' | 'include' | undefined {
-        const my_trimmed = line_content.trim();
-
-        // Check for command pattern (uses module-level DO_INCLUDE_PATTERN)
-        const command_match = my_trimmed.match(DO_INCLUDE_PATTERN);
-        if (command_match) {
-            return command_match[1] as 'do' | 'run' | 'include';
+    private validate_call_statement(
+        parent_content: string,
+        line_number: number,
+        block_ranges: Range[]
+    ): 'do' | 'run' | 'include' | undefined {
+        const doc = {
+            content: parent_content,
+            line_offsets: compute_line_offsets(parent_content),
+        };
+        const line_content = get_line_text(doc, line_number);
+        // classify_call_line is anchored, so it already ignores a call inside a
+        // trailing inline comment; the only case it cannot see is a line whose
+        // leading text is itself inside a block comment (a continuation line of a
+        // multi-line /* ... */). Skip those here.
+        const leading_col = line_content.search(/\S/);
+        if (leading_col >= 0 &&
+            position_in_block_comment(line_number, leading_col, block_ranges)) {
+            return undefined;
         }
-
-        // Check for directive pattern in comment lines
-        if (my_trimmed.startsWith('*') || my_trimmed.startsWith('//')) {
-            const directive_match = my_trimmed.match(DIRECTIVE_PATTERN);
-            if (directive_match) {
-                return directive_match[1] as 'do' | 'run' | 'include';
-            }
-        }
-
-        // No valid call statement found
-        return undefined;
+        return this.directive_parser.classify_call_line(line_content);
     }
 
     /**
@@ -1710,6 +1707,10 @@ export class ScopeResolver {
             let effective_call_type: 'do' | 'run' | 'include' = my_directive.type === 'included-by' ? 'include' : 'do';
 
             if (my_directive.call_site) {
+                // Block-comment spans are inert, so a call site must never
+                // resolve into one. Computed once and shared by the line= and
+                // match= validation below.
+                const my_block_ranges = block_comment_ranges(my_parent_content);
                 if (my_directive.call_site.type === 'line') {
                     // User-provided line=N is 1-indexed; convert to 0-indexed
                     my_call_site_line = (my_directive.call_site.value as number) - 1;
@@ -1732,10 +1733,11 @@ export class ScopeResolver {
                             ? Number.MAX_SAFE_INTEGER
                             : 0;
                     } else {
-                        // Validate line contains a call statement (Req 1.4)
-                        const doc = { content: my_parent_content, line_offsets: compute_line_offsets(my_parent_content) };
-                        const line_content = get_line_text(doc, my_call_site_line);
-                        const call_validation = this.validate_call_statement(line_content);
+                        // Validate line contains a call statement (Req 1.4).
+                        // A malformed/block-commented line returns undefined, so
+                        // it no longer flips effective_call_type/inheritance.
+                        const call_validation = this.validate_call_statement(
+                            my_parent_content, my_call_site_line, my_block_ranges);
 
                         if (!call_validation) {
                             diagnostics.push({
@@ -1759,10 +1761,12 @@ export class ScopeResolver {
                         }
                     }
                 } else {
-                    // find_match_line returns 0-indexed line number
+                    // find_match_line returns 0-indexed line number. Pass the
+                    // already-computed block lines to avoid re-lexing the parent.
                     const my_match_line = this.directive_parser.find_match_line(
                         my_parent_content,
-                        my_directive.call_site.value as string
+                        my_directive.call_site.value as string,
+                        my_block_ranges
                     );
                     if (my_match_line === undefined) {
                         // Req 1.6: match= not found emits warning
@@ -1784,9 +1788,8 @@ export class ScopeResolver {
                         my_call_site_line = my_match_line;
 
                         // Try to infer call type from the matched line so we can emit mismatch diagnostics
-                        const doc = { content: my_parent_content, line_offsets: compute_line_offsets(my_parent_content) };
-                        const line_content = get_line_text(doc, my_call_site_line);
-                        const matched_call_type = this.validate_call_statement(line_content);
+                        const matched_call_type = this.validate_call_statement(
+                            my_parent_content, my_call_site_line, my_block_ranges);
                         if (matched_call_type) {
                             effective_call_type = matched_call_type;
 

--- a/src/utils/block-comment-utils.ts
+++ b/src/utils/block-comment-utils.ts
@@ -18,31 +18,67 @@
  */
 
 import { Token } from '../types';
+import { Range } from 'vscode-languageserver-textdocument';
 import { StataLexer } from '../lexer';
 import { compute_line_offsets, get_line_text, get_line_count } from './line-utils';
+
+/**
+ * Character spans of multi-line comment tokens (0-based line/character ranges).
+ * `tokens` should be the lexer tokens for `content`; when omitted, `content` is
+ * lexed.
+ *
+ * Considered comments are block comments (any — a block comment is never a
+ * directive) and line comments the lexer spans across lines. A single-line line
+ * comment (the common `// sight: ...` directive) is excluded so a real directive
+ * on its own line still parses.
+ */
+export function block_comment_ranges(content: string, tokens?: Token[]): Range[] {
+    const the_tokens = tokens ?? new StataLexer().tokenize(content).tokens;
+    return the_tokens
+        .filter(my_token =>
+            my_token.type === 'COMMENT_BLOCK' ||
+            (my_token.type === 'COMMENT_LINE' &&
+                my_token.range.end.line > my_token.range.start.line))
+        .map(my_token => my_token.range);
+}
+
+/**
+ * Whether the (0-based line, character) position falls inside any of the given
+ * comment ranges. The range is half-open: [start, end) — so the character just
+ * after a closing comment marker is NOT inside.
+ */
+export function position_in_block_comment(
+    line: number,
+    character: number,
+    ranges: Range[]
+): boolean {
+    for (const my_range of ranges) {
+        const after_start = line > my_range.start.line ||
+            (line === my_range.start.line && character >= my_range.start.character);
+        const before_end = line < my_range.end.line ||
+            (line === my_range.end.line && character < my_range.end.character);
+        if (after_start && before_end) {
+            return true;
+        }
+    }
+    return false;
+}
 
 /**
  * Line indices (0-based) whose first non-whitespace character is inside a
  * multi-line comment token. `tokens` should be the lexer tokens for `content`;
  * when omitted, `content` is lexed.
  *
- * Considered comments are block comments (any — a block comment is never a
- * directive) and line comments the lexer spans across lines. A single-line
- * line comment (the common `// sight: ...` directive) is excluded so a real
- * directive on its own line still parses. Anchoring on the line's first
- * non-whitespace character means a real code line with a trailing block comment
- * (code, then a block opener) is NOT marked — its leading text is the code, not
- * the comment — while a comment whose leading text is itself the comment (a bare
- * block comment, or a line-leading-star span) IS marked.
+ * Anchoring on the line's first non-whitespace character means a real code line
+ * with a trailing block comment (code, then a block opener) is NOT marked — its
+ * leading text is the code, not the comment — while a comment whose leading text
+ * is itself the comment (a bare block comment, or a line-leading-star span) IS
+ * marked. Callers that need to test a non-leading position (e.g. a `match=`
+ * substring anywhere on a line) should use {@link position_in_block_comment}
+ * with {@link block_comment_ranges} instead.
  */
 export function block_comment_lines(content: string, tokens?: Token[]): Set<number> {
-    const the_tokens = tokens ?? new StataLexer().tokenize(content).tokens;
-    const the_comment_ranges = the_tokens
-        .filter(my_token =>
-            my_token.type === 'COMMENT_BLOCK' ||
-            (my_token.type === 'COMMENT_LINE' &&
-                my_token.range.end.line > my_token.range.start.line))
-        .map(my_token => my_token.range);
+    const the_comment_ranges = block_comment_ranges(content, tokens);
 
     const the_lines = new Set<number>();
     if (the_comment_ranges.length === 0) {
@@ -57,15 +93,8 @@ export function block_comment_lines(content: string, tokens?: Token[]): Set<numb
         if (my_col < 0) {
             continue; // blank line
         }
-        for (const my_range of the_comment_ranges) {
-            const after_start = my_line > my_range.start.line ||
-                (my_line === my_range.start.line && my_col >= my_range.start.character);
-            const before_end = my_line < my_range.end.line ||
-                (my_line === my_range.end.line && my_col < my_range.end.character);
-            if (after_start && before_end) {
-                the_lines.add(my_line);
-                break;
-            }
+        if (position_in_block_comment(my_line, my_col, the_comment_ranges)) {
+            the_lines.add(my_line);
         }
     }
     return the_lines;

--- a/tests/property/find-match-line-indexing.prop.test.ts
+++ b/tests/property/find-match-line-indexing.prop.test.ts
@@ -170,7 +170,12 @@ describe('find_match_line Returns 0-Indexed Line Numbers', () => {
         fc.assert(
             fc.property(
                 fc.string({ minLength: 3, maxLength: 30 })
-                    .filter(s => !s.includes('\n') && s.trim().length > 0),
+                    // Exclude content whose leading text opens a block comment:
+                    // find_match_line now skips block-commented lines, so such a
+                    // single line is inert and correctly yields undefined (this
+                    // property is about position semantics, not comment handling).
+                    .filter(s => !s.includes('\n') && s.trim().length > 0
+                        && !s.trimStart().startsWith('/*')),
                 (match_string) => {
                     const content = match_string;
                     const result = parser.find_match_line(content, match_string);

--- a/tests/unit/directive-parser-classify-call-line.test.ts
+++ b/tests/unit/directive-parser-classify-call-line.test.ts
@@ -68,6 +68,15 @@ describe('DirectiveParser.classify_call_line', () => {
         expect(parser.classify_call_line('// just a comment')).toBeUndefined();
     });
 
+    test('rejects directive bodies without a valid comment prefix', () => {
+        // A bare `sight:` line is not a Stata comment, and `#` is not a valid
+        // directive prefix; the directive branch only fires after `//` or `*`.
+        expect(parser.classify_call_line('sight: do: "x.do"')).toBeUndefined();
+        expect(parser.classify_call_line('# sight: do: "x.do"')).toBeUndefined();
+        // Sanity: the same body with a valid prefix is recognized.
+        expect(parser.classify_call_line('// sight: do: "x.do"')).toBe('do');
+    });
+
     test('is single-line: it does not apply @lsp-ignore-next context', () => {
         // classify_call_line has no surrounding context, so an ignore-next on a
         // previous line cannot suppress it. Documents the deliberate out-of-scope

--- a/tests/unit/directive-parser-classify-call-line.test.ts
+++ b/tests/unit/directive-parser-classify-call-line.test.ts
@@ -1,0 +1,193 @@
+import { describe, test, expect } from 'bun:test';
+import { DirectiveParser } from '../../src/directive-parser';
+
+// Tests for issue #240: scope-resolver call-site validation must match the
+// directive parser. classify_call_line is the shared single-line classifier;
+// find_match_line and the inference scanners must skip block comments and reject
+// param-like unquoted tokens.
+
+describe('DirectiveParser.classify_call_line', () => {
+    const parser = new DirectiveParser();
+
+    test('classifies real do/run/include commands with a path', () => {
+        expect(parser.classify_call_line('do "x.do"')).toBe('do');
+        expect(parser.classify_call_line('run x.do')).toBe('run');
+        expect(parser.classify_call_line('include "x.do"')).toBe('include');
+    });
+
+    test('keeps do-file arguments valid (junk after path is a script arg)', () => {
+        // Stata runs `do file arg1 arg2`; the trailing tokens are arguments,
+        // not malformed syntax. Must NOT be rejected.
+        expect(parser.classify_call_line('do "x.do" arg1 arg2')).toBe('do');
+        expect(parser.classify_call_line('do x.do junk')).toBe('do');
+    });
+
+    test('classifies prefixed commands', () => {
+        expect(parser.classify_call_line('qui do "x.do"')).toBe('do');
+        expect(parser.classify_call_line('cap include x.do')).toBe('include');
+        expect(parser.classify_call_line('noisily run "x.do"')).toBe('run');
+    });
+
+    test('rejects a pathless do command', () => {
+        expect(parser.classify_call_line('do ')).toBeUndefined();
+        expect(parser.classify_call_line('do')).toBeUndefined();
+    });
+
+    test('accepts a real path with a trailing comment', () => {
+        // The path token is captured before any trailing comment.
+        expect(parser.classify_call_line('do "x.do" /* run it */')).toBe('do');
+        expect(parser.classify_call_line('do x.do // run it')).toBe('do');
+    });
+
+    test('classifies valid forward directives (both prefixes)', () => {
+        expect(parser.classify_call_line('// sight: do: "x.do"')).toBe('do');
+        expect(parser.classify_call_line('* sight: include: "x.do"')).toBe('include');
+        expect(parser.classify_call_line('// @lsp-run: "x.do"')).toBe('run');
+    });
+
+    test('classifies a forward directive with a valid param tail', () => {
+        expect(parser.classify_call_line('// sight: do: "x.do" line=2')).toBe('do');
+        expect(parser.classify_call_line('// sight: do: "x.do" match="foo"')).toBe('do');
+    });
+
+    test('rejects a forward directive with no path (param-like token)', () => {
+        // `// sight: do line=5` has no path: `line=5` is a param-like unquoted
+        // token, which parse_forward_call_directives also rejects as malformed.
+        expect(parser.classify_call_line('// sight: do line=5')).toBeUndefined();
+        expect(parser.classify_call_line('// @lsp-do match="foo"')).toBeUndefined();
+    });
+
+    test('rejects a forward directive with trailing junk after the path', () => {
+        // The directive param tail only accepts line=/match=; trailing `junk`
+        // is malformed (unlike a real `do` command, where it would be an arg).
+        expect(parser.classify_call_line('// sight: do: "x.do" junk')).toBeUndefined();
+    });
+
+    test('returns undefined for a non-call line', () => {
+        expect(parser.classify_call_line('gen x = 1')).toBeUndefined();
+        expect(parser.classify_call_line('// just a comment')).toBeUndefined();
+    });
+
+    test('is single-line: it does not apply @lsp-ignore-next context', () => {
+        // classify_call_line has no surrounding context, so an ignore-next on a
+        // previous line cannot suppress it. Documents the deliberate out-of-scope
+        // behavior for explicit call-site validation (see issue #240 spec).
+        expect(parser.classify_call_line('// sight: do: "x.do"')).toBe('do');
+    });
+});
+
+describe('DirectiveParser.find_match_line block-comment awareness', () => {
+    const parser = new DirectiveParser();
+
+    test('skips a match inside a /* ... */ block comment', () => {
+        const content = [
+            '/*',
+            'do "child.do"',   // line 1: inside block comment, inert
+            '*/',
+            'global mid 1',
+            'do "child.do"',   // line 4: the real call
+        ].join('\n');
+        expect(parser.find_match_line(content, 'do "child.do"')).toBe(4);
+    });
+
+    test('returns undefined when the only match is block-commented', () => {
+        const content = [
+            '/*',
+            'do "child.do"',
+            '*/',
+        ].join('\n');
+        expect(parser.find_match_line(content, 'do "child.do"')).toBeUndefined();
+    });
+
+    test('finds a non-block-commented match normally', () => {
+        const content = ['display 1', 'do "child.do"', 'display 2'].join('\n');
+        expect(parser.find_match_line(content, 'do "child.do"')).toBe(1);
+    });
+
+    test('finds a live call after a leading inline block comment (span-aware)', () => {
+        // `/* note */ do "child.do"` has the do AFTER the */, which is live code.
+        // Span-aware search checks the match POSITION (col 11), which is outside
+        // the comment span [0,10), so the match is found on line 0.
+        const content = ['/* note */ do "child.do"'].join('\n');
+        expect(parser.find_match_line(content, 'do "child.do"')).toBe(0);
+    });
+
+    test('skips a match inside a trailing inline block comment', () => {
+        // `display 1 /* do "child.do" */` has the match text INSIDE an inline
+        // block comment on an otherwise-active line; it must be skipped, and the
+        // real call on a later line found instead.
+        const content = [
+            'display 1 /* do "child.do" */',
+            'do "child.do"',
+        ].join('\n');
+        expect(parser.find_match_line(content, 'do "child.do"')).toBe(1);
+    });
+
+    test('returns undefined when the only match is in a trailing inline comment', () => {
+        const content = ['display 1 /* do "child.do" */'].join('\n');
+        expect(parser.find_match_line(content, 'do "child.do"')).toBeUndefined();
+    });
+
+    test('an empty match string terminates over block-commented content', () => {
+        // Regression: an unbounded indexOf('') scan would never terminate on a
+        // multi-line block comment (every position stays inside the span). The
+        // key guarantee is that the call returns rather than hanging.
+        const commented = ['/*', 'x', '*/'].join('\n');
+        expect(typeof parser.find_match_line(commented, '')).toBe('number');
+        const with_code = ['display 1', '/*', 'x', '*/'].join('\n');
+        expect(parser.find_match_line(with_code, '')).toBe(0);
+    });
+});
+
+describe('inference scanners reject param-like unquoted directive tokens', () => {
+    const parser = new DirectiveParser();
+
+    test('find_all_call_sites_for_file ignores `do line=5` for child line=5.do', () => {
+        // Without the guard, `// sight: do line=5` would capture `line=5` and
+        // wrongly match a child literally named line=5.do (issue #240 Finding B).
+        const parent = ['display 1', '// sight: do line=5'].join('\n');
+        expect(parser.find_all_call_sites_for_file(parent, 'line=5.do')).toEqual([]);
+    });
+
+    test('a real command targeting line=5.do still matches', () => {
+        const parent = ['do "line=5.do"'].join('\n');
+        const sites = parser.find_all_call_sites_for_file(parent, 'line=5.do');
+        expect(sites.length).toBe(1);
+        expect(sites[0].call_type).toBe('do');
+    });
+
+    test('a normal forward directive still matches', () => {
+        const parent = ['// sight: do: "child.do"'].join('\n');
+        const sites = parser.find_all_call_sites_for_file(parent, 'child.do');
+        expect(sites.length).toBe(1);
+        expect(sites[0].call_type).toBe('do');
+    });
+
+    // The guard lives in all three inference scanners; assert each so the
+    // shared invariant cannot regress in just one of them.
+    test('infer_call_type_for_file ignores `do line=5` for child line=5.do', () => {
+        const parent = ['display 1', '// sight: do line=5'].join('\n');
+        expect(parser.infer_call_type_for_file(parent, 'line=5.do')).toBeUndefined();
+    });
+
+    test('infer_call_site_for_file ignores `do line=5` for child line=5.do', () => {
+        const parent = ['display 1', '// sight: do line=5'].join('\n');
+        expect(parser.infer_call_site_for_file(parent, 'line=5.do')).toBeUndefined();
+    });
+
+    test('infer_call_type_for_file still matches a normal forward directive', () => {
+        const parent = ['// sight: do: "child.do"'].join('\n');
+        expect(parser.infer_call_type_for_file(parent, 'child.do')).toEqual({
+            line: 0,
+            call_type: 'do',
+        });
+    });
+
+    test('inference scanners match a real command path', () => {
+        const parent = ['do child.do'].join('\n');
+        expect(parser.infer_call_site_for_file(parent, 'child.do')).toBe(0);
+        const sites = parser.find_all_call_sites_for_file(parent, 'child.do');
+        expect(sites.length).toBe(1);
+        expect(sites[0].call_type).toBe('do');
+    });
+});

--- a/tests/unit/issue240-call-site-validation.test.ts
+++ b/tests/unit/issue240-call-site-validation.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
+
+import { ScopeResolver } from '../../src/scope-resolver';
+
+// Issue #240: the scope-resolver's call-site validation must apply the same
+// validation/comment-awareness as the directive parser, so a call site is never
+// resolved to a line the parser would reject or treat as inert.
+describe('Issue #240: call-site validation honors malformed / block-commented lines', () => {
+    let temp_dir: string;
+    let resolver: ScopeResolver;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sight-issue240-'));
+        resolver = new ScopeResolver();
+    });
+
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    function create_file(filename: string, content: string): string {
+        const file_path = path.join(temp_dir, filename);
+        fs.mkdirSync(path.dirname(file_path), { recursive: true });
+        fs.writeFileSync(file_path, content, 'utf8');
+        return file_path;
+    }
+
+    it('(a) a malformed forward directive at an explicit line= does not flip included-by to do', async () => {
+        // parent.do:
+        //   line 1: local p_local 1        (defined before the call site)
+        //   line 2: // sight: do line=5    (malformed forward directive: no path)
+        const parent_content = ['local p_local 1', '// sight: do line=5'].join('\n');
+        create_file('parent.do', parent_content);
+
+        // child requests included-by with the call site at parent line 2.
+        const child_content = [
+            '// @lsp-included-by: "parent.do" line=2',
+            "display `p_local'",
+        ].join('\n');
+        const child_path = create_file('child.do', child_content);
+
+        const result = await resolver.resolve(
+            URI.file(child_path).toString(),
+            child_content
+        );
+
+        // Include semantics preserved: the parent local is inherited. Under the
+        // pre-fix behavior, line 2 was mis-read as a `do` call, flipping to
+        // done-by and dropping all parent locals.
+        expect(result.symbols.localMacros.has('p_local')).toBe(true);
+
+        // The malformed line is reported as not containing a call statement.
+        const warning = result.diagnostics.find(
+            (d) =>
+                d.severity === 'warning' &&
+                d.message.includes('does not contain a do/run/include command')
+        );
+        expect(warning).toBeDefined();
+    });
+
+    it('(a2) an explicit line= pointing inside a block comment does not flip included-by to do', async () => {
+        // parent.do (1-indexed lines):
+        //   1: local p_local 1
+        //   2: /*                 (block comment opener)
+        //   3: do "child.do"      (inside the block comment -> inert)
+        //   4: */
+        const parent_content = [
+            'local p_local 1',
+            '/*',
+            'do "child.do"',
+            '*/',
+        ].join('\n');
+        create_file('parent.do', parent_content);
+
+        // child points the call site at line 3, which is block-commented.
+        const child_content = [
+            '// @lsp-included-by: "parent.do" line=3',
+            "display `p_local'",
+        ].join('\n');
+        const child_path = create_file('child.do', child_content);
+
+        const result = await resolver.resolve(
+            URI.file(child_path).toString(),
+            child_content
+        );
+
+        // The block-commented line is inert: validation returns undefined, so
+        // include semantics are preserved and the parent local is inherited.
+        // Pre-fix, line 3 was read as a `do` call and flipped to done-by.
+        expect(result.symbols.localMacros.has('p_local')).toBe(true);
+        const warning = result.diagnostics.find(
+            (d) =>
+                d.severity === 'warning' &&
+                d.message.includes('does not contain a do/run/include command')
+        );
+        expect(warning).toBeDefined();
+    });
+
+    it('(b) match= skips a block-commented call and resolves to the real one', async () => {
+        // parent.do: the first textual occurrence of the do command is inside a
+        // /* ... */ block comment and must be skipped; the real call is later.
+        const parent_content = [
+            '/*',
+            'do "child.do"', // line 1: inert (block comment)
+            '*/',
+            'global mid 1', // line 3: between bogus and real call
+            'do "child.do"', // line 4: the real call
+            'global after 1', // line 5: after the real call site
+        ].join('\n');
+        create_file('parent.do', parent_content);
+
+        const child_content = [
+            '// @lsp-done-by: "parent.do" match="do \\"child.do\\""',
+            "display `=1'",
+        ].join('\n');
+        const child_path = create_file('child.do', child_content);
+
+        const result = await resolver.resolve(
+            URI.file(child_path).toString(),
+            child_content
+        );
+
+        // The match resolved to a real call site (the block-commented one on
+        // line 1 was skipped), so there is no "match not found" fallback.
+        const not_found = result.diagnostics.find((d) =>
+            d.message.includes('not found in parent file')
+        );
+        expect(not_found).toBeUndefined();
+
+        // The real call site is line 4 (0-indexed): $mid (line 3) is on/before
+        // it and in scope; $after (line 5) is after it and out of scope. Had the
+        // match fallen back to the end-of-file assumption, $after would wrongly
+        // be in scope too — so this pins the call site to line 4, not the end.
+        expect(result.symbols.globalMacros.has('mid')).toBe(true);
+        expect(result.symbols.globalMacros.has('after')).toBe(false);
+        const mid_out_of_scope = result.out_of_scope_symbols.find(
+            (s) => s.name === 'mid'
+        );
+        expect(mid_out_of_scope).toBeUndefined();
+    });
+
+    it('(b2) match= skips an occurrence inside a trailing inline block comment', async () => {
+        // The match text appears inside an inline /* ... */ on an otherwise-active
+        // line (line 1); the real call is on line 3. Span-aware find_match_line
+        // must pick line 3, not the inline-commented occurrence on line 1.
+        const parent_content = [
+            'display 1 /* do "child.do" */', // line 0: match text is inert (inline)
+            'global mid 1', // line 1
+            'do "child.do"', // line 2: the real call
+            'global after 1', // line 3: after the real call
+        ].join('\n');
+        create_file('parent.do', parent_content);
+
+        const child_content = [
+            '// @lsp-done-by: "parent.do" match="do \\"child.do\\""',
+            "display `=1'",
+        ].join('\n');
+        const child_path = create_file('child.do', child_content);
+
+        const result = await resolver.resolve(
+            URI.file(child_path).toString(),
+            child_content
+        );
+
+        const not_found = result.diagnostics.find((d) =>
+            d.message.includes('not found in parent file')
+        );
+        expect(not_found).toBeUndefined();
+
+        // Call site pinned to line 2: $mid (line 1) in scope, $after (line 3) out.
+        expect(result.symbols.globalMacros.has('mid')).toBe(true);
+        expect(result.symbols.globalMacros.has('after')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #240. The scope-resolver's call-site validation (`validate_call_statement`) and `match=` search (`find_match_line`) in `src/scope-resolver/index.ts` operated on raw line text and did **not** apply the directive parser's validation or comment-awareness, so a call site could resolve to a line the parser would reject or treat as inert. This brought two concrete failures:

- **(a)** A malformed forward directive at a call site (e.g. `// sight: do line=5` with no path) was accepted as a `do` call, flipping a child's `included-by` inheritance to `done-by` and wrongly dropping inherited parent locals.
- **(b)** A `match=` / `line=` call site could resolve to a `do "child.do"` that sits inside a `/* ... */` block comment (which Stata never executes), mis-scoping the symbols between it and the real call.

## Changes

- **New shared classifier `DirectiveParser.classify_call_line`.** Commands require a captured path; forward directives use the full `FORWARD_CALL_DIRECTIVE_PATTERN` + `looks_like_unquoted_path_token`, matching `parse_forward_call_directives`. `validate_call_statement` now delegates to it, so malformed directives no longer flip inheritance.
- **Span-aware block-comment handling.** `src/utils/block-comment-utils.ts` gains `block_comment_ranges()` and `position_in_block_comment()`; `block_comment_lines()` is refactored to reuse them (behavior unchanged). `find_match_line` skips a `match=` occurrence whose **position** is inside a block-comment span — correctly skipping inline (`display 1 /* do "x" */`) and fully-commented occurrences while still finding a live call after a `*/` — and its per-line scan is bounded so an empty match string terminates. `validate_call_statement` skips a line whose leading text is inside a block comment.
- **Inference-scanner guard.** The three inference scanners' directive branches gained the `looks_like_unquoted_path_token` guard so a param-like token can't match a child basename.
- **Cleanup.** The byte-identical `CALL_DIRECTIVE_PATTERN` is consolidated into `FORWARD_CALL_DIRECTIVE_PATTERN`; now-dead constants/imports are removed from the scope-resolver.

## Out of scope (pre-existing, identical on `main`)

These are shared limitations of the regex-based call detection, not part of #240, and deliberately left alone: command-abbreviation (`ru`) and colon-prefix support in `build_do_include_pattern`; comment-as-path in command lines (`do /* x */`, `do //x`); and recognizing a live call preceded by a leading inline block comment.

## Tests

- `tests/unit/directive-parser-classify-call-line.test.ts` — `classify_call_line` table, `find_match_line` span-awareness (inline/fully-commented/live-after-`*/`, empty-match termination), and the inference-scanner param-token guard.
- `tests/unit/issue240-call-site-validation.test.ts` — end-to-end resolver scenarios: (a) malformed `line=` and a block-commented `line=` no longer flip `included-by`; (b)/(b2) `match=` skips block-commented (and inline-commented) occurrences and pins the real call site (verified via in-/out-of-scope symbols).
- Existing `find-match-line-indexing.prop.test.ts` narrowed to exclude block-comment-opener single-line inputs.

`bun run test` (typecheck + full suite) and `bun run lint` pass.

https://claude.ai/code/session_011L6z83JrYfaF8rgh11Wfhr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of call-site directives so comment text inside block comments is no longer treated as an executable call.
  * Made `line=` and `match=` resolution more reliable, reducing incorrect links to the wrong call site.
  * Tightened validation of directive-like text to avoid misreading malformed lines as valid commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->