### PR TITLE
Support directory/glob exclusions in sight.toml (#255)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@jbearak/sight",
       "dependencies": {
         "@jbearak/dta-parser": "^0.3.0",
+        "picomatch": "^4.0.2",
         "smol-toml": "^1.6.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.11",
@@ -16,6 +17,7 @@
         "@glideapps/glide-data-grid": "^6.0.3",
         "@types/jest": "^29.5.8",
         "@types/node": "^24.0.0",
+        "@types/picomatch": "^4.0.2",
         "bun-types": "^1.3.5",
         "esbuild": "^0.27.2",
         "eslint": "^9.18.0",
@@ -30,7 +32,7 @@
     },
     "client": {
       "name": "sight",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "dependencies": {
         "@glideapps/glide-data-grid": "^6.0.3",
         "@jbearak/dta-parser": "^0.3.0",
@@ -379,6 +381,8 @@
     "@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
+    "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
@@ -1118,7 +1122,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
@@ -1494,6 +1498,8 @@
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
+    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
     "babel-merge/deepmerge": ["deepmerge@2.2.1", "", {}, "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="],
 
     "babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
@@ -1544,6 +1550,8 @@
 
     "jest-util/@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
 
+    "jest-util/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
     "jest-watcher/@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
 
     "jest-worker/@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
@@ -1553,6 +1561,8 @@
     "jws/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "mocha/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -1615,8 +1625,6 @@
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "test-exclude/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
-
-    "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "tunnel-agent/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -329,6 +329,14 @@
           "default": [],
           "description": "Additional paths to search for ADO files"
         },
+        "sight.exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Workspace-relative glob patterns to exclude from `sight check` and workspace indexing (e.g. [\"output/**\"]). Files opened directly in the editor are still analyzed."
+        },
         "sight.sendToStata.stataApp": {
           "type": "string",
           "default": "",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,6 +17,12 @@ chains resolve correctly. Positional `PATHS...` only filter which files report
 diagnostics. With no paths, Sight reports every `.do`, `.ado`, `.doh`, and
 `.mata` file under the workspace.
 
+Paths matching the `exclude` setting (see
+[configuration](configuration.md#excluding-files-and-directories)) are skipped
+by both the index and the directory walk. An explicitly-named path
+(`sight check output/foo.do`) is always checked, even when it matches `exclude`;
+exclusion only filters directory walks.
+
 Options:
 
 - `--workspace DIR`: workspace root to index. Defaults to the current directory.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,6 +136,48 @@ Configure workspace indexing behavior for cross-file features.
 | `sight.indexWorkspace`            | boolean | `true`   | Enable workspace-wide symbol indexing            |
 | `sight.indexing.maxFileSizeBytes` | number  | `500000` | Maximum file size in bytes for indexing (~500KB) |
 
+## Excluding files and directories
+
+Exclude generated or vendored directories from analysis with workspace-relative
+glob patterns. This is most useful for repositories that mix hand-written Stata
+source with generated output (for example, downloaded `.do` files under
+`output/`) that would otherwise dominate `sight check` results.
+
+| Setting          | Type  | Default | Description                                                          |
+| ---------------- | ----- | ------- | -------------------------------------------------------------------- |
+| `sight.exclude`  | array | `[]`    | Workspace-relative glob patterns to skip during bulk analysis        |
+
+```jsonc
+{
+  "sight.exclude": ["output/**", "**/_generated/**", "**/*.gen.do"]
+}
+```
+
+Or in `sight.toml`:
+
+```toml
+exclude = ["output/**", "**/_generated/**"]
+```
+
+Behavior:
+
+- **`sight check`** does not read or report diagnostics for excluded paths when
+  walking a directory (including the default workspace-root walk).
+- The **workspace indexer** skips excluded paths when building cross-file
+  context.
+- **Explicitly-named files are always checked.** `sight check output/foo.do`
+  analyzes that file even when `output/**` is excluded; exclusion only filters
+  directory walks.
+- **Files opened directly in the editor are still analyzed.** Exclusion governs
+  bulk scanning and `sight check`, not in-editor live diagnostics — if you open
+  a generated file you still get diagnostics and navigation for it.
+
+Patterns use [picomatch](https://github.com/micromatch/picomatch) glob syntax
+(`*`, `**`, `?`, `{a,b}`) and are matched relative to the workspace root. A
+leading `!` re-includes a previously-excluded path (e.g.
+`["output/**", "!output/manifest.do"]`). Paths outside the workspace (such as
+configured ADO paths) are never excluded.
+
 ## ADO Paths
 
 Configure additional search paths for ADO files.
@@ -226,6 +268,7 @@ canonical spelling wins.
 ```toml
 indexWorkspace = true
 adoPaths = []
+exclude = ["output/**"]
 lineCommentStyle = "//"
 debug = false
 
@@ -281,6 +324,7 @@ caseMismatch = "auto"
 | --------------------------------------- | -------------------- | --------------- | ----------------------------------------------------------------------- |
 | `indexWorkspace`                        | boolean              | `true`          | Global workspace-indexing switch                                        |
 | `adoPaths`                              | string array         | `[]`            | Additional ADO search paths                                             |
+| `exclude`                               | string array         | `[]`            | Workspace-relative globs to skip during `sight check` and indexing      |
 | `lineCommentStyle`                      | `"//"` \| `"*"`      | `"//"`         | Line comment style used when formatting resolves `"line"`               |
 | `debug`                                 | boolean              | `false`         | Enable debug logging                                                    |
 | `diagnostics.enabled`                   | boolean              | `true`          | Enable diagnostics                                                      |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,17 +147,31 @@ source with generated output (for example, downloaded `.do` files under
 | ---------------- | ----- | ------- | -------------------------------------------------------------------- |
 | `sight.exclude`  | array | `[]`    | Workspace-relative glob patterns to skip during bulk analysis        |
 
-```jsonc
-{
-  "sight.exclude": ["output/**", "**/_generated/**", "**/*.gen.do"]
-}
-```
+You can set this in two places:
 
-Or in `sight.toml`:
+- **`sight.toml`** at the project root, as the top-level `exclude` key. This is
+  read by both the editor (LSP server) and the `sight check` CLI:
 
-```toml
-exclude = ["output/**", "**/_generated/**"]
-```
+  ```toml
+  exclude = ["output/**", "**/_generated/**", "**/*.gen.do"]
+  ```
+
+- **VS Code settings** — your User `settings.json` or the project's Workspace
+  settings (`.vscode/settings.json`) — as the `sight.exclude` key. This affects
+  the **editor only**:
+
+  ```jsonc
+  {
+    "sight.exclude": ["output/**", "**/_generated/**", "**/*.gen.do"]
+  }
+  ```
+
+> **`sight check` (the CLI used in CI) reads only `sight.toml`** (or a file
+> passed with `--config`). It does not read VS Code settings, which are
+> client-side and reach only the running LSP server. So to exclude paths from CI
+> runs, put them in `sight.toml`. When both are present for the editor, the LSP
+> server lets `sight.toml` take precedence over VS Code settings (see
+> [Project Configuration File](#project-configuration-file)).
 
 Behavior:
 
@@ -175,8 +189,14 @@ Behavior:
 Patterns use [picomatch](https://github.com/micromatch/picomatch) glob syntax
 (`*`, `**`, `?`, `{a,b}`) and are matched relative to the workspace root. A
 leading `!` re-includes a previously-excluded path (e.g.
-`["output/**", "!output/manifest.do"]`). Paths outside the workspace (such as
-configured ADO paths) are never excluded.
+`["output/**", "!output/manifest.do"]`).
+
+`exclude` only applies to files inside your workspace folder. Sight also scans
+your configured ADO paths (and auto-detected Stata install directories), which
+normally live outside the workspace — `exclude` has no effect on those files, so
+you cannot use it to filter ADO scanning. (If you point an ADO path at a folder
+*inside* the workspace, it is in-workspace like any other file and `exclude`
+patterns do apply to it.)
 
 ## ADO Paths
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@jbearak/dta-parser": "^0.3.0",
+    "picomatch": "^4.0.2",
     "smol-toml": "^1.6.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.11",
@@ -72,6 +73,7 @@
     "@glideapps/glide-data-grid": "^6.0.3",
     "@types/jest": "^29.5.8",
     "@types/node": "^24.0.0",
+    "@types/picomatch": "^4.0.2",
     "bun-types": "^1.3.5",
     "esbuild": "^0.27.2",
     "eslint": "^9.18.0",

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -30,6 +30,7 @@ import {
     size_limit_diagnostic,
     unreadable_diagnostic,
 } from './source-files';
+import { create_exclude_matcher } from '../utils/exclude-matcher';
 import {
     ColorChoice,
     DiagnosticRecord,
@@ -488,6 +489,7 @@ export async function collect_check_diagnostics(
 ): Promise<DiagnosticRecord[]> {
     const workspace_symbols = context.workspace_indexer.get_all_symbols();
     const files_indexed = context.workspace_indexer.get_metrics().files_indexed;
+    const exclude_matcher = create_exclude_matcher(config.exclude);
     const the_slots: DiagnosticRecord[][] = new Array(targets.length);
 
     async function collect_target_diagnostics(
@@ -532,10 +534,16 @@ export async function collect_check_diagnostics(
         // it for every in-workspace target (not just explicit ones, so the
         // default `sight check .` surfaces the problem too) rather than emitting
         // silently-wrong results.
+        //
+        // Excluded files are deliberately never indexed (not a cap casualty),
+        // and the only way one becomes a target is an explicit name on the CLI,
+        // which is always honored (#255). So skip this guard for them rather
+        // than emitting a misleading "not indexed" diagnostic.
         if (
             is_within_workspace(workspace_root, target.path) &&
             files_indexed >= config.cross_file.max_indexed_files &&
-            !context.workspace_indexer.has_indexed_file(uri)
+            !context.workspace_indexer.has_indexed_file(uri) &&
+            !exclude_matcher.is_excluded_file(target.path, [workspace_root])
         ) {
             records.push(diagnostic_record(
                 target.relative_path,
@@ -725,7 +733,8 @@ export async function run_check_with_cwd(
     const target_result = collect_report_targets(
         result.args.paths,
         workspace_root,
-        cwd
+        cwd,
+        config_result.config.exclude
     );
     if (target_result.operator_errors.length > 0) {
         for (const message of target_result.operator_errors) {

--- a/src/cli/source-files.ts
+++ b/src/cli/source-files.ts
@@ -3,6 +3,10 @@ import * as path from 'path';
 import { TextDecoder } from 'util';
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { hasStataExtension, VCS_METADATA_DIRS } from '../utils/file-path-utils';
+import {
+    create_exclude_matcher,
+    type ExcludeMatcher,
+} from '../utils/exclude-matcher';
 import { diagnostic_code_description_fields } from '../utils/diagnostic-code-description';
 import { compare_strings, error_message } from './shared';
 
@@ -68,7 +72,9 @@ export function is_within_workspace(
 function walk_sources(
     dir_path: string,
     out: string[],
-    operator_errors: string[]
+    operator_errors: string[],
+    workspace_roots: readonly string[],
+    exclude_matcher: ExcludeMatcher
 ): void {
     let entries: fs.Dirent[];
     try {
@@ -94,8 +100,29 @@ function walk_sources(
         // completion, the `.sthlp` lookup).
         if (entry.isDirectory()) {
             if (VCS_METADATA_DIRS.has(entry.name)) continue;
-            walk_sources(entry_path, out, operator_errors);
+            // Prune directories excluded by workspace `exclude` patterns
+            // (issue #255). Explicitly-named files bypass exclusion (handled in
+            // collect_report_targets); only walked descendants are filtered.
+            if (
+                !exclude_matcher.is_empty &&
+                exclude_matcher.is_excluded_dir(entry_path, workspace_roots)
+            ) {
+                continue;
+            }
+            walk_sources(
+                entry_path,
+                out,
+                operator_errors,
+                workspace_roots,
+                exclude_matcher
+            );
         } else if (entry.isFile() && hasStataExtension(entry.name)) {
+            if (
+                !exclude_matcher.is_empty &&
+                exclude_matcher.is_excluded_file(entry_path, workspace_roots)
+            ) {
+                continue;
+            }
             out.push(entry_path);
         }
     }
@@ -104,7 +131,8 @@ function walk_sources(
 export function collect_report_targets(
     input_paths: string[],
     workspace_root: string,
-    cwd: string
+    cwd: string,
+    exclude_patterns: readonly string[] = []
 ): ReportTargetResult {
     const operator_errors: string[] = [];
     const source_paths: string[] = [];
@@ -114,6 +142,8 @@ export function collect_report_targets(
     } catch {
         // Workspace validation happens before target collection in check.ts.
     }
+    const exclude_matcher = create_exclude_matcher(exclude_patterns);
+    const exclude_roots = [normalized_root];
     const has_explicit_paths = input_paths.length > 0;
     const paths_to_collect = input_paths.length > 0
         ? input_paths
@@ -146,7 +176,16 @@ export function collect_report_targets(
             continue;
         }
         if (stat.isDirectory()) {
-            walk_sources(absolute_path, source_paths, operator_errors);
+            // Directory inputs (including the default workspace root) walk with
+            // exclusion applied to descendants. An explicitly-named file below
+            // is always honored regardless of `exclude` (issue #255).
+            walk_sources(
+                absolute_path,
+                source_paths,
+                operator_errors,
+                exclude_roots,
+                exclude_matcher
+            );
         } else if (stat.isFile() && hasStataExtension(absolute_path)) {
             source_paths.push(absolute_path);
         }

--- a/src/config-file/schema.ts
+++ b/src/config-file/schema.ts
@@ -59,6 +59,7 @@ const BACKWARD_DEPENDENCY_VALUES = ['auto', 'explicit'] as const;
 const SERVER_TOP_LEVEL_KEYS = [
     'indexWorkspace',
     'adoPaths',
+    'exclude',
     'lineCommentStyle',
     'debug',
     'diagnostics',
@@ -647,6 +648,16 @@ export function map_public_config_to_partial_config(
             mapped.adoPaths = ado_paths;
         } else {
             warn_invalid_value('adoPaths', ado_paths, warn);
+        }
+    }
+
+    const exclude = pick_key(raw, 'exclude', warn, 'exclude');
+    if (exclude !== undefined) {
+        if (Array.isArray(exclude)
+            && exclude.every((item) => typeof item === 'string')) {
+            mapped.exclude = exclude;
+        } else {
+            warn_invalid_value('exclude', exclude, warn);
         }
     }
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -55,6 +55,10 @@ import {
     VCS_METADATA_DIRS,
 } from '../utils/file-path-utils';
 import { entry_is_file_async } from '../utils/symlink-aware-entry';
+import {
+    create_exclude_matcher,
+    type ExcludeMatcher,
+} from '../utils/exclude-matcher';
 
 const MAX_PARALLEL = 4;
 const YIELD_INTERVAL_MS = 100;
@@ -109,6 +113,7 @@ export class WorkspaceIndexer {
     };
     private cancelled = false;
     private size_threshold_bytes: number = 512 * 1024; // 500KB default
+    private exclude_matcher: ExcludeMatcher = create_exclude_matcher([]);
     private skipped_files: Map<string, number> = new Map();
     private max_indexed_files: number = 1000;
     private max_files_reached = false;
@@ -364,11 +369,32 @@ export class WorkspaceIndexer {
                     if (VCS_METADATA_DIRS.has(entry.name)) {
                         continue;
                     }
+                    // Prune directories whose every descendant is excluded by
+                    // the workspace `exclude` patterns (issue #255). Paths
+                    // outside the workspace roots (ado paths) never match.
+                    if (
+                        !this.exclude_matcher.is_empty &&
+                        this.exclude_matcher.is_excluded_dir(
+                            entry_path,
+                            this.workspace_roots
+                        )
+                    ) {
+                        continue;
+                    }
                     await this.scan_directory(entry_path, generation);
                 } else if (
                     entry.isFile() &&
                     hasStataExtension(entry.name)
                 ) {
+                    if (
+                        !this.exclude_matcher.is_empty &&
+                        this.exclude_matcher.is_excluded_file(
+                            entry_path,
+                            this.workspace_roots
+                        )
+                    ) {
+                        continue;
+                    }
                     file_paths.push(entry_path);
                 }
             }
@@ -480,6 +506,18 @@ export class WorkspaceIndexer {
     ): Promise<void> {
         if (!this.is_active_generation(generation) || !this.enabled) return;
         const file_uri = URI.file(file_path).toString();
+        // Honor workspace `exclude` patterns on the incremental update path
+        // (issue #255): scan_directory already prunes excluded files on the
+        // bulk scan, but schedule_update -> index_file bypasses it. Clearing a
+        // previously-indexed entry drops stale symbols/edges when a file
+        // becomes excluded (e.g. a new pattern, or a moved file).
+        if (
+            !this.exclude_matcher.is_empty &&
+            this.exclude_matcher.is_excluded_file(file_path, this.workspace_roots)
+        ) {
+            this.clear_stale_entry(file_uri);
+            return;
+        }
         // Re-indexing a file already in the index does not grow the distinct-
         // file count, so the cap must not block it; otherwise an edit to an
         // already-indexed file is silently skipped once the cap is reached,
@@ -830,6 +868,8 @@ export class WorkspaceIndexer {
         // walk during indexing uses the same config as open-document
         // resolution.
         this.scope_resolver_config = scope_resolver_config_for(config);
+
+        this.exclude_matcher = create_exclude_matcher(config.exclude ?? []);
 
         const threshold = config?.indexing?.maxFileSizeBytes;
         if (typeof threshold === 'number' && threshold > 0) {

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -207,6 +207,7 @@ export function indexing_affecting_signature(
 ): string {
     return JSON.stringify({
         adoPaths: config?.adoPaths ?? null,
+        exclude: config?.exclude ?? null,
         indexWorkspace: config?.indexWorkspace ?? null,
         index_workspace: config?.cross_file?.index_workspace ?? null,
         max_indexed_files: config?.cross_file?.max_indexed_files ?? null,

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -128,6 +128,7 @@ export const DEFAULT_SETTINGS: StataLSPConfig = {
     },
     adoPaths: [],
     indexWorkspace: true,
+    exclude: [],
     cross_file: {
         index_workspace: true,
         max_indexed_files: 1000,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -561,6 +561,10 @@ export interface StataLSPConfig {
   adoPaths: string[];
   indexWorkspace: boolean;
   cross_file: CrossFileConfig;
+  // Workspace-relative glob patterns to exclude from `sight check` and the
+  // workspace index (issue #255), e.g. ["output/**"]. In-editor open documents
+  // are still analyzed; exclusion governs bulk scanning only.
+  exclude: string[];
   debug?: boolean;
 }
 

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -247,6 +247,11 @@ export function validate_comment_formatting_config(
         validated_config.adoPaths = config.adoPaths;
     }
 
+    if (Array.isArray(config.exclude)
+        && config.exclude.every((item) => typeof item === 'string')) {
+        validated_config.exclude = config.exclude;
+    }
+
     if (typeof config.indexWorkspace === 'boolean') {
         validated_config.indexWorkspace = config.indexWorkspace;
     }

--- a/src/utils/exclude-matcher.ts
+++ b/src/utils/exclude-matcher.ts
@@ -1,0 +1,202 @@
+/**
+ * Workspace-relative path exclusion for the `exclude` config setting
+ * (issue #255). Patterns from `sight.toml` (top-level `exclude = [...]`) are
+ * matched against the path of each candidate file/directory expressed relative
+ * to its containing workspace root, using picomatch glob semantics.
+ *
+ * Two scanners consume this: the workspace indexer (`src/indexer/index.ts`) and
+ * the `sight check` directory walk (`src/cli/source-files.ts`). Both skip files
+ * whose relative path matches, and prune directories that can contain only
+ * excluded descendants. Files outside every workspace root (e.g. ado paths)
+ * never match — exclusion is strictly workspace-relative.
+ */
+
+import path from 'path';
+import picomatch from 'picomatch';
+
+export interface ExcludeMatcher {
+    /** True when there are no patterns; lets callers cheaply skip the work. */
+    readonly is_empty: boolean;
+    /** True if `abs_path` (a file) is excluded relative to a containing root. */
+    is_excluded_file(abs_path: string, workspace_roots: readonly string[]): boolean;
+    /**
+     * True if `abs_path` (a directory) can be pruned because every descendant
+     * would be excluded. Conservative: returns false (no pruning) when negation
+     * (re-include) patterns are present, since a re-included file could live
+     * inside.
+     */
+    is_excluded_dir(abs_path: string, workspace_roots: readonly string[]): boolean;
+}
+
+const NEVER_MATCHER: ExcludeMatcher = {
+    is_empty: true,
+    is_excluded_file: () => false,
+    is_excluded_dir: () => false,
+};
+
+const PICOMATCH_OPTIONS: picomatch.PicomatchOptions = { dot: true };
+
+/**
+ * Normalize a raw pattern to the POSIX form picomatch expects: trim, convert
+ * backslashes to forward slashes, drop a leading `./`, and rewrite a trailing
+ * `/` to `/**` (gitignore-style "directory and everything under it", e.g.
+ * `output/` -> `output/**`). A leading `!` (negation) is preserved and the rest
+ * of the pattern is normalized after it (so `!./output/` -> `!output/**`).
+ * Returns `''` for blank patterns so callers can drop them.
+ */
+function normalize_pattern(raw: string): string {
+    const trimmed = raw.trim();
+    if (trimmed === '') return '';
+    const is_negated = trimmed.startsWith('!');
+    let pattern = (is_negated ? trimmed.slice(1) : trimmed).replace(/\\/g, '/');
+    while (pattern.startsWith('./')) {
+        pattern = pattern.slice(2);
+    }
+    if (pattern.length > 1 && pattern.endsWith('/')) {
+        pattern = `${pattern}**`;
+    }
+    // A bare `/` (or `./`, `.//` reduced to it) targets the filesystem root,
+    // never a workspace-relative path, so it would match nothing — drop it
+    // rather than feed picomatch a no-op pattern.
+    if (pattern === '' || pattern === '/') return '';
+    return is_negated ? `!${pattern}` : pattern;
+}
+
+/**
+ * Derive a directory-prune pattern by stripping a trailing globstar tail
+ * (a slash followed by a globstar, optionally then a slash and star). A
+ * directory can be pruned only when every descendant at any depth is excluded,
+ * which is exactly what a globstar means. A single-star
+ * tail (`build/*`) matches only direct children, NOT nested files like
+ * `build/nested/keep.do`, so it must never prune the directory — hence `/*` is
+ * deliberately not stripped. Returns the input unchanged when there is no
+ * globstar tail.
+ */
+function derive_dir_pattern(pattern: string): string {
+    const stripped = pattern.replace(/\/(?:\*\*\/\*|\*\*)$/, '');
+    return stripped === '' ? pattern : stripped;
+}
+
+/**
+ * Compute `abs_path` relative to the deepest workspace root that contains it,
+ * in POSIX form. Returns `null` when no root contains the path (e.g. ado paths
+ * outside the workspace), so such paths are never excluded. The empty string
+ * (path equals a root) is returned as-is and never matches a pattern.
+ */
+function relative_to_containing_root(
+    abs_path: string,
+    workspace_roots: readonly string[]
+): string | null {
+    const target = path.resolve(abs_path);
+    let best: string | null = null;
+    let best_root_length = -1;
+    for (const my_root of workspace_roots) {
+        const root = path.resolve(my_root);
+        const my_relative = path.relative(root, target);
+        // Treat the path as outside the root only when `..` is a real path
+        // component (`..` exactly, or `../` style), matching
+        // `workspace_relative` in cli/source-files.ts. A leading `..` that is
+        // part of a filename (e.g. `..foo.do`) is still inside the workspace.
+        const contained =
+            my_relative === '' ||
+            (my_relative !== '..' &&
+                !my_relative.startsWith(`..${path.sep}`) &&
+                !path.isAbsolute(my_relative));
+        if (contained && root.length > best_root_length) {
+            best = my_relative;
+            best_root_length = root.length;
+        }
+    }
+    if (best === null) return null;
+    return best.split(path.sep).join('/');
+}
+
+/**
+ * Compile `patterns` into an {@link ExcludeMatcher}. The picomatch matchers are
+ * built once here, not per path. An empty pattern list yields a cheap no-op
+ * matcher.
+ */
+export function create_exclude_matcher(
+    patterns: readonly string[]
+): ExcludeMatcher {
+    // Compile each pattern to its own matcher, preserving order. Evaluation
+    // applies gitignore-style "last match wins" semantics (a positive excludes,
+    // a leading `!` re-includes, and a later positive can exclude again), which
+    // picomatch's own array handling does NOT provide (a lone `!p` matches
+    // everything-except-p). Order matters, so the two signs cannot be split into
+    // separate sets.
+    const compiled: Array<{ is_negated: boolean; match: (s: string) => boolean }> =
+        [];
+    const positive_dir_patterns: string[] = [];
+    let positive_count = 0;
+    let has_negation = false;
+    for (const my_pattern of patterns) {
+        const normalized = normalize_pattern(my_pattern);
+        if (normalized === '') continue;
+        if (normalized.startsWith('!')) {
+            const body = normalized.slice(1);
+            if (body === '') continue;
+            compiled.push({
+                is_negated: true,
+                match: picomatch(body, PICOMATCH_OPTIONS),
+            });
+            has_negation = true;
+        } else {
+            compiled.push({
+                is_negated: false,
+                match: picomatch(normalized, PICOMATCH_OPTIONS),
+            });
+            // A pattern may prune directories only if it guarantees the whole
+            // subtree is excluded — i.e. it is globstar-terminated. A single-
+            // star (`build/*`) or plain glob (`*.do`, `**/*.gen.do`) matches
+            // only some descendants, so it must never prune: the raw pattern
+            // would wrongly match (and skip) intermediate dirs like
+            // `build/nested`, dropping non-excluded files beneath them. For a
+            // globstar pattern, both the raw form (matches descendants) and its
+            // stripped base (matches the dir itself) are safe to prune on.
+            const dir_base = derive_dir_pattern(normalized);
+            if (dir_base !== normalized || normalized === '**') {
+                positive_dir_patterns.push(normalized);
+                if (dir_base !== normalized) positive_dir_patterns.push(dir_base);
+            }
+            positive_count++;
+        }
+    }
+    // A list with no positive patterns (empty, or only re-includes) excludes
+    // nothing.
+    if (positive_count === 0) return NEVER_MATCHER;
+
+    // Directory-prune matcher: built only from globstar-terminated positives
+    // (see above), deduplicated. Pruning is disabled (dir_match === null) when
+    // re-include patterns exist (a re-included file could live inside an
+    // otherwise-excluded directory) or when no globstar pattern can ever prune a
+    // directory — so `is_excluded_dir` short-circuits instead of running an
+    // always-false matcher.
+    const dir_match =
+        has_negation || positive_dir_patterns.length === 0
+            ? null
+            : picomatch(
+                  Array.from(new Set(positive_dir_patterns)),
+                  PICOMATCH_OPTIONS
+              );
+
+    return {
+        is_empty: false,
+        is_excluded_file(abs_path, workspace_roots) {
+            const relative = relative_to_containing_root(abs_path, workspace_roots);
+            if (relative === null || relative === '') return false;
+            let excluded = false;
+            for (const my_rule of compiled) {
+                if (my_rule.match(relative)) {
+                    excluded = !my_rule.is_negated;
+                }
+            }
+            return excluded;
+        },
+        is_excluded_dir(abs_path, workspace_roots) {
+            if (dir_match === null) return false;
+            const relative = relative_to_containing_root(abs_path, workspace_roots);
+            return relative !== null && relative !== '' && dir_match(relative);
+        },
+    };
+}

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -74,6 +74,50 @@ describe('sight check integration', () => {
         expect(result.stdout).toContain('info:');
     });
 
+    it('excludes paths matching sight.toml exclude from the default walk', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(
+            path.join(root, 'sight.toml'),
+            'exclude = ["output/**"]\n'
+        );
+        fs.mkdirSync(path.join(root, 'output'));
+        // Both files contain an undefined-macro error; only src/main.do should
+        // be reported, since output/** is excluded from the default walk.
+        fs.writeFileSync(path.join(root, 'main.do'), "display \"`bad_main'\"\n");
+        fs.writeFileSync(
+            path.join(root, 'output', 'gen.do'),
+            "display \"`bad_gen'\"\n"
+        );
+
+        const result = await run_capture(['--workspace', root, '--quiet'], root);
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('main.do:1:');
+        expect(result.stdout).not.toContain('output/gen.do');
+        expect(result.stdout).not.toContain('bad_gen');
+    });
+
+    it('still checks an explicitly-named file under an excluded path', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(
+            path.join(root, 'sight.toml'),
+            'exclude = ["output/**"]\n'
+        );
+        fs.mkdirSync(path.join(root, 'output'));
+        fs.writeFileSync(
+            path.join(root, 'output', 'gen.do'),
+            "display \"`bad_gen'\"\n"
+        );
+
+        const result = await run_capture(
+            ['--workspace', root, 'output/gen.do', '--quiet'],
+            root
+        );
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('output/gen.do:1:');
+    });
+
     it('does not fail on default spaced comparison diagnostics', async () => {
         const root = temp_dir();
         fs.writeFileSync(path.join(root, 'main.do'), 'display 1 < = 2\ndisplay 3 > = 2\n');
@@ -189,6 +233,32 @@ describe('sight check integration', () => {
         expect(result.code).toBe(EXIT_CHECK_FAILED);
         expect(result.stdout).toContain('was not indexed');
         expect(result.stdout).toContain('maxIndexedFiles');
+    });
+
+    it('checks an explicit excluded file even at the max-indexed-files cap', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(
+            path.join(root, 'sight.toml'),
+            'exclude = ["output/**"]\n[crossFile]\nmaxIndexedFiles = 1\n'
+        );
+        // a.do is indexed and fills the cap; output/ is excluded from indexing.
+        fs.writeFileSync(path.join(root, 'a.do'), 'display 1\n');
+        fs.mkdirSync(path.join(root, 'output'));
+        fs.writeFileSync(
+            path.join(root, 'output', 'gen.do'),
+            "display \"`bad_gen'\"\n"
+        );
+
+        const result = await run_capture(
+            ['--workspace', root, 'output/gen.do', '--quiet'],
+            root
+        );
+
+        // The explicit excluded file is analyzed (real undefined-macro
+        // diagnostic), not blocked with a misleading "not indexed" message.
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        expect(result.stdout).toContain('output/gen.do:1:');
+        expect(result.stdout).not.toContain('was not indexed');
     });
 
     it('reports explicit .mata files skipped by max indexed files', async () => {

--- a/tests/property/config-schema-completeness.prop.test.ts
+++ b/tests/property/config-schema-completeness.prop.test.ts
@@ -149,6 +149,10 @@ const EXPECTED_CONFIG_FIELDS: ConfigFieldSpec[] = [
         type: 'array',
     },
     {
+        path: 'sight.exclude',
+        type: 'array',
+    },
+    {
         path: 'sight.indexWorkspace',
         type: 'boolean',
     },

--- a/tests/property/rename-validation-comprehensive.prop.test.ts
+++ b/tests/property/rename-validation-comprehensive.prop.test.ts
@@ -54,8 +54,8 @@ describe('Comprehensive Rename Validation Property Tests', () => {
                         // Verify valid categories
                         const valid_categories = [
                             'diagnostics', 'formatting', 'indexing',
-                            'indexWorkspace', 'adoPaths', 'sendToStata',
-                            'lineCommentStyle', 'personalAdoDir',
+                            'indexWorkspace', 'adoPaths', 'exclude',
+                            'sendToStata', 'lineCommentStyle', 'personalAdoDir',
                             'dataBrowser', 'depthColors'
                         ];
                         

--- a/tests/unit/cli/source-files.test.ts
+++ b/tests/unit/cli/source-files.test.ts
@@ -70,6 +70,39 @@ describe('sight check source files', () => {
         expect(result.operator_errors).toEqual([]);
     });
 
+    it('skips excluded directories when walking, honoring explicit files', () => {
+        const root = temp_dir();
+        fs.mkdirSync(path.join(root, 'output'));
+        fs.mkdirSync(path.join(root, 'src'));
+        fs.writeFileSync(path.join(root, 'src', 'main.do'), 'display 1\n');
+        fs.writeFileSync(path.join(root, 'output', 'gen.do'), 'display 2\n');
+
+        // Default walk excludes output/**.
+        const walked = collect_report_targets([], root, root, ['output/**']);
+        expect(walked.operator_errors).toEqual([]);
+        expect(walked.targets.map((t) => t.relative_path)).toEqual(['src/main.do']);
+
+        // An explicitly-named file under an excluded path is still checked.
+        const explicit = collect_report_targets(
+            ['output/gen.do'],
+            root,
+            root,
+            ['output/**']
+        );
+        expect(explicit.targets.map((t) => t.relative_path)).toEqual([
+            'output/gen.do',
+        ]);
+    });
+
+    it('excludes individual files matching a glob during a walk', () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'keep.do'), 'display 1\n');
+        fs.writeFileSync(path.join(root, 'build.gen.do'), 'display 2\n');
+
+        const result = collect_report_targets([], root, root, ['**/*.gen.do']);
+        expect(result.targets.map((t) => t.relative_path)).toEqual(['keep.do']);
+    });
+
     it('turns oversize explicit targets into error diagnostics', () => {
         const diagnostic = size_limit_diagnostic(11, 10);
 

--- a/tests/unit/config-file/case-alias.test.ts
+++ b/tests/unit/config-file/case-alias.test.ts
@@ -64,6 +64,7 @@ const PUBLIC_SETTINGS: ReadonlyArray<{ path: string[]; value: unknown }> = [
     // Top-level
     { path: ['indexWorkspace'], value: false },
     { path: ['adoPaths'], value: ['/custom/ado', '/more/ado'] },
+    { path: ['exclude'], value: ['output/**', 'tmp/*.do'] },
     { path: ['lineCommentStyle'], value: '*' },
     { path: ['debug'], value: true },
 

--- a/tests/unit/config-file/schema.test.ts
+++ b/tests/unit/config-file/schema.test.ts
@@ -6,6 +6,7 @@ describe('map_public_config_to_partial_config', () => {
         const result = map_public_config_to_partial_config({
             indexWorkspace: false,
             adoPaths: ['/ado'],
+            exclude: ['output/**', '!output/keep.do'],
             lineCommentStyle: '*',
             debug: true,
             diagnostics: {
@@ -58,6 +59,7 @@ describe('map_public_config_to_partial_config', () => {
 
         expect(result.indexWorkspace).toBe(false);
         expect(result.adoPaths).toEqual(['/ado']);
+        expect(result.exclude).toEqual(['output/**', '!output/keep.do']);
         expect(result.lineCommentStyle).toBe('*');
         expect(result.debug).toBe(true);
         expect(result.diagnostics?.enabled).toBe(false);
@@ -80,6 +82,17 @@ describe('map_public_config_to_partial_config', () => {
 
         expect(result.cross_file?.backward_dependencies).toBe('auto');
         expect(result.cross_file?.diagnostics?.missing_file).toBe('information');
+    });
+
+    it('warns and ignores a non-string-array exclude', () => {
+        const warnings: string[] = [];
+        const result = map_public_config_to_partial_config(
+            { exclude: ['output/**', 42] },
+            (warning) => warnings.push(warning.message)
+        );
+
+        expect(result.exclude).toBeUndefined();
+        expect(warnings.join('\n')).toContain('exclude');
     });
 
     it('warns and ignores colliding aliases when no canonical spelling exists', () => {

--- a/tests/unit/indexing-signature.test.ts
+++ b/tests/unit/indexing-signature.test.ts
@@ -81,6 +81,16 @@ describe('indexing_affecting_signature', () => {
         );
     });
 
+    it('differs when exclude changes', () => {
+        // exclude governs which files are scanned/indexed (#255), so changing
+        // it must trigger a full re-scan rather than leaving stale symbols for
+        // newly-excluded (or newly-included) paths.
+        const changed = with_change((c) => { c.exclude = ['output/**']; });
+        expect(indexing_affecting_signature(changed)).not.toBe(
+            indexing_affecting_signature(base)
+        );
+    });
+
     it('is equal when only a non-indexing field changes', () => {
         // A severity / debug tweak must NOT trigger a re-index.
         const changed = with_change((c) => {

--- a/tests/unit/utils/exclude-matcher.test.ts
+++ b/tests/unit/utils/exclude-matcher.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'bun:test';
+import * as path from 'path';
+import { create_exclude_matcher } from '../../../src/utils/exclude-matcher';
+
+const ROOT = path.resolve('/workspace/project');
+
+function abs(rel: string): string {
+    return path.join(ROOT, ...rel.split('/'));
+}
+
+describe('exclude-matcher', () => {
+    it('treats an empty pattern list as a no-op', () => {
+        const matcher = create_exclude_matcher([]);
+        expect(matcher.is_empty).toBe(true);
+        expect(matcher.is_excluded_file(abs('output/a.do'), [ROOT])).toBe(false);
+        expect(matcher.is_excluded_dir(abs('output'), [ROOT])).toBe(false);
+    });
+
+    it('drops blank patterns and stays empty', () => {
+        const matcher = create_exclude_matcher(['  ', '']);
+        expect(matcher.is_empty).toBe(true);
+    });
+
+    it('matches files under a globstar directory pattern', () => {
+        const matcher = create_exclude_matcher(['output/**']);
+        expect(matcher.is_excluded_file(abs('output/a.do'), [ROOT])).toBe(true);
+        expect(matcher.is_excluded_file(abs('output/sub/b.do'), [ROOT])).toBe(true);
+        expect(matcher.is_excluded_file(abs('src/a.do'), [ROOT])).toBe(false);
+    });
+
+    it('prunes the directory itself for dir/**, dir/**/*, and dir/', () => {
+        for (const my_pattern of ['output/**', 'output/**/*', 'output/']) {
+            const matcher = create_exclude_matcher([my_pattern]);
+            expect(matcher.is_excluded_dir(abs('output'), [ROOT])).toBe(true);
+        }
+    });
+
+    it('does not prune (or exclude contents of) a bare directory name', () => {
+        // Under picomatch, a bare `output` matches only the literal path
+        // `output`, not files inside it, so it must not prune the directory.
+        const matcher = create_exclude_matcher(['output']);
+        expect(matcher.is_excluded_dir(abs('output'), [ROOT])).toBe(false);
+        expect(matcher.is_excluded_file(abs('output/a.do'), [ROOT])).toBe(false);
+    });
+
+    it('does not over-prune sibling or parent directories', () => {
+        const matcher = create_exclude_matcher(['data/{raw,tmp}/**']);
+        expect(matcher.is_excluded_dir(abs('data/raw'), [ROOT])).toBe(true);
+        expect(matcher.is_excluded_dir(abs('data/tmp'), [ROOT])).toBe(true);
+        // `data` may still hold non-excluded subdirs, so it must not be pruned.
+        expect(matcher.is_excluded_dir(abs('data'), [ROOT])).toBe(false);
+        expect(matcher.is_excluded_dir(abs('data/keep'), [ROOT])).toBe(false);
+    });
+
+    it('supports leading **/ and file globs without pruning unrelated dirs', () => {
+        const matcher = create_exclude_matcher(['**/_generated/**', '**/*.gen.do']);
+        expect(
+            matcher.is_excluded_file(abs('a/b/_generated/x.do'), [ROOT])
+        ).toBe(true);
+        expect(matcher.is_excluded_dir(abs('a/b/_generated'), [ROOT])).toBe(true);
+        expect(matcher.is_excluded_file(abs('a/build.gen.do'), [ROOT])).toBe(true);
+        // A bare *.gen.do file glob must not prune an ordinary directory.
+        expect(matcher.is_excluded_dir(abs('a'), [ROOT])).toBe(false);
+    });
+
+    it('normalizes backslash and ./ prefixes in patterns', () => {
+        const matcher = create_exclude_matcher(['./output\\**']);
+        expect(matcher.is_excluded_file(abs('output/a.do'), [ROOT])).toBe(true);
+    });
+
+    it('never matches paths outside any workspace root', () => {
+        const matcher = create_exclude_matcher(['output/**']);
+        const outside = path.resolve('/elsewhere/output/a.do');
+        expect(matcher.is_excluded_file(outside, [ROOT])).toBe(false);
+        expect(matcher.is_excluded_dir(path.resolve('/elsewhere/output'), [ROOT]))
+            .toBe(false);
+    });
+
+    it('still matches a filename that begins with .. inside the root', () => {
+        // A leading `..` in a filename is not a parent-directory component, so
+        // the path is inside the workspace and exclusion still applies.
+        const matcher = create_exclude_matcher(['**/*.do']);
+        expect(matcher.is_excluded_file(abs('..foo.do'), [ROOT])).toBe(true);
+        expect(matcher.is_excluded_file(abs('sub/..bar.do'), [ROOT])).toBe(true);
+    });
+
+    it('never matches a path equal to the workspace root', () => {
+        const matcher = create_exclude_matcher(['**']);
+        expect(matcher.is_excluded_dir(ROOT, [ROOT])).toBe(false);
+    });
+
+    it('matches relative to the deepest containing workspace root', () => {
+        const parent = path.resolve('/workspace/project');
+        const nested = path.resolve('/workspace/project/sub');
+        const matcher = create_exclude_matcher(['output/**']);
+        const target = path.join(nested, 'output', 'a.do');
+        // Relative to the parent the path is `sub/output/a.do` (no match), but
+        // relative to the deeper `sub` root it is `output/a.do` (match).
+        expect(matcher.is_excluded_file(target, [parent, nested])).toBe(true);
+    });
+
+    it('does not prune a directory for a single-star (direct-child) glob', () => {
+        const matcher = create_exclude_matcher(['build/*']);
+        // `build/*` matches only direct children, so the tree must be walked —
+        // neither `build` nor the intermediate `build/nested` may be pruned.
+        expect(matcher.is_excluded_dir(abs('build'), [ROOT])).toBe(false);
+        expect(matcher.is_excluded_dir(abs('build/nested'), [ROOT])).toBe(false);
+        expect(matcher.is_excluded_file(abs('build/a.do'), [ROOT])).toBe(true);
+        // Nested files do not match `build/*` and must survive.
+        expect(
+            matcher.is_excluded_file(abs('build/nested/keep.do'), [ROOT])
+        ).toBe(false);
+    });
+
+    it('does not prune any directory for a bare file glob', () => {
+        const matcher = create_exclude_matcher(['*.do']);
+        expect(matcher.is_excluded_dir(abs('src'), [ROOT])).toBe(false);
+        expect(matcher.is_excluded_file(abs('a.do'), [ROOT])).toBe(true);
+    });
+
+    it('disables directory pruning when no pattern is globstar-terminated', () => {
+        // Neither `build/*` nor `*.gen.do` can ever prune a directory, so
+        // is_excluded_dir is a short-circuit no-op (no false pruning at any
+        // depth) while file exclusion still applies.
+        const matcher = create_exclude_matcher(['build/*', '*.gen.do']);
+        expect(matcher.is_excluded_dir(abs('build'), [ROOT])).toBe(false);
+        expect(matcher.is_excluded_dir(abs('build/nested'), [ROOT])).toBe(false);
+        expect(matcher.is_excluded_file(abs('build/a.do'), [ROOT])).toBe(true);
+        expect(matcher.is_excluded_file(abs('x.gen.do'), [ROOT])).toBe(true);
+    });
+
+    it('drops a bare slash pattern (no over-exclusion)', () => {
+        const matcher = create_exclude_matcher(['/']);
+        expect(matcher.is_empty).toBe(true);
+    });
+
+    it('treats a trailing slash as the whole subtree', () => {
+        const matcher = create_exclude_matcher(['output/']);
+        expect(matcher.is_excluded_dir(abs('output'), [ROOT])).toBe(true);
+        expect(matcher.is_excluded_file(abs('output/a.do'), [ROOT])).toBe(true);
+        expect(matcher.is_excluded_file(abs('output/sub/b.do'), [ROOT])).toBe(true);
+    });
+
+    it('disables directory pruning when a negation pattern is present', () => {
+        const matcher = create_exclude_matcher(['output/**', '!output/keep.do']);
+        // Pruning would skip the re-included file, so dir pruning is off.
+        expect(matcher.is_excluded_dir(abs('output'), [ROOT])).toBe(false);
+        // File matching still honors the negation.
+        expect(matcher.is_excluded_file(abs('output/a.do'), [ROOT])).toBe(true);
+        expect(matcher.is_excluded_file(abs('output/keep.do'), [ROOT])).toBe(false);
+    });
+
+    it('applies gitignore-style last-match-wins ordering for negation', () => {
+        // A later positive re-excludes a path that an earlier `!` re-included.
+        const reexcluded = create_exclude_matcher([
+            '!output/keep.do',
+            'output/**',
+        ]);
+        expect(reexcluded.is_excluded_file(abs('output/keep.do'), [ROOT])).toBe(
+            true
+        );
+
+        // A later `!` re-includes a path that an earlier positive excluded.
+        const reincluded = create_exclude_matcher([
+            'output/**',
+            '!output/keep.do',
+        ]);
+        expect(reincluded.is_excluded_file(abs('output/keep.do'), [ROOT])).toBe(
+            false
+        );
+    });
+
+    it('excludes nothing when given only negation patterns', () => {
+        const matcher = create_exclude_matcher(['!output/keep.do']);
+        expect(matcher.is_empty).toBe(true);
+    });
+
+    it('normalizes ./ and trailing slash inside a negation pattern', () => {
+        const matcher = create_exclude_matcher(['output/**', '!./output/keep/']);
+        // `!./output/keep/` normalizes to `!output/keep/**` and re-includes
+        // everything under output/keep.
+        expect(matcher.is_excluded_file(abs('output/a.do'), [ROOT])).toBe(true);
+        expect(
+            matcher.is_excluded_file(abs('output/keep/b.do'), [ROOT])
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Implements #255: a top-level `exclude` array of workspace-relative glob patterns in `sight.toml` (and `sight.exclude` in VS Code settings). `sight check` and the workspace indexer skip matching paths during bulk scanning, so generated/output directories (e.g. `output/**`) no longer dominate CI diagnostics or the cross-file index.

```toml
# sight.toml
exclude = ["output/**", "**/_generated/**", "**/*.gen.do"]
```

## Behavior

- **`sight check`** prunes excluded paths from the directory walk (including the default workspace-root walk).
- **The workspace indexer** skips excluded paths when building cross-file context.
- **Explicitly-named files are always checked** — `sight check output/foo.do` analyzes that file even when `output/**` is excluded (including at the `maxIndexedFiles` cap). Exclusion only filters directory walks.
- **In-editor open documents are still analyzed** — exclusion governs bulk scanning + `sight check` only, not live LSP diagnostics.
- Patterns use picomatch glob syntax (`*`, `**`, `?`, `{a,b}`), match relative to the deepest containing workspace root, support gitignore-style order-sensitive `!` re-includes, and never apply to paths outside the workspace (e.g. ado paths).

## Implementation

- New `src/utils/exclude-matcher.ts`: compiles picomatch patterns once; matches workspace-relative paths; prunes directories only for globstar-terminated patterns (single-star/plain globs never prune, so nested non-excluded files survive); deepest-containing-root resolution with no fallback.
- Indexer (`scan_directory` pruning + `index_file` incremental guard that clears stale entries when a file becomes excluded).
- `sight check` walk + `collect_report_targets`; `collect_check_diagnostics` exempts excluded explicit files from the index-cap `SIGHT_FILE_NOT_INDEXED` guard.
- Config plumbing mirrors `adoPaths` (schema, validator, `DEFAULT_SETTINGS`, `indexing_affecting_signature`, `client/package.json`).
- Adds `picomatch` as a runtime dependency.
- Docs (`configuration.md`, `cli.md`) and unit/integration tests.

## Testing

- `bun run test` (typecheck + full suite): 6482 pass, 0 fail.
- `bun run lint`: clean.
- Server bundle + client `copy-server` builds succeed (picomatch bundles cleanly).
- New unit tests in `tests/unit/utils/exclude-matcher.test.ts` cover globstar/single-star/plain-glob/brace/trailing-slash/negation-ordering/`..`-filename/deepest-root edge cases; integration tests in `tests/integration/cli-check.test.ts` cover walk-exclusion, explicit-file bypass, and cap-bypass end-to-end.

Closes #255.

https://claude.ai/code/session_014YBtkUn6ZqwqHjH2XxjCdK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace exclusion setting so matching files and folders can be skipped from indexing and `sight check`.
  * Directly opened files are still analyzed, even if they match an exclusion rule.

* **Bug Fixes**
  * Improved handling of excluded paths so explicit file checks still report results correctly.
  * Excluded items no longer affect indexing limits or leave stale results behind.

* **Documentation**
  * Updated configuration and CLI docs with examples and behavior details for exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->