### PR TITLE
Shadow dynamic outer-loop iterators in loop-macro expansion

### DIFF
--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -276,6 +276,8 @@ export class SemanticAnalyzer {
     // block that may never run must not be injected, or it would falsely
     // suppress a legitimate undefined-macro warning after the block.
     private nonexec_depth = 0;
+    private nonexec_range_stack: Range[] = [];
+    private nonexec_conditional_depth = 0;
 
     /**
      * Analyze an AST and build symbol tables.
@@ -301,6 +303,8 @@ export class SemanticAnalyzer {
         this.cd_nesting_depth = 0;
         this.loop_frames = []; // Reset loop iterator frames
         this.nonexec_depth = 0; // Reset non-executing-context depth
+        this.nonexec_range_stack = [];
+        this.nonexec_conditional_depth = 0;
         this.workspace_symbols = workspace_symbols; // Store workspace symbols
         this.tokens = tokens; // Keep tokens for command-level pattern checks
 
@@ -860,15 +864,21 @@ export class SemanticAnalyzer {
         // cd-nesting tracking (issue #252) still applies inside the program.
         const saved_loop_frames = this.loop_frames;
         const saved_nonexec_depth = this.nonexec_depth;
+        const saved_nonexec_range_stack = this.nonexec_range_stack;
+        const saved_nonexec_conditional_depth = this.nonexec_conditional_depth;
         this.loop_frames = [];
         // A program body executes top-level when the program is called, so reset
         // the non-executing-context depth for its own internal loops.
         this.nonexec_depth = 0;
+        this.nonexec_range_stack = [];
+        this.nonexec_conditional_depth = 0;
         try {
             this.build_symbols_in_body(node.body, symbols, program_scope, all_scopes);
         } finally {
             this.loop_frames = saved_loop_frames;
             this.nonexec_depth = saved_nonexec_depth;
+            this.nonexec_range_stack = saved_nonexec_range_stack;
+            this.nonexec_conditional_depth = saved_nonexec_conditional_depth;
         }
 
         // Guard body-metadata extractions on first definition only.
@@ -1075,7 +1085,12 @@ export class SemanticAnalyzer {
                 // `if`/`while` body, or a dynamic/empty loop body) is not
                 // guaranteed to run, so its value must not be folded into a
                 // later loop's value-set or constructed names.
-                ...(this.nonexec_depth > 0 ? { maybe_unexecuted: true } : {}),
+                ...(this.nonexec_depth > 0 ? {
+                    maybe_unexecuted: true,
+                    maybe_unexecuted_range: this.nonexec_range_stack[
+                        this.nonexec_range_stack.length - 1
+                    ],
+                } : {}),
                 // Defined inside a guaranteed loop with a value that captured the
                 // loop iterator (e.g. `` local suffix `i' ``): its runtime value
                 // is iteration-dependent and must not be statically folded.
@@ -2568,7 +2583,9 @@ export class SemanticAnalyzer {
         const value_set = resolve_loop_value_set(
             loop_type,
             node.loopSpec,
-            build_static_value_env(scoped_macros)
+            build_static_value_env(scoped_macros, undefined, {
+                allow_maybe_unexecuted_ranges: this.nonexec_range_stack,
+            })
         );
         const pushed = value_set.kind === 'static' && !!node.loopVar;
         if (pushed) {
@@ -2591,11 +2608,18 @@ export class SemanticAnalyzer {
         // fold sees only macros visible before the loop, and expand AFTER the
         // body is walked so a body-literal definition of the same concrete name
         // remains the primary symbol.
-        const can_expand = guaranteed && this.tokens != null && this.nonexec_depth === 0;
+        const can_expand =
+            guaranteed && this.tokens != null && this.nonexec_conditional_depth === 0;
         const pre_loop_macros = can_expand
             ? this.snapshot_macro_maps(scoped_macros)
             : undefined;
-        if (!guaranteed) this.nonexec_depth++;
+        const expanded_visibility_range = this.nonexec_range_stack[
+            this.nonexec_range_stack.length - 1
+        ];
+        if (!guaranteed) {
+            this.nonexec_depth++;
+            this.nonexec_range_stack.push(node.range);
+        }
         try {
             // Process loop body with the same scope (loop doesn't create new
             // scope). build_symbols_in_body tracks cd-nesting depth (issue #252).
@@ -2648,19 +2672,24 @@ export class SemanticAnalyzer {
                             the_drop.unknown
                             || this.command_creates_dynamic_macro(statement, symbols);
                         return { names, unknown };
-                    }
+                    },
+                    { allow_maybe_unexecuted_ranges: this.nonexec_range_stack }
                 );
                 for (const my_macro of the_expanded) {
                     this.inject_expanded_macro(
                         my_macro,
                         symbols,
                         current_scope,
-                        node_index
+                        node_index,
+                        expanded_visibility_range
                     );
                 }
             }
         } finally {
-            if (!guaranteed) this.nonexec_depth--;
+            if (!guaranteed) {
+                this.nonexec_depth--;
+                this.nonexec_range_stack.pop();
+            }
             if (pushed) {
                 this.loop_frames.pop();
             }
@@ -2773,7 +2802,8 @@ export class SemanticAnalyzer {
         macro: { name: string; scope: 'local' | 'global'; sourceRange: Range },
         symbols: SymbolTable,
         current_scope: ScopeInfo,
-        node_index: number
+        node_index: number,
+        visibility_range?: Range
     ): void {
         const target = macro.scope === 'local'
             ? symbols.localMacros
@@ -2809,17 +2839,20 @@ export class SemanticAnalyzer {
                     line: existing.definition_line ?? definition_line,
                     location: existing.location,
                     is_expanded: existing.is_expanded,
+                    visibility_range: existing.visibility_range,
                 });
                 existing.location = expanded_location;
                 existing.definition_line = definition_line;
                 existing.definition_index = node_index;
                 existing.is_expanded = true;
+                existing.visibility_range = visibility_range;
             } else {
                 existing.additional_definitions.push({
                     index: node_index,
                     line: definition_line,
                     location: expanded_location,
                     is_expanded: true,
+                    visibility_range,
                 });
             }
             return;
@@ -2832,6 +2865,7 @@ export class SemanticAnalyzer {
             containingScope: current_scope.type,
             definition_line,
             is_expanded: true,
+            visibility_range,
         };
         target.set(macro.name, symbol);
         if (macro.scope === 'local') {
@@ -2853,12 +2887,20 @@ export class SemanticAnalyzer {
         // inside them must be suppressed. `frame X { ... }` always runs, so it
         // does not gate expansion.
         const is_conditional = node.type !== 'frame';
-        if (is_conditional) this.nonexec_depth++;
+        if (is_conditional) {
+            this.nonexec_depth++;
+            this.nonexec_conditional_depth++;
+            this.nonexec_range_stack.push(node.range);
+        }
         try {
             // Process body with the same scope
             this.build_symbols_in_body(node.body, symbols, current_scope, all_scopes);
         } finally {
-            if (is_conditional) this.nonexec_depth--;
+            if (is_conditional) {
+                this.nonexec_depth--;
+                this.nonexec_conditional_depth--;
+                this.nonexec_range_stack.pop();
+            }
         }
     }
 
@@ -3196,7 +3238,10 @@ export class SemanticAnalyzer {
     }
 
     private is_reference_before_macro_definition(
-        macro: MacroSymbol,
+        definition: {
+            definition_line?: number;
+            location: { range: Range };
+        },
         reference_range?: Range
     ): boolean {
         if (reference_range === undefined) {
@@ -3211,14 +3256,86 @@ export class SemanticAnalyzer {
         // already in scope on the reference's line and must not be treated as
         // a same-line forward reference.
         const definition_line =
-            macro.definition_line ?? macro.location.range.start.line;
-        if (definition_line !== macro.location.range.start.line) {
+            definition.definition_line ?? definition.location.range.start.line;
+        if (definition_line !== definition.location.range.start.line) {
             return false;
         }
         return (
-            macro.location.range.start.line === reference_range.start.line &&
-            this.compare_ranges(reference_range, macro.location.range) < 0
+            definition.location.range.start.line === reference_range.start.line &&
+            this.compare_ranges(reference_range, definition.location.range) < 0
         );
+    }
+
+    private reference_inside_visibility_range(
+        visibility_range: Range,
+        reference_line?: number,
+        reference_range?: Range
+    ): boolean {
+        if (reference_range !== undefined) {
+            return this.position_within_range(
+                reference_range.start,
+                visibility_range
+            );
+        }
+        if (reference_line !== undefined) {
+            return (
+                reference_line >= visibility_range.start.line &&
+                reference_line <= visibility_range.end.line
+            );
+        }
+        return false;
+    }
+
+    private macro_definition_resolves_at_reference(
+        definition: {
+            definition_index?: number;
+            definition_line?: number;
+            location: { range: Range };
+            visibility_start?: { line: number; character: number };
+            visibility_range?: Range;
+        },
+        reference_index?: number,
+        reference_line?: number,
+        reference_range?: Range
+    ): boolean {
+        if (
+            definition.visibility_range !== undefined &&
+            !this.reference_inside_visibility_range(
+                definition.visibility_range,
+                reference_line,
+                reference_range
+            )
+        ) {
+            return false;
+        }
+        if (definition.visibility_start !== undefined) {
+            return !this.is_reference_before_visibility_start(
+                definition,
+                reference_line,
+                reference_range
+            );
+        }
+        // Forward reference by preorder index.
+        if (
+            reference_index !== undefined &&
+            definition.definition_index !== undefined &&
+            definition.definition_index > reference_index
+        ) {
+            return false;
+        }
+        // Forward reference by line number.
+        if (
+            reference_line !== undefined &&
+            definition.definition_line !== undefined &&
+            definition.definition_line > reference_line
+        ) {
+            return false;
+        }
+        // Same-line forward reference.
+        if (this.is_reference_before_macro_definition(definition, reference_range)) {
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -3236,34 +3353,34 @@ export class SemanticAnalyzer {
         reference_line?: number,
         reference_range?: Range
     ): boolean {
-        if (macro.visibility_start !== undefined) {
-            return !this.is_reference_before_visibility_start(
+        if (
+            this.macro_definition_resolves_at_reference(
                 macro,
+                reference_index,
                 reference_line,
                 reference_range
-            );
-        }
-        // Forward reference by preorder index.
-        if (
-            reference_index !== undefined &&
-            macro.definition_index !== undefined &&
-            macro.definition_index > reference_index
+            )
         ) {
-            return false;
+            return true;
         }
-        // Forward reference by line number.
-        if (
-            reference_line !== undefined &&
-            macro.definition_line !== undefined &&
-            macro.definition_line > reference_line
-        ) {
-            return false;
+        for (const definition of macro.additional_definitions ?? []) {
+            if (
+                this.macro_definition_resolves_at_reference(
+                    {
+                        definition_index: definition.index,
+                        definition_line: definition.line,
+                        location: definition.location,
+                        visibility_range: definition.visibility_range,
+                    },
+                    reference_index,
+                    reference_line,
+                    reference_range
+                )
+            ) {
+                return true;
+            }
         }
-        // Same-line forward reference.
-        if (this.is_reference_before_macro_definition(macro, reference_range)) {
-            return false;
-        }
-        return true;
+        return false;
     }
 
     /**
@@ -3273,7 +3390,7 @@ export class SemanticAnalyzer {
      * reference position when available, else the line.
      */
     private is_reference_before_visibility_start(
-        macro: MacroSymbol,
+        macro: { visibility_start?: { line: number; character: number } },
         reference_line?: number,
         reference_range?: Range
     ): boolean {

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -270,13 +270,21 @@ export class SemanticAnalyzer {
     // bindings for loop-expanded macro names.
     private loop_frames: BindingFrame[] = [];
 
-    // Depth of enclosing bodies that are NOT guaranteed to execute: `if`/
-    // `else`/`while` blocks, and dynamic or empty-value-set loops. While this
-    // is > 0, loop-macro expansion is suppressed — a constructed name inside a
-    // block that may never run must not be injected, or it would falsely
-    // suppress a legitimate undefined-macro warning after the block.
+    // Enclosing bodies that are not guaranteed to execute: `if`/`else`/`while`
+    // blocks, and dynamic or empty-value-set loops. This state is for value
+    // folding, not local-macro visibility. Stata locals are scoped to the
+    // containing do-file/program, not to loop blocks, so a constructed macro
+    // whose name depends only on static inner iterators is intentionally
+    // injected even when an outer loop has a dynamic value set. The dynamic
+    // ancestor only means values defined there are foldable while analysis is
+    // still inside that same active body.
     private nonexec_depth = 0;
     private nonexec_range_stack: Range[] = [];
+    // Conditional bodies are different from dynamic loop ancestors for loop-name
+    // expansion. A conditional branch may not run and has no iteration frame
+    // that lets us enumerate runtime executions, so constructed definitions in
+    // it remain conservative misses. Dynamic loop ancestors do not increment
+    // this counter because they do not create a local-macro scope.
     private nonexec_conditional_depth = 0;
 
     /**
@@ -2597,25 +2605,29 @@ export class SemanticAnalyzer {
 
         // The loop body is guaranteed to execute (≥1 iteration) only when the
         // value-set is static AND non-empty. A dynamic or empty-value-set loop
-        // body may not run, so a constructed name inside it must not be
-        // expanded — and any nested static loop must be suppressed too.
+        // body still contributes symbols to the containing Stata local scope
+        // (loops do not create scopes), but values defined there are not
+        // globally foldable because the body may never run.
         const guaranteed = pushed
             && (value_set as { kind: 'static'; values: string[] }).values.length > 0;
-        // Expand only when this loop runs unconditionally AND the whole
-        // enclosing context does too (no `if`/`while` or non-guaranteed loop
-        // above us). Snapshot the pre-loop macros (cloning additional_definitions
-        // so body redefinitions cannot retroactively poison the fold) so the
-        // fold sees only macros visible before the loop, and expand AFTER the
-        // body is walked so a body-literal definition of the same concrete name
-        // remains the primary symbol.
+        // Expand constructed names whenever THIS loop has a static, non-empty
+        // value set and we are not inside a conditional branch. This is
+        // deliberate: an outer dynamic loop makes its own iterator unknown, but
+        // it does NOT make local macros block-scoped. If the constructed name
+        // references only this loop's static iterator (or helpers foldable in
+        // the active dynamic body), the concrete macro name is tractable and
+        // remains visible after the loop in Stata.
+        //
+        // Snapshot the pre-loop macros (cloning additional_definitions so body
+        // redefinitions cannot retroactively poison the fold) so the fold sees
+        // only macros visible before the loop, and expand AFTER the body is
+        // walked so a body-literal definition of the same concrete name remains
+        // the primary symbol.
         const can_expand =
             guaranteed && this.tokens != null && this.nonexec_conditional_depth === 0;
         const pre_loop_macros = can_expand
             ? this.snapshot_macro_maps(scoped_macros)
             : undefined;
-        const expanded_visibility_range = this.nonexec_range_stack[
-            this.nonexec_range_stack.length - 1
-        ];
         if (!guaranteed) {
             this.nonexec_depth++;
             this.nonexec_range_stack.push(node.range);
@@ -2680,8 +2692,7 @@ export class SemanticAnalyzer {
                         my_macro,
                         symbols,
                         current_scope,
-                        node_index,
-                        expanded_visibility_range
+                        node_index
                     );
                 }
             }
@@ -2802,8 +2813,7 @@ export class SemanticAnalyzer {
         macro: { name: string; scope: 'local' | 'global'; sourceRange: Range },
         symbols: SymbolTable,
         current_scope: ScopeInfo,
-        node_index: number,
-        visibility_range?: Range
+        node_index: number
     ): void {
         const target = macro.scope === 'local'
             ? symbols.localMacros
@@ -2839,20 +2849,17 @@ export class SemanticAnalyzer {
                     line: existing.definition_line ?? definition_line,
                     location: existing.location,
                     is_expanded: existing.is_expanded,
-                    visibility_range: existing.visibility_range,
                 });
                 existing.location = expanded_location;
                 existing.definition_line = definition_line;
                 existing.definition_index = node_index;
                 existing.is_expanded = true;
-                existing.visibility_range = visibility_range;
             } else {
                 existing.additional_definitions.push({
                     index: node_index,
                     line: definition_line,
                     location: expanded_location,
                     is_expanded: true,
-                    visibility_range,
                 });
             }
             return;
@@ -2865,7 +2872,6 @@ export class SemanticAnalyzer {
             containingScope: current_scope.type,
             definition_line,
             is_expanded: true,
-            visibility_range,
         };
         target.set(macro.name, symbol);
         if (macro.scope === 'local') {
@@ -2883,9 +2889,12 @@ export class SemanticAnalyzer {
         current_scope: ScopeInfo,
         all_scopes: ScopeInfo[]
     ): void {
-        // `if`/`else`/`while` bodies may not execute, so loop-macro expansion
-        // inside them must be suppressed. `frame X { ... }` always runs, so it
-        // does not gate expansion.
+        // `if`/`else`/`while` bodies may not execute, so constructed-name
+        // expansion inside them stays conservative. This is intentionally
+        // narrower than dynamic loop handling: loops do not create local-macro
+        // scope, but conditionals do not provide enumerable iterator bindings
+        // and branch execution is not guaranteed. `frame X { ... }` always
+        // runs, so it does not gate expansion.
         const is_conditional = node.type !== 'frame';
         if (is_conditional) {
             this.nonexec_depth++;
@@ -3266,48 +3275,17 @@ export class SemanticAnalyzer {
         );
     }
 
-    private reference_inside_visibility_range(
-        visibility_range: Range,
-        reference_line?: number,
-        reference_range?: Range
-    ): boolean {
-        if (reference_range !== undefined) {
-            return this.position_within_range(
-                reference_range.start,
-                visibility_range
-            );
-        }
-        if (reference_line !== undefined) {
-            return (
-                reference_line >= visibility_range.start.line &&
-                reference_line <= visibility_range.end.line
-            );
-        }
-        return false;
-    }
-
     private macro_definition_resolves_at_reference(
         definition: {
             definition_index?: number;
             definition_line?: number;
             location: { range: Range };
             visibility_start?: { line: number; character: number };
-            visibility_range?: Range;
         },
         reference_index?: number,
         reference_line?: number,
         reference_range?: Range
     ): boolean {
-        if (
-            definition.visibility_range !== undefined &&
-            !this.reference_inside_visibility_range(
-                definition.visibility_range,
-                reference_line,
-                reference_range
-            )
-        ) {
-            return false;
-        }
         if (definition.visibility_start !== undefined) {
             return !this.is_reference_before_visibility_start(
                 definition,
@@ -3370,7 +3348,6 @@ export class SemanticAnalyzer {
                         definition_index: definition.index,
                         definition_line: definition.line,
                         location: definition.location,
-                        visibility_range: definition.visibility_range,
                     },
                     reference_index,
                     reference_line,

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -278,8 +278,20 @@ export class SemanticAnalyzer {
     // injected even when an outer loop has a dynamic value set. The dynamic
     // ancestor only means values defined there are foldable while analysis is
     // still inside that same active body.
-    private nonexec_depth = 0;
+    // One entry per enclosing non-executing body (loop with a dynamic/empty
+    // value set, or `if`/`else`/`while`). Its length is the non-executing depth
+    // and its top is the nearest enclosing non-executing range used to tag
+    // `maybe_unexecuted` definitions.
     private nonexec_range_stack: Range[] = [];
+    // Every enclosing loop iterator, in nesting order (innermost last), tagged
+    // by whether its value set is DYNAMIC (no static frame). A DYNAMIC iterator
+    // is rebound to unknown runtime values, so a nested constructed name or
+    // value-set that interpolates it must NOT fold it to a stale pre-loop value
+    // (that would fabricate a name that never exists at runtime — a false
+    // suppression). Order matters because a name can be rebound by both a static
+    // and a dynamic loop at different depths; the INNERMOST binding decides
+    // whether it is shadowed (see `dynamic_iterator_shadow_set`).
+    private loop_iter_stack: Array<{ var: string; dynamic: boolean }> = [];
     // Conditional bodies are different from dynamic loop ancestors for loop-name
     // expansion. A conditional branch may not run and has no iteration frame
     // that lets us enumerate runtime executions, so constructed definitions in
@@ -310,8 +322,8 @@ export class SemanticAnalyzer {
         this.cd_commands = []; // Reset cd commands (issue #252)
         this.cd_nesting_depth = 0;
         this.loop_frames = []; // Reset loop iterator frames
-        this.nonexec_depth = 0; // Reset non-executing-context depth
-        this.nonexec_range_stack = [];
+        this.nonexec_range_stack = []; // Reset non-executing-context stack
+        this.loop_iter_stack = []; // Reset loop iterator nesting stack
         this.nonexec_conditional_depth = 0;
         this.workspace_symbols = workspace_symbols; // Store workspace symbols
         this.tokens = tokens; // Keep tokens for command-level pattern checks
@@ -871,21 +883,21 @@ export class SemanticAnalyzer {
         // against the enclosing do-file iterator. Uses build_symbols_in_body so
         // cd-nesting tracking (issue #252) still applies inside the program.
         const saved_loop_frames = this.loop_frames;
-        const saved_nonexec_depth = this.nonexec_depth;
         const saved_nonexec_range_stack = this.nonexec_range_stack;
+        const saved_loop_iter_stack = this.loop_iter_stack;
         const saved_nonexec_conditional_depth = this.nonexec_conditional_depth;
         this.loop_frames = [];
         // A program body executes top-level when the program is called, so reset
-        // the non-executing-context depth for its own internal loops.
-        this.nonexec_depth = 0;
+        // the non-executing-context state for its own internal loops.
         this.nonexec_range_stack = [];
+        this.loop_iter_stack = [];
         this.nonexec_conditional_depth = 0;
         try {
             this.build_symbols_in_body(node.body, symbols, program_scope, all_scopes);
         } finally {
             this.loop_frames = saved_loop_frames;
-            this.nonexec_depth = saved_nonexec_depth;
             this.nonexec_range_stack = saved_nonexec_range_stack;
+            this.loop_iter_stack = saved_loop_iter_stack;
             this.nonexec_conditional_depth = saved_nonexec_conditional_depth;
         }
 
@@ -1039,9 +1051,19 @@ export class SemanticAnalyzer {
      * iterators are always locals, so only local refs can match.
      */
     private value_captures_active_iterator(value: string | undefined): boolean {
-        if (!value || this.loop_frames.length === 0) return false;
-        const the_iterator_vars = new Set(
-            this.loop_frames.map((my_frame) => my_frame.var)
+        if (!value || this.loop_iter_stack.length === 0) {
+            return false;
+        }
+        // Every enclosing loop iterator — static OR dynamic. A value
+        // interpolating one is per-iteration: a static loop holds the last
+        // binding, a dynamic loop an unknown runtime binding. Either way folding
+        // it would fabricate a name from a stale or unknown value, so the macro
+        // is iteration-dependent and unfoldable. This also closes the transitive
+        // leak: `` local h `survey' `` inside a dynamic `foreach survey` makes
+        // `h` unfoldable, so a later `` local x_`h'_`i' `` cannot resolve to the
+        // stale `survey` value.
+        const the_iterator_vars = new Set<string>(
+            this.loop_iter_stack.map((my_iter) => my_iter.var)
         );
         let captures = false;
         scan_macro_refs(value, {
@@ -1053,6 +1075,28 @@ export class SemanticAnalyzer {
             global_ref: () => true,
         });
         return captures;
+    }
+
+    /**
+     * Names whose INNERMOST enclosing loop binding is DYNAMIC (no static frame),
+     * so the iterator holds an unknown runtime value. A constructed name or
+     * value-set referencing one must stay unresolved (folding the stale pre-loop
+     * value would fabricate a name that never exists at runtime). The innermost
+     * binding decides: a name a dynamic loop rebinds is shadowed even if an
+     * OUTER static loop reused it, and a name a static loop rebinds is NOT
+     * shadowed even if an OUTER dynamic loop reused it.
+     */
+    private dynamic_iterator_shadow_set(): Set<string> {
+        // Walk outermost->innermost; the last write per name wins.
+        const innermost_is_dynamic = new Map<string, boolean>();
+        for (const my_iter of this.loop_iter_stack) {
+            innermost_is_dynamic.set(my_iter.var, my_iter.dynamic);
+        }
+        const the_shadowed = new Set<string>();
+        for (const [my_var, is_dynamic] of innermost_is_dynamic) {
+            if (is_dynamic) the_shadowed.add(my_var);
+        }
+        return the_shadowed;
     }
 
     private process_macro_def(
@@ -1093,15 +1137,17 @@ export class SemanticAnalyzer {
                 // `if`/`while` body, or a dynamic/empty loop body) is not
                 // guaranteed to run, so its value must not be folded into a
                 // later loop's value-set or constructed names.
-                ...(this.nonexec_depth > 0 ? {
+                ...(this.nonexec_range_stack.length > 0 ? {
                     maybe_unexecuted: true,
                     maybe_unexecuted_range: this.nonexec_range_stack[
                         this.nonexec_range_stack.length - 1
                     ],
                 } : {}),
-                // Defined inside a guaranteed loop with a value that captured the
-                // loop iterator (e.g. `` local suffix `i' ``): its runtime value
-                // is iteration-dependent and must not be statically folded.
+                // Defined inside a loop with a value that captured a loop
+                // iterator (static, e.g. `` local suffix `i' ``, OR dynamic,
+                // e.g. `` local h `survey' `` inside `foreach survey in ...`):
+                // its runtime value is iteration-dependent and must not be
+                // statically folded.
                 ...(this.value_captures_active_iterator(node.value)
                     ? { iteration_dependent: true }
                     : {}),
@@ -2593,6 +2639,10 @@ export class SemanticAnalyzer {
             node.loopSpec,
             build_static_value_env(scoped_macros, undefined, {
                 allow_maybe_unexecuted_ranges: this.nonexec_range_stack,
+                // An enclosing dynamic loop's iterator must not fold to its stale
+                // pre-loop value when resolving THIS loop's value set (e.g. a
+                // nested `foreach v in `survey'`).
+                shadowed_locals: this.dynamic_iterator_shadow_set(),
             })
         );
         const pushed = value_set.kind === 'static' && !!node.loopVar;
@@ -2618,6 +2668,17 @@ export class SemanticAnalyzer {
         // the active dynamic body), the concrete macro name is tractable and
         // remains visible after the loop in Stata.
         //
+        // ACCEPTED TRADEOFF: a dynamic outer loop (e.g. `foreach s in
+        // `r(levels)'`) may iterate zero times at runtime, in which case the
+        // inner loop's constructed names are never actually defined and a later
+        // reference to them is NOT a true undefined-macro. Expanding here
+        // suppresses that warning — a deliberate, intended relaxation (asserted
+        // by the `dynamic outer loop` integration tests). Names that interpolate
+        // the dynamic outer iterator itself are still excluded — see
+        // `dynamic_iterator_shadow_set` / `loop_iter_stack` — since folding its
+        // stale pre-loop value would fabricate a specific name unrelated to any
+        // runtime iteration.
+        //
         // Snapshot the pre-loop macros (cloning additional_definitions so body
         // redefinitions cannot retroactively poison the fold) so the fold sees
         // only macros visible before the loop, and expand AFTER the body is
@@ -2629,8 +2690,18 @@ export class SemanticAnalyzer {
             ? this.snapshot_macro_maps(scoped_macros)
             : undefined;
         if (!guaranteed) {
-            this.nonexec_depth++;
             this.nonexec_range_stack.push(node.range);
+        }
+        // Record this loop's iterator (if any) in nesting order, tagged by
+        // whether its value set is DYNAMIC (no static frame). A dynamic
+        // iterator is rebound to unknown runtime values inside the body, so a
+        // nested constructed name / value-set that interpolates it must treat it
+        // as shadowed (see dynamic_iterator_shadow_set) rather than fold a stale
+        // pre-loop value. Recorded for STATIC iterators too so the innermost
+        // binding of a reused name can be determined.
+        const pushed_iter = node.loopVar !== undefined;
+        if (pushed_iter) {
+            this.loop_iter_stack.push({ var: node.loopVar!, dynamic: !pushed });
         }
         try {
             // Process loop body with the same scope (loop doesn't create new
@@ -2685,7 +2756,14 @@ export class SemanticAnalyzer {
                             || this.command_creates_dynamic_macro(statement, symbols);
                         return { names, unknown };
                     },
-                    { allow_maybe_unexecuted_ranges: this.nonexec_range_stack }
+                    { allow_maybe_unexecuted_ranges: this.nonexec_range_stack },
+                    // Iterators of enclosing DYNAMIC loops are rebound to unknown
+                    // runtime values, so a constructed name interpolating one
+                    // must stay unresolved rather than fold a stale pre-loop
+                    // value. An inner static loop reusing the name is excluded —
+                    // its static frame supplies the binding (see
+                    // `dynamic_iterator_shadow_set`).
+                    this.dynamic_iterator_shadow_set()
                 );
                 for (const my_macro of the_expanded) {
                     this.inject_expanded_macro(
@@ -2698,8 +2776,10 @@ export class SemanticAnalyzer {
             }
         } finally {
             if (!guaranteed) {
-                this.nonexec_depth--;
                 this.nonexec_range_stack.pop();
+            }
+            if (pushed_iter) {
+                this.loop_iter_stack.pop();
             }
             if (pushed) {
                 this.loop_frames.pop();
@@ -2897,7 +2977,6 @@ export class SemanticAnalyzer {
         // runs, so it does not gate expansion.
         const is_conditional = node.type !== 'frame';
         if (is_conditional) {
-            this.nonexec_depth++;
             this.nonexec_conditional_depth++;
             this.nonexec_range_stack.push(node.range);
         }
@@ -2906,7 +2985,6 @@ export class SemanticAnalyzer {
             this.build_symbols_in_body(node.body, symbols, current_scope, all_scopes);
         } finally {
             if (is_conditional) {
-                this.nonexec_depth--;
                 this.nonexec_conditional_depth--;
                 this.nonexec_range_stack.pop();
             }
@@ -3247,10 +3325,7 @@ export class SemanticAnalyzer {
     }
 
     private is_reference_before_macro_definition(
-        definition: {
-            definition_line?: number;
-            location: { range: Range };
-        },
+        macro: MacroSymbol,
         reference_range?: Range
     ): boolean {
         if (reference_range === undefined) {
@@ -3265,55 +3340,14 @@ export class SemanticAnalyzer {
         // already in scope on the reference's line and must not be treated as
         // a same-line forward reference.
         const definition_line =
-            definition.definition_line ?? definition.location.range.start.line;
-        if (definition_line !== definition.location.range.start.line) {
+            macro.definition_line ?? macro.location.range.start.line;
+        if (definition_line !== macro.location.range.start.line) {
             return false;
         }
         return (
-            definition.location.range.start.line === reference_range.start.line &&
-            this.compare_ranges(reference_range, definition.location.range) < 0
+            macro.location.range.start.line === reference_range.start.line &&
+            this.compare_ranges(reference_range, macro.location.range) < 0
         );
-    }
-
-    private macro_definition_resolves_at_reference(
-        definition: {
-            definition_index?: number;
-            definition_line?: number;
-            location: { range: Range };
-            visibility_start?: { line: number; character: number };
-        },
-        reference_index?: number,
-        reference_line?: number,
-        reference_range?: Range
-    ): boolean {
-        if (definition.visibility_start !== undefined) {
-            return !this.is_reference_before_visibility_start(
-                definition,
-                reference_line,
-                reference_range
-            );
-        }
-        // Forward reference by preorder index.
-        if (
-            reference_index !== undefined &&
-            definition.definition_index !== undefined &&
-            definition.definition_index > reference_index
-        ) {
-            return false;
-        }
-        // Forward reference by line number.
-        if (
-            reference_line !== undefined &&
-            definition.definition_line !== undefined &&
-            definition.definition_line > reference_line
-        ) {
-            return false;
-        }
-        // Same-line forward reference.
-        if (this.is_reference_before_macro_definition(definition, reference_range)) {
-            return false;
-        }
-        return true;
     }
 
     /**
@@ -3324,6 +3358,13 @@ export class SemanticAnalyzer {
      * inline unit ends); otherwise fall back to preorder-index, line-number,
      * and same-line forward-reference checks. Identical for both scopes — the
      * scope-specific lookups and fallbacks stay in `is_macro_defined`.
+     *
+     * Only the PRIMARY definition is consulted: `inject_expanded_macro` keeps
+     * the primary as the EARLIEST definition (line/index/location), so an
+     * `additional_definitions` entry is always at-or-after it and could never
+     * turn a genuine forward reference into a resolved one — see the
+     * "Consumers read the PRIMARY definition markers" invariant in
+     * `inject_expanded_macro`.
      */
     private macro_resolves_at_reference(
         macro: MacroSymbol,
@@ -3331,33 +3372,34 @@ export class SemanticAnalyzer {
         reference_line?: number,
         reference_range?: Range
     ): boolean {
-        if (
-            this.macro_definition_resolves_at_reference(
+        if (macro.visibility_start !== undefined) {
+            return !this.is_reference_before_visibility_start(
                 macro,
-                reference_index,
                 reference_line,
                 reference_range
-            )
+            );
+        }
+        // Forward reference by preorder index.
+        if (
+            reference_index !== undefined &&
+            macro.definition_index !== undefined &&
+            macro.definition_index > reference_index
         ) {
-            return true;
+            return false;
         }
-        for (const definition of macro.additional_definitions ?? []) {
-            if (
-                this.macro_definition_resolves_at_reference(
-                    {
-                        definition_index: definition.index,
-                        definition_line: definition.line,
-                        location: definition.location,
-                    },
-                    reference_index,
-                    reference_line,
-                    reference_range
-                )
-            ) {
-                return true;
-            }
+        // Forward reference by line number.
+        if (
+            reference_line !== undefined &&
+            macro.definition_line !== undefined &&
+            macro.definition_line > reference_line
+        ) {
+            return false;
         }
-        return false;
+        // Same-line forward reference.
+        if (this.is_reference_before_macro_definition(macro, reference_range)) {
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -3367,7 +3409,7 @@ export class SemanticAnalyzer {
      * reference position when available, else the line.
      */
     private is_reference_before_visibility_start(
-        macro: { visibility_start?: { line: number; character: number } },
+        macro: MacroSymbol,
         reference_line?: number,
         reference_range?: Range
     ): boolean {

--- a/src/analyzer/loop-expander/index.ts
+++ b/src/analyzer/loop-expander/index.ts
@@ -15,6 +15,7 @@ import {
     is_constructed_increment,
     template_references_redefined,
 } from './name-expander';
+import { StaticValueEnvOptions } from './static-value-env';
 
 export { build_static_value_env } from './static-value-env';
 export type { StaticValue, StaticValueEnv } from './static-value-env';
@@ -84,7 +85,8 @@ export function expand_loop_body(
         // `macro drop _all`) — the target is unknown, so every later template
         // must be skipped.
         unknown: boolean;
-    }
+    },
+    env_options?: StaticValueEnvOptions
 ): ExpandedLoopMacro[] {
     // If any active loop has an empty iteration set, the (innermost) body never
     // executes, so no constructed name is actually defined. Expanding here —
@@ -147,7 +149,11 @@ export function expand_loop_body(
                 return;
             }
             const the_names = expand_template(
-                template, active_frames, symbols, shadowed_locals
+                template,
+                active_frames,
+                symbols,
+                shadowed_locals,
+                env_options
             );
             if (the_names.length === 0) {
                 // The constructed name could not be resolved in this frame

--- a/src/analyzer/loop-expander/index.ts
+++ b/src/analyzer/loop-expander/index.ts
@@ -217,12 +217,14 @@ export function expand_loop_body(
     // Walk the body in execution order. `frame X { … }` always executes, so it
     // stays expandable. Conditional bodies (`if`/`else`/`while`) and nested
     // loops may not execute (or execute with different bindings), so their
-    // constructed names must NOT be injected — but any helper they reassign
-    // still shadows the pre-loop value for LATER templates, so we must descend
-    // into them to POISON those redefinitions (otherwise a stale pre-loop fold
-    // fabricates a concrete name that never exists at runtime, suppressing a
-    // legitimate undefined-macro warning). Nested foreach/forvalues additionally
-    // handle their own expansion via their own analyzer-level process_loop call.
+    // constructed names must NOT be injected by this PARENT poison walk — but
+    // any helper they reassign still shadows the pre-loop value for LATER
+    // templates, so we must descend into them to POISON those redefinitions
+    // (otherwise a stale pre-loop fold fabricates a concrete name that never
+    // exists at runtime, suppressing a legitimate undefined-macro warning).
+    // Nested foreach/forvalues handle their own expansion via their own
+    // analyzer-level process_loop call; that expansion is by design even under
+    // a dynamic outer loop when the nested loop's name template is tractable.
     //
     // A nested `foreach`/`forvalues` rebinds its own loop variable, so inside it
     // a constructed name that interpolates that name must NOT resolve to the

--- a/src/analyzer/loop-expander/index.ts
+++ b/src/analyzer/loop-expander/index.ts
@@ -86,7 +86,13 @@ export function expand_loop_body(
         // must be skipped.
         unknown: boolean;
     },
-    env_options?: StaticValueEnvOptions
+    env_options?: StaticValueEnvOptions,
+    // Local names that an ENCLOSING dynamic loop rebinds (its iterator has no
+    // static frame). A constructed name interpolating one of these must stay
+    // unresolved rather than fold a stale pre-loop value of the same name —
+    // otherwise it fabricates a concrete name that never exists at runtime,
+    // falsely suppressing an undefined-macro warning.
+    initial_shadowed_locals?: ReadonlySet<string>
 ): ExpandedLoopMacro[] {
     // If any active loop has an empty iteration set, the (innermost) body never
     // executes, so no constructed name is actually defined. Expanding here —
@@ -289,6 +295,6 @@ export function expand_loop_body(
             }
         }
     };
-    walk(node.body, true, frames, new Set<string>());
+    walk(node.body, true, frames, new Set<string>(initial_shadowed_locals));
     return the_expanded;
 }

--- a/src/analyzer/loop-expander/name-expander.ts
+++ b/src/analyzer/loop-expander/name-expander.ts
@@ -9,7 +9,7 @@
 import { SymbolTable, Token } from '../../types';
 import { is_valid_identifier } from '../option-argument-parser';
 import { SINGLE_LINE_PREFIX_COMMANDS } from '../../utils/stata-prefix-commands';
-import { build_static_value_env } from './static-value-env';
+import { build_static_value_env, StaticValueEnvOptions } from './static-value-env';
 import { scan_macro_refs } from './macro-ref-scanner';
 
 export type NamePart =
@@ -231,7 +231,8 @@ export function expand_template(
     // to one of these is per-iteration and unknown here, so it must NOT resolve
     // to the outer frame OR to a stale pre-loop value — treat it as
     // unresolvable so the constructed name's target stays unknown.
-    shadowed_locals?: ReadonlySet<string>
+    shadowed_locals?: ReadonlySet<string>,
+    env_options?: StaticValueEnvOptions
 ): string[] {
     const the_needed = relevant_frames(template, frames);
     let tuple_count = 1;
@@ -250,7 +251,7 @@ export function expand_template(
     // the env's resolvers read the overlay live, so there is no need to rebuild
     // (and reallocate) it for each of the up-to-EXPANSION_CAP iterations.
     const the_overlay = new Map<string, string>();
-    const my_env = build_static_value_env(symbols, the_overlay);
+    const my_env = build_static_value_env(symbols, the_overlay, env_options);
     for (let i = 0; i < tuple_count; i++) {
         let my_divisor = 1;
         for (const my_frame of the_needed) {

--- a/src/analyzer/loop-expander/static-value-env.ts
+++ b/src/analyzer/loop-expander/static-value-env.ts
@@ -171,9 +171,14 @@ export function build_static_value_env(
     ): StaticValue => {
         if (symbol.value === undefined) return null;
         // A definition that may not execute at runtime (inside an `if`/`while`
-        // body or a dynamic/empty loop body) has no guaranteed value, so it is
-        // dynamic for folding purposes. Folding it would fabricate iteration
-        // values or constructed names that may never exist at runtime.
+        // body or a dynamic/empty loop body) has no guaranteed value OUTSIDE
+        // that active body, so it is normally dynamic for folding purposes.
+        // This is a value-folding rule only, not a visibility rule: Stata locals
+        // are not loop-block scoped. While analyzing a later statement inside
+        // the same active dynamic loop body, the analyzer deliberately allows
+        // folding via `allow_maybe_unexecuted_ranges`; this is what lets
+        // `local vars ...` feed a static inner loop that constructs macros like
+        // `` local `v'_exists ``.
         if (!maybe_unexecuted_is_allowed(symbol)) return null;
         // Defined inside a guaranteed loop with a value that captured the loop
         // iterator: its runtime value is the last iteration's binding, unknown

--- a/src/analyzer/loop-expander/static-value-env.ts
+++ b/src/analyzer/loop-expander/static-value-env.ts
@@ -57,6 +57,13 @@ export interface StaticValueEnv {
 
 export interface StaticValueEnvOptions {
     allow_maybe_unexecuted_ranges?: readonly Range[];
+    // Local names rebound by an enclosing DYNAMIC loop (its iterator has no
+    // static frame). Their stored pre-loop value is stale relative to the
+    // unknown runtime binding, so folding them — e.g. resolving the spec of a
+    // nested `foreach v in `survey'` to `survey`'s pre-loop value — would
+    // fabricate a value/name that never exists at runtime. Treat as
+    // unresolvable.
+    shadowed_locals?: ReadonlySet<string>;
 }
 
 type MacroMaps = Pick<SymbolTable, 'localMacros' | 'globalMacros'>;
@@ -114,17 +121,17 @@ export function build_static_value_env(
     overlay?: Map<string, string>,
     options?: StaticValueEnvOptions
 ): StaticValueEnv {
-    const same_range = (a: Range, b: Range): boolean =>
-        a.start.line === b.start.line
-        && a.start.character === b.start.character
-        && a.end.line === b.end.line
-        && a.end.character === b.end.character;
-
     const maybe_unexecuted_is_allowed = (symbol: MacroSymbol): boolean => {
         if (!symbol.maybe_unexecuted) return true;
         if (!symbol.maybe_unexecuted_range) return false;
+        // A symbol's `maybe_unexecuted_range` is the exact Range object pushed
+        // onto `nonexec_range_stack` at definition time, and
+        // `allow_maybe_unexecuted_ranges` is that same live stack, so identity
+        // (`===`) is the correct membership test: it matches only while the
+        // defining body is still active, and avoids a coincidental
+        // structural match between two distinct bodies with equal coordinates.
         return options?.allow_maybe_unexecuted_ranges?.some(
-            (range) => same_range(range, symbol.maybe_unexecuted_range!)
+            (range) => range === symbol.maybe_unexecuted_range
         ) ?? false;
     };
 
@@ -138,24 +145,33 @@ export function build_static_value_env(
     // its definition, so a reference captured there cannot see a macro defined
     // later in the file. Honoring this prevents fabricating a name from a
     // forward-defined macro (which would falsely suppress a real warning).
+    // `direct` is true while resolving text that appears LITERALLY in the source
+    // being analyzed (a loop-spec item or constructed name), and false once we
+    // descend into a stored macro's value via `fold_symbol`. It controls dynamic
+    // -iterator shadowing: a direct reference to a rebound iterator must not fold
+    // to its stale pre-loop value, but a pre-loop helper that captured the value
+    // (reached only through a fold) legitimately holds it.
     const interpolate = (
         text: string,
         visited: Set<string>,
         depth: number,
-        max_index: number
+        max_index: number,
+        direct: boolean
     ): StaticValue => {
         if (depth > MAX_FOLD_DEPTH) return null;
         const parts: string[] = [];
         const ok = scan_macro_refs(text, {
             literal: (ch) => { parts.push(ch); },
             local_ref: (name) => {
-                const resolved = resolve_local_internal(name, visited, depth + 1, max_index);
+                const resolved =
+                    resolve_local_internal(name, visited, depth + 1, max_index, direct);
                 if (resolved === null) return false;
                 parts.push(resolved);
                 return true;
             },
             global_ref: (name) => {
-                const resolved = resolve_global_internal(name, visited, depth + 1, max_index);
+                const resolved =
+                    resolve_global_internal(name, visited, depth + 1, max_index, direct);
                 if (resolved === null) return false;
                 parts.push(resolved);
                 return true;
@@ -203,18 +219,21 @@ export function build_static_value_env(
         const next_max = symbol.definition_index ?? Number.POSITIVE_INFINITY;
         const literal = strip_string_literal(value);
         if (literal !== null) {
-            return interpolate(literal, visited, depth, next_max);
+            // Descending into a stored value: references inside it are no longer
+            // direct source references (see `interpolate`'s `direct`).
+            return interpolate(literal, visited, depth, next_max, false);
         }
         // A non-literal `= expr` value (e.g. `2+2`) is dynamic.
         if (symbol.hasEquals) return null;
-        return interpolate(value, visited, depth, next_max);
+        return interpolate(value, visited, depth, next_max, false);
     };
 
     const resolve_local_internal = (
         name: string,
         visited: Set<string>,
         depth: number,
-        max_index: number
+        max_index: number,
+        direct: boolean
     ): StaticValue => {
         // The overlay (loop iterator value) supplies a `` `i' `` written
         // directly in the constructed name (depth 0), which Stata re-evaluates
@@ -226,6 +245,18 @@ export function build_static_value_env(
             const overlaid = overlay?.get(name);
             if (overlaid !== undefined) return overlaid;
         }
+        // A DIRECT source reference (written literally in the loop spec /
+        // constructed name, whether reached via resolve_local at depth 0 or via
+        // interpolate at depth 1) to an enclosing dynamic loop's iterator — e.g.
+        // a nested `foreach v in `survey'` or `foreach v in x`survey'` spec —
+        // must not fold to the stale pre-loop value, since the iterator is
+        // rebound to unknown runtime values. Only direct references are shadowed:
+        // a helper defined BEFORE the loop that captured the iterator's value
+        // holds a legitimate pre-loop value and is reached only through a fold
+        // (`direct` is then false), where it must still fold. (A helper defined
+        // INSIDE the loop that captures the iterator is separately marked
+        // iteration_dependent and is unfoldable for that reason.)
+        if (direct && options?.shadowed_locals?.has(name)) return null;
         const key = `local:${name}`;
         if (visited.has(key)) return null; // cycle
         const symbol = symbols.localMacros.get(name);
@@ -244,7 +275,8 @@ export function build_static_value_env(
         name: string,
         visited: Set<string>,
         depth: number,
-        max_index: number
+        max_index: number,
+        _direct: boolean
     ): StaticValue => {
         const key = `global:${name}`;
         if (visited.has(key)) return null; // cycle
@@ -271,18 +303,18 @@ export function build_static_value_env(
             if (overlaid !== undefined) return overlaid;
             if (memo_local.has(name)) return memo_local.get(name)!;
             const resolved = resolve_local_internal(
-                name, new Set(), 0, Number.POSITIVE_INFINITY);
+                name, new Set(), 0, Number.POSITIVE_INFINITY, true);
             memo_local.set(name, resolved);
             return resolved;
         },
         resolve_global: (name: string) => {
             if (memo_global.has(name)) return memo_global.get(name)!;
             const resolved = resolve_global_internal(
-                name, new Set(), 0, Number.POSITIVE_INFINITY);
+                name, new Set(), 0, Number.POSITIVE_INFINITY, true);
             memo_global.set(name, resolved);
             return resolved;
         },
         interpolate: (text: string) =>
-            interpolate(text, new Set(), 0, Number.POSITIVE_INFINITY),
+            interpolate(text, new Set(), 0, Number.POSITIVE_INFINITY, true),
     };
 }

--- a/src/analyzer/loop-expander/static-value-env.ts
+++ b/src/analyzer/loop-expander/static-value-env.ts
@@ -37,6 +37,7 @@
  * the false suppression this feature must never produce. (See the design spec's
  * "Out of scope" section.)
  */
+import { Range } from 'vscode-languageserver-textdocument';
 import { MacroSymbol, SymbolTable } from '../../types';
 import { scan_macro_refs } from './macro-ref-scanner';
 
@@ -52,6 +53,10 @@ export interface StaticValueEnv {
      * any referenced macro is dynamic/unknown.
      */
     interpolate(text: string): StaticValue;
+}
+
+export interface StaticValueEnvOptions {
+    allow_maybe_unexecuted_ranges?: readonly Range[];
 }
 
 type MacroMaps = Pick<SymbolTable, 'localMacros' | 'globalMacros'>;
@@ -106,8 +111,23 @@ function strip_string_literal(text: string): string | null {
 
 export function build_static_value_env(
     symbols: MacroMaps,
-    overlay?: Map<string, string>
+    overlay?: Map<string, string>,
+    options?: StaticValueEnvOptions
 ): StaticValueEnv {
+    const same_range = (a: Range, b: Range): boolean =>
+        a.start.line === b.start.line
+        && a.start.character === b.start.character
+        && a.end.line === b.end.line
+        && a.end.character === b.end.character;
+
+    const maybe_unexecuted_is_allowed = (symbol: MacroSymbol): boolean => {
+        if (!symbol.maybe_unexecuted) return true;
+        if (!symbol.maybe_unexecuted_range) return false;
+        return options?.allow_maybe_unexecuted_ranges?.some(
+            (range) => same_range(range, symbol.maybe_unexecuted_range!)
+        ) ?? false;
+    };
+
     // Interpolate macro references inside a value string. Returns null if any
     // referenced macro is dynamic/unknown, or if the value uses constructs we
     // do not statically evaluate (nested macro refs, `=expr', unbalanced refs).
@@ -154,7 +174,7 @@ export function build_static_value_env(
         // body or a dynamic/empty loop body) has no guaranteed value, so it is
         // dynamic for folding purposes. Folding it would fabricate iteration
         // values or constructed names that may never exist at runtime.
-        if (symbol.maybe_unexecuted) return null;
+        if (!maybe_unexecuted_is_allowed(symbol)) return null;
         // Defined inside a guaranteed loop with a value that captured the loop
         // iterator: its runtime value is the last iteration's binding, unknown
         // statically. Folding the iterator's stale stored value would fabricate

--- a/src/analyzer/loop-expander/value-set-resolver.ts
+++ b/src/analyzer/loop-expander/value-set-resolver.ts
@@ -113,7 +113,18 @@ function resolve_int(token: string, env: StaticValueEnv): number | null {
 
 function resolve_foreach(spec_tail: string, env: StaticValueEnv): IteratorValueSet {
     const values: string[] = [];
+    // Partial resolution is intentional when a mixed list has both static and
+    // dynamic pieces (`a `maybe' c` -> a/c). But when EVERY item is unresolved,
+    // the loop is dynamic, not statically empty. This distinction is critical
+    // for dynamic outer loops such as `foreach survey in `r(levels)'`: an empty
+    // static frame would make nested static constructed names disappear even
+    // though Stata locals created in those nested loops remain in the
+    // do-file/program scope whenever the dynamic outer loop executes.
+    let saw_item = false;
+    let saw_resolved_item = false;
+    let saw_unresolved_item = false;
     for (const my_item of split_quote_aware(spec_tail)) {
+        saw_item = true;
         if (my_item.quoted) {
             // A quoted element is a SINGLE iterator value; expand any embedded
             // macro refs (e.g. `` "a`m'b" `` -> "amidb"). Drop it if a
@@ -121,7 +132,11 @@ function resolve_foreach(spec_tail: string, env: StaticValueEnv): IteratorValueS
             // un-expanded text (which would carry a backtick and never form a
             // valid macro name downstream).
             const interpolated = env.interpolate(my_item.text);
-            if (interpolated === null) continue;
+            if (interpolated === null) {
+                saw_unresolved_item = true;
+                continue;
+            }
+            saw_resolved_item = true;
             values.push(interpolated);
             if (values.length > VALUE_SET_CAP) return { kind: 'dynamic' };
             continue;
@@ -134,7 +149,11 @@ function resolve_foreach(spec_tail: string, env: StaticValueEnv): IteratorValueS
             const folded = local_match
                 ? env.resolve_local(local_match[1])
                 : env.resolve_global(global_ref_name(global_match!));
-            if (folded === null) continue; // partial: drop unresolvable item
+            if (folded === null) {
+                saw_unresolved_item = true;
+                continue; // partial: drop unresolvable item
+            }
+            saw_resolved_item = true;
             for (const my_value of split_list(folded)) {
                 values.push(my_value);
                 if (values.length > VALUE_SET_CAP) return { kind: 'dynamic' };
@@ -151,8 +170,10 @@ function resolve_foreach(spec_tail: string, env: StaticValueEnv): IteratorValueS
                 // A referenced macro is unresolvable: partial, drop the item
                 // (matching the quoted-element and pure-ref branches) rather
                 // than carry un-interpolated backtick text.
+                saw_unresolved_item = true;
                 continue;
             }
+            saw_resolved_item = true;
             if (MACRO_SIGIL.test(interpolated)) {
                 // The text held a malformed macro form that did not fully
                 // resolve; preserve it verbatim as a literal element.
@@ -165,6 +186,9 @@ function resolve_foreach(spec_tail: string, env: StaticValueEnv): IteratorValueS
                 if (values.length > VALUE_SET_CAP) return { kind: 'dynamic' };
             }
         }
+    }
+    if (values.length === 0 && saw_item && saw_unresolved_item && !saw_resolved_item) {
+        return { kind: 'dynamic' };
     }
     return { kind: 'static', values };
 }

--- a/src/analyzer/loop-expander/value-set-resolver.ts
+++ b/src/analyzer/loop-expander/value-set-resolver.ts
@@ -120,11 +120,17 @@ function resolve_foreach(spec_tail: string, env: StaticValueEnv): IteratorValueS
     // static frame would make nested static constructed names disappear even
     // though Stata locals created in those nested loops remain in the
     // do-file/program scope whenever the dynamic outer loop executes.
-    let saw_item = false;
+    //
+    // ACCEPTED TRADEOFF: this classifies a runtime-empty list (e.g.
+    // `foreach v in `undef'` where `undef' expands to nothing) as dynamic, so
+    // the analyzer expands nested constructed names that never exist when the
+    // loop runs zero times — suppressing those undefined-macro warnings. This
+    // is the intended relaxation gated in `process_loop` (see its can_expand
+    // "ACCEPTED TRADEOFF" note); the unresolvable-vs-empty cases cannot be told
+    // apart statically, and the project chose to favor the `r(levels)` case.
     let saw_resolved_item = false;
     let saw_unresolved_item = false;
     for (const my_item of split_quote_aware(spec_tail)) {
-        saw_item = true;
         if (my_item.quoted) {
             // A quoted element is a SINGLE iterator value; expand any embedded
             // macro refs (e.g. `` "a`m'b" `` -> "amidb"). Drop it if a
@@ -187,7 +193,7 @@ function resolve_foreach(spec_tail: string, env: StaticValueEnv): IteratorValueS
             }
         }
     }
-    if (values.length === 0 && saw_item && saw_unresolved_item && !saw_resolved_item) {
+    if (values.length === 0 && saw_unresolved_item && !saw_resolved_item) {
         return { kind: 'dynamic' };
     }
     return { kind: 'static', values };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -408,6 +408,14 @@ export interface MacroSymbol {
   // visible (the end of the inline `mata:` statement). References before
   // this position are in the same Mata unit and not yet defined.
   visibility_start?: { line: number; character: number };
+  // For synthesized definitions that are only guaranteed within an enclosing
+  // non-executing body (for example, a static inner loop inside a dynamic
+  // outer loop), references outside this range must not be suppressed.
+  visibility_range?: Range;
+  // All enclosing non-guaranteed execution contexts that bound visibility.
+  // The singular `visibility_range` is retained for older callers/tests; new
+  // analyzer code uses this plural form so nested contexts are represented.
+  visibility_contexts?: Range[];
   // True when this symbol was synthesized by the loop expander from a
   // constructed name (e.g. `local x_`i'`). Its `location` points at the
   // loop-body template statement, whose text does NOT contain the concrete
@@ -420,6 +428,13 @@ export interface MacroSymbol {
   // expansion (doing so could fabricate iteration values or constructed names
   // that never exist at runtime, falsely suppressing undefined-macro warnings).
   maybe_unexecuted?: boolean;
+  // Nearest enclosing non-executing range for a maybe-unexecuted definition.
+  // Static folding may still use this value while resolving a later statement
+  // inside the same currently-active range.
+  maybe_unexecuted_range?: Range;
+  // All non-guaranteed execution contexts active at the definition. The value
+  // is foldable only while analysis is still inside every listed context.
+  maybe_unexecuted_contexts?: Range[];
   // True when this macro is defined inside a guaranteed loop body and its value
   // interpolates an active loop iterator (e.g. `` local suffix `i' `` inside
   // `foreach i ...`). Its runtime value is the last iteration's binding, which
@@ -428,7 +443,7 @@ export interface MacroSymbol {
   // would fabricate names that never exist at runtime, falsely suppressing
   // undefined-macro warnings).
   iteration_dependent?: boolean;
-  additional_definitions?: Array<{ index: number, line: number, location: { uri: string; range: Range }, is_expanded?: boolean }>;
+  additional_definitions?: Array<{ index: number, line: number, location: { uri: string; range: Range }, is_expanded?: boolean, visibility_range?: Range, visibility_contexts?: Range[] }>;
 }
 
 export interface VariableSymbol {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -415,7 +415,7 @@ export interface MacroSymbol {
   is_expanded?: boolean;
   // True when this macro's FIRST definition is inside a context that may not
   // execute at runtime (an `if`/`else`/`while` body, or a dynamic/empty loop
-  // body, i.e. `nonexec_depth > 0` at definition time). This does NOT make the
+  // body, tracked via `nonexec_range_stack`). This does NOT make the
   // macro block-scoped: Stata locals remain visible in the containing do-file /
   // program after loops. The flag only says its stored `value` must not be
   // statically folded outside the active execution context, because doing so

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -408,14 +408,6 @@ export interface MacroSymbol {
   // visible (the end of the inline `mata:` statement). References before
   // this position are in the same Mata unit and not yet defined.
   visibility_start?: { line: number; character: number };
-  // For synthesized definitions that are only guaranteed within an enclosing
-  // non-executing body (for example, a static inner loop inside a dynamic
-  // outer loop), references outside this range must not be suppressed.
-  visibility_range?: Range;
-  // All enclosing non-guaranteed execution contexts that bound visibility.
-  // The singular `visibility_range` is retained for older callers/tests; new
-  // analyzer code uses this plural form so nested contexts are represented.
-  visibility_contexts?: Range[];
   // True when this symbol was synthesized by the loop expander from a
   // constructed name (e.g. `local x_`i'`). Its `location` points at the
   // loop-body template statement, whose text does NOT contain the concrete
@@ -423,18 +415,17 @@ export interface MacroSymbol {
   is_expanded?: boolean;
   // True when this macro's FIRST definition is inside a context that may not
   // execute at runtime (an `if`/`else`/`while` body, or a dynamic/empty loop
-  // body, i.e. `nonexec_depth > 0` at definition time). Its stored `value`
-  // is therefore not guaranteed and must NOT be statically folded for loop
-  // expansion (doing so could fabricate iteration values or constructed names
-  // that never exist at runtime, falsely suppressing undefined-macro warnings).
+  // body, i.e. `nonexec_depth > 0` at definition time). This does NOT make the
+  // macro block-scoped: Stata locals remain visible in the containing do-file /
+  // program after loops. The flag only says its stored `value` must not be
+  // statically folded outside the active execution context, because doing so
+  // could fabricate iteration values or constructed names that never exist.
   maybe_unexecuted?: boolean;
   // Nearest enclosing non-executing range for a maybe-unexecuted definition.
-  // Static folding may still use this value while resolving a later statement
-  // inside the same currently-active range.
+  // Static folding may still use this value while resolving later statements
+  // inside the same currently-active range. This supports by-design expansion
+  // of static inner-loop constructed names inside dynamic outer loops.
   maybe_unexecuted_range?: Range;
-  // All non-guaranteed execution contexts active at the definition. The value
-  // is foldable only while analysis is still inside every listed context.
-  maybe_unexecuted_contexts?: Range[];
   // True when this macro is defined inside a guaranteed loop body and its value
   // interpolates an active loop iterator (e.g. `` local suffix `i' `` inside
   // `foreach i ...`). Its runtime value is the last iteration's binding, which
@@ -443,7 +434,7 @@ export interface MacroSymbol {
   // would fabricate names that never exist at runtime, falsely suppressing
   // undefined-macro warnings).
   iteration_dependent?: boolean;
-  additional_definitions?: Array<{ index: number, line: number, location: { uri: string; range: Range }, is_expanded?: boolean, visibility_range?: Range, visibility_contexts?: Range[] }>;
+  additional_definitions?: Array<{ index: number, line: number, location: { uri: string; range: Range }, is_expanded?: boolean }>;
 }
 
 export interface VariableSymbol {

--- a/tests/integration/loop-macro-expansion.test.ts
+++ b/tests/integration/loop-macro-expansion.test.ts
@@ -30,16 +30,6 @@ describe('Loop macro expansion (integration)', () => {
             .map((d) => d.symbol_name ?? '');
     }
 
-    function undefined_macro_lines(source: string, name: string): number[] {
-        return analyze(source)
-            .diagnostics
-            .filter((d) =>
-                d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
-                d.symbol_name === name
-            )
-            .map((d) => d.range.start.line);
-    }
-
     function diagnostic_codes(source: string): StataDiagnosticCode[] {
         return analyze(source).diagnostics.map((d) => d.code);
     }
@@ -136,19 +126,23 @@ describe('Loop macro expansion (integration)', () => {
         expect(symbols.localMacros.has('x_b')).toBe(false);
     });
 
-    it('does not expand a static loop nested inside a dynamic loop', () => {
-        // The outer `of varlist` loop may iterate zero times, so the inner
-        // static loop's constructed names are not guaranteed to be defined.
+    it('expands static inner-loop names inside a dynamic outer loop', () => {
+        // `foreach` does not create a local-macro scope in Stata. The outer loop
+        // value set is dynamic, but the constructed names only depend on the
+        // static inner iterator, so they remain tractable and visible afterward.
         const source = [
             'foreach v of varlist somevar {',
             '    foreach i in a b {',
             "        local x_`i'",
             '    }',
+            "    display `x_a'",
             '}',
+            "display `x_a'",
         ].join('\n');
         const { symbols } = analyze(source);
-        expect(symbols.localMacros.has('x_a')).toBe(false);
-        expect(symbols.localMacros.has('x_b')).toBe(false);
+        expect(symbols.localMacros.has('x_a')).toBe(true);
+        expect(symbols.localMacros.has('x_b')).toBe(true);
+        expect(undefined_macros(source)).not.toContain('x_a');
     });
 
     it('keeps an earlier body-literal definition as the primary on collision', () => {
@@ -348,7 +342,11 @@ describe('Loop macro expansion (integration)', () => {
         expect(undefined_macros(source)).not.toContain('m10_exists');
     });
 
-    it('does not leak dynamic-outer-loop expansions after the outer loop', () => {
+    it('keeps dynamic-outer-loop expansions visible after the outer loop', () => {
+        // Stata locals are scoped to the do-file/program, not to loop blocks.
+        // The outer iterator is dynamic, but the constructed name only uses the
+        // static inner iterator, so `m10_exists' is intentionally visible after
+        // the outer loop as well.
         const source = [
             'levelsof survey',
             "foreach survey in `r(levels)' {",
@@ -359,7 +357,7 @@ describe('Loop macro expansion (integration)', () => {
             '}',
             "display `m10_exists'",
         ].join('\n');
-        expect(undefined_macro_lines(source, 'm10_exists')).toEqual([7]);
+        expect(undefined_macros(source)).not.toContain('m10_exists');
     });
 
     it('records collisions as additional definitions, not drops', () => {

--- a/tests/integration/loop-macro-expansion.test.ts
+++ b/tests/integration/loop-macro-expansion.test.ts
@@ -360,6 +360,181 @@ describe('Loop macro expansion (integration)', () => {
         expect(undefined_macros(source)).not.toContain('m10_exists');
     });
 
+    it('does not fold a dynamic outer iterator to a stale pre-loop value', () => {
+        // The constructed name interpolates the DYNAMIC outer iterator `survey`,
+        // whose runtime values come from `r(levels)` (unknown here). A pre-loop
+        // `local survey old` must NOT be folded into the name: at runtime
+        // `survey' is never "old" (unless "old" is in r(levels)), so injecting
+        // `x_old_1' would be a false suppression. The name must stay unresolved.
+        const source = [
+            'local survey old',
+            "foreach survey in `r(levels)' {",
+            '    forvalues i = 1/2 {',
+            "        local x_`survey'_`i' = 1",
+            '    }',
+            '}',
+            "display `x_old_1'",
+        ].join('\n');
+        expect(undefined_macros(source)).toContain('x_old_1');
+    });
+
+    it('does not fold a dynamic outer iterator into a nested loop value set', () => {
+        // The nested loop iterates over the DYNAMIC outer iterator's value
+        // (`foreach v in `survey'`). Folding `survey` to its stale pre-loop
+        // value `old` would make the nested loop static `{old}` and inject
+        // `x_old`, suppressing a real undefined-macro warning. The nested value
+        // set must instead be dynamic, leaving `x_old' unresolved.
+        const source = [
+            'local survey old',
+            "foreach survey in `r(levels)' {",
+            "    foreach v in `survey' {",
+            "        local x_`v' = 1",
+            '    }',
+            '}',
+            "display `x_old'",
+        ].join('\n');
+        expect(undefined_macros(source)).toContain('x_old');
+    });
+
+    it('does not fold a dynamic outer iterator inside an interpolated list item', () => {
+        // The nested loop's list item embeds the dynamic iterator adjacent to
+        // literal text (`x`survey'`), which resolves via interpolation. Folding
+        // `survey` to its stale pre-loop value `old` would inject `y_xold`; the
+        // shadow must apply to this DIRECT source reference too, so `y_xold'
+        // stays unresolved.
+        const source = [
+            'local survey old',
+            "foreach survey in `r(levels)' {",
+            "    foreach v in x`survey' {",
+            "        local y_`v' = 1",
+            '    }',
+            '}',
+            "display `y_xold'",
+        ].join('\n');
+        expect(undefined_macros(source)).toContain('y_xold');
+    });
+
+    it('does not fold a dynamic outer iterator captured through a helper', () => {
+        // A helper assigned the dynamic iterator's value (`local h `survey'`)
+        // captures a per-iteration value, so it is iteration-dependent and must
+        // not be folded. A later constructed name `x_`h'_`i'` therefore stays
+        // unresolved rather than fabricating `x_old_1` from the stale `survey`.
+        const source = [
+            'local survey old',
+            "foreach survey in `r(levels)' {",
+            "    local h `survey'",
+            '    forvalues i = 1/2 {',
+            "        local x_`h'_`i' = 1",
+            '    }',
+            '}',
+            "display `x_old_1'",
+        ].join('\n');
+        expect(undefined_macros(source)).toContain('x_old_1');
+    });
+
+    it('folds a pre-loop helper that captured the iterator value, under a dynamic loop', () => {
+        // `list` is assigned BEFORE the dynamic loop, so it holds a legitimate
+        // pre-loop value and a nested `foreach v of local list` must still fold
+        // it (and expand the constructed name). The dynamic-iterator shadow
+        // applies only to DIRECT references to the active iterator, not to
+        // pre-loop captures reached transitively.
+        const source = [
+            'local survey old',
+            "local list `survey'",
+            "foreach survey in `r(levels)' {",
+            '    foreach v of local list {',
+            "        local x_`v' = 1",
+            '    }',
+            '}',
+            "display `x_old'",
+        ].join('\n');
+        expect(undefined_macros(source)).not.toContain('x_old');
+    });
+
+    it('lets an inner static loop reuse a dynamic outer iterator name', () => {
+        // The inner `foreach survey in a b` rebinds `survey` with a static
+        // frame, so `x_`survey'` resolves to x_a/x_b from that frame — the outer
+        // dynamic iterator of the same name must not shadow it.
+        const source = [
+            "foreach survey in `r(levels)' {",
+            '    foreach survey in a b {',
+            "        local x_`survey' = 1",
+            '    }',
+            '}',
+            "display `x_a'",
+        ].join('\n');
+        expect(undefined_macros(source)).not.toContain('x_a');
+    });
+
+    it('shadows an inner dynamic loop that reuses an outer static iterator name', () => {
+        // `i` is bound statically by the outer loop but rebound DYNAMICALLY by
+        // the middle loop, so inside it `i` holds unknown runtime values. The
+        // innermost binding wins: `x_`i'_`j'` must stay unresolved (not fold to
+        // the outer static i=a/b), so `x_a_c' warns.
+        const source = [
+            'foreach i in a b {',
+            "    foreach i in `r(levels)' {",
+            '        foreach j in c {',
+            "            local x_`i'_`j' = 1",
+            '        }',
+            '    }',
+            '}',
+            "display `x_a_c'",
+        ].join('\n');
+        expect(undefined_macros(source)).toContain('x_a_c');
+    });
+
+    it('still expands inner-only names under a dynamic outer with a stale local', () => {
+        // Even when a same-named pre-loop local exists, a constructed name that
+        // depends ONLY on the static inner iterator (not the dynamic outer one)
+        // remains tractable and is injected by design.
+        const source = [
+            'local survey old',
+            "foreach survey in `r(levels)' {",
+            '    foreach i in a b {',
+            "        local x_`i' = 1",
+            '    }',
+            '}',
+            "display `x_a'",
+        ].join('\n');
+        expect(undefined_macros(source)).not.toContain('x_a');
+    });
+
+    it('conservatively warns for a reused iterator after an unresolved-list loop', () => {
+        // `foreach v in `undef'` is dynamic (may execute), so afterwards `v`
+        // holds an unknown last-iteration value and is iteration-dependent — its
+        // stale pre-loop value must NOT be folded into `forvalues 1/`v''. Warning
+        // on `x_3' is the safe "a miss, never a false suppression" direction (at
+        // runtime the empty list leaves `v' empty, so x_3 is genuinely undefined).
+        const source = [
+            'local v 5',
+            "foreach v in `undef' {",
+            '}',
+            "forvalues j = 1/`v' {",
+            "    local x_`j' = 1",
+            '}',
+            "display `x_3'",
+        ].join('\n');
+        expect(undefined_macros(source)).toContain('x_3');
+    });
+
+    it('conservatively suppresses expansion for a mixed empty+unresolved list', () => {
+        // The outer list has an empty-resolving item and an unresolved item and
+        // no concrete values, so it is treated as (statically) empty: the inner
+        // constructed names are NOT injected and a later reference warns — the
+        // safe direction (never fabricate a name that may not exist at runtime).
+        const source = [
+            'local emptymac',
+            "foreach s in `emptymac' `undef' {",
+            '    foreach i in a b {',
+            "        local y_`i' = 1",
+            '    }',
+            '}',
+            "display `y_a'",
+        ].join('\n');
+        expect(undefined_macros(source)).toContain('y_a');
+    });
+
     it('records collisions as additional definitions, not drops', () => {
         const source = [
             'foreach i in a b {',

--- a/tests/integration/loop-macro-expansion.test.ts
+++ b/tests/integration/loop-macro-expansion.test.ts
@@ -30,6 +30,16 @@ describe('Loop macro expansion (integration)', () => {
             .map((d) => d.symbol_name ?? '');
     }
 
+    function undefined_macro_lines(source: string, name: string): number[] {
+        return analyze(source)
+            .diagnostics
+            .filter((d) =>
+                d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                d.symbol_name === name
+            )
+            .map((d) => d.range.start.line);
+    }
+
     function diagnostic_codes(source: string): StataDiagnosticCode[] {
         return analyze(source).diagnostics.map((d) => d.code);
     }
@@ -319,6 +329,37 @@ describe('Loop macro expansion (integration)', () => {
             expect(symbols.localMacros.has(name)).toBe(true);
         }
         expect(undefined_macros(source)).not.toContain('out_b');
+    });
+
+    it('expands a static inner loop inside a dynamic outer loop body', () => {
+        const source = [
+            'levelsof survey',
+            "foreach survey in `r(levels)' {",
+            '    local vars m10 cm_lastbirth',
+            '    foreach v of local vars {',
+            "        capture confirm variable `v'",
+            '        local `v\'_exists = _rc == 0',
+            '    }',
+            "    if (`m10_exists' == 1) {",
+            '        display "ok"',
+            '    }',
+            '}',
+        ].join('\n');
+        expect(undefined_macros(source)).not.toContain('m10_exists');
+    });
+
+    it('does not leak dynamic-outer-loop expansions after the outer loop', () => {
+        const source = [
+            'levelsof survey',
+            "foreach survey in `r(levels)' {",
+            '    local vars m10',
+            '    foreach v of local vars {',
+            '        local `v\'_exists = 1',
+            '    }',
+            '}',
+            "display `m10_exists'",
+        ].join('\n');
+        expect(undefined_macro_lines(source, 'm10_exists')).toEqual([7]);
     });
 
     it('records collisions as additional definitions, not drops', () => {

--- a/tests/unit/loop-expander/value-set-resolver.test.ts
+++ b/tests/unit/loop-expander/value-set-resolver.test.ts
@@ -66,6 +66,11 @@ describe('resolve_loop_value_set: foreach in', () => {
             .toEqual({ kind: 'static', values: ['a', 'c'] });
     });
 
+    it('is dynamic when every list item is unresolvable', () => {
+        expect(resolve_loop_value_set('foreach', "in `r(levels)'", EMPTY))
+            .toEqual({ kind: 'dynamic' });
+    });
+
     it('interpolates a macro ref adjacent to literal text in an unquoted item', () => {
         const env = env_from({ m: 'b' }, { g: '1' });
         expect(resolve_loop_value_set('foreach', "in a`m' x$g", env))


### PR DESCRIPTION
## Summary

Makes loop-macro expansion correct when a **static inner loop is nested
inside a dynamic outer loop**. Stata locals are scoped to the do-file /
program (not to loop blocks), so a constructed name whose value depends only
on a static inner iterator remains visible after the loop — but the dynamic
outer iterator itself must never fold to a stale pre-loop value.

## What changed

**1. Dynamic-iterator stale fold (false suppression) — fixed in all forms:**
- directly in a constructed name (`` local x_`survey'_`i' ``),
- transitively through a helper defined inside the loop
  (`` local h `survey' `` then `` x_`h' ``),
- in a nested loop's value set, both a pure ref (`` foreach v in `survey' ``)
  and one embedded in an item (`` foreach v in x`survey' ``).

Every enclosing loop iterator is tracked in `loop_iter_stack` (nesting order,
tagged static/dynamic). The **innermost** binding of a name decides shadowing,
so it is correct even when inner/outer loops reuse a name (inner static under
outer dynamic resolves from its frame; inner dynamic under outer static stays
shadowed). Shadowing applies only to **direct source references** — the
value-set env threads a `direct` flag that clears once folding descends into a
stored macro value, so a helper captured *before* the loop keeps its
legitimate pre-loop value.

**2. `macro_resolves_at_reference`:** removed the `additional_definitions`
loop. The primary is always the earliest definition, so an additional
definition can never resolve a genuine forward reference (dead code), and
demoted entries carry no `visibility_start`, so consulting them wrongly
resolved a reference still inside a Mata setter's inline unit (a false
suppression). Restored to the documented "consumers read the PRIMARY
definition markers" invariant.

**3. Cleanups:** removed `nonexec_depth` (redundant with
`nonexec_range_stack.length`), dropped a redundant `saw_item` flag, matched
`maybe_unexecuted_range` by identity, and restored `src/types/index.ts` to
uniform CRLF so its diff shows only the new `maybe_unexecuted_range` field.

## Accepted tradeoff

A dynamic outer loop that iterates **zero** times at runtime will still have
its inner constructed names injected, suppressing an undefined-macro warning
for names that never get defined. This is a **deliberate, documented
tradeoff**: the runtime-empty case is statically indistinguishable from the
`` `r(levels)' `` case, and the project favors the latter. It is asserted by
the dynamic-outer-loop integration tests and documented at the `process_loop`
`can_expand` gate and the value-set resolver. Edge cases where the analyzer
can be conservative (e.g. an all-unresolved or mixed empty/unresolved list)
warn rather than suppress — the "a miss, never a false suppression" direction.

## Testing

`bun run test` (typecheck + 6787 tests) and `bun run lint` pass. The
`loop-macro-expansion` integration suite adds coverage for each scenario
above.

## Review

Reviewed with Codex and `/code-review` across multiple rounds; all confirmed
correctness findings were fixed. The only remaining reported item is the
accepted tradeoff described above.

https://claude.ai/code/session_0169bQiNR6Fy4wMwGw27cwPt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of loop-based name expansion, including cases with dynamic or partially known iterators.
  * Added more conservative detection for unresolved loop value sets, helping keep runtime-dependent names unresolved when appropriate.

* **Bug Fixes**
  * Fixed cases where names from nested loops could be expanded too early or incorrectly reused.
  * Reduced false undefined-macro warnings and improved behavior for mixed resolved/unresolved list items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->