### PR TITLE
Track in-script Stata cd statements as line-sensitive working directory (#252)

### DIFF
--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -23,6 +23,7 @@ import {
     OptionSpec,
     ProgramSignature,
     ForwardCall,
+    CdCommand,
     IdentifierNode,
 } from '../types';
 import { DirectiveParser } from '../directive-parser';
@@ -55,6 +56,10 @@ export interface AnalysisResult {
     diagnostics: SemanticDiagnostic[];
     scopes: ScopeInfo[];
     forward_calls: ForwardCall[];
+    // Top-level literal `cd` commands in source order (issue #252). Consumers
+    // resolve these via `build_cd_timeline` to derive the line-sensitive
+    // working directory for re-stamping forward calls.
+    cd_commands: CdCommand[];
     ignored_lines: Set<number>;
 }
 
@@ -180,6 +185,13 @@ export class SemanticAnalyzer {
     private preorder_index: number = 0;
     private directive_parser = new DirectiveParser();
     private forward_calls: ForwardCall[] = [];
+    // Top-level literal `cd` commands recorded in source order (issue #252).
+    private cd_commands: CdCommand[] = [];
+    // Nesting depth for the symbol-building walk. Incremented around recursion
+    // into program/loop/control-flow bodies. Only `cd` commands at depth 0 are
+    // recorded; `do`/`run`/`include` detection is intentionally NOT gated by
+    // this (its behavior must stay unchanged at every nesting level).
+    private cd_nesting_depth: number = 0;
     private workspace_symbols?: SymbolTable;
     private tokens?: Token[];
     private current_diagnostics: SemanticDiagnostic[] = [];
@@ -204,6 +216,8 @@ export class SemanticAnalyzer {
         this.uri = uri;
         this.config = { ...create_default_config(), ...config };
         this.forward_calls = []; // Reset forward calls
+        this.cd_commands = []; // Reset cd commands (issue #252)
+        this.cd_nesting_depth = 0;
         this.workspace_symbols = workspace_symbols; // Store workspace symbols
         this.tokens = tokens; // Keep tokens for command-level pattern checks
 
@@ -259,6 +273,7 @@ export class SemanticAnalyzer {
             diagnostics,
             scopes,
             forward_calls: this.forward_calls,
+            cd_commands: this.cd_commands,
             ignored_lines: this.config.ignored_lines,
         };
     }
@@ -589,6 +604,26 @@ export class SemanticAnalyzer {
     }
 
     /**
+     * Build symbols for a nested body (program/loop/control-flow), tracking
+     * nesting depth so that `detect_cd_command` records `cd` only at the top
+     * level (issue #252). Forward-call detection is unaffected — it fires at
+     * every depth, exactly as before.
+     */
+    private build_symbols_in_body(
+        nodes: StataNode[],
+        symbols: SymbolTable,
+        current_scope: ScopeInfo,
+        all_scopes: ScopeInfo[]
+    ): void {
+        this.cd_nesting_depth++;
+        try {
+            this.build_symbols(nodes, symbols, current_scope, all_scopes);
+        } finally {
+            this.cd_nesting_depth--;
+        }
+    }
+
+    /**
      * Traverse AST nodes in preorder, calling callback for each node.
      * CRITICAL: Both symbol building and reference checking MUST use this method.
      * Note: Does NOT recurse into program/control_flow bodies - callers handle that
@@ -723,7 +758,7 @@ export class SemanticAnalyzer {
         // Process program body with the new scope — unconditional for the
         // same reason: locals defined inside each body deserve diagnostic
         // coverage regardless of which definition is "primary".
-        this.build_symbols(node.body, symbols, program_scope, all_scopes);
+        this.build_symbols_in_body(node.body, symbols, program_scope, all_scopes);
 
         // Guard body-metadata extractions on first definition only.
         // These all mutate program_symbol.* and must follow first-def-wins
@@ -1145,48 +1180,33 @@ export class SemanticAnalyzer {
     }
 
     /**
-     * Detect forward call commands (do, run, include).
+     * Extract the first file-path argument from a file command's varlist.
+     *
+     * Shared by `detect_forward_call` (do/run/include) and `detect_cd_command`
+     * (cd). Surrounding quotes are stripped; `has_macro` is true when the path
+     * contains a `` ` `` or `$` macro reference (the lexer splits a quoted path
+     * with a macro into multiple tokens, so partial-quoted paths are
+     * concatenated until the closing quote).
+     *
+     * Returns `null` when the command has no varlist argument (e.g. bare `cd`).
      */
-    private detect_forward_call(node: CommandNode): void {
-        const cmd_name = node.name;
-        
-        // Check for do, run, include commands (with abbreviations)
-        // do has no abbreviation - must be spelled out fully
-        // run can be abbreviated to 'ru'
-        // include has no abbreviation
-        const is_do = cmd_name === 'do';
-        const is_run = cmd_name === 'run' || cmd_name === 'ru';
-        const is_include = cmd_name === 'include';
-        
-        if (!is_do && !is_run && !is_include) {
-            return;
-        }
-        
-        // Skip if this line is ignored via @lsp-ignore or @lsp-ignore-next
-        if (this.config.ignored_lines.has(node.range.start.line)) {
-            return;
-        }
-        
-        // Get the first argument (path) - subsequent arguments are script arguments
-        // e.g., `do "wfs/survey.do" Cameroon 1978` - only "wfs/survey.do" is the path
+    private extract_command_path(
+        node: CommandNode
+    ): { raw_path: string; has_macro: boolean } | null {
         if (!node.varlist || node.varlist.length === 0) {
-            return;
+            return null;
         }
-        
-        // Extract the file path from varlist
-        // When a quoted path contains macro references, the lexer splits it into multiple tokens
-        // e.g., `do "`macro'"` becomes varlist: ['"', '`macro\'', '"']
-        // We need to detect this and concatenate items to form the complete path
+
         let raw_path = '';
         let has_macro = false;
-        
+
         const first_item = node.varlist[0];
         const first_name = first_item.name;
-        
+
         // Check if this is a complete quoted string (starts and ends with same quote)
         const is_complete_double_quoted = first_name.startsWith('"') && first_name.endsWith('"') && first_name.length > 1;
         const is_complete_single_quoted = first_name.startsWith("'") && first_name.endsWith("'") && first_name.length > 1;
-        
+
         if (is_complete_double_quoted || is_complete_single_quoted) {
             // Complete quoted path - use only the first item
             // Subsequent items are script arguments
@@ -1198,16 +1218,16 @@ export class SemanticAnalyzer {
             const quote_char = first_name[0];
             raw_path = first_name;
             has_macro = raw_path.includes('`') || raw_path.includes('$');
-            
+
             for (let i = 1; i < node.varlist.length; i++) {
                 const item_name = node.varlist[i].name;
                 raw_path += item_name;
-                
+
                 // Check for macro references in this item
                 if (item_name.includes('`') || item_name.includes('$')) {
                     has_macro = true;
                 }
-                
+
                 // Stop when we find the closing quote
                 if (item_name.endsWith(quote_char)) {
                     break;
@@ -1219,13 +1239,47 @@ export class SemanticAnalyzer {
             raw_path = first_name;
             has_macro = raw_path.includes('`') || raw_path.includes('$');
         }
-        
+
         // Strip surrounding quotes if present
         if ((raw_path.startsWith('"') && raw_path.endsWith('"')) ||
             (raw_path.startsWith("'") && raw_path.endsWith("'"))) {
             raw_path = raw_path.slice(1, -1);
         }
-        
+
+        return { raw_path, has_macro };
+    }
+
+    /**
+     * Detect forward call commands (do, run, include).
+     */
+    private detect_forward_call(node: CommandNode): void {
+        const cmd_name = node.name;
+
+        // Check for do, run, include commands (with abbreviations)
+        // do has no abbreviation - must be spelled out fully
+        // run can be abbreviated to 'ru'
+        // include has no abbreviation
+        const is_do = cmd_name === 'do';
+        const is_run = cmd_name === 'run' || cmd_name === 'ru';
+        const is_include = cmd_name === 'include';
+
+        if (!is_do && !is_run && !is_include) {
+            return;
+        }
+
+        // Skip if this line is ignored via @lsp-ignore or @lsp-ignore-next
+        if (this.config.ignored_lines.has(node.range.start.line)) {
+            return;
+        }
+
+        // Get the first argument (path) - subsequent arguments are script arguments
+        // e.g., `do "wfs/survey.do" Cameroon 1978` - only "wfs/survey.do" is the path
+        const extracted = this.extract_command_path(node);
+        if (!extracted) {
+            return;
+        }
+        const { raw_path, has_macro } = extracted;
+
         const call_type: 'do' | 'run' | 'include' = is_do ? 'do' : is_run ? 'run' : 'include';
 
         // No path resolution here: consumers (dependency graph,
@@ -1242,6 +1296,56 @@ export class SemanticAnalyzer {
             is_static: !has_macro,
             caller_uri: this.uri,
             working_directory: this.config.working_directory,
+        });
+    }
+
+    /**
+     * Detect a top-level `cd` command and record it for the working-directory
+     * timeline (issue #252).
+     *
+     * Conservative recognition — only records `cd` when ALL hold:
+     *  - the command name is exactly lowercase `cd` (Stata is case-sensitive),
+     *  - it is at the top level of the file (`cd_nesting_depth === 0`): `cd`
+     *    inside loops/programs/branches is out of scope,
+     *  - it has NO prefix (skips `capture cd`, `quietly cd`, etc. — conditional
+     *    or error-swallowing forms that must not change the timeline),
+     *  - it has a path argument (bare `cd`, which changes to the home
+     *    directory, is unmodelable and is skipped — leaving the WD unchanged).
+     *
+     * No path resolution happens here (the analyzer is filesystem-pure);
+     * `build_cd_timeline` resolves the recorded paths in source order.
+     *
+     * KNOWN LIMITATION — `#delimit ;` files: the parser does not attach a file
+     * command's path as a `varlist` argument under semicolon delimiting
+     * (`cd "raw";` parses as a `cd` node with no varlist plus a separate
+     * `"raw"` node), so `extract_command_path` returns null and the `cd` is
+     * skipped. This is a PRE-EXISTING parser limitation that affects ALL
+     * file-path commands equally — `do`/`run`/`include` forward-call detection
+     * (`detect_forward_call`) is already a no-op for `#delimit ;` files for the
+     * same reason. `cd` tracking is therefore consistent with the existing
+     * cross-file feature; full `#delimit ;` support is a separate parser change,
+     * out of scope for issue #252.
+     */
+    private detect_cd_command(node: CommandNode): void {
+        if (node.name !== 'cd') {
+            return;
+        }
+        // Top-level only; prefixed forms (capture/quietly/...) are skipped.
+        if (this.cd_nesting_depth !== 0) {
+            return;
+        }
+        if (node.prefix && node.prefix.length > 0) {
+            return;
+        }
+        const extracted = this.extract_command_path(node);
+        if (!extracted) {
+            // Bare `cd` (home directory) — unmodelable; leave WD unchanged.
+            return;
+        }
+        this.cd_commands.push({
+            raw_path: extracted.raw_path,
+            range: node.range,
+            is_static: !extracted.has_macro,
         });
     }
 
@@ -1266,7 +1370,10 @@ export class SemanticAnalyzer {
     ): void {
         // Detect forward calls first
         this.detect_forward_call(node);
-        
+        // Detect top-level `cd` commands for the working-directory timeline
+        // (issue #252). Gated to depth 0 inside detect_cd_command.
+        this.detect_cd_command(node);
+
         const cmd_name = node.fullName;
 
         // Check for variable-creating commands
@@ -2178,7 +2285,7 @@ export class SemanticAnalyzer {
         }
 
         // Process loop body with the same scope (loop doesn't create new scope)
-        this.build_symbols(node.body, symbols, current_scope, all_scopes);
+        this.build_symbols_in_body(node.body, symbols, current_scope, all_scopes);
     }
 
     /**
@@ -2192,7 +2299,7 @@ export class SemanticAnalyzer {
         all_scopes: ScopeInfo[]
     ): void {
         // Process body with the same scope
-        this.build_symbols(node.body, symbols, current_scope, all_scopes);
+        this.build_symbols_in_body(node.body, symbols, current_scope, all_scopes);
     }
 
     /**

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -25,8 +25,11 @@ import {
   get_workspace_root_for_uri,
   resolve_working_directory_directive,
 } from './utils/workspace-roots';
+import { build_cd_timeline, apply_cd_timeline } from './utils/file-path-utils';
 
 import * as fs from 'fs';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
 
 export interface DocumentState {
   uri: string;
@@ -784,11 +787,36 @@ export class DocumentStore {
       analyze_result.result!.diagnostics
     );
 
+    // Re-stamp command-detected forward calls with the line-sensitive working
+    // directory implied by in-script `cd` commands (issue #252). The timeline
+    // starts from the file's resolved working directory (own/inherited) and
+    // resolves each top-level `cd` target in source order. Diagnostics from the
+    // helper are DISCARDED here — they are emitted only by ForwardScopeResolver
+    // for the diagnostic-owner file, to avoid double emission. Guard the whole
+    // block: a malformed URI (URI.parse throws) must not abort the parse — fall
+    // back to the analyzer's calls unchanged.
+    let restamped_command_calls = analyze_result.result!.forward_calls;
+    try {
+      const my_caller_dir = path.dirname(URI.parse(uri).fsPath);
+      const { timeline: cd_timeline } = build_cd_timeline({
+        starting_wd: resolved_working_directory,
+        caller_dir: my_caller_dir,
+        cd_commands: analyze_result.result!.cd_commands,
+        workspace_roots: this.workspace_roots,
+      });
+      restamped_command_calls = apply_cd_timeline(
+        analyze_result.result!.forward_calls,
+        cd_timeline,
+      );
+    } catch {
+      // Malformed URI or resolution error - use analyzer calls unchanged.
+    }
+
     // Parse directive-based forward calls and merge with analyzer's
     // command-detected calls.  Stamp caller_uri and working_directory on
-    // directive calls; analyzer calls already carry these fields because
-    // we passed resolved_working_directory into analyze() above.
-    let all_forward_calls = analyze_result.result!.forward_calls;
+    // directive calls; directive calls keep the file-wide working directory
+    // (directive behavior is intentionally unchanged by cd tracking).
+    let all_forward_calls = restamped_command_calls;
     try {
       const directive_parser = new DirectiveParser();
       const directive_result = directive_parser.parse_forward_call_directives(
@@ -807,7 +835,7 @@ export class DocumentStore {
         working_directory: resolved_working_directory,
       }));
       all_forward_calls = [
-        ...analyze_result.result!.forward_calls,
+        ...restamped_command_calls,
         ...directive_forward_calls,
       ];
     } catch {

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -11,6 +11,7 @@ import { CancellationToken } from 'vscode-languageserver/node';
 import {
     SymbolTable,
     ForwardCall,
+    CdCommand,
     ForwardCallType,
     EffectiveCallType,
     ForwardResolveContext,
@@ -25,6 +26,8 @@ import { ScopeResolver } from '../scope-resolver';
 import {
     resolve_forward_call_rich,
     is_resolvable_static_call,
+    build_cd_timeline,
+    wd_for_position,
     type RichResolveFs,
     type PathCaseOutcome,
 } from '../utils/file-path-utils';
@@ -348,6 +351,49 @@ export class ForwardScopeResolver {
         const the_call_sites: ForwardCallSite[] = [];
         let accumulated_symbols = create_empty_symbol_table();
 
+        // Build the working-directory timeline for THIS file's in-script `cd`
+        // commands (issue #252), starting from the call-site WD inherited into
+        // this frame (my_context.working_directory). Recomputing here — rather
+        // than trusting the WD stamped at parse time — is what makes nested
+        // callee resolution correct: a callee reached via a parent's `cd A; do
+        // child` resolves child's relative paths from A even though parse-time
+        // stamping could not know the call-site WD.
+        const my_caller_dir = path.dirname(URI.parse(file_uri).fsPath);
+        const { timeline: cd_timeline, diagnostics: cd_diagnostics } =
+            build_cd_timeline({
+                starting_wd: my_context.working_directory,
+                caller_dir: my_caller_dir,
+                cd_commands: my_context.cd_commands ?? [],
+                workspace_roots: this.workspace_roots.length > 0
+                    ? this.workspace_roots
+                    : undefined,
+                fs: this.resolve_fs,
+            });
+
+        // Emit cd diagnostics only for the diagnostic-owner file at depth 0 —
+        // the same single-emission guard used for do/run/include
+        // path_case_mismatch. Nested/ancestor passes resolve the timeline
+        // leniently but suppress emission to avoid cascade / double-emit.
+        if (
+            my_context.diagnostic_owner_uri !== undefined &&
+            file_uri === my_context.diagnostic_owner_uri &&
+            my_context.depth === 0
+        ) {
+            const my_source_filename = path.basename(
+                URI.parse(file_uri).fsPath,
+            );
+            for (const my_cd_diag of cd_diagnostics) {
+                my_context.diagnostics.push({
+                    ...my_cd_diag,
+                    source: {
+                        source_file: my_source_filename,
+                        source_line: my_cd_diag.range.start.line,
+                        original_range: my_cd_diag.range,
+                    },
+                });
+            }
+        }
+
         // Filter to only static calls and sort by call_site_line
         // This ensures earlier calls are processed first, which is important for
         // duplicate detection (the earliest call to a file should win)
@@ -356,6 +402,15 @@ export class ForwardScopeResolver {
             .sort((a, b) => a.call_site_line - b.call_site_line);
 
         for (const my_call of static_calls) {
+            // The effective working directory for THIS call: for command-
+            // detected calls, the WD active at the call's position per the cd
+            // timeline; for directive calls, their own stamped WD (directive
+            // behavior is unchanged). Used uniformly below for path resolution,
+            // callee scope fetch, end-state computation, and nested recursion.
+            const effective_call_wd: string | undefined =
+                my_call.source === 'command'
+                    ? wd_for_position(cd_timeline, my_call.range.start)
+                    : (my_call.working_directory ?? my_context.working_directory);
             // Check cancellation in loop
             if (token?.isCancellationRequested) {
                 my_stack.delete(file_uri);
@@ -441,7 +496,7 @@ export class ForwardScopeResolver {
             const my_path_result = this.resolve_call_path(
                 my_call.raw_path,
                 file_uri,
-                my_context.working_directory,
+                effective_call_wd,
             );
             const resolved_path = my_path_result.resolved_path;
             const callee_uri = URI.file(resolved_path).toString();
@@ -539,7 +594,7 @@ export class ForwardScopeResolver {
             }
 
             // Get callee symbols
-            const callee_result = await this.get_callee_scope(resolved_path, callee_uri, my_context.working_directory);
+            const callee_result = await this.get_callee_scope(resolved_path, callee_uri, effective_call_wd);
 
             if (decision.action === 'boundary_only') {
                 // Dedup'd do/run re-visit at the outermost resolve()
@@ -562,7 +617,7 @@ export class ForwardScopeResolver {
                 const effective_end_state = await this.compute_effective_end_state_locals(
                     callee_uri,
                     resolved_path,
-                    callee_result.working_directory ?? my_context.working_directory,
+                    callee_result.working_directory ?? effective_call_wd,
                     new Set(my_stack),
                     my_context.depth + 1,
                     resolved_config,
@@ -647,7 +702,7 @@ export class ForwardScopeResolver {
                 const effective_end_state = await this.compute_effective_end_state_locals(
                     callee_uri,
                     resolved_path,
-                    callee_result.working_directory ?? my_context.working_directory,
+                    callee_result.working_directory ?? effective_call_wd,
                     new Set(my_stack),
                     my_context.depth + 1,
                     resolved_config,
@@ -679,7 +734,10 @@ export class ForwardScopeResolver {
                         effective_call_type: my_effective_type,
                         depth: my_context.depth + 1,
                         diagnostics: my_context.diagnostics,
-                        working_directory: callee_result.working_directory ?? my_context.working_directory,
+                        working_directory: callee_result.working_directory ?? effective_call_wd,
+                        // The callee's own in-script cd commands drive its
+                        // frame's timeline (issue #252).
+                        cd_commands: callee_result.cd_commands,
                         call_chain: [...(my_context.call_chain ?? []), my_call.raw_path],
                         // Pass the original owner through unchanged so the
                         // single-emission guard remains correct: nested
@@ -962,12 +1020,30 @@ export class ForwardScopeResolver {
             the_events.sort((a, b) => a.line - b.line || a.character - b.character);
 
             const the_effective = new Map<string, MacroSymbol>();
-            const nested_working_dir = callee_result.working_directory ?? working_directory;
+            // Working-directory timeline for the callee's own in-script `cd`
+            // commands (issue #252), starting from the WD it was entered with.
+            // Each nested `include` resolves against the WD active at its
+            // position, so a `cd` before an include in the callee is honored.
+            const nested_base_wd = callee_result.working_directory ?? working_directory;
+            const { timeline: nested_cd_timeline } = build_cd_timeline({
+                starting_wd: nested_base_wd,
+                caller_dir: path.dirname(URI.parse(callee_uri).fsPath),
+                cd_commands: callee_result.cd_commands,
+                workspace_roots: this.workspace_roots.length > 0
+                    ? this.workspace_roots
+                    : undefined,
+                fs: this.resolve_fs,
+            });
             for (const my_event of the_events) {
                 if (token?.isCancellationRequested) break;
                 if (my_event.kind === 'local') {
                     the_effective.set(my_event.name, my_event.symbol);
                 } else {
+                    // WD active at this include's position (honors callee cd).
+                    const event_wd = wd_for_position(
+                        nested_cd_timeline,
+                        my_event.call.range.start,
+                    );
                     // Use the simple resolver here: compute_effective_end_state_locals
                     // does not emit diagnostics, so the rich resolve_path_rich
                     // classification is unnecessary and its walk-from-root
@@ -975,7 +1051,7 @@ export class ForwardScopeResolver {
                     const nested_resolved = this.resolve_call_path_simple(
                         my_event.call.raw_path,
                         callee_uri,
-                        nested_working_dir,
+                        event_wd,
                     );
                     // null → ambiguous or missing; the nested callee is
                     // unresolved so it contributes nothing to end-state locals.
@@ -986,7 +1062,7 @@ export class ForwardScopeResolver {
                     const nested_effective = await this.compute_effective_end_state_locals(
                         nested_uri,
                         nested_resolved,
-                        nested_working_dir,
+                        event_wd,
                         stack,
                         depth + 1,
                         resolved_config,
@@ -1013,7 +1089,7 @@ export class ForwardScopeResolver {
         fs_path: string,
         uri: string,
         working_directory?: string
-    ): Promise<{ symbols: SymbolTable; forward_calls: ForwardCall[]; working_directory?: string } | { error: string }> {
+    ): Promise<{ symbols: SymbolTable; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string } | { error: string }> {
         let final_fs_path = fs_path;
         let final_uri = uri;
         const paths_tried: string[] = [fs_path];
@@ -1042,6 +1118,8 @@ export class ForwardScopeResolver {
         return {
             symbols: parsed_result.symbols,
             forward_calls: parsed_result.forward_calls,
+            // Defensive default: older/mocked parse results may omit cd_commands.
+            cd_commands: parsed_result.cd_commands ?? [],
             working_directory: parsed_result.working_directory,
         };
     }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -53,6 +53,8 @@ import {
 import {
     hasStataExtension,
     VCS_METADATA_DIRS,
+    build_cd_timeline,
+    apply_cd_timeline,
 } from '../utils/file-path-utils';
 import { entry_is_file_async } from '../utils/symlink-aware-entry';
 
@@ -577,16 +579,25 @@ export class WorkspaceIndexer {
                         );
             }
 
-            // Stamp caller_uri and working_directory onto command-detected
-            // forward calls produced by the analyzer.  The analyzer already
-            // sets caller_uri (= file_uri) on each call; we add
-            // working_directory here because the analyzer does not have access
-            // to the effective WD in this context (the indexer analyzes without
-            // threading WD to preserve the existing path-resolution behavior).
-            const stamped_analyzer_calls: ForwardCall[] = analyzeResult.forward_calls.map(fc => ({
-                ...fc,
-                working_directory: effective_working_directory,
-            }));
+            // Re-stamp command-detected forward calls with the line-sensitive
+            // working directory implied by in-script `cd` commands (issue #252).
+            // The timeline starts from the file's effective WD (own/inherited)
+            // and resolves each top-level `cd` in source order, so the dep-graph
+            // edges match what DocumentStore produces for the same source. The
+            // analyzer sets caller_uri (= file_uri); apply_cd_timeline sets the
+            // per-call working_directory. Diagnostics are discarded here (only
+            // ForwardScopeResolver emits cd diagnostics, for the owner file).
+            const my_caller_dir = path.dirname(file_path);
+            const { timeline: cd_timeline } = build_cd_timeline({
+                starting_wd: effective_working_directory,
+                caller_dir: my_caller_dir,
+                cd_commands: analyzeResult.cd_commands,
+                workspace_roots: this.workspace_roots,
+            });
+            const stamped_analyzer_calls: ForwardCall[] = apply_cd_timeline(
+                analyzeResult.forward_calls,
+                cd_timeline,
+            );
 
             // Compute context ranges for embedded language support
             const context_tracker = new ContextTracker();

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -46,7 +46,7 @@ import * as path from 'path';
 // vscode-uri is a small standalone library for parsing file:// URIs.
 // It does not require VS Code at runtime; it is safe for running the LSP standalone.
 import { URI } from 'vscode-uri';
-import { resolve_path_rich } from '../utils/file-path-utils';
+import { resolve_path_rich, resolve_forward_call_rich } from '../utils/file-path-utils';
 import { get_line_text } from '../utils/line-utils';
 import { is_cursor_in_comment, is_cursor_in_block_comment } from '../utils/comment-utils';
 import {
@@ -1524,7 +1524,19 @@ export class DefinitionProvider {
                 include_match[0].length - file_path.length - (include_match[2] ? 1 : 0);
             const path_end = path_start + file_path.length;
             if (position.character >= path_start && position.character <= path_end) {
-                const resolved_path = this.resolve_file_path(document.uri, file_path);
+                // When a tracked command call matches this cursor, resolve it
+                // EXCLUSIVELY via the per-call working directory implied by any
+                // in-script `cd` (issue #252) — do NOT fall back to plain
+                // document-relative resolution, since Stata would not run the
+                // file from there (that fallback could jump to a same-named
+                // file beside the caller). Only when no command call matches
+                // (e.g. dynamic/macro paths the analyzer did not record) do we
+                // use the legacy document-relative resolution.
+                const my_cmd = this.resolve_command_path_at(
+                    document, position, file_path);
+                const resolved_path = my_cmd.matched
+                    ? my_cmd.path
+                    : this.resolve_file_path(document.uri, file_path);
                 if (resolved_path) {
                     return {
                         uri: URI.file(resolved_path).toString(),
@@ -1596,6 +1608,49 @@ export class DefinitionProvider {
         // Allow start of line or semicolon delimiter as anchor
         const extended_macro_pattern = /(?:^|;)\s*(local|global)\s+\w+\s*:\s*(list|word|piece)\s+/;
         return extended_macro_pattern.test(text_before_cursor);
+    }
+
+    /**
+     * Resolve a `do`/`run`/`include` command path using the per-call working
+     * directory recorded on the document's forward calls (issue #252).
+     *
+     * Correlates the cursor with the forward call whose range contains it AND
+     * whose `raw_path` matches the clicked path — range containment (not line
+     * alone) disambiguates same-line `#delimit ;` calls like
+     * `cd A; do x; cd B; do x`.
+     *
+     * Returns `{ matched: false }` when no tracked command call sits under the
+     * cursor (the caller may then fall back to document-relative resolution).
+     * Returns `{ matched: true, path }` with the real-cased on-disk path for
+     * exact/case-only outcomes, or `{ matched: true, path: null }` when the
+     * cwd-aware target is missing/ambiguous — in which case the caller MUST NOT
+     * fall back (Stata would not run it from the document directory either).
+     */
+    private resolve_command_path_at(
+        document: DocumentState,
+        position: Position,
+        file_path: string
+    ): { matched: boolean; path: string | null } {
+        const the_call = (document.forward_calls ?? []).find(
+            my_call =>
+                my_call.source === 'command' &&
+                my_call.raw_path === file_path &&
+                this.position_in_range(position, my_call.range)
+        );
+        if (!the_call) {
+            return { matched: false, path: null };
+        }
+        const current_dir = path.dirname(URI.parse(document.uri).fsPath);
+        const my_outcome = resolve_forward_call_rich(
+            file_path,
+            current_dir,
+            the_call.working_directory,
+            { workspace_roots: this.workspace_roots },
+        );
+        if (my_outcome.kind === 'exact' || my_outcome.kind === 'case_only') {
+            return { matched: true, path: my_outcome.path };
+        }
+        return { matched: true, path: null };
     }
 
     /**

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -1137,6 +1137,32 @@ export class DiagnosticsProvider {
             };
         }
 
+        // ── missing_directory branch (issue #252) ────────────────────────────
+        // A static in-script `cd` whose target directory is not found (or is
+        // case-insensitively ambiguous). Defaults to Warning (per design), but
+        // reuses the `missing_file` config toggle so users can downgrade or
+        // suppress it ('off' → hidden) — keeping the new diagnostic low-noise
+        // and configurable.
+        if (diagnostic.kind === 'missing_directory') {
+            const missing_file_setting =
+                config.cross_file?.diagnostics?.missing_file;
+            if (missing_file_setting === 'off') {
+                return null;
+            }
+            const severity = missing_file_setting
+                ? this.get_severity_from_config(missing_file_setting)
+                    ?? DiagnosticSeverity.Warning
+                : DiagnosticSeverity.Warning;
+            return {
+                range: diagnostic.range,
+                message: diagnostic.message,
+                severity,
+                code: diagnostic.code,
+                source: 'sight',
+                ...diagnostic_code_description_fields(diagnostic.code),
+            };
+        }
+
         // ── missing_file / legacy branch ─────────────────────────────────────
         // Keyed on `kind === 'missing_file'` OR the legacy prose substring.
         const is_missing_file =

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -20,6 +20,7 @@ import {
     ScopeCacheMetrics,
     ScopeResolverLogger,
     ForwardCall,
+    CdCommand,
     EffectiveCallType,
     ForwardResolvedScope,
     CallEdge,
@@ -50,6 +51,8 @@ import {
     resolve_forward_call_rich,
     outcome_fs_path,
     is_resolvable_static_call,
+    build_cd_timeline,
+    apply_cd_timeline,
     type RichResolveFs,
 } from '../utils/file-path-utils';
 import {
@@ -124,7 +127,7 @@ export function scope_resolver_config_for(
  * Cache for file parsing results within a single resolution request.
  * Ensures we only read/parse each file once per request.
  */
-type ParsedFileResult = { content: string; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] } | { error: string };
+type ParsedFileResult = { content: string; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] } | { error: string };
 type RequestCache = Map<string, Promise<ParsedFileResult>>;
 
 /**
@@ -143,6 +146,8 @@ interface ForwardScopeResolverInterface {
             depth: number;
             diagnostics: DirectiveDiagnostic[];
             working_directory?: string;
+            /** Top-level cd commands of the file being resolved (issue #252). */
+            cd_commands?: CdCommand[];
             call_chain?: string[];
             /** See ForwardResolveContext.diagnostic_owner_uri. */
             diagnostic_owner_uri?: string;
@@ -164,8 +169,7 @@ export class ScopeResolver {
     private parser: StataParser;
     private analyzer: SemanticAnalyzer;
     // Cache key is "uri|working_directory" (or just "uri" if no working directory)
-    // Cache key is "uri|working_directory" (or just "uri" if no working directory)
-    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] }>;
+    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] }>;
     private scope_cache: Map<string, ScopeCacheEntry>;
     // Secondary index: uri -> Set<cache_keys> for O(1) scope cache invalidation by URI
     private uri_to_cache_keys: Map<string, Set<string>>;
@@ -1060,7 +1064,12 @@ export class ScopeResolver {
         let forward_call_symbols: import('../types').ForwardCallSite[] | undefined;
         const effective_working_directory = own_working_directory ?? inherited_working_directory;
 
-        if (this.forward_scope_resolver && my_parse_result.forward_calls.length > 0) {
+        // Enter forward resolution when there are forward calls OR in-script
+        // `cd` commands: the latter must run even with no do/run/include so a
+        // lone `cd` with a casing/missing issue is still diagnosed (issue #252).
+        if (this.forward_scope_resolver &&
+            (my_parse_result.forward_calls.length > 0 ||
+             my_parse_result.cd_commands.length > 0)) {
             const forward_result = await this.forward_scope_resolver.resolve(
                 file_uri,
                 my_parse_result.forward_calls,
@@ -1071,6 +1080,8 @@ export class ScopeResolver {
                     depth: 0,
                     diagnostics: the_diagnostics,
                     working_directory: effective_working_directory,
+                    // The owner file's own cd commands drive its frame timeline.
+                    cd_commands: my_parse_result.cd_commands,
                     call_chain: [],
                     // Thread the owner so path_case_mismatch fires for
                     // case-only do/run/include written in THIS file at
@@ -1196,6 +1207,7 @@ export class ScopeResolver {
     private async resolve_parent_forward_calls(
         parent_uri: string,
         parent_forward_calls: ForwardCall[],
+        parent_cd_commands: CdCommand[],
         call_site_line: number,
         backward_directive_type: 'done-by' | 'included-by',
         working_directory: string | undefined,
@@ -1322,6 +1334,9 @@ export class ScopeResolver {
                 depth: 0,
                 diagnostics: the_diagnostics,
                 working_directory,
+                // Parent's own cd commands make its forward calls line-sensitive
+                // (issue #252).
+                cd_commands: parent_cd_commands,
                 call_chain: [],
             },
             recursion_stack,
@@ -1484,7 +1499,22 @@ export class ScopeResolver {
                 continue;
             }
 
-            // If the parent has a working_directory directive, resolve it for inheritance
+            // Backward working-directory inheritance is DIRECTIVE-BASED only.
+            //
+            // Issue #252 (in-script `cd`) is intentionally scoped to make a
+            // file's OWN later calls line-sensitive, starting from "the existing
+            // directive or inherited working directory". A parent's in-script
+            // `cd` is deliberately NOT propagated as the inherited starting WD
+            // of a child opened standalone: doing so would require call-site
+            // matching inside this cache-keyed backward walk and is a separate
+            // enhancement. The FORWARD direction is fully handled — resolving
+            // the parent as the owner recurses into the child using the call-
+            // site WD (see ForwardScopeResolver effective_call_wd). Keeping
+            // backward inheritance directive-only also keeps the owner file's
+            // producer and resolver timelines identical, preserving dep-graph
+            // edge parity (acceptance criterion 4).
+            //
+            // If the parent has a working_directory directive, resolve it for inheritance.
             if (my_parent_result.working_directory_directive) {
                 let resolved_path = my_parent_result.working_directory_directive.resolved_path;
                 
@@ -1951,6 +1981,7 @@ export class ScopeResolver {
             const forward_result = await this.resolve_parent_forward_calls(
                 my_parent_uri,
                 my_parent_result.forward_calls,
+                my_parent_result.cd_commands,
                 my_call_site_line,
                 inheritance_type,
                 effective_working_directory,
@@ -2000,11 +2031,11 @@ export class ScopeResolver {
     private parse_file(
         uri: string,
         content: string
-    ): { symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; diagnostics: DirectiveDiagnostic[] } {
+    ): { symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; diagnostics: DirectiveDiagnostic[] } {
         const content_hash = this.hash_content(content);
         const cached = this.file_cache.get(uri);
         if (cached && cached.content_hash === content_hash) {
-            return { symbols: cached.symbols, directives: cached.directives, forward_calls: cached.forward_calls, diagnostics: cached.diagnostics };
+            return { symbols: cached.symbols, directives: cached.directives, forward_calls: cached.forward_calls, cd_commands: cached.cd_commands, diagnostics: cached.diagnostics };
         }
 
         try {
@@ -2017,6 +2048,7 @@ export class ScopeResolver {
                 symbols: my_parse_result.symbols,
                 directives: my_parse_result.directives,
                 forward_calls: my_parse_result.forward_calls,
+                cd_commands: my_parse_result.cd_commands,
                 working_directory: my_parse_result.working_directory,
                 working_directory_directive: my_parse_result.working_directory_directive,
                 diagnostics: my_parse_result.diagnostics,
@@ -2026,6 +2058,7 @@ export class ScopeResolver {
                 symbols: my_parse_result.symbols,
                 directives: my_parse_result.directives,
                 forward_calls: my_parse_result.forward_calls,
+                cd_commands: my_parse_result.cd_commands,
                 diagnostics: my_parse_result.diagnostics,
             };
         } catch (error) {
@@ -2037,6 +2070,7 @@ export class ScopeResolver {
                 symbols: empty_symbols,
                 directives: [],
                 forward_calls: [],
+                cd_commands: [],
                 diagnostics: [{
                     message: `Parse error in file: ${uri}`,
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
@@ -2058,7 +2092,7 @@ export class ScopeResolver {
         uri: string,
         content: string,
         inherited_working_directory?: string
-    ): { symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] } {
+    ): { symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] } {
         const my_directive_result = this.directive_parser.parse(content, uri);
         const my_lex_result = this.lexer.tokenize(content);
         const my_parse_result = this.parser.parse(my_lex_result.tokens);
@@ -2086,12 +2120,29 @@ export class ScopeResolver {
             working_directory: effective_working_directory,
         }, my_lex_result.tokens);
 
+        // Re-stamp command-detected forward calls with the line-sensitive
+        // working directory implied by in-script `cd` commands (issue #252),
+        // so the reverse-dependency keys this file feeds (resolve_callee_uri)
+        // agree with the dep-graph edges DocumentStore/Indexer build. The
+        // timeline starts from the file's effective WD. Diagnostics from the
+        // helper are discarded here — ForwardScopeResolver emits cd diagnostics
+        // for the owner file (single emission); see resolve().
+        const my_caller_dir = path.dirname(URI.parse(uri).fsPath);
+        const { timeline: cd_timeline } = build_cd_timeline({
+            starting_wd: effective_working_directory,
+            caller_dir: my_caller_dir,
+            cd_commands: my_analysis.cd_commands,
+            workspace_roots: this.workspace_roots,
+            fs: this.resolve_fs,
+        });
+        const restamped_command_calls = apply_cd_timeline(
+            my_analysis.forward_calls,
+            cd_timeline,
+        );
+
         // Combine forward calls from commands and directives.
-        // Stamp caller_uri and working_directory on directive calls so every
-        // ForwardCall carries the resolution context needed by Tasks 6/7.
-        // Analyzer-produced calls already carry these fields (caller_uri was
-        // set by SemanticAnalyzer; effective_working_directory is threaded in
-        // above via the analyzer config).
+        // Directive calls keep the file-wide working directory (directive
+        // behavior is intentionally unchanged by cd tracking).
         const directive_forward_calls: ForwardCall[] = (my_directive_result.forward_calls ?? []).map(d => ({
             type: d.type,
             raw_path: d.raw_path,
@@ -2104,7 +2155,7 @@ export class ScopeResolver {
         }));
 
         const all_forward_calls: ForwardCall[] = [
-            ...my_analysis.forward_calls,
+            ...restamped_command_calls,
             ...directive_forward_calls,
         ];
 
@@ -2113,6 +2164,7 @@ export class ScopeResolver {
             symbols: my_analysis.symbols,
             directives: my_directive_result.directives,
             forward_calls: all_forward_calls,
+            cd_commands: my_analysis.cd_commands,
             working_directory: effective_working_directory,
             working_directory_directive: my_directive_result.working_directory,
             diagnostics: my_directive_result.diagnostics,
@@ -2178,6 +2230,7 @@ export class ScopeResolver {
                 symbols: cached.symbols,
                 directives: cached.directives,
                 forward_calls: cached.forward_calls,
+                cd_commands: cached.cd_commands,
                 working_directory: cached.working_directory,
                 working_directory_directive: cached.working_directory_directive,
                 diagnostics: cached.diagnostics
@@ -2203,6 +2256,7 @@ export class ScopeResolver {
                     symbols: cached.symbols,
                     directives: cached.directives,
                     forward_calls: cached.forward_calls,
+                    cd_commands: cached.cd_commands,
                     working_directory: cached.working_directory,
                     working_directory_directive: cached.working_directory_directive,
                     diagnostics: cached.diagnostics
@@ -2240,6 +2294,7 @@ export class ScopeResolver {
                                 symbols: fallback_cached.symbols,
                                 directives: fallback_cached.directives,
                                 forward_calls: fallback_cached.forward_calls,
+                                cd_commands: fallback_cached.cd_commands,
                                 working_directory: fallback_cached.working_directory,
                                 diagnostics: fallback_cached.diagnostics
                             };
@@ -2277,6 +2332,7 @@ export class ScopeResolver {
                 symbols: actual_cached.symbols,
                 directives: actual_cached.directives,
                 forward_calls: actual_cached.forward_calls,
+                cd_commands: actual_cached.cd_commands,
                 working_directory: actual_cached.working_directory,
                 working_directory_directive: actual_cached.working_directory_directive,
                 diagnostics: actual_cached.diagnostics
@@ -2306,6 +2362,7 @@ export class ScopeResolver {
                 symbols: parse_result.symbols,
                 directives: parse_result.directives,
                 forward_calls: parse_result.forward_calls,
+                cd_commands: parse_result.cd_commands,
                 working_directory: parse_result.working_directory,
                 working_directory_directive: parse_result.working_directory_directive,
                 diagnostics: parse_result.diagnostics,
@@ -2332,6 +2389,7 @@ export class ScopeResolver {
                 symbols: empty_symbols,
                 directives: [],
                 forward_calls: [],
+                cd_commands: [],
                 working_directory: undefined,
                 diagnostics: [{
                     message: `Parse error in file: ${actual_uri}`,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -636,7 +636,7 @@ export interface DirectiveDiagnostic {
   severity: 'error' | 'warning' | 'information';
   source?: DiagnosticSource;  // Source attribution for diagnostics from parent files
   /** Structured discriminator for severity routing. */
-  kind?: 'missing_file' | 'path_case_mismatch' | 'truncation';
+  kind?: 'missing_file' | 'path_case_mismatch' | 'truncation' | 'missing_directory';
   /** Stable code included on the emitted LSP Diagnostic (e.g. PATH_CASE_MISMATCH). */
   code?: StataDiagnosticCode;
   /**
@@ -873,12 +873,40 @@ export interface ForwardCall {
                                // caller file's own directory).
 }
 
+/**
+ * A top-level Stata `cd` command recognized by the analyzer (issue #252).
+ *
+ * Only literal, unprefixed `cd` statements at the top level of a file are
+ * recorded; `capture cd`, macro-interpolated paths, bare `cd` (no argument),
+ * and `cd` inside loops/programs/branches are NOT recorded (they must not
+ * poison the effective working-directory timeline).
+ *
+ * The analyzer performs NO path resolution: it only records the raw path and
+ * the command's range. The shared `build_cd_timeline` helper
+ * (`src/utils/file-path-utils.ts`) resolves these against the filesystem in
+ * source (position) order to produce the line-sensitive working directory used
+ * to re-stamp each `ForwardCall.working_directory`.
+ */
+export interface CdCommand {
+  raw_path: string;       // Path exactly as written (quotes already stripped)
+  range: Range;           // Command range; range.start orders the cd timeline
+  is_static: boolean;     // false if raw_path contains a macro reference
+}
+
 export interface ForwardResolveContext {
   visited: Map<string, EffectiveCallType>;
   effective_call_type: EffectiveCallType;
   depth: number;
   diagnostics: DirectiveDiagnostic[];
   working_directory?: string;  // Inherited working directory for path resolution
+  /**
+   * Top-level `cd` commands of the file being resolved in THIS frame
+   * (issue #252). The resolver builds a working-directory timeline from
+   * `working_directory` (the call-site WD) + these commands, so each forward
+   * call resolves against the WD active at its position. Each recursion level
+   * carries the callee's own cd_commands.
+   */
+  cd_commands?: CdCommand[];
   call_chain?: string[];       // Call chain for diagnostic messages
   /**
    * URI of the file whose diagnostics are being collected in this

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -4,10 +4,18 @@
 
 import * as node_fs from 'fs';
 import * as node_path from 'path';
+import type { Position } from 'vscode-languageserver-textdocument';
 import {
     entry_is_directory_sync,
     entry_is_file_sync,
 } from './symlink-aware-entry';
+import {
+    type CdCommand,
+    type DirectiveDiagnostic,
+    type ForwardCall,
+    StataDiagnosticCode,
+} from '../types';
+import { get_workspace_root_for_path } from './workspace-roots';
 
 // Commands that accept file paths as their first argument
 export const FILE_COMMANDS = new Set([
@@ -108,6 +116,16 @@ export interface RichResolveFs {
 export interface RichResolveOptions {
     /** Append `.do` when the final component has no extension (default true). */
     try_do_fallback?: boolean;
+    /**
+     * What the final path component must resolve to (default `'file'`).
+     *
+     * `'directory'` (used for Stata `cd` targets, issue #252) matches the leaf
+     * via directory entries (`entry_is_dir`) instead of files, never applies
+     * the `.do` fallback, and — outside all workspace roots — requires
+     * `statSync(...).isDirectory()` rather than plain existence so a file named
+     * like the target is not accepted as a directory. File mode is unchanged.
+     */
+    target_kind?: 'file' | 'directory';
     /**
      * Directories that form the workspace boundary. The walk starts at the
      * deepest root that is a prefix of `resolved_fs_path`. Paths outside all
@@ -214,7 +232,10 @@ export function resolve_path_rich(
     // default. The default reads the real filesystem, so it only runs in
     // production / integration paths, never in the injected-fs unit tests.
     const the_fs: RichResolveFs = options?.fs ?? make_default_fs();
-    const try_do_fallback = options?.try_do_fallback ?? true;
+    const target_kind = options?.target_kind ?? 'file';
+    // Directory targets (cd) never get a `.do` extension fallback.
+    const try_do_fallback =
+        target_kind === 'directory' ? false : (options?.try_do_fallback ?? true);
     const the_roots = options?.workspace_roots ?? [];
 
     // Normalise path separators (OS-agnostic; tests use '/' on all platforms)
@@ -245,6 +266,22 @@ export function resolve_path_rich(
     // the analyzed file's own root as a workspace_roots entry when they want
     // case handling. Without roots we cannot know which volume to probe.
     if (chosen_root === null) {
+        if (target_kind === 'directory') {
+            // Directory target: require it to exist AND be a directory, so a
+            // file named like the target is not accepted as a cd destination.
+            // No case handling outside roots (we cannot probe a volume), and
+            // never a `.do` fallback for directories.
+            if (the_fs.existsSync(norm_path)) {
+                try {
+                    if (the_fs.statSync(norm_path).isDirectory()) {
+                        return { kind: 'exact', path: norm_path };
+                    }
+                } catch {
+                    // Dangling/inaccessible → treat as missing.
+                }
+            }
+            return { kind: 'missing', requested: resolved_fs_path };
+        }
         // Try exact path first.
         if (the_fs.existsSync(norm_path)) {
             return { kind: 'exact', path: norm_path };
@@ -343,19 +380,30 @@ export function resolve_path_rich(
         }
 
         // ── Final component ───────────────────────────────────────────────────
+        // For directory targets (cd) the leaf must be a directory; otherwise a
+        // file. The predicate follows symlinks via the shared entry helpers.
+        const entry_matches_target = (
+            e: { name: string; isFile(): boolean; isDirectory(): boolean; isSymbolicLink(): boolean },
+            full: string,
+        ): boolean =>
+            target_kind === 'directory'
+                ? entry_is_dir(e, full, the_fs)
+                : entry_is_file(e, full, the_fs);
+
         // Candidate names: the component itself, plus (when no extension and
-        // try_do_fallback) the component + '.do'.
+        // try_do_fallback) the component + '.do'. Directory mode disables the
+        // `.do` fallback, so the candidate list is just the component.
         const the_candidates: string[] = [my_component];
         if (try_do_fallback && !has_extension(my_component)) {
             the_candidates.push(`${my_component}.do`);
         }
 
-        // Step 1: exact file match (candidates in order); symlinks followed
-        // via entry_is_file so a symlinked file is treated as a file.
+        // Step 1: exact leaf match (candidates in order); symlinks followed so
+        // a symlinked file/directory is treated as its target kind.
         for (const my_cand of the_candidates) {
             const my_exact_file = my_entries.find(
                 e => e.name === my_cand &&
-                    entry_is_file(e, join_path(current_dir, e.name), the_fs),
+                    entry_matches_target(e, join_path(current_dir, e.name)),
             );
             if (my_exact_file !== undefined) {
                 const my_full = join_path(current_dir, my_exact_file.name);
@@ -370,19 +418,18 @@ export function resolve_path_rich(
             }
         }
 
-        // Step 2: case-insensitive file matches over the candidate set.
-        // Collect all (distinct) file entries whose names ci-match any
-        // candidate; symlinks are followed via entry_is_file.
+        // Step 2: case-insensitive leaf matches over the candidate set.
+        // Collect all (distinct) entries whose names ci-match any candidate
+        // and are of the target kind; symlinks are followed.
         const the_ci_files: string[] = [];
         const seen_names = new Set<string>();
         for (const my_cand of the_candidates) {
             for (const my_entry of my_entries) {
                 if (
                     ascii_ci_equal(my_entry.name, my_cand) &&
-                    entry_is_file(
+                    entry_matches_target(
                         my_entry,
                         join_path(current_dir, my_entry.name),
-                        the_fs,
                     ) &&
                     !seen_names.has(my_entry.name)
                 ) {
@@ -696,4 +743,213 @@ export function resolve_forward_call_rich(
     // Unreachable: the candidate list always has at least the script-relative
     // entry. Return a well-formed missing outcome to satisfy the type.
     return { kind: 'missing', requested: raw_path };
+}
+
+// ─── cd working-directory timeline (issue #252) ──────────────────────────────
+
+/** One step of the effective-working-directory timeline. */
+export interface CdTimelineEntry {
+    /** Start position of the `cd` command that established `wd`. */
+    cd_pos: Position;
+    /** Effective WD after this `cd` (undefined => script-relative). */
+    wd: string | undefined;
+}
+
+/** Source-ordered working-directory timeline produced by `build_cd_timeline`. */
+export interface CdTimeline {
+    /** Effective WD before the first `cd` (undefined => script-relative). */
+    starting_wd: string | undefined;
+    /** Entries in ascending `cd_pos` order. */
+    entries: CdTimelineEntry[];
+}
+
+/** True when `a` is strictly before `b` (line, then character). */
+function position_before(a: Position, b: Position): boolean {
+    return a.line < b.line || (a.line === b.line && a.character < b.character);
+}
+
+/**
+ * The effective working directory for a call at `pos`: the WD established by
+ * the latest `cd` whose position is STRICTLY before `pos`, else the timeline's
+ * starting WD. Ordering is by full source position (line, then character) — not
+ * line alone — so it stays correct if a `cd` and a call ever share a line. (In
+ * practice each top-level statement occupies its own line under the default
+ * `#delimit cr`; `#delimit ;` multi-statement lines are not produced as cd
+ * commands today — see detect_cd_command's known limitation.)
+ */
+export function wd_for_position(
+    timeline: CdTimeline,
+    pos: Position,
+): string | undefined {
+    let my_wd = timeline.starting_wd;
+    for (const my_entry of timeline.entries) {
+        if (position_before(my_entry.cd_pos, pos)) {
+            my_wd = my_entry.wd;
+        } else {
+            // Entries are sorted ascending; once one is not before pos, none
+            // after it can be either.
+            break;
+        }
+    }
+    return my_wd;
+}
+
+/**
+ * Build the effective working-directory timeline for a file by walking its
+ * top-level `cd` commands in source (position) order, resolving each target
+ * directory against the filesystem so the WD carries the REAL on-disk casing.
+ *
+ * Using the real-cased directory prevents a cascade: if `cd "raw"` (on-disk
+ * `Raw`) left the WD lower-cased, every later `do`/`run`/`include` resolved
+ * through it would also be flagged as a case mismatch. Resolving once here
+ * keeps later calls exact.
+ *
+ * Outcomes per static `cd`:
+ *  - `exact`     → WD becomes the real path; no diagnostic.
+ *  - `case_only` → WD becomes the real-cased path; emit `path_case_mismatch`.
+ *  - `missing`   → WD becomes the normalized joined path (preserve the author's
+ *                  intent so later calls resolve against where they MEANT to
+ *                  be); emit a `missing_directory` warning.
+ *  - `ambiguous` → WD is LEFT UNCHANGED (no safe choice); emit a warning.
+ *
+ * Non-static `cd` commands are ignored entirely (the analyzer only records
+ * static ones), so dynamic/`capture`/bare `cd` never poison the timeline.
+ *
+ * The returned `diagnostics` are always computed; callers decide whether to
+ * emit them (only the diagnostic-owner file at depth 0 should — every producer
+ * that merely re-stamps forward calls discards them to avoid double emission).
+ */
+export function build_cd_timeline(params: {
+    starting_wd: string | undefined;
+    caller_dir: string;
+    cd_commands: CdCommand[];
+    workspace_roots?: string[];
+    fs?: RichResolveFs;
+}): { timeline: CdTimeline; diagnostics: DirectiveDiagnostic[] } {
+    const { starting_wd, caller_dir, cd_commands, workspace_roots, fs } = params;
+    const the_diagnostics: DirectiveDiagnostic[] = [];
+    const the_entries: CdTimelineEntry[] = [];
+
+    // Process static cd commands in ascending position order. Tolerate an
+    // absent list (defensive: some callers/mocks omit cd_commands).
+    const the_statics = (cd_commands ?? [])
+        .filter(c => c.is_static && c.raw_path.length > 0)
+        .sort((a, b) =>
+            position_before(a.range.start, b.range.start) ? -1 :
+            position_before(b.range.start, a.range.start) ? 1 : 0,
+        );
+
+    let current_wd = starting_wd;
+    for (const my_cd of the_statics) {
+        // Stata resolves `cd` against the CURRENT working directory only (or an
+        // absolute path) — NOT via do/run/include's script-relative or
+        // workspace-root fallbacks. Build the single candidate accordingly so a
+        // missing WD-relative target stays missing (and is diagnosed) instead
+        // of silently snapping to a same-named directory beside the script.
+        const my_normalized_raw = my_cd.raw_path.replace(/\\/g, '/');
+        const my_is_abs =
+            node_path.isAbsolute(my_normalized_raw) ||
+            /^[a-zA-Z]:\//.test(my_normalized_raw);
+        const my_candidate = my_is_abs
+            ? node_path.normalize(my_normalized_raw)
+            : current_wd
+                ? node_path.normalize(node_path.join(current_wd, my_normalized_raw))
+                : node_path.resolve(caller_dir, my_cd.raw_path);
+        const my_outcome = resolve_path_rich(my_candidate, {
+            workspace_roots,
+            fs,
+            target_kind: 'directory',
+        });
+
+        if (my_outcome.kind === 'exact') {
+            current_wd = my_outcome.path;
+        } else if (my_outcome.kind === 'case_only') {
+            current_wd = my_outcome.path;
+            the_diagnostics.push(
+                make_cd_case_mismatch_diagnostic(my_cd, my_outcome, caller_dir, workspace_roots),
+            );
+        } else if (my_outcome.kind === 'missing') {
+            // Preserve the author's intent: later relative calls resolve against
+            // where the cd MEANT to go, even though it is not on disk now.
+            current_wd = my_outcome.requested;
+            the_diagnostics.push({
+                message:
+                    `Cannot change directory: "${my_cd.raw_path}" ` +
+                    `(directory not found)`,
+                range: my_cd.range,
+                severity: 'warning',
+                kind: 'missing_directory',
+                code: StataDiagnosticCode.CROSS_FILE_MISSING_FILE,
+            });
+        } else {
+            // ambiguous: two or more case-insensitive matches — no safe choice.
+            // Leave the WD unchanged so we do not poison later resolution.
+            the_diagnostics.push({
+                message:
+                    `Ambiguous directory for cd: "${my_cd.raw_path}" ` +
+                    `(multiple case-insensitive matches)`,
+                range: my_cd.range,
+                severity: 'warning',
+                kind: 'missing_directory',
+                code: StataDiagnosticCode.CROSS_FILE_MISSING_FILE,
+            });
+        }
+        the_entries.push({ cd_pos: my_cd.range.start, wd: current_wd });
+    }
+
+    return {
+        timeline: { starting_wd, entries: the_entries },
+        diagnostics: the_diagnostics,
+    };
+}
+
+/** Build the `path_case_mismatch` diagnostic for a case-only `cd` target. */
+function make_cd_case_mismatch_diagnostic(
+    cd: CdCommand,
+    outcome: { kind: 'case_only'; path: string; requested: string },
+    caller_dir: string,
+    workspace_roots?: string[],
+): DirectiveDiagnostic {
+    const my_req_disp = node_path
+        .relative(caller_dir, outcome.requested)
+        .replace(/\\/g, '/') || outcome.requested;
+    const my_real_disp = node_path
+        .relative(caller_dir, outcome.path)
+        .replace(/\\/g, '/') || outcome.path;
+    const my_seed = workspace_roots
+        ? (get_workspace_root_for_path(workspace_roots, outcome.path) ??
+           node_path.dirname(outcome.path))
+        : node_path.dirname(outcome.path);
+    return {
+        message:
+            `Path "${my_req_disp}" does not match the directory on disk ` +
+            `"${my_real_disp}"; Stata will not find it on case-sensitive ` +
+            `filesystems (Linux). Update the path to match.`,
+        range: cd.range,
+        severity: 'warning',
+        kind: 'path_case_mismatch',
+        code: StataDiagnosticCode.PATH_CASE_MISMATCH,
+        case_mismatch_seed_dir: my_seed,
+    };
+}
+
+/**
+ * Re-stamp each command-sourced forward call's `working_directory` from the
+ * cd timeline (issue #252). Directive-sourced calls keep their WD unchanged
+ * (directive behavior is intentionally untouched). Returns a new array; the
+ * input calls are not mutated.
+ */
+export function apply_cd_timeline(
+    forward_calls: ForwardCall[],
+    timeline: CdTimeline,
+): ForwardCall[] {
+    return forward_calls.map(my_call => {
+        if (my_call.source !== 'command') {
+            return my_call;
+        }
+        return {
+            ...my_call,
+            working_directory: wd_for_position(timeline, my_call.range.start),
+        };
+    });
 }

--- a/tests/integration/cd-statement-tracking.test.ts
+++ b/tests/integration/cd-statement-tracking.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Integration tests for issue #252: in-script Stata `cd` statements provide
+ * line-sensitive working-directory context, so `do`/`run`/`include` paths
+ * resolve relative to the working directory active at each call site.
+ *
+ * Covers the acceptance criteria:
+ *  1. Two top-level literal `cd`s resolve later calls per-call-site.
+ *  3. `cd` target casing diagnosed like do/run/include path-case mismatches.
+ *  4. Open-document parsing and workspace indexing agree on dep-graph edges.
+ *  5. Go-to-definition uses the per-call working directory.
+ *  6. Dynamic / prefixed `cd` does not cause false confident resolution.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { DocumentStore } from '../../src/document-store';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { DefinitionProvider } from '../../src/providers/definition';
+import { get_visible_symbols_at } from '../../src/scope-resolver';
+import { create_test_scope_resolver_logger } from '../test-logger';
+
+describe('Issue #252: in-script cd statement tracking', () => {
+    let test_dir: string;
+    let document_store: DocumentStore;
+    let scope_resolver: ScopeResolver;
+    let forward_resolver: ForwardScopeResolver;
+
+    beforeEach(() => {
+        // Resolve symlinks (macOS /tmp → /private/tmp) for exact path matching.
+        test_dir = fs.realpathSync.native(
+            fs.mkdtempSync(path.join(os.tmpdir(), 'cd-tracking-')),
+        );
+        scope_resolver = new ScopeResolver(create_test_scope_resolver_logger());
+        scope_resolver.set_workspace_roots([test_dir]);
+        forward_resolver = new ForwardScopeResolver(scope_resolver);
+        forward_resolver.set_workspace_roots([test_dir]);
+        scope_resolver.set_forward_scope_resolver(forward_resolver);
+        document_store = new DocumentStore();
+        document_store.set_workspace_roots([test_dir]);
+        document_store.set_scope_resolver(scope_resolver);
+    });
+
+    afterEach(() => {
+        fs.rmSync(test_dir, { recursive: true, force: true });
+    });
+
+    function write_file(rel_path: string, content: string): string {
+        const full_path = path.join(test_dir, rel_path);
+        fs.mkdirSync(path.dirname(full_path), { recursive: true });
+        fs.writeFileSync(full_path, content);
+        return full_path;
+    }
+
+    function file_uri(rel_path: string): string {
+        return URI.file(path.join(test_dir, rel_path)).toString();
+    }
+
+    // ── Criterion 1: per-call-site resolution ─────────────────────────────────
+
+    it('resolves later do calls relative to the WD active at each call site', async () => {
+        write_file('raw/import.do', 'global from_import = 1\n');
+        write_file('analysis/clean.do', 'global from_clean = 1\n');
+        const main = write_file(
+            'main.do',
+            'cd "raw"\ndo import\ncd "../analysis"\ndo clean\n',
+        );
+        const uri = URI.file(main).toString();
+        await document_store.open(uri, fs.readFileSync(main, 'utf8'), 1);
+
+        const state = document_store.get(uri)!;
+        const import_call = state.forward_calls.find(c => c.raw_path === 'import')!;
+        const clean_call = state.forward_calls.find(c => c.raw_path === 'clean')!;
+
+        expect(import_call.working_directory).toBe(path.join(test_dir, 'raw'));
+        expect(clean_call.working_directory).toBe(path.join(test_dir, 'analysis'));
+    });
+
+    // ── Criterion 4: open-doc vs indexer dep-graph parity ─────────────────────
+
+    it('open-document and workspace indexing produce the same dep-graph edges', async () => {
+        write_file('raw/import.do', 'global g_import = 1\n');
+        write_file('analysis/clean.do', 'global g_clean = 1\n');
+        write_file('main.do', 'cd "raw"\ndo import\ncd "../analysis"\ndo clean\n');
+
+        // Indexer path.
+        const indexer = new WorkspaceIndexer();
+        const idx_graph = new DependencyGraph();
+        idx_graph.set_workspace_roots([test_dir]);
+        indexer.set_dependency_graph(idx_graph);
+        const idx_scope = new ScopeResolver(create_test_scope_resolver_logger());
+        idx_scope.set_workspace_roots([test_dir]);
+        indexer.set_scope_resolver(idx_scope);
+        await indexer.initialize([test_dir]);
+
+        const main_uri = file_uri('main.do');
+        const indexed_callees = idx_graph.get_callees(main_uri);
+
+        // Open-document path: build a dep graph from the opened forward calls.
+        const open_graph = new DependencyGraph();
+        open_graph.set_workspace_roots([test_dir]);
+        const main_path = path.join(test_dir, 'main.do');
+        await document_store.open(main_uri, fs.readFileSync(main_path, 'utf8'), 1);
+        open_graph.update_caller(main_uri, document_store.get(main_uri)!.forward_calls);
+        const open_callees = open_graph.get_callees(main_uri);
+
+        const expected_import = file_uri('raw/import.do');
+        const expected_clean = file_uri('analysis/clean.do');
+
+        for (const my_graph of [indexed_callees, open_callees]) {
+            expect(my_graph.has(expected_import)).toBe(true);
+            expect(my_graph.has(expected_clean)).toBe(true);
+        }
+        // The two paths agree on the full callee set.
+        expect(new Set(open_callees.keys())).toEqual(new Set(indexed_callees.keys()));
+    });
+
+    // ── Criterion 3: cd target casing diagnostic ──────────────────────────────
+
+    it('diagnoses a case-only cd target like do/run/include path-case', async () => {
+        write_file('Raw/import.do', 'global g = 1\n');     // on disk: Raw
+        const main = write_file('main.do', 'cd "raw"\ndo import\n'); // source: raw
+        const uri = URI.file(main).toString();
+        const content = fs.readFileSync(main, 'utf8');
+
+        const resolved = await scope_resolver.resolve(uri, content);
+        const case_diags = resolved.diagnostics.filter(
+            d => d.kind === 'path_case_mismatch' && d.range.start.line === 0,
+        );
+        // Exactly one cd-line case-mismatch — and NO cascade onto the `do` line.
+        expect(case_diags).toHaveLength(1);
+        const do_line_case = resolved.diagnostics.filter(
+            d => d.kind === 'path_case_mismatch' && d.range.start.line === 1,
+        );
+        expect(do_line_case).toHaveLength(0);
+    });
+
+    it('warns when a static cd target directory does not exist', async () => {
+        const main = write_file('main.do', 'cd "nope"\n');
+        const uri = URI.file(main).toString();
+        const content = fs.readFileSync(main, 'utf8');
+
+        const resolved = await scope_resolver.resolve(uri, content);
+        const missing = resolved.diagnostics.filter(
+            d => d.kind === 'missing_directory' && d.range.start.line === 0,
+        );
+        expect(missing).toHaveLength(1);
+        expect(missing[0]!.severity).toBe('warning');
+    });
+
+    // ── Criterion 6: dynamic / prefixed cd does not poison ────────────────────
+
+    it('does not change WD for a dynamic (macro) cd path', async () => {
+        write_file('base/sub.do', 'global g = 1\n');
+        const main = write_file(
+            'main.do',
+            '// @lsp-cd: "base"\ncd "`somedir\'"\ndo sub\n',
+        );
+        const uri = URI.file(main).toString();
+        await document_store.open(uri, fs.readFileSync(main, 'utf8'), 1);
+        const state = document_store.get(uri)!;
+        const sub_call = state.forward_calls.find(c => c.raw_path === 'sub')!;
+        // The dynamic cd is skipped, so the directive WD (base) still applies.
+        expect(sub_call.working_directory).toBe(path.join(test_dir, 'base'));
+    });
+
+    // ── Nested: call-site WD propagates into the callee (codex review #1) ─────
+
+    it('resolves a grandchild relative to the WD active at the parent call site', async () => {
+        // parent (in test_dir) cd's into data/, then do's a child physically in
+        // scripts/. In Stata the cwd stays `data` while child runs, so child's
+        // relative `do helper` must resolve to data/helper.do — NOT
+        // scripts/helper.do (child's own directory).
+        write_file('scripts/child.do', 'do helper\nglobal from_child = 1\n');
+        write_file('data/helper.do', 'global from_helper = 1\n');
+        const parent = write_file('parent.do', 'cd "data"\ndo ../scripts/child\n');
+        const uri = URI.file(parent).toString();
+        const content = fs.readFileSync(parent, 'utf8');
+
+        const resolved = await scope_resolver.resolve(uri, content);
+        // Forward-call symbols are visible after the call site (line 1).
+        const visible = get_visible_symbols_at(resolved, 100);
+        // Direct child's global is visible.
+        expect(visible.globalMacros.has('from_child')).toBe(true);
+        // Grandchild found only via the call-site WD (data/), proving the
+        // effective call-site WD propagated into the nested resolution.
+        expect(visible.globalMacros.has('from_helper')).toBe(true);
+    });
+
+    // ── Criterion 5: go-to-definition uses per-call WD ────────────────────────
+
+    it('go-to-definition on a path after cd jumps to the WD-relative file', async () => {
+        write_file('raw/import.do', 'global g = 1\n');
+        const main = write_file('main.do', 'cd "raw"\ndo import\n');
+        const uri = URI.file(main).toString();
+        await document_store.open(uri, fs.readFileSync(main, 'utf8'), 1);
+
+        const definition_provider = new DefinitionProvider();
+        definition_provider.set_workspace_roots([test_dir]);
+
+        const state = document_store.get(uri)!;
+        // Cursor on `import` (line 1). Column inside the path token.
+        const result = await definition_provider.get_definition(
+            state,
+            { line: 1, character: 4 },
+            undefined,
+            state.context_tracker,
+            scope_resolver,
+        );
+        const target = Array.isArray(result) ? result[0] : result;
+        expect(target).not.toBeNull();
+        expect(target!.uri).toBe(file_uri('raw/import.do'));
+    });
+});

--- a/tests/unit/analyzer/cd-command-detection.test.ts
+++ b/tests/unit/analyzer/cd-command-detection.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The analyzer records top-level literal `cd` commands (issue #252) so a
+ * downstream helper can build the line-sensitive working-directory timeline.
+ * Recognition is conservative: only unprefixed, static, top-level `cd` with a
+ * path argument is recorded. The analyzer performs NO path resolution.
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { SemanticAnalyzer } from '../../../src/analyzer/index';
+import { StataLexer } from '../../../src/lexer';
+import { StataParser } from '../../../src/parser';
+
+describe('Analyzer cd_command detection (issue #252)', () => {
+    let my_analyzer: SemanticAnalyzer;
+    let my_lexer: StataLexer;
+    let my_parser: StataParser;
+
+    beforeEach(() => {
+        my_analyzer = new SemanticAnalyzer();
+        my_lexer = new StataLexer();
+        my_parser = new StataParser();
+    });
+
+    function cd_paths(my_source: string): string[] {
+        const my_lex = my_lexer.tokenize(my_source);
+        const my_parse = my_parser.parse(my_lex.tokens);
+        const my_result = my_analyzer.analyze(
+            my_parse.ast,
+            'file:///test.do',
+            undefined,
+            undefined,
+            my_lex.tokens,
+        );
+        return my_result.cd_commands.map(c => c.raw_path);
+    }
+
+    function cd_commands(my_source: string) {
+        const my_lex = my_lexer.tokenize(my_source);
+        const my_parse = my_parser.parse(my_lex.tokens);
+        return my_analyzer.analyze(
+            my_parse.ast, 'file:///test.do', undefined, undefined, my_lex.tokens,
+        ).cd_commands;
+    }
+
+    it('records quoted and unquoted top-level cd targets in order', () => {
+        expect(cd_paths('cd "raw"\ncd ../analysis\n')).toEqual(['raw', '../analysis']);
+    });
+
+    it('marks macro-containing cd paths as non-static', () => {
+        const the_cds = cd_commands('cd "`dir\'"\n');
+        expect(the_cds).toHaveLength(1);
+        expect(the_cds[0]!.is_static).toBe(false);
+    });
+
+    it('skips bare cd (no path argument)', () => {
+        expect(cd_paths('cd\ndisplay 1\n')).toEqual([]);
+    });
+
+    it('skips prefixed cd (capture/quietly)', () => {
+        expect(cd_paths('capture cd "x"\nquietly cd "y"\n')).toEqual([]);
+    });
+
+    it('skips cd inside a program body (out of scope)', () => {
+        const src = `cd "top"\nprogram define foo\n    cd "inside"\nend\n`;
+        expect(cd_paths(src)).toEqual(['top']);
+    });
+
+    it('skips cd inside a loop body (out of scope)', () => {
+        const src = `cd "top"\nforeach v in a b {\n    cd "inside"\n}\n`;
+        expect(cd_paths(src)).toEqual(['top']);
+    });
+
+    it('skips cd inside an if branch (out of scope)', () => {
+        const src = `cd "top"\nif 1 == 1 {\n    cd "inside"\n}\n`;
+        expect(cd_paths(src)).toEqual(['top']);
+    });
+
+    it('is case-sensitive: `CD` is not a cd command', () => {
+        expect(cd_paths('CD "x"\n')).toEqual([]);
+    });
+
+    it('does not record cd under #delimit ; (pre-existing parser limitation)', () => {
+        // KNOWN LIMITATION: under `#delimit ;` the parser does not attach the
+        // path as a varlist argument (`cd "raw";` becomes a `cd` node with no
+        // varlist plus a separate `"raw"` node), so cd is skipped. This affects
+        // do/run/include forward-call detection identically and is out of scope
+        // for #252. Pinned here so the behavior change is explicit if the parser
+        // later gains #delimit ; file-command support.
+        const src = `#delimit ;\ncd "raw";\ndo import;\n`;
+        const the_lex = my_lexer.tokenize(src);
+        const the_parse = my_parser.parse(the_lex.tokens);
+        const the_result = my_analyzer.analyze(
+            the_parse.ast, 'file:///test.do', undefined, undefined, the_lex.tokens,
+        );
+        expect(the_result.cd_commands).toEqual([]);
+        // do/run/include detection is a no-op here too — consistency check.
+        expect(the_result.forward_calls).toEqual([]);
+    });
+
+    it('records the command range start for ordering', () => {
+        const the_cds = cd_commands('display 1\ncd "raw"\n');
+        expect(the_cds).toHaveLength(1);
+        expect(the_cds[0]!.range.start.line).toBe(1);
+    });
+});

--- a/tests/unit/cd-timeline.test.ts
+++ b/tests/unit/cd-timeline.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from 'bun:test';
+import {
+    resolve_path_rich,
+    build_cd_timeline,
+    wd_for_position,
+    apply_cd_timeline,
+} from '../../src/utils/file-path-utils';
+import type { CdCommand, ForwardCall } from '../../src/types';
+
+// ─── In-memory filesystem helper (mirrors path-resolve-rich.test.ts) ──────────
+
+type FsEntry = [string, boolean | 'link-dir' | 'link-file' | 'link-dead'];
+
+function make_fs(tree: Record<string, Array<FsEntry>>) {
+    const the_dir_set = new Set(Object.keys(tree));
+    const the_file_set = new Set<string>();
+    const the_kind_map = new Map<string, FsEntry[1]>();
+    for (const [my_dir, my_entries] of Object.entries(tree)) {
+        for (const [my_name, my_kind] of my_entries) {
+            const my_full = `${my_dir}/${my_name}`;
+            the_kind_map.set(my_full, my_kind);
+            if (my_kind === true || my_kind === 'link-file') {
+                the_file_set.add(my_full);
+            }
+        }
+    }
+    return {
+        existsSync: (p: string) => the_dir_set.has(p) || the_file_set.has(p),
+        readdirSync: (p: string, _opts: { withFileTypes: true }) =>
+            (tree[p] ?? []).map(([my_name, my_kind]) => ({
+                name: my_name,
+                isFile: () => my_kind === true,
+                isDirectory: () => my_kind === false,
+                isSymbolicLink: () =>
+                    my_kind === 'link-dir' ||
+                    my_kind === 'link-file' ||
+                    my_kind === 'link-dead',
+            })),
+        statSync: (p: string): { isFile(): boolean; isDirectory(): boolean } => {
+            const my_kind = the_kind_map.get(p);
+            if (my_kind === 'link-dead' || my_kind === undefined) {
+                throw new Error(`ENOENT: no such file or directory, stat '${p}'`);
+            }
+            const my_is_file = my_kind === true || my_kind === 'link-file';
+            const my_is_dir = my_kind === false || my_kind === 'link-dir';
+            return { isFile: () => my_is_file, isDirectory: () => my_is_dir };
+        },
+    };
+}
+
+const cd = (raw_path: string, line: number, character = 0, is_static = true): CdCommand => ({
+    raw_path,
+    range: {
+        start: { line, character },
+        end: { line, character: character + 2 + raw_path.length },
+    },
+    is_static,
+});
+
+const fwd = (raw_path: string, line: number, character = 0): ForwardCall => ({
+    type: 'do',
+    raw_path,
+    call_site_line: line,
+    range: { start: { line, character }, end: { line, character: character + 3 + raw_path.length } },
+    source: 'command',
+    is_static: true,
+    caller_uri: 'file:///ws/main.do',
+});
+
+// ─── resolve_path_rich directory mode ─────────────────────────────────────────
+
+describe('resolve_path_rich target_kind: directory', () => {
+    const roots = ['/ws'];
+
+    it('matches a directory leaf exactly (no .do fallback)', () => {
+        const fs = make_fs({ '/ws': [['raw', false]] });
+        expect(
+            resolve_path_rich('/ws/raw', { workspace_roots: roots, fs, target_kind: 'directory' }),
+        ).toEqual({ kind: 'exact', path: '/ws/raw' });
+    });
+
+    it('does NOT match a FILE leaf in directory mode', () => {
+        const fs = make_fs({ '/ws': [['raw', true]] });
+        expect(
+            resolve_path_rich('/ws/raw', { workspace_roots: roots, fs, target_kind: 'directory' }),
+        ).toEqual({ kind: 'missing', requested: '/ws/raw' });
+    });
+
+    it('case-only directory match', () => {
+        const fs = make_fs({ '/ws': [['Raw', false]] });
+        expect(
+            resolve_path_rich('/ws/raw', { workspace_roots: roots, fs, target_kind: 'directory' }),
+        ).toEqual({ kind: 'case_only', path: '/ws/Raw', requested: '/ws/raw' });
+    });
+
+    it('ambiguous when two case variants exist', () => {
+        const fs = make_fs({ '/ws': [['Raw', false], ['raw', false]] });
+        const outcome = resolve_path_rich('/ws/RAW', { workspace_roots: roots, fs, target_kind: 'directory' });
+        expect(outcome.kind).toBe('ambiguous');
+    });
+
+    it('outside workspace roots: requires isDirectory (a file is not a dir)', () => {
+        const fs = make_fs({ '/elsewhere': [['data', true]] });
+        // No workspace roots → plain-existence branch; a FILE must not satisfy a directory target.
+        expect(
+            resolve_path_rich('/elsewhere/data', { fs, target_kind: 'directory' }),
+        ).toEqual({ kind: 'missing', requested: '/elsewhere/data' });
+    });
+
+    it('outside workspace roots: a real directory resolves exact', () => {
+        const fs = make_fs({ '/elsewhere': [['data', false]], '/elsewhere/data': [] });
+        expect(
+            resolve_path_rich('/elsewhere/data', { fs, target_kind: 'directory' }),
+        ).toEqual({ kind: 'exact', path: '/elsewhere/data' });
+    });
+});
+
+// ─── build_cd_timeline + wd_for_position ──────────────────────────────────────
+
+describe('build_cd_timeline', () => {
+    const roots = ['/ws'];
+
+    it('resolves two sequential cd targets relative to the running WD', () => {
+        const fs = make_fs({
+            '/ws': [['raw', false], ['analysis', false]],
+            '/ws/raw': [],
+            '/ws/analysis': [],
+        });
+        const { timeline, diagnostics } = build_cd_timeline({
+            starting_wd: undefined,
+            caller_dir: '/ws',
+            cd_commands: [cd('raw', 0), cd('../analysis', 2)],
+            workspace_roots: roots,
+            fs,
+        });
+        expect(diagnostics).toEqual([]);
+        // Before any cd → starting (script-relative / undefined)
+        expect(wd_for_position(timeline, { line: 0, character: 0 })).toBeUndefined();
+        // After `cd raw` → /ws/raw
+        expect(wd_for_position(timeline, { line: 1, character: 0 })).toBe('/ws/raw');
+        // After `cd ../analysis` (joined against /ws/raw) → /ws/analysis
+        expect(wd_for_position(timeline, { line: 3, character: 0 })).toBe('/ws/analysis');
+    });
+
+    it('uses the REAL on-disk casing for the WD (kills the cascade)', () => {
+        const fs = make_fs({ '/ws': [['Raw', false]], '/ws/Raw': [] });
+        const { timeline, diagnostics } = build_cd_timeline({
+            starting_wd: undefined,
+            caller_dir: '/ws',
+            cd_commands: [cd('raw', 0)],
+            workspace_roots: roots,
+            fs,
+        });
+        // WD is the real-cased path, so later calls resolve exact (no cascade).
+        expect(wd_for_position(timeline, { line: 1, character: 0 })).toBe('/ws/Raw');
+        // One case-mismatch diagnostic on the cd line.
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]!.kind).toBe('path_case_mismatch');
+        expect(diagnostics[0]!.range.start.line).toBe(0);
+    });
+
+    it('missing cd target → warning, WD becomes the joined intent path', () => {
+        const fs = make_fs({ '/ws': [] });
+        const { timeline, diagnostics } = build_cd_timeline({
+            starting_wd: undefined,
+            caller_dir: '/ws',
+            cd_commands: [cd('out', 0)],
+            workspace_roots: roots,
+            fs,
+        });
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]!.kind).toBe('missing_directory');
+        expect(diagnostics[0]!.severity).toBe('warning');
+        // WD preserves the author's intent for later relative calls.
+        expect(wd_for_position(timeline, { line: 1, character: 0 })).toBe('/ws/out');
+    });
+
+    it('ambiguous cd → warning, WD UNCHANGED (does not poison later calls)', () => {
+        // Two case variants of the target exist under the active WD.
+        const fs = make_fs({
+            '/ws': [['start', false]],
+            '/ws/start': [['Out', false], ['out', false]],
+            '/ws/start/Out': [],
+            '/ws/start/out': [],
+        });
+        const { timeline, diagnostics } = build_cd_timeline({
+            starting_wd: '/ws/start',
+            caller_dir: '/ws',
+            cd_commands: [cd('OUT', 0)],
+            workspace_roots: roots,
+            fs,
+        });
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]!.kind).toBe('missing_directory');
+        // WD stays at the starting value — ambiguous never poisons.
+        expect(wd_for_position(timeline, { line: 1, character: 0 })).toBe('/ws/start');
+    });
+
+    it('resolves cd ONLY against the current WD (no script-relative fallback)', () => {
+        // `raw/` exists beside the script, but the active WD is `base`, where
+        // `raw` does NOT exist. Stata would fail `cd raw` here; we must report
+        // missing — never silently snap to the script-relative `raw/`.
+        const fs = make_fs({
+            '/ws': [['raw', false], ['base', false]],
+            '/ws/raw': [],
+            '/ws/base': [],
+        });
+        const { timeline, diagnostics } = build_cd_timeline({
+            starting_wd: '/ws/base',
+            caller_dir: '/ws',
+            cd_commands: [cd('raw', 0)],
+            workspace_roots: roots,
+            fs,
+        });
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]!.kind).toBe('missing_directory');
+        // WD becomes the intended (missing) base/raw, NOT the script-relative /ws/raw.
+        expect(wd_for_position(timeline, { line: 1, character: 0 })).toBe('/ws/base/raw');
+    });
+
+    it('ignores non-static cd commands (dynamic paths never poison)', () => {
+        const fs = make_fs({ '/ws': [['raw', false]], '/ws/raw': [] });
+        const { timeline, diagnostics } = build_cd_timeline({
+            starting_wd: '/ws/base',
+            caller_dir: '/ws',
+            cd_commands: [cd('`dir\'', 0, 0, /* is_static */ false)],
+            workspace_roots: roots,
+            fs,
+        });
+        expect(diagnostics).toEqual([]);
+        expect(wd_for_position(timeline, { line: 1, character: 0 })).toBe('/ws/base');
+    });
+});
+
+// ─── wd_for_position same-line position ordering (defensive) ──────────────────
+// Ordering is by full (line, character) position, so it stays correct even if a
+// cd and a call were to share a line. (Note: under `#delimit ;` the parser does
+// not currently produce cd commands — see detect_cd_command — so these synthetic
+// positions exercise the ordering function directly, not end-to-end `;` parsing.)
+
+describe('wd_for_position same-line position ordering', () => {
+    const roots = ['/ws'];
+    const fs = make_fs({ '/ws': [['a', false]], '/ws/a': [] });
+
+    it('a call AFTER a same-line cd sees the new WD', () => {
+        const { timeline } = build_cd_timeline({
+            starting_wd: undefined,
+            caller_dir: '/ws',
+            cd_commands: [cd('a', 5, /* character */ 0)],
+            workspace_roots: roots,
+            fs,
+        });
+        // `cd a` at (5,0); `do x` at (5,6) → after the cd.
+        expect(wd_for_position(timeline, { line: 5, character: 6 })).toBe('/ws/a');
+    });
+
+    it('a call BEFORE a same-line cd keeps the prior WD', () => {
+        const { timeline } = build_cd_timeline({
+            starting_wd: undefined,
+            caller_dir: '/ws',
+            cd_commands: [cd('a', 5, /* character */ 8)],
+            workspace_roots: roots,
+            fs,
+        });
+        // `do x` at (5,0); `cd a` at (5,8) → call is before the cd.
+        expect(wd_for_position(timeline, { line: 5, character: 0 })).toBeUndefined();
+    });
+});
+
+// ─── apply_cd_timeline ────────────────────────────────────────────────────────
+
+describe('apply_cd_timeline', () => {
+    const roots = ['/ws'];
+    const fs = make_fs({
+        '/ws': [['raw', false], ['analysis', false]],
+        '/ws/raw': [],
+        '/ws/analysis': [],
+    });
+
+    it('re-stamps command calls per the timeline; leaves directive calls alone', () => {
+        const { timeline } = build_cd_timeline({
+            starting_wd: undefined,
+            caller_dir: '/ws',
+            // `cd raw` (script-relative → /ws/raw), then `cd ../analysis`
+            // (relative to /ws/raw → /ws/analysis).
+            cd_commands: [cd('raw', 0), cd('../analysis', 2)],
+            workspace_roots: roots,
+            fs,
+        });
+        const directive_call: ForwardCall = {
+            ...fwd('helper', 5),
+            source: 'directive',
+            working_directory: '/ws/fixed',
+        };
+        const calls: ForwardCall[] = [fwd('import', 1), fwd('clean', 3), directive_call];
+        const restamped = apply_cd_timeline(calls, timeline);
+        expect(restamped[0]!.working_directory).toBe('/ws/raw');      // after cd raw
+        expect(restamped[1]!.working_directory).toBe('/ws/analysis'); // after cd analysis
+        expect(restamped[2]!.working_directory).toBe('/ws/fixed');    // directive untouched
+    });
+});


### PR DESCRIPTION
Closes #252.

## What

Models top-level literal `cd` commands so later `do`/`run`/`include` paths resolve relative to the working directory active at **each call site**, instead of a single file-wide working directory.

```stata
cd "raw"
do import        // resolves in raw/
cd "../analysis"
do clean         // resolves in analysis/
```

## How

- **Analyzer** records top-level, unprefixed, static `cd` commands (`cd_commands`) and stays filesystem-pure. A nesting-depth guard keeps `cd` inside loops/programs/branches out of scope; `do`/`run`/`include` detection is unchanged.
- **Shared helpers** in `file-path-utils.ts`:
  - `resolve_path_rich` gains `target_kind: 'directory'` (matches a directory leaf, no `.do` fallback, and the outside-workspace branch requires `statSync().isDirectory()`).
  - `build_cd_timeline` / `wd_for_position` / `apply_cd_timeline` build the source-ordered WD timeline. `cd` resolves **only** against the current WD (or absolute) — single-candidate, matching Stata semantics — and uses the real on-disk casing (so a case-only `cd` does not cascade case-mismatch warnings onto every later call). Missing target → joined-intent WD + warning; ambiguous → WD unchanged + warning; case-only → `path_case_mismatch`.
- **Producers re-stamp** command forward calls per the timeline so dependency-graph edges and reverse-dep keys are line-sensitive and agree across open-document (`DocumentStore`), workspace scan (`WorkspaceIndexer`, reordered), and cross-file resolution (`ScopeResolver.parse_content`).
- **ForwardScopeResolver** recomputes the timeline per frame from the call-site WD and uses the effective per-call WD everywhere (path resolution, callee scope, end-state, nested recursion), so a callee reached via a parent `cd A; do child` resolves its relative paths from `A`. `cd` diagnostics are emitted once, for the diagnostic-owner file at depth 0.
- **DefinitionProvider** resolves `do`/`run`/`include` path navigation via the matching forward call's working directory (honors both `@lsp-cd` and in-script `cd`), correlating by cursor range containment.
- **Diagnostics provider** routes the new `missing_directory` kind (warning, reusing the `missing_file` toggle); `cd` casing reuses the existing `case_mismatch` config + host-probe severity.

## Acceptance criteria

All six from #252 are covered by tests: per-call-site resolution, `@lsp-cd` tests unchanged, casing diagnostics, open-document vs. indexer dep-graph parity, forward-scope/diagnostics/completion/definition/references using the per-call WD, and dynamic/ambiguous `cd` not causing false confident resolution.

## Out of scope (documented in code)

- A parent's in-script `cd` is not propagated to a child opened standalone (backward WD inheritance stays directive-based).
- `#delimit ;` files: the parser does not attach file-command paths as a `varlist` argument, so `cd` is not detected — a pre-existing limitation that affects `do`/`run`/`include` detection identically.
- Path-literal **filename** completion remains WD-unaware (it honors no WD context today, not even `@lsp-cd`).

## Follow-up

Review surfaced that forward-call resolution (`resolve_forward_call_rich`) falls back to script-relative/workspace candidates when a WD-relative target is missing — pre-existing shared-resolver leniency that applies to all WD sources, and not a regression (this PR only improves resolution; the missing-target fallback is identical to prior behavior). Tightening it to be WD-strict is tracked separately in #258.

## Verification

`bun run typecheck`, `bun run lint`, and the full `bun test` suite (6500+ tests) pass. New tests: `tests/unit/cd-timeline.test.ts`, `tests/unit/analyzer/cd-command-detection.test.ts`, `tests/integration/cd-statement-tracking.test.ts`.

https://claude.ai/code/session_01VFXGE9sjjLtPK4wctypnyD