### PR TITLE
[codex] Fix Mata setter loop-expansion poisoning

### DIFF
--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -3616,6 +3616,11 @@ export class SemanticAnalyzer {
             cross_lines: boolean
         ): number => {
             let paren_depth = 0;
+            // Mata subscripts (`names[1,2]`) put commas inside brackets that
+            // are NOT the st_local argument separator. Track bracket depth so a
+            // read-only call like `st_local(names[1,2])` is not misread as a
+            // two-argument setter (which would poison loop expansion).
+            let bracket_depth = 0;
             for (let k = from; k < tokens.length; k++) {
                 const my_token = tokens[k];
                 if (
@@ -3653,7 +3658,17 @@ export class SemanticAnalyzer {
                             return -1;
                         }
                         paren_depth--;
-                    } else if (my_char === ',' && paren_depth === 0) {
+                    } else if (my_char === '[') {
+                        bracket_depth++;
+                    } else if (my_char === ']') {
+                        if (bracket_depth > 0) {
+                            bracket_depth--;
+                        }
+                    } else if (
+                        my_char === ',' &&
+                        paren_depth === 0 &&
+                        bracket_depth === 0
+                    ) {
                         return k;
                     }
                 }

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -2608,16 +2608,22 @@ export class SemanticAnalyzer {
                     this.loop_frames,
                     pre_loop_macros,
                     // Let the expander poison a helper that the loop body
-                    // reassigns via an analyzer-known macro-creating command/
-                    // option (e.g. `levelsof ..., local(suffix)`) before a later
-                    // constructed name interpolates it.
+                    // reassigns via an analyzer-known macro-creating construct
+                    // (e.g. `levelsof ..., local(suffix)` or a Mata
+                    // `st_local("suffix", ...)`) before a later constructed name
+                    // interpolates it.
                     (statement) => {
+                        const mata_redefs = this.get_mata_setter_redefinitions(
+                            statement
+                        );
+                        const names = mata_redefs.names;
                         if (statement.type !== 'command') {
-                            return { names: [], unknown: false };
+                            return mata_redefs;
                         }
-                        const names: Array<{ scope: 'local' | 'global'; name: string }> =
-                            this.get_command_created_macros(statement, symbols)
-                                .map((m) => ({ scope: m.scope, name: m.name }));
+                        names.push(
+                            ...this.get_command_created_macros(statement, symbols)
+                                .map((m) => ({ scope: m.scope, name: m.name }))
+                        );
                         // Positional macro-creating commands (gettoken/unab/
                         // args/tempvar/file read) reassign LOCAL macros that the
                         // option-based path above does not cover.
@@ -2638,6 +2644,7 @@ export class SemanticAnalyzer {
                         // A macro-creating command with a DYNAMIC target name
                         // (`` local(`i') ``) reassigns an unknown macro.
                         const unknown =
+                            mata_redefs.unknown ||
                             the_drop.unknown
                             || this.command_creates_dynamic_macro(statement, symbols);
                         return { names, unknown };
@@ -2676,6 +2683,54 @@ export class SemanticAnalyzer {
                 existing_iterator.iteration_dependent = true;
             }
         }
+    }
+
+    /**
+     * The loop expander runs before the analyzer's whole-file Mata setter pass.
+     * Reuse that scanner on this embedded-block statement's token slice so a
+     * preceding `st_local("helper", ...)` / `st_global("HELPER", ...)` poisons
+     * stale pre-loop helper folds in execution order.
+     */
+    private get_mata_setter_redefinitions(
+        statement: StataNode
+    ): {
+        names: Array<{ scope: 'local' | 'global'; name: string }>;
+        unknown: boolean;
+    } {
+        if (
+            statement.type !== 'embedded_block' ||
+            statement.language !== 'mata' ||
+            this.tokens === undefined
+        ) {
+            return { names: [], unknown: false };
+        }
+
+        const the_tokens = this.tokens.filter(
+            token =>
+                this.compare_positions(token.range.start, statement.range.start) >= 0 &&
+                this.compare_positions(token.range.end, statement.range.end) <= 0
+        );
+        if (the_tokens.length === 0) {
+            return { names: [], unknown: false };
+        }
+
+        const temp_symbols = create_empty_symbol_table();
+        const unknown = this.extract_mata_st_local_declarations(
+            the_tokens,
+            temp_symbols,
+            [statement]
+        );
+        const names = [
+            ...Array.from(temp_symbols.localMacros.keys()).map(name => ({
+                scope: 'local' as const,
+                name,
+            })),
+            ...Array.from(temp_symbols.globalMacros.keys()).map(name => ({
+                scope: 'global' as const,
+                name,
+            })),
+        ];
+        return { names, unknown };
     }
 
     /**
@@ -3366,7 +3421,8 @@ export class SemanticAnalyzer {
         tokens: Token[],
         symbols: SymbolTable,
         nodes: StataNode[]
-    ): void {
+    ): boolean {
+        let saw_unknown_setter = false;
         // Position-precise program ranges (start of `program` keyword to end
         // of `end`). Used to scope a setter to `program` vs `dofile`. Unlike
         // the line-based `collect_program_ranges`, this stays correct when a
@@ -3555,6 +3611,55 @@ export class SemanticAnalyzer {
             token.type === 'COMMA' ||
             (token.type === 'EMBEDDED_CONTENT' &&
                 token.value.trimStart().startsWith(','));
+        const find_setter_comma = (
+            from: number,
+            cross_lines: boolean
+        ): number => {
+            let paren_depth = 0;
+            for (let k = from; k < tokens.length; k++) {
+                const my_token = tokens[k];
+                if (
+                    !cross_lines &&
+                    my_token.type === 'STATEMENT_TERMINATOR' &&
+                    !is_continuation_terminator(k)
+                ) {
+                    return -1;
+                }
+                if (
+                    my_token.type === 'END_MATA' ||
+                    my_token.type === 'END_PYTHON' ||
+                    my_token.type === 'RBRACE' ||
+                    (
+                        my_token.type === 'WORD' &&
+                        my_token.value === 'end' &&
+                        begins_statement(k) &&
+                        ends_statement(k)
+                    )
+                ) {
+                    return -1;
+                }
+                if (
+                    my_token.type === 'STRING' ||
+                    my_token.type === 'COMMENT_LINE' ||
+                    my_token.type === 'COMMENT_BLOCK'
+                ) {
+                    continue;
+                }
+                for (const my_char of my_token.value) {
+                    if (my_char === '(') {
+                        paren_depth++;
+                    } else if (my_char === ')') {
+                        if (paren_depth === 0) {
+                            return -1;
+                        }
+                        paren_depth--;
+                    } else if (my_char === ',' && paren_depth === 0) {
+                        return k;
+                    }
+                }
+            }
+            return -1;
+        };
 
         for (let i = 0; i < tokens.length; i++) {
             const token = tokens[i];
@@ -3801,25 +3906,24 @@ export class SemanticAnalyzer {
             if (name_idx >= tokens.length) {
                 continue;
             }
+            const comma_idx = find_setter_comma(name_idx, cross_lines);
+            if (comma_idx < 0) {
+                continue;
+            }
             const name_token = tokens[name_idx];
+            const after_name_idx = next_significant(name_idx + 1, cross_lines);
             if (
                 name_token.type !== 'STRING' ||
-                name_token.quoteStyle === 'compound'
+                name_token.quoteStyle === 'compound' ||
+                after_name_idx >= tokens.length ||
+                !is_comma(tokens[after_name_idx])
             ) {
+                saw_unknown_setter = true;
                 continue;
             }
             const name_match = MATA_STRING_NAME_RE.exec(name_token.value);
             if (!name_match) {
-                continue;
-            }
-
-            // Two-argument (setter) form only: a comma must follow the name.
-            // The one-argument read form `st_local("name")` is closed by `)`.
-            const after_name_idx = next_significant(name_idx + 1, cross_lines);
-            if (
-                after_name_idx >= tokens.length ||
-                !is_comma(tokens[after_name_idx])
-            ) {
+                saw_unknown_setter = true;
                 continue;
             }
 
@@ -3918,6 +4022,7 @@ export class SemanticAnalyzer {
                 visibility_start
             );
         }
+        return saw_unknown_setter;
     }
 
     /**

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -3661,6 +3661,10 @@ export class SemanticAnalyzer {
                     } else if (my_char === '[') {
                         bracket_depth++;
                     } else if (my_char === ']') {
+                        // Unlike an unmatched `)` (which ends the call's
+                        // argument list, so we bail above), an unmatched `]`
+                        // says nothing about the arg list — just clamp so a
+                        // later top-level comma is still found.
                         if (bracket_depth > 0) {
                             bracket_depth--;
                         }

--- a/tests/integration/loop-macro-expansion.test.ts
+++ b/tests/integration/loop-macro-expansion.test.ts
@@ -1079,6 +1079,41 @@ describe('Loop macro expansion (integration)', () => {
         expect(undefined_macros(source)).toContain('x_foo');
     });
 
+    it('does not poison when a read-only Mata st_local has a subscript comma', () => {
+        // `st_local(names[1,2])` is a one-argument READ: the comma is a Mata
+        // subscript separator, not the st_local argument separator. It declares
+        // nothing and must not be misread as an unknown setter that poisons the
+        // later constructed `x_foo`.
+        const source = [
+            'local suffix foo',
+            'foreach i in a {',
+            '    mata: st_local(names[1,2])',
+            "    local x_`suffix' = 1",
+            '}',
+            "display `x_foo'",
+        ].join('\n');
+        const { symbols } = analyze(source);
+        expect(symbols.localMacros.has('x_foo')).toBe(true);
+        expect(undefined_macros(source)).not.toContain('x_foo');
+    });
+
+    it('treats a dynamic two-arg Mata setter with a bracketed name as unknown', () => {
+        // `st_local(names[1], "bar")` IS a two-argument setter whose target is
+        // dynamic (unknown). The separating comma sits at bracket depth 0, so it
+        // must still be found and poison the later constructed name.
+        const source = [
+            'local suffix foo',
+            'foreach i in a {',
+            '    mata: st_local(names[1], "bar")',
+            "    local x_`suffix' = 1",
+            '}',
+            "display `x_foo'",
+        ].join('\n');
+        const { symbols } = analyze(source);
+        expect(symbols.localMacros.has('x_foo')).toBe(false);
+        expect(undefined_macros(source)).toContain('x_foo');
+    });
+
     it('treats dynamic Mata setter targets as unknown redefinitions', () => {
         // The first argument to st_local() may evaluate to any macro name. Once a
         // loop body writes an unknown target, later constructed names must be

--- a/tests/integration/loop-macro-expansion.test.ts
+++ b/tests/integration/loop-macro-expansion.test.ts
@@ -1062,6 +1062,40 @@ describe('Loop macro expansion (integration)', () => {
         expect(undefined_macros(source)).not.toContain('a');
     });
 
+    it('poisons helpers reassigned by Mata setters before constructed names', () => {
+        // `st_local("suffix", "bar")` runs before `local x_`suffix'`, so
+        // Stata defines x_bar, not x_foo. The loop expander must not fold the
+        // stale pre-loop suffix=foo value and inject x_foo.
+        const source = [
+            'local suffix foo',
+            'foreach i in a {',
+            '    mata: st_local("suffix", "bar")',
+            "    local x_`suffix' = 1",
+            '}',
+            "display `x_foo'",
+        ].join('\n');
+        const { symbols } = analyze(source);
+        expect(symbols.localMacros.has('x_foo')).toBe(false);
+        expect(undefined_macros(source)).toContain('x_foo');
+    });
+
+    it('treats dynamic Mata setter targets as unknown redefinitions', () => {
+        // The first argument to st_local() may evaluate to any macro name. Once a
+        // loop body writes an unknown target, later constructed names must be
+        // skipped rather than folded from stale pre-loop helpers.
+        const source = [
+            'local suffix foo',
+            'foreach i in a {',
+            '    mata: st_local(target, "bar")',
+            "    local x_`suffix' = 1",
+            '}',
+            "display `x_foo'",
+        ].join('\n');
+        const { symbols } = analyze(source);
+        expect(symbols.localMacros.has('x_foo')).toBe(false);
+        expect(undefined_macros(source)).toContain('x_foo');
+    });
+
     it('keeps semicolon-mode cross-line value tokens separated at column 0', () => {
         // In `#delimit ;` mode a newline is ordinary whitespace, so an
         // unindented continuation token must still be separated. `local xs a`

--- a/tests/unit/st-local-mata.test.ts
+++ b/tests/unit/st-local-mata.test.ts
@@ -237,6 +237,12 @@ describe('st_local / st_global declarations in Mata', () => {
         expect(undefined_macros(src)).toEqual(['foo']);
     });
 
+    it('string expression name is not declared as its first literal', () => {
+        const src = 'mata: st_local("foo" + "bar", "1")\ndisplay `foo\'';
+        expect(analyze(src).symbols.localMacros.has('foo')).toBe(false);
+        expect(undefined_macros(src)).toEqual(['foo']);
+    });
+
     it('compound-quoted name is not declared (only simple double quotes)', () => {
         const src = 'mata: st_local(`"foo"\', "1")\ndisplay `foo\'';
         expect(analyze(src).symbols.localMacros.has('foo')).toBe(false);


### PR DESCRIPTION
## Summary

- Poison loop-expansion helper folds when a Mata st_local/st_global setter redefines a macro inside a loop.
- Treat dynamic Mata setter targets as unknown redefinitions for conservative expansion.
- Add regression coverage for literal and dynamic Mata setter targets, plus a guard for string-expression setter names.

## Root Cause

PR #260 added conservative loop expansion based on macro redefinitions it could observe during the AST walk. PR #262 added Mata setter extraction later in the analyzer, after the loop expander had already folded pre-loop helper values. A Mata setter inside a loop could therefore leave the expander using a stale helper value and injecting a fabricated constructed macro.

## Validation

- bun test tests/integration/loop-macro-expansion.test.ts tests/unit/st-local-mata.test.ts tests/unit/completion.test.ts
- bun run test
- bun run lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loop macro handling when values are set inside embedded Mata code, reducing cases where later text was expanded using stale or incorrect macro values.
  * Better handles complex or dynamic Mata setter arguments, so undefined names are detected more reliably and expansion is skipped when the target can’t be determined.
  * Fixed parsing for nested expressions and bracketed names in Mata calls, helping avoid false positives and false negatives in macro expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->