### PR TITLE
Scope local-macro identity to defining program bodies

### DIFF
--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -4846,11 +4846,20 @@ export class SemanticAnalyzer {
                 continue;
             }
 
-            // Suppress undefined global macro warnings inside program blocks
+            // Suppress undefined global macro warnings inside program
+            // BODIES only. The header (`program define ...`) and `end`
+            // lines are excluded: Stata expands macros on the header at
+            // definition time, so an undefined global there is a real
+            // warning (matches the pre-split line-exclusive ranges).
             if (token.type === 'MACRO_REF_GLOBAL') {
                 const enclosing_scope =
                     this.find_enclosing_scope(scopes, token.range.start);
-                if (enclosing_scope.type === 'program') {
+                const token_line = token.range.start.line;
+                if (
+                    enclosing_scope.type === 'program' &&
+                    token_line > enclosing_scope.range.start.line &&
+                    token_line < enclosing_scope.range.end.line
+                ) {
                     continue;
                 }
             }

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -3440,6 +3440,17 @@ export class SemanticAnalyzer {
                 if (my_scope.type !== 'program' || !my_scope.program_name) {
                     continue;
                 }
+                // A redeclared program's other bodies share the
+                // reference's own program name — blaming them would
+                // read as self-contradictory ("defined only inside
+                // program foo" while inside program foo). Skip them;
+                // the plain undefined message is correct there.
+                if (
+                    reference_scope.type === 'program' &&
+                    my_scope.program_name === reference_scope.program_name
+                ) {
+                    continue;
+                }
                 if (my_scope.localMacros.has(name)) {
                     the_program_names.add(my_scope.program_name);
                 }

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -19,7 +19,6 @@ import {
     StataDiagnosticCode,
     Token,
     TokenType,
-    ScopeType,
     SyntaxNode,
     ArgumentSpec,
     OptionSpec,
@@ -57,7 +56,19 @@ export interface SemanticDiagnostic {
     // 2026-06-26-diagnostic-message-code-deduplication.md.
     symbol_name?: string;
     reference_kind?: 'local' | 'global' | 'variable';
+    // Present on UNDEFINED_MACRO local diagnostics when same-named
+    // definitions exist only inside other program bodies in the same
+    // file, so the provider can emit a scope-isolation message (#145).
+    scope_isolation?: { defined_in_programs: string[] };
 }
+
+// Result of a scoped local-macro reference lookup (issue #261). The
+// 'out_of_scope_program_local' arm means: not visible here, but defined
+// inside the named program bodies elsewhere in this file (#145).
+type LocalMacroLookupResult =
+    | { kind: 'defined' }
+    | { kind: 'undefined' }
+    | { kind: 'out_of_scope_program_local'; defined_in_programs: string[] };
 
 // Analysis result returned by the semantic analyzer
 export interface AnalysisResult {
@@ -298,6 +309,10 @@ export class SemanticAnalyzer {
     // it remain conservative misses. Dynamic loop ancestors do not increment
     // this counter because they do not create a local-macro scope.
     private nonexec_conditional_depth = 0;
+    // The scopes array of the in-flight analyze() call, so reference
+    // lookups can reach the do-file scope (index 0) and the scope-
+    // isolation scan without threading it through every signature.
+    private current_scopes: ScopeInfo[] = [];
 
     /**
      * Analyze an AST and build symbol tables.
@@ -335,13 +350,15 @@ export class SemanticAnalyzer {
         this.current_diagnostics = diagnostics;
         const scopes: ScopeInfo[] = [];
 
-        // Create the top-level do-file scope
+        // Create the top-level do-file scope (always id 0)
         const dofile_scope: ScopeInfo = {
             type: 'dofile',
             range: this.get_full_range(ast),
             localMacros: new Map(),
+            id: 0,
         };
         scopes.push(dofile_scope);
+        this.current_scopes = scopes;
 
         // First pass: extract comment directives
         this.extract_comment_directives(ast);
@@ -349,7 +366,7 @@ export class SemanticAnalyzer {
         // Also extract directives from tokens if provided
         // Pass symbols so declaration directives can register symbols
         if (tokens) {
-            this.extract_comment_directives_from_tokens(tokens, symbols);
+            this.extract_comment_directives_from_tokens(tokens, symbols, dofile_scope);
         }
 
         // Second pass: build symbol table
@@ -364,7 +381,7 @@ export class SemanticAnalyzer {
         // `tokens` (not on undefined_macro_enabled) so the declarations also
         // feed completion.
         if (tokens) {
-            this.extract_mata_st_local_declarations(tokens, symbols, ast.nodes);
+            this.extract_mata_st_local_declarations(tokens, symbols, scopes);
         }
 
         // Third pass: detect undefined references
@@ -373,12 +390,11 @@ export class SemanticAnalyzer {
             this.preorder_index = 0;
             // Track ranges reported by AST pass to avoid duplicates in token pass
             const reported_ranges = new Set<string>();
-            this.detect_undefined_references(ast.nodes, symbols, diagnostics, reported_ranges);
+            this.detect_undefined_references(ast.nodes, symbols, diagnostics, reported_ranges, dofile_scope);
             
             // Also check tokens for macro references if provided
             if (tokens && this.config.undefined_macro_enabled) {
-                const program_ranges = this.collect_program_ranges(ast.nodes);
-                this.check_token_macro_references(tokens, symbols, diagnostics, reported_ranges, program_ranges);
+                this.check_token_macro_references(tokens, symbols, diagnostics, reported_ranges, scopes);
             }
         }
 
@@ -386,6 +402,7 @@ export class SemanticAnalyzer {
         this.workspace_symbols = undefined;
         this.tokens = undefined;
         this.current_diagnostics = [];
+        this.current_scopes = [];
 
         return {
             symbols,
@@ -412,10 +429,14 @@ export class SemanticAnalyzer {
      * This catches directives in standalone comments not attached to AST nodes.
      * Also processes declaration directives (@lsp-local, @lsp-global, @lsp-scalar, @lsp-matrix, @lsp-program).
      */
-    extract_comment_directives_from_tokens(tokens: Token[], symbols?: SymbolTable): void {
+    extract_comment_directives_from_tokens(
+        tokens: Token[],
+        symbols?: SymbolTable,
+        dofile_scope?: ScopeInfo
+    ): void {
         // Parse declaration directives directly from comment tokens
         // This avoids issues with multi-line block comments causing line number mismatches
-        this.parse_declaration_directives_from_tokens(tokens, symbols);
+        this.parse_declaration_directives_from_tokens(tokens, symbols, dofile_scope);
         
         // Process other directives. `ignore` and variable
         // declarations may appear in trailing `//` comments.
@@ -506,7 +527,11 @@ export class SemanticAnalyzer {
      * This fixes a bug where multi-line block comments would cause line number mismatches
      * when reconstructing content for the directive parser.
      */
-    private parse_declaration_directives_from_tokens(tokens: Token[], symbols?: SymbolTable): void {
+    private parse_declaration_directives_from_tokens(
+        tokens: Token[],
+        symbols?: SymbolTable,
+        dofile_scope?: ScopeInfo
+    ): void {
         for (let i = 0; i < tokens.length; i++) {
             const token = tokens[i];
             // Declaration directives live in real line comments and are
@@ -533,7 +558,7 @@ export class SemanticAnalyzer {
                 // following lines.
                 const my_actual_line = token.range.start.line;
                 for (const my_name of the_names) {
-                    this.register_declaration_directive(my_type, my_name, my_actual_line, symbols);
+                    this.register_declaration_directive(my_type, my_name, my_actual_line, symbols, dofile_scope);
                 }
             }
         }
@@ -546,7 +571,8 @@ export class SemanticAnalyzer {
         type: 'local' | 'global' | 'scalar' | 'matrix' | 'program',
         name: string,
         line: number,
-        symbols?: SymbolTable
+        symbols?: SymbolTable,
+        dofile_scope?: ScopeInfo
     ): void {
         const my_range: Range = {
             start: { line, character: 0 },
@@ -563,9 +589,14 @@ export class SemanticAnalyzer {
                         location: { uri: this.uri, range: my_range },
                         sourceUri: this.uri,
                         containingScope: 'dofile',
+                        scope_id: 0,
                         definition_line: line,
                     };
                     symbols.localMacros.set(name, macro_symbol);
+                    // Directive-declared locals are do-file-scope citizens:
+                    // seeding the scope map keeps them chained with later
+                    // real `local` statements once identity is scope-keyed.
+                    dofile_scope?.localMacros.set(name, macro_symbol);
                 }
                 break;
                 
@@ -871,6 +902,8 @@ export class SemanticAnalyzer {
             type: 'program',
             range: node.range,
             localMacros: new Map(),
+            id: all_scopes.length,
+            program_name: node.name,
         };
         all_scopes.push(program_scope);
 
@@ -1099,69 +1132,111 @@ export class SemanticAnalyzer {
         return the_shadowed;
     }
 
+    /**
+     * THE single registration choke point for plain local-macro
+     * definition sites. Existence (first-definition-wins) is decided
+     * inside `scope.localMacros` ONLY — never the flat map — so
+     * same-named locals in different scopes stay distinct symbols
+     * (issue #261). A repeat definition in the same scope appends to
+     * `additional_definitions`, exactly like the pre-split behavior.
+     * New primaries get their scope identity stamped here and are
+     * published to the compatibility flat view. Any `containingScope`/
+     * `scope_id`/`containing_program_name` set by `create_primary` is
+     * overwritten — this function owns those fields.
+     */
+    private register_local_macro(
+        scope: ScopeInfo,
+        symbols: SymbolTable,
+        name: string,
+        node_index: number,
+        range: Range,
+        create_primary: () => MacroSymbol
+    ): MacroSymbol {
+        const existing = scope.localMacros.get(name);
+        if (existing) {
+            if (!existing.additional_definitions) {
+                existing.additional_definitions = [];
+            }
+            existing.additional_definitions.push({
+                index: node_index,
+                line: range.start.line,
+                location: { uri: this.uri, range },
+            });
+            return existing;
+        }
+        const macro_symbol = create_primary();
+        macro_symbol.containingScope = scope.type;
+        macro_symbol.scope_id = scope.id;
+        if (scope.type === 'program') {
+            macro_symbol.containing_program_name = scope.program_name;
+        }
+        scope.localMacros.set(name, macro_symbol);
+        this.publish_flat_local(symbols, scope, macro_symbol);
+        return macro_symbol;
+    }
+
     private process_macro_def(
         node: MacroDefNode,
         symbols: SymbolTable,
         current_scope: ScopeInfo,
         node_index: number
     ): void {
-        // Check if macro already exists (first definition wins)
-        const existing = node.scope === 'local' 
-            ? symbols.localMacros.get(node.name)
-            : symbols.globalMacros.get(node.name);
-        
-        if (existing) {
-            // Add to additional_definitions array
-            if (!existing.additional_definitions) {
-                existing.additional_definitions = [];
-            }
-            existing.additional_definitions.push({
-                index: node_index,
-                line: node.range.start.line,
-                location: { uri: this.uri, range: node.range }
-            });
-        } else {
-            // Create new macro with first definition
-            const macro_symbol: MacroSymbol = {
-                name: node.name,
-                scope: node.scope,
-                location: { uri: this.uri, range: node.range },
-                sourceUri: this.uri,
-                value: node.value,
-                hasEquals: node.hasEquals,
-                containingScope: current_scope.type,
-                extendedFunction: node.extendedFunction,
-                definition_index: node_index,
-                definition_line: node.range.start.line,
-                // A definition reached under a non-executing context (an
-                // `if`/`while` body, or a dynamic/empty loop body) is not
-                // guaranteed to run, so its value must not be folded into a
-                // later loop's value-set or constructed names.
-                ...(this.nonexec_range_stack.length > 0 ? {
-                    maybe_unexecuted: true,
-                    maybe_unexecuted_range: this.nonexec_range_stack[
-                        this.nonexec_range_stack.length - 1
-                    ],
-                } : {}),
-                // Defined inside a loop with a value that captured a loop
-                // iterator (static, e.g. `` local suffix `i' ``, OR dynamic,
-                // e.g. `` local h `survey' `` inside `foreach survey in ...`):
-                // its runtime value is iteration-dependent and must not be
-                // statically folded.
-                ...(this.value_captures_active_iterator(node.value)
-                    ? { iteration_dependent: true }
-                    : {}),
-            };
+        const create_primary = (): MacroSymbol => ({
+            name: node.name,
+            scope: node.scope,
+            location: { uri: this.uri, range: node.range },
+            sourceUri: this.uri,
+            value: node.value,
+            hasEquals: node.hasEquals,
+            containingScope: current_scope.type,
+            extendedFunction: node.extendedFunction,
+            definition_index: node_index,
+            definition_line: node.range.start.line,
+            // A definition reached under a non-executing context (an
+            // `if`/`while` body, or a dynamic/empty loop body) is not
+            // guaranteed to run, so its value must not be folded into a
+            // later loop's value-set or constructed names.
+            ...(this.nonexec_range_stack.length > 0 ? {
+                maybe_unexecuted: true,
+                maybe_unexecuted_range: this.nonexec_range_stack[
+                    this.nonexec_range_stack.length - 1
+                ],
+            } : {}),
+            // Defined inside a loop with a value that captured a loop
+            // iterator (static, e.g. `` local suffix `i' ``, OR dynamic,
+            // e.g. `` local h `survey' `` inside `foreach survey in ...`):
+            // its runtime value is iteration-dependent and must not be
+            // statically folded.
+            ...(this.value_captures_active_iterator(node.value)
+                ? { iteration_dependent: true }
+                : {}),
+        });
 
-            // Register macro in symbol table regardless of extended function type
-            if (node.scope === 'local') {
-                current_scope.localMacros.set(node.name, macro_symbol);
-                symbols.localMacros.set(node.name, macro_symbol);
+        if (node.scope === 'local') {
+            this.register_local_macro(
+                current_scope,
+                symbols,
+                node.name,
+                node_index,
+                node.range,
+                create_primary
+            );
+        } else {
+            // Globals are file-wide: flat identity, unchanged semantics.
+            const existing = symbols.globalMacros.get(node.name);
+            if (existing) {
+                if (!existing.additional_definitions) {
+                    existing.additional_definitions = [];
+                }
+                existing.additional_definitions.push({
+                    index: node_index,
+                    line: node.range.start.line,
+                    location: { uri: this.uri, range: node.range }
+                });
             } else {
-                symbols.globalMacros.set(node.name, macro_symbol);
+                symbols.globalMacros.set(node.name, create_primary());
             }
         }
-
     }
 
     /**
@@ -1215,63 +1290,33 @@ export class SemanticAnalyzer {
         symbols: SymbolTable,
         node_index: number
     ): void {
+        const register_implicit = (name: string, range: Range): void => {
+            this.register_local_macro(
+                current_scope,
+                symbols,
+                name,
+                node_index,
+                range,
+                () => ({
+                    name,
+                    scope: 'local',
+                    location: { uri: this.uri, range },
+                    sourceUri: this.uri,
+                    definition_index: node_index,
+                    definition_line: range.start.line,
+                })
+            );
+        };
+
         // Register each argument as an implicit local
         for (const arg of signature.arguments) {
             const arg_name = this.get_implicit_local_name(arg);
             if (arg_name) {
-                // Check if macro already exists (first definition wins)
-                const existing_macro = symbols.localMacros.get(arg_name);
-                if (existing_macro) {
-                    // Add to additional_definitions array
-                    if (!existing_macro.additional_definitions) {
-                        existing_macro.additional_definitions = [];
-                    }
-                    existing_macro.additional_definitions.push({
-                        index: node_index,
-                        line: arg.range.start.line,
-                        location: { uri: this.uri, range: arg.range }
-                    });
-                } else {
-                    // Create new macro with first definition
-                    const macro_symbol: MacroSymbol = {
-                        name: arg_name,
-                        scope: 'local',
-                        location: { uri: this.uri, range: arg.range },
-                        sourceUri: this.uri,
-                        containingScope: current_scope.type,
-                        definition_index: node_index,
-                        definition_line: arg.range.start.line,
-                    };
+                register_implicit(arg_name, arg.range);
 
-                    current_scope.localMacros.set(arg_name, macro_symbol);
-                    symbols.localMacros.set(arg_name, macro_symbol);
-                }
-                
                 // For weight types, also register 'exp' as implicit local
                 if ((WEIGHT_TYPES as readonly string[]).includes(arg.type)) {
-                    const existing_exp = symbols.localMacros.get('exp');
-                    if (existing_exp) {
-                        if (!existing_exp.additional_definitions) {
-                            existing_exp.additional_definitions = [];
-                        }
-                        existing_exp.additional_definitions.push({
-                            index: node_index,
-                            line: arg.range.start.line,
-                            location: { uri: this.uri, range: arg.range }
-                        });
-                    } else {
-                        const exp_symbol: MacroSymbol = {
-                            name: 'exp',
-                            scope: 'local',
-                            location: { uri: this.uri, range: arg.range },
-                            sourceUri: this.uri,
-                            containingScope: current_scope.type,
-                            definition_index: node_index,
-                            definition_line: arg.range.start.line,
-                        };
-                        current_scope.localMacros.set('exp', exp_symbol);
-                        symbols.localMacros.set('exp', exp_symbol);
-                    }
+                    register_implicit('exp', arg.range);
                 }
             }
         }
@@ -1281,31 +1326,7 @@ export class SemanticAnalyzer {
         // abbreviation (e.g. `Cache(string)`), but the implicit local Stata
         // creates at runtime is always lowercased.
         for (const opt of signature.options) {
-            const local_name = opt.name.toLowerCase();
-            const existing_macro = symbols.localMacros.get(local_name);
-            if (existing_macro) {
-                if (!existing_macro.additional_definitions) {
-                    existing_macro.additional_definitions = [];
-                }
-                existing_macro.additional_definitions.push({
-                    index: node_index,
-                    line: opt.range.start.line,
-                    location: { uri: this.uri, range: opt.range }
-                });
-            } else {
-                const macro_symbol: MacroSymbol = {
-                    name: local_name,
-                    scope: 'local',
-                    location: { uri: this.uri, range: opt.range },
-                    sourceUri: this.uri,
-                    containingScope: current_scope.type,
-                    definition_index: node_index,
-                    definition_line: opt.range.start.line,
-                };
-
-                current_scope.localMacros.set(local_name, macro_symbol);
-                symbols.localMacros.set(local_name, macro_symbol);
-            }
+            register_implicit(opt.name.toLowerCase(), opt.range);
         }
     }
 
@@ -1638,6 +1659,12 @@ export class SemanticAnalyzer {
         }
         
         if (program?.c_locals) {
+            // c_local writes into the CALLER's scope (real Stata semantics:
+            // the called program sets locals in its caller's frame), so the
+            // registration deliberately targets `current_scope` at the call
+            // site. Quirk preserved from the pre-split code: each call
+            // OVERWRITES the scope entry unconditionally (no
+            // additional_definitions chaining).
             for (const macro_name of program.c_locals) {
                 const macro_symbol: MacroSymbol = {
                     name: macro_name,
@@ -1645,11 +1672,21 @@ export class SemanticAnalyzer {
                     location: { uri: this.uri, range: node.range },
                     sourceUri: program.sourceUri,
                     containingScope: current_scope.type,
+                    scope_id: current_scope.id,
+                    ...(current_scope.type === 'program'
+                        ? { containing_program_name: current_scope.program_name }
+                        : {}),
                     definition_index: node_index,
                     definition_line: node.range.start.line,
                 };
+                const replaced = current_scope.localMacros.get(macro_name);
                 current_scope.localMacros.set(macro_name, macro_symbol);
-                symbols.localMacros.set(macro_name, macro_symbol);
+                this.publish_flat_local(
+                    symbols,
+                    current_scope,
+                    macro_symbol,
+                    replaced
+                );
             }
         }
     }
@@ -2045,34 +2082,22 @@ export class SemanticAnalyzer {
         }
 
         for (const var_node of node.varlist) {
-            // Check if macro already exists (first definition wins)
-            const existing_macro = symbols.localMacros.get(var_node.name);
-            if (existing_macro) {
-                // Add to additional_definitions array
-                if (!existing_macro.additional_definitions) {
-                    existing_macro.additional_definitions = [];
-                }
-                existing_macro.additional_definitions.push({
-                    index: node_index,
-                    line: var_node.range.start.line,
-                    location: { uri: this.uri, range: var_node.range }
-                });
-            } else {
-                // Create new macro with first definition
-                const macro_symbol: MacroSymbol = {
+            this.register_local_macro(
+                current_scope,
+                symbols,
+                var_node.name,
+                node_index,
+                var_node.range,
+                () => ({
                     name: var_node.name,
                     scope: 'local',
                     location: { uri: this.uri, range: var_node.range },
                     sourceUri: this.uri,
                     value: `__tempvar_${var_node.name}__`, // Placeholder value
-                    containingScope: current_scope.type,
                     definition_index: node_index,
                     definition_line: node.range.start.line,
-                };
-
-                current_scope.localMacros.set(var_node.name, macro_symbol);
-                symbols.localMacros.set(var_node.name, macro_symbol);
-            }
+                })
+            );
         }
     }
 
@@ -2090,34 +2115,24 @@ export class SemanticAnalyzer {
         // For unab command, the first argument is the macro name
         // The syntax is: unab macname : varlist
         if (node.varlist && node.varlist.length > 0) {
-            const macro_name = node.varlist[0].name;
-
-            // Check if macro already exists (first definition wins)
-            const existing_macro = symbols.localMacros.get(macro_name);
-            if (existing_macro) {
-                if (!existing_macro.additional_definitions) {
-                    existing_macro.additional_definitions = [];
-                }
-                existing_macro.additional_definitions.push({
-                    index: node_index,
-                    line: node.varlist[0].range.start.line,
-                    location: { uri: this.uri, range: node.varlist[0].range }
-                });
-            } else {
-                const macro_symbol: MacroSymbol = {
+            const macro_node = node.varlist[0];
+            const macro_name = macro_node.name;
+            this.register_local_macro(
+                current_scope,
+                symbols,
+                macro_name,
+                node_index,
+                macro_node.range,
+                () => ({
                     name: macro_name,
                     scope: 'local',
-                    location: { uri: this.uri, range: node.varlist[0].range },
+                    location: { uri: this.uri, range: macro_node.range },
                     sourceUri: this.uri,
                     value: `__unab_${macro_name}__`, // Placeholder value
-                    containingScope: current_scope.type,
                     definition_index: node_index,
                     definition_line: node.range.start.line,
-                };
-
-                current_scope.localMacros.set(macro_name, macro_symbol);
-                symbols.localMacros.set(macro_name, macro_symbol);
-            }
+                })
+            );
         }
     }
 
@@ -2139,38 +2154,27 @@ export class SemanticAnalyzer {
         if (node.varlist && node.varlist.length > 0) {
             for (const my_var_node of node.varlist) {
                 const macro_name = my_var_node.name;
-                
-                // Check if macro already exists (first definition wins)
-                const existing_macro = symbols.localMacros.get(macro_name);
-                if (existing_macro) {
-                    // Add to additional_definitions array
-                    if (!existing_macro.additional_definitions) {
-                        existing_macro.additional_definitions = [];
-                    }
-                    existing_macro.additional_definitions.push({
-                        index: node_index,
-                        line: my_var_node.range.start.line,
-                        location: { uri: this.uri, range: my_var_node.range }
-                    });
-                } else {
-                    // Use definition_index: 0 and definition_line: 0 because args macros
-                    // represent parameters passed into the program/file. Unlike regular
-                    // `local` definitions, they should be valid from the start of the scope
-                    // to avoid false "undefined local macro" warnings for forward references.
-                    const macro_symbol: MacroSymbol = {
+                // Use definition_index: 0 and definition_line: 0 because args
+                // macros represent parameters passed into the program/file.
+                // Unlike regular `local` definitions, they should be valid
+                // from the start of the scope to avoid false "undefined local
+                // macro" warnings for forward references.
+                this.register_local_macro(
+                    current_scope,
+                    symbols,
+                    macro_name,
+                    node_index,
+                    my_var_node.range,
+                    () => ({
                         name: macro_name,
                         scope: 'local',
                         location: { uri: this.uri, range: my_var_node.range },
                         sourceUri: this.uri,
                         value: `__args_${macro_name}__`, // Placeholder value
-                        containingScope: current_scope.type,
                         definition_index: 0,
                         definition_line: 0,
-                    };
-
-                    current_scope.localMacros.set(macro_name, macro_symbol);
-                    symbols.localMacros.set(macro_name, macro_symbol);
-                }
+                    })
+                );
             }
         }
     }
@@ -2210,34 +2214,22 @@ export class SemanticAnalyzer {
                 continue;
             }
 
-            // Check if macro already exists (first definition wins)
-            const existing_macro = symbols.localMacros.get(macro_name);
-            if (existing_macro) {
-                // Add to additional_definitions array
-                if (!existing_macro.additional_definitions) {
-                    existing_macro.additional_definitions = [];
-                }
-                existing_macro.additional_definitions.push({
-                    index: node_index,
-                    line: my_var_node.range.start.line,
-                    location: { uri: this.uri, range: my_var_node.range }
-                });
-            } else {
-                // Create new macro with first definition
-                const macro_symbol: MacroSymbol = {
+            this.register_local_macro(
+                current_scope,
+                symbols,
+                macro_name,
+                node_index,
+                my_var_node.range,
+                () => ({
                     name: macro_name,
                     scope: 'local',
                     location: { uri: this.uri, range: my_var_node.range },
                     sourceUri: this.uri,
                     value: `__gettoken_${macro_name}__`, // Placeholder value
-                    containingScope: current_scope.type,
                     definition_index: node_index,
                     definition_line: node.range.start.line,
-                };
-
-                current_scope.localMacros.set(macro_name, macro_symbol);
-                symbols.localMacros.set(macro_name, macro_symbol);
-            }
+                })
+            );
         }
     }
 
@@ -2276,32 +2268,22 @@ export class SemanticAnalyzer {
             return;
         }
 
-        // Check if macro already exists (first definition wins)
-        const existing_macro = symbols.localMacros.get(macro_name);
-        if (existing_macro) {
-            if (!existing_macro.additional_definitions) {
-                existing_macro.additional_definitions = [];
-            }
-            existing_macro.additional_definitions.push({
-                index: node_index,
-                line: macro_node.range.start.line,
-                location: { uri: this.uri, range: macro_node.range }
-            });
-        } else {
-            const macro_symbol: MacroSymbol = {
+        this.register_local_macro(
+            current_scope,
+            symbols,
+            macro_name,
+            node_index,
+            macro_node.range,
+            () => ({
                 name: macro_name,
                 scope: 'local',
                 location: { uri: this.uri, range: macro_node.range },
                 sourceUri: this.uri,
                 value: `__file_read_${macro_name}__`,
-                containingScope: current_scope.type,
                 definition_index: node_index,
                 definition_line: node.range.start.line,
-            };
-
-            current_scope.localMacros.set(macro_name, macro_symbol);
-            symbols.localMacros.set(macro_name, macro_symbol);
-        }
+            })
+        );
     }
 
     /**
@@ -2346,10 +2328,31 @@ export class SemanticAnalyzer {
     ): void {
         for (const my_created of this.get_command_created_macros(node, symbols)) {
             const my_range = my_created.argument_range ?? node.range;
-            const target = my_created.scope === 'local'
-                ? symbols.localMacros
-                : symbols.globalMacros;
-            const existing_macro = target.get(my_created.name);
+            const create_primary = (): MacroSymbol => ({
+                name: my_created.name,
+                scope: my_created.scope,
+                location: { uri: this.uri, range: my_range },
+                sourceUri: this.uri,
+                value: `__option_${my_created.scope}_${my_created.name}__`,
+                containingScope: current_scope.type,
+                definition_index: node_index,
+                definition_line: node.range.start.line,
+            });
+
+            if (my_created.scope === 'local') {
+                this.register_local_macro(
+                    current_scope,
+                    symbols,
+                    my_created.name,
+                    node_index,
+                    my_range,
+                    create_primary
+                );
+                continue;
+            }
+
+            // Globals are file-wide: flat identity, unchanged semantics.
+            const existing_macro = symbols.globalMacros.get(my_created.name);
             if (existing_macro) {
                 // Add to additional_definitions array (first definition wins)
                 if (!existing_macro.additional_definitions) {
@@ -2361,21 +2364,7 @@ export class SemanticAnalyzer {
                     location: { uri: this.uri, range: my_range },
                 });
             } else {
-                // Create new macro with first definition
-                const macro_symbol: MacroSymbol = {
-                    name: my_created.name,
-                    scope: my_created.scope,
-                    location: { uri: this.uri, range: my_range },
-                    sourceUri: this.uri,
-                    value: `__option_${my_created.scope}_${my_created.name}__`,
-                    containingScope: current_scope.type,
-                    definition_index: node_index,
-                    definition_line: node.range.start.line,
-                };
-                target.set(my_created.name, macro_symbol);
-                if (my_created.scope === 'local') {
-                    current_scope.localMacros.set(my_created.name, macro_symbol);
-                }
+                symbols.globalMacros.set(my_created.name, create_primary());
             }
         }
     }
@@ -2597,25 +2586,30 @@ export class SemanticAnalyzer {
         all_scopes: ScopeInfo[],
         node_index: number
     ): void {
-        // Loop variable is a local macro in the enclosing scope
+        // Loop variable is a local macro in the enclosing scope. Quirk
+        // preserved from the pre-split code: an already-defined iterator
+        // name is left alone entirely (no additional_definitions append),
+        // but the existence check is now against the ACTIVE scope so a
+        // same-named local in an unrelated program body no longer blocks
+        // the iterator's registration.
         if (node.loopVar) {
-            // Check if macro already exists (first definition wins)
-            const existing = symbols.localMacros.get(node.loopVar);
-            
-            const macro_symbol: MacroSymbol = {
-                name: node.loopVar,
-                scope: 'local',
-                location: { uri: this.uri, range: node.range },
-                sourceUri: this.uri,
-                containingScope: current_scope.type,
-                definition_index: existing?.definition_index ?? node_index,
-                definition_line: existing?.definition_line ?? node.range.start.line,
-            };
-
-            // Add to enclosing scope (not a new scope) only if not already defined
-            if (!existing) {
-                current_scope.localMacros.set(node.loopVar, macro_symbol);
-                symbols.localMacros.set(node.loopVar, macro_symbol);
+            const loop_var = node.loopVar;
+            if (!current_scope.localMacros.has(loop_var)) {
+                this.register_local_macro(
+                    current_scope,
+                    symbols,
+                    loop_var,
+                    node_index,
+                    node.range,
+                    () => ({
+                        name: loop_var,
+                        scope: 'local',
+                        location: { uri: this.uri, range: node.range },
+                        sourceUri: this.uri,
+                        definition_index: node_index,
+                        definition_line: node.range.start.line,
+                    })
+                );
             }
         }
 
@@ -2835,10 +2829,18 @@ export class SemanticAnalyzer {
         }
 
         const temp_symbols = create_empty_symbol_table();
+        // The probe only reads the produced NAMES, never scope identity,
+        // so a synthetic do-file scope covering the statement suffices.
+        const probe_scope: ScopeInfo = {
+            type: 'dofile',
+            range: statement.range,
+            localMacros: new Map(),
+            id: 0,
+        };
         const unknown = this.extract_mata_st_local_declarations(
             the_tokens,
             temp_symbols,
-            [statement]
+            [probe_scope]
         );
         const names = [
             ...Array.from(temp_symbols.localMacros.keys()).map(name => ({
@@ -2895,8 +2897,13 @@ export class SemanticAnalyzer {
         current_scope: ScopeInfo,
         node_index: number
     ): void {
+        // Locals resolve identity in the ACTIVE scope's map (issue #261):
+        // a same-named local in an unrelated program body is a different
+        // symbol and must not absorb this expansion. Promotion below
+        // mutates the symbol in place, so when the flat view's slot points
+        // at this same object it stays consistent automatically.
         const target = macro.scope === 'local'
-            ? symbols.localMacros
+            ? current_scope.localMacros
             : symbols.globalMacros;
         const definition_line = macro.sourceRange.start.line;
         const existing = target.get(macro.name);
@@ -2950,12 +2957,30 @@ export class SemanticAnalyzer {
             location: { uri: this.uri, range: macro.sourceRange },
             sourceUri: this.uri,
             containingScope: current_scope.type,
+            ...(macro.scope === 'local'
+                ? {
+                    scope_id: current_scope.id,
+                    ...(current_scope.type === 'program'
+                        ? {
+                            containing_program_name:
+                                current_scope.program_name,
+                        }
+                        : {}),
+                }
+                : {}),
+            // The loop's own preorder index (captured before its body was
+            // walked). Required so publish_flat_local's earliest-index
+            // tie-break never treats an expanded macro as later (Infinity)
+            // than a real local in another scope; the line-based
+            // forward-reference gate below is unaffected because
+            // definition_line (the defining statement's line) is stricter.
+            definition_index: node_index,
             definition_line,
             is_expanded: true,
         };
         target.set(macro.name, symbol);
         if (macro.scope === 'local') {
-            current_scope.localMacros.set(macro.name, symbol);
+            this.publish_flat_local(symbols, current_scope, symbol);
         }
     }
 
@@ -3001,10 +3026,10 @@ export class SemanticAnalyzer {
         symbols: SymbolTable,
         diagnostics: SemanticDiagnostic[],
         reported_ranges: Set<string>,
-        inside_program = false
+        current_scope: ScopeInfo
     ): void {
         this.traverse_ast_preorder(nodes, (node, node_index) => {
-            this.check_node_references(node, symbols, diagnostics, reported_ranges, node_index, inside_program);
+            this.check_node_references(node, symbols, diagnostics, reported_ranges, node_index, current_scope);
         });
     }
 
@@ -3014,12 +3039,13 @@ export class SemanticAnalyzer {
         diagnostics: SemanticDiagnostic[],
         reported_ranges: Set<string>,
         node_index: number,
-        inside_program: boolean
+        current_scope: ScopeInfo
     ): void {
         // Check if this line should be ignored
         if (this.config.ignored_lines.has(node.range.start.line)) {
             return;
         }
+        const inside_program = current_scope.type === 'program';
 
         switch (node.type) {
             case 'macro_ref':
@@ -3027,7 +3053,7 @@ export class SemanticAnalyzer {
                 if (inside_program && node.scope === 'global') {
                     break;
                 }
-                this.check_macro_reference(node, symbols, diagnostics, reported_ranges, node_index);
+                this.check_macro_reference(node, symbols, diagnostics, reported_ranges, node_index, current_scope);
                 break;
 
             case 'macro_def':
@@ -3045,7 +3071,7 @@ export class SemanticAnalyzer {
                             if (inside_program && macro_ref.scope === 'global') {
                                 continue;
                             }
-                            this.check_extended_macro_reference(macro_ref, symbols, diagnostics, reported_ranges, node_index);
+                            this.check_extended_macro_reference(macro_ref, symbols, diagnostics, reported_ranges, node_index, current_scope);
                         }
                     }
                 }
@@ -3055,10 +3081,22 @@ export class SemanticAnalyzer {
                 this.check_command_references(node, symbols, diagnostics);
                 break;
 
-            case 'program':
-                // Recurse into program body with inside_program = true
-                this.detect_undefined_references(node.body, symbols, diagnostics, reported_ranges, true);
+            case 'program': {
+                // Recurse into the program body with ITS scope. Both passes
+                // traverse the same AST object graph, and `process_program`
+                // stores `range: node.range` by reference, so range object
+                // identity recovers exactly the ScopeInfo built for this
+                // body. If the match ever fails, keeping the enclosing
+                // scope reproduces the pre-split (suppressive) behavior —
+                // a miss, never a false positive.
+                const program_scope = this.current_scopes.find(
+                    my_scope =>
+                        my_scope.type === 'program' &&
+                        my_scope.range === node.range
+                ) ?? current_scope;
+                this.detect_undefined_references(node.body, symbols, diagnostics, reported_ranges, program_scope);
                 break;
+            }
 
             case 'foreach':
             case 'forvalues':
@@ -3066,8 +3104,9 @@ export class SemanticAnalyzer {
             case 'else':
             case 'while':
             case 'frame':
-                // Recurse into control flow body, preserving inside_program context
-                this.detect_undefined_references(node.body, symbols, diagnostics, reported_ranges, inside_program);
+                // Recurse into control flow body, preserving the scope
+                // (control flow does not create scope in Stata).
+                this.detect_undefined_references(node.body, symbols, diagnostics, reported_ranges, current_scope);
                 break;
 
             default:
@@ -3076,24 +3115,80 @@ export class SemanticAnalyzer {
     }
 
     /**
-     * Check a macro reference for undefined macros.
-     * This is a simplified version that doesn't track scope context.
-     * For proper scope tracking, we would need to pass scope context through the tree.
+     * Push an UNDEFINED_MACRO diagnostic for an unresolved local
+     * reference, carrying scope-isolation info when the lookup found the
+     * name only inside other program bodies (#145). Shared by the AST
+     * pass (which records the range for dedup against the token pass)
+     * and the token pass (which does not).
+     */
+    private emit_undefined_local_diagnostic(
+        result: LocalMacroLookupResult,
+        name: string,
+        range: Range,
+        diagnostics: SemanticDiagnostic[],
+        reported_ranges?: Set<string>
+    ): void {
+        if (result.kind === 'defined') {
+            return;
+        }
+        if (reported_ranges) {
+            const range_key = `${range.start.line}:${range.start.character}:${range.end.line}:${range.end.character}`;
+            reported_ranges.add(range_key);
+        }
+        diagnostics.push({
+            message: format_undefined_macro_message('local', name),
+            range,
+            code: StataDiagnosticCode.UNDEFINED_MACRO,
+            severity: 'warning',
+            symbol_name: name,
+            reference_kind: 'local',
+            ...(result.kind === 'out_of_scope_program_local'
+                ? {
+                    scope_isolation: {
+                        defined_in_programs: result.defined_in_programs,
+                    },
+                }
+                : {}),
+        });
+    }
+
+    /**
+     * Check a macro reference for undefined macros, resolving locals
+     * against the reference's scope (issue #261).
      */
     private check_macro_reference(
         node: { type: 'macro_ref'; scope: 'local' | 'global'; name: string; range: Range },
         symbols: SymbolTable,
         diagnostics: SemanticDiagnostic[],
         reported_ranges: Set<string>,
-        reference_index: number
+        reference_index: number,
+        current_scope: ScopeInfo
     ): void {
         if (!this.config.undefined_macro_enabled) {
             return;
         }
 
-        const is_defined = this.is_macro_defined(
+        if (node.scope === 'local') {
+            const result = this.lookup_local_macro(
+                node.name,
+                symbols,
+                current_scope,
+                reference_index,
+                node.range.start.line,
+                node.range
+            );
+            this.emit_undefined_local_diagnostic(
+                result,
+                node.name,
+                node.range,
+                diagnostics,
+                reported_ranges
+            );
+            return;
+        }
+
+        const is_defined = this.is_global_macro_defined(
             node.name,
-            node.scope,
             symbols,
             reference_index,
             node.range.start.line,
@@ -3122,15 +3217,34 @@ export class SemanticAnalyzer {
         symbols: SymbolTable,
         diagnostics: SemanticDiagnostic[],
         reported_ranges: Set<string>,
-        reference_index: number
+        reference_index: number,
+        current_scope: ScopeInfo
     ): void {
         if (!this.config.undefined_macro_enabled) {
             return;
         }
 
-        const is_defined = this.is_macro_defined(
+        if (macro_ref.scope === 'local') {
+            const result = this.lookup_local_macro(
+                macro_ref.name,
+                symbols,
+                current_scope,
+                reference_index,
+                macro_ref.range.start.line,
+                macro_ref.range
+            );
+            this.emit_undefined_local_diagnostic(
+                result,
+                macro_ref.name,
+                macro_ref.range,
+                diagnostics,
+                reported_ranges
+            );
+            return;
+        }
+
+        const is_defined = this.is_global_macro_defined(
             macro_ref.name,
-            macro_ref.scope,
             symbols,
             reference_index,
             macro_ref.range.start.line,
@@ -3223,102 +3337,158 @@ export class SemanticAnalyzer {
     }
 
     /**
-     * Check if a macro is defined.
-     * Macros are case-sensitive.
-     * Also checks declaration directives (@lsp-local, @lsp-global) with forward-only effect.
-     * Falls back to workspace symbols if not found locally.
+     * Resolve a LOCAL macro reference against the scoped environment
+     * model. THE single reference-side choke point (issue #261): a local
+     * suppresses a warning only when it is visible from the reference's
+     * scope — the reference's own scope always, plus the do-file scope
+     * when the reference sits inside a program (one-directional,
+     * deliberately permissive; see issue #261's proposed semantics).
+     * Programs never see each other's locals — no code path here reads
+     * another program's scope map for the resolution decision.
+     *
+     * When NO visible scope defines the name but some other program body
+     * does, the result carries those program names so the diagnostic can
+     * say "defined only inside program X" (#145). A same-name symbol
+     * that exists in a visible scope but is not yet visible (a forward
+     * reference) stays a plain 'undefined' so the existing
+     * same-file-forward rewrite keeps working.
      */
-    private is_macro_defined(
+    private lookup_local_macro(
         name: string,
-        scope: 'local' | 'global',
+        symbols: SymbolTable,
+        reference_scope: ScopeInfo,
+        reference_index?: number,
+        reference_line?: number,
+        reference_range?: Range
+    ): LocalMacroLookupResult {
+        // Positional arguments (`1', `2', ...) are always potentially
+        // defined — they represent command-line arguments.
+        if (this.is_positional_argument(name)) {
+            return { kind: 'defined' };
+        }
+
+        // Check declared locals from @lsp-local directive (file-wide by
+        // decision, forward-only effect).
+        const declared_local = this.config.declared_locals.get(name);
+        if (declared_local) {
+            // Only suppress warning if reference is at or after the directive line
+            if (reference_line !== undefined && reference_line >= declared_local.line) {
+                return { kind: 'defined' };
+            }
+            // If no reference_line, check if we have a reference_index
+            // In this case, we can't do forward-only check, so we accept it
+            if (reference_line === undefined && reference_index !== undefined) {
+                const macro = symbols.localMacros.get(name);
+                if (macro && macro.definition_line !== undefined) {
+                    return { kind: 'defined' };
+                }
+            }
+        }
+
+        const dofile_scope = this.current_scopes[0];
+        const the_visible_scopes =
+            reference_scope.type !== 'dofile' &&
+            dofile_scope !== undefined &&
+            dofile_scope !== reference_scope
+                ? [reference_scope, dofile_scope]
+                : [reference_scope];
+
+        let same_name_in_visible_scope = false;
+        for (const my_scope of the_visible_scopes) {
+            const macro = my_scope.localMacros.get(name);
+            if (!macro) {
+                continue;
+            }
+            same_name_in_visible_scope = true;
+            if (
+                this.macro_resolves_at_reference(
+                    macro,
+                    reference_index,
+                    reference_line,
+                    reference_range
+                )
+            ) {
+                return { kind: 'defined' };
+            }
+        }
+
+        // NOTE: Workspace symbols do NOT suppress undefined macro warnings.
+        // Only cross-file directives (@lsp-done-by, @lsp-included-by, @lsp-do, etc.)
+        // provide scope resolution. Workspace symbols are used only for:
+        // - Completions and go-to-definition
+        // - Looking up called programs for c_locals registration
+
+        if (!same_name_in_visible_scope) {
+            const the_program_names = new Set<string>();
+            for (const my_scope of this.current_scopes) {
+                if (my_scope === reference_scope) {
+                    continue;
+                }
+                if (my_scope.type !== 'program' || !my_scope.program_name) {
+                    continue;
+                }
+                if (my_scope.localMacros.has(name)) {
+                    the_program_names.add(my_scope.program_name);
+                }
+            }
+            if (the_program_names.size > 0) {
+                return {
+                    kind: 'out_of_scope_program_local',
+                    defined_in_programs: [...the_program_names],
+                };
+            }
+        }
+
+        return { kind: 'undefined' };
+    }
+
+    /**
+     * Check if a GLOBAL macro is defined (globals are file-wide; local
+     * lookups go through `lookup_local_macro`). Macros are case-sensitive.
+     * Also checks the @lsp-global declaration directive (forward-only) and
+     * falls back to Stata's system globals.
+     */
+    private is_global_macro_defined(
+        name: string,
         symbols: SymbolTable,
         reference_index?: number,
         reference_line?: number,
         reference_range?: Range
     ): boolean {
-        if (scope === 'local') {
-            // Check for positional arguments (numeric macro names like `1', `2', etc.)
-            // These are always potentially defined as they represent command-line arguments
-            if (this.is_positional_argument(name)) {
+        // Check declared globals from @lsp-global directive (forward-only effect)
+        const declared_global = this.config.declared_globals.get(name);
+        if (declared_global) {
+            // Only suppress warning if reference is at or after the directive line
+            if (reference_line !== undefined && reference_line >= declared_global.line) {
                 return true;
             }
-
-            // Check declared locals from @lsp-local directive (forward-only effect)
-            const declared_local = this.config.declared_locals.get(name);
-            if (declared_local) {
-                // Only suppress warning if reference is at or after the directive line
-                if (reference_line !== undefined && reference_line >= declared_local.line) {
-                    return true;
-                }
-                // If no reference_line, check if we have a reference_index
-                // In this case, we can't do forward-only check, so we accept it
-                if (reference_line === undefined && reference_index !== undefined) {
-                    // We need to be conservative here - the symbol is declared
-                    // but we can't verify forward-only without line info
-                    // Check the symbol table entry for line info
-                    const macro = symbols.localMacros.get(name);
-                    if (macro && macro.definition_line !== undefined) {
-                        // Use the macro's definition line for comparison
-                        // This is set from the directive's line
-                        return true; // Symbol exists in table, let normal check handle it
-                    }
+            // If no reference_line, check if we have a reference_index
+            if (reference_line === undefined && reference_index !== undefined) {
+                const macro = symbols.globalMacros.get(name);
+                if (macro && macro.definition_line !== undefined) {
+                    return true; // Symbol exists in table, let normal check handle it
                 }
             }
+        }
 
-            // Check local macros (case-sensitive)
-            // For local macros, we need to check if ANY definition exists
-            // since we don't have proper scope tracking yet
-            const macro = symbols.localMacros.get(name);
-            if (macro) {
-                return this.macro_resolves_at_reference(
-                    macro,
-                    reference_index,
-                    reference_line,
-                    reference_range
-                );
-            }
+        // Check global macros (case-sensitive)
+        const macro = symbols.globalMacros.get(name);
+        if (macro) {
+            return this.macro_resolves_at_reference(
+                macro,
+                reference_index,
+                reference_line,
+                reference_range
+            );
+        }
 
-            // NOTE: Workspace symbols do NOT suppress undefined macro warnings.
-            // Only cross-file directives (@lsp-done-by, @lsp-included-by, @lsp-do, etc.)
-            // provide scope resolution. Workspace symbols are used only for:
-            // - Completions and go-to-definition
-            // - Looking up called programs for c_locals registration
-        } else {
-            // Check declared globals from @lsp-global directive (forward-only effect)
-            const declared_global = this.config.declared_globals.get(name);
-            if (declared_global) {
-                // Only suppress warning if reference is at or after the directive line
-                if (reference_line !== undefined && reference_line >= declared_global.line) {
-                    return true;
-                }
-                // If no reference_line, check if we have a reference_index
-                if (reference_line === undefined && reference_index !== undefined) {
-                    const macro = symbols.globalMacros.get(name);
-                    if (macro && macro.definition_line !== undefined) {
-                        return true; // Symbol exists in table, let normal check handle it
-                    }
-                }
-            }
+        // NOTE: Workspace symbols do NOT suppress undefined macro warnings.
+        // Only cross-file directives provide scope resolution.
 
-            // Check global macros (case-sensitive)
-            const macro = symbols.globalMacros.get(name);
-            if (macro) {
-                return this.macro_resolves_at_reference(
-                    macro,
-                    reference_index,
-                    reference_line,
-                    reference_range
-                );
-            }
-
-            // NOTE: Workspace symbols do NOT suppress undefined macro warnings.
-            // Only cross-file directives provide scope resolution.
-
-            // NEW: Check for system-defined global macros as FALLBACK
-            // Only reached if not found in symbol table or directives
-            if (this.is_system_global(name)) {
-                return true;
-            }
+        // Check for system-defined global macros as FALLBACK
+        // Only reached if not found in symbol table or directives
+        if (this.is_system_global(name)) {
+            return true;
         }
 
         return false;
@@ -3461,48 +3631,6 @@ export class SemanticAnalyzer {
         return false;
     }
 
-    /**
-     * Collect line ranges of program block bodies from the AST (recursively).
-     * Uses exclusive boundaries (start.line + 1, end.line - 1) to match
-     * the AST pass which only operates on body nodes, not the header/end lines.
-     */
-    private collect_program_ranges(nodes: StataNode[]): Array<[number, number]> {
-        const the_ranges: Array<[number, number]> = [];
-        for (const my_node of nodes) {
-            if (my_node.type === 'program') {
-                // Exclude the header line (program define ...) and the end line
-                the_ranges.push([my_node.range.start.line + 1, my_node.range.end.line - 1]);
-                // Recurse for nested programs
-                the_ranges.push(...this.collect_program_ranges(my_node.body));
-            } else if ('body' in my_node && Array.isArray(my_node.body)) {
-                the_ranges.push(...this.collect_program_ranges(my_node.body));
-            }
-        }
-        return the_ranges;
-    }
-
-    /**
-     * Full (character-precise) ranges of every program block, including
-     * nested ones. Used to scope Mata setters precisely even when a setter
-     * shares a physical line with the program header or its `end`.
-     */
-    private collect_program_position_ranges(nodes: StataNode[]): Range[] {
-        const the_ranges: Range[] = [];
-        for (const my_node of nodes) {
-            if (my_node.type === 'program') {
-                the_ranges.push(my_node.range);
-                the_ranges.push(
-                    ...this.collect_program_position_ranges(my_node.body)
-                );
-            } else if ('body' in my_node && Array.isArray(my_node.body)) {
-                the_ranges.push(
-                    ...this.collect_program_position_ranges(my_node.body)
-                );
-            }
-        }
-        return the_ranges;
-    }
-
     /** Is `position` within `range` (inclusive), comparing line then char? */
     private position_within_range(
         position: { line: number; character: number },
@@ -3512,6 +3640,45 @@ export class SemanticAnalyzer {
             this.compare_positions(position, range.start) >= 0 &&
             this.compare_positions(position, range.end) <= 0
         );
+    }
+
+    /**
+     * THE single mechanism for "which scope owns this position" — shared
+     * by the token reference pass and the Mata setter pass (the AST pass
+     * threads scopes structurally). Returns the innermost program scope
+     * whose (character-precise, inclusive) range contains `position`,
+     * else the do-file scope (`scopes[0]`). Do not add a second way to
+     * answer this question.
+     *
+     * Limitation (pre-existing): the parser only builds `program` block
+     * nodes under `#delimit cr`, so under `#delimit ;` positions inside
+     * a program fall back to the do-file scope.
+     */
+    private find_enclosing_scope(
+        scopes: ScopeInfo[],
+        position: { line: number; character: number }
+    ): ScopeInfo {
+        let innermost: ScopeInfo | undefined;
+        for (const my_scope of scopes) {
+            if (my_scope.type !== 'program') {
+                continue;
+            }
+            if (!this.position_within_range(position, my_scope.range)) {
+                continue;
+            }
+            // Nested program scopes start later than their enclosing
+            // scope, so the latest-starting match is the innermost.
+            if (
+                innermost === undefined ||
+                this.compare_positions(
+                    my_scope.range.start,
+                    innermost.range.start
+                ) > 0
+            ) {
+                innermost = my_scope;
+            }
+        }
+        return innermost ?? scopes[0];
     }
 
     /**
@@ -3556,16 +3723,9 @@ export class SemanticAnalyzer {
     private extract_mata_st_local_declarations(
         tokens: Token[],
         symbols: SymbolTable,
-        nodes: StataNode[]
+        scopes: ScopeInfo[]
     ): boolean {
         let saw_unknown_setter = false;
-        // Position-precise program ranges (start of `program` keyword to end
-        // of `end`). Used to scope a setter to `program` vs `dofile`. Unlike
-        // the line-based `collect_program_ranges`, this stays correct when a
-        // setter shares a physical line with the program header or `end`
-        // (common under `#delimit ;`, e.g. `... ;end ;`).
-        const program_position_ranges =
-            this.collect_program_position_ranges(nodes);
 
         // Track whether we are inside a Mata block / inline expression:
         //   'inline'      — `mata: <expr>`, ends at the statement terminator
@@ -4156,23 +4316,17 @@ export class SemanticAnalyzer {
 
             // Scope the setter to the innermost enclosing program (character-
             // precise, so a setter sharing the program header or `end` line is
-            // still attributed correctly). Limitation: the parser only builds
-            // `program` block nodes under `#delimit cr`; under `#delimit ;` a
-            // `program define ... end` is parsed as flat commands with no
-            // block node, so setters there fall back to `dofile` scope.
-            const containing_scope: ScopeType = program_position_ranges.some(
-                program_range =>
-                    this.position_within_range(token.range.start, program_range)
-            )
-                ? 'program'
-                : 'dofile';
+            // still attributed correctly). See `find_enclosing_scope` for the
+            // `#delimit ;` fallback-to-dofile limitation.
+            const owning_scope =
+                this.find_enclosing_scope(scopes, token.range.start);
 
             this.register_mata_macro(
                 macro_name,
                 scope,
                 name_token.range,
                 definition_line,
-                containing_scope,
+                owning_scope,
                 symbols,
                 visibility_start
             );
@@ -4187,12 +4341,55 @@ export class SemanticAnalyzer {
      * `additional_definitions`; otherwise record it as an additional
      * definition in source order.
      */
+    /**
+     * Maintain the compatibility flat view `symbols.localMacros` after a
+     * scoped registration created (or promoted) a primary `symbol` in
+     * `scope`. Ownership rules for the flat slot:
+     *   1. a do-file-scope definition, if any exists, always owns it;
+     *   2. else the earliest-`definition_index` program-scope definition.
+     * Pass `replaced` when a same-scope promotion demoted the previous
+     * primary, so an occupied slot pointing at the demoted symbol is
+     * updated. The flat view never merges cross-scope
+     * `additional_definitions` — that chaining lives only inside each
+     * scope's own map (issue #261).
+     */
+    private publish_flat_local(
+        symbols: SymbolTable,
+        scope: ScopeInfo,
+        symbol: MacroSymbol,
+        replaced?: MacroSymbol
+    ): void {
+        const current_flat = symbols.localMacros.get(symbol.name);
+        if (!current_flat || current_flat === replaced) {
+            symbols.localMacros.set(symbol.name, symbol);
+            return;
+        }
+        if (current_flat === symbol) {
+            return;
+        }
+        if (current_flat.containingScope === 'dofile') {
+            // A do-file definition always keeps the flat slot.
+            return;
+        }
+        if (scope.type === 'dofile') {
+            symbols.localMacros.set(symbol.name, symbol);
+            return;
+        }
+        // Both program-scoped: earliest definition wins (deterministic,
+        // matches the pre-split first-def-wins flat behavior).
+        const candidate_index = symbol.definition_index ?? Infinity;
+        const current_index = current_flat.definition_index ?? Infinity;
+        if (candidate_index < current_index) {
+            symbols.localMacros.set(symbol.name, symbol);
+        }
+    }
+
     private register_mata_macro(
         name: string,
         scope: 'local' | 'global',
         range: Range,
         definition_line: number,
-        containing_scope: ScopeType,
+        owning_scope: ScopeInfo,
         symbols: SymbolTable,
         visibility_start?: { line: number; character: number }
     ): void {
@@ -4205,8 +4402,11 @@ export class SemanticAnalyzer {
             return;
         }
 
+        // Locals get scoped identity (issue #261): existence/promotion is
+        // decided inside the owning scope's map, and the flat view is kept
+        // consistent via `publish_flat_local`. Globals stay file-wide.
         const symbol_map =
-            scope === 'local' ? symbols.localMacros : symbols.globalMacros;
+            scope === 'local' ? owning_scope.localMacros : symbols.globalMacros;
 
         const new_symbol: MacroSymbol = {
             name,
@@ -4214,7 +4414,11 @@ export class SemanticAnalyzer {
             location: { uri: this.uri, range },
             sourceUri: this.uri,
             value: scope === 'local' ? '__st_local__' : '__st_global__',
-            containingScope: containing_scope,
+            containingScope: owning_scope.type,
+            ...(scope === 'local' ? { scope_id: owning_scope.id } : {}),
+            ...(scope === 'local' && owning_scope.type === 'program'
+                ? { containing_program_name: owning_scope.program_name }
+                : {}),
             definition_line,
             visibility_start,
         };
@@ -4222,6 +4426,9 @@ export class SemanticAnalyzer {
         const existing = symbol_map.get(name);
         if (!existing) {
             symbol_map.set(name, new_symbol);
+            if (scope === 'local') {
+                this.publish_flat_local(symbols, owning_scope, new_symbol);
+            }
             return;
         }
 
@@ -4234,6 +4441,14 @@ export class SemanticAnalyzer {
             ];
             this.sort_additional_definitions(new_symbol.additional_definitions);
             symbol_map.set(name, new_symbol);
+            if (scope === 'local') {
+                this.publish_flat_local(
+                    symbols,
+                    owning_scope,
+                    new_symbol,
+                    existing
+                );
+            }
             return;
         }
 
@@ -4632,7 +4847,7 @@ export class SemanticAnalyzer {
         symbols: SymbolTable,
         diagnostics: SemanticDiagnostic[],
         reported_ranges: Set<string>,
-        program_ranges: Array<[number, number]>
+        scopes: ScopeInfo[]
     ): void {
         for (const token of tokens) {
             // Check if this line should be ignored
@@ -4649,8 +4864,9 @@ export class SemanticAnalyzer {
 
             // Suppress undefined global macro warnings inside program blocks
             if (token.type === 'MACRO_REF_GLOBAL') {
-                const token_line = token.range.start.line;
-                if (program_ranges.some(([start, end]) => token_line >= start && token_line <= end)) {
+                const enclosing_scope =
+                    this.find_enclosing_scope(scopes, token.range.start);
+                if (enclosing_scope.type === 'program') {
                     continue;
                 }
             }
@@ -4696,28 +4912,25 @@ export class SemanticAnalyzer {
                 }
                 
                 const token_line = token.range.start.line;
-                if (
-                    macro_name &&
-                    !this.is_macro_defined(
+                if (macro_name) {
+                    const reference_scope = this.find_enclosing_scope(
+                        scopes,
+                        token.range.start
+                    );
+                    const result = this.lookup_local_macro(
                         macro_name,
-                        'local',
                         symbols,
+                        reference_scope,
                         undefined,
                         token_line,
                         token.range
-                    )
-                ) {
-                    diagnostics.push({
-                        message: format_undefined_macro_message(
-                            'local',
-                            macro_name
-                        ),
-                        range: token.range,
-                        code: StataDiagnosticCode.UNDEFINED_MACRO,
-                        severity: 'warning',
-                        symbol_name: macro_name,
-                        reference_kind: 'local',
-                    });
+                    );
+                    this.emit_undefined_local_diagnostic(
+                        result,
+                        macro_name,
+                        token.range,
+                        diagnostics
+                    );
                 }
             } else if (token.type === 'MACRO_REF_GLOBAL') {
                 // Extract macro name from $name or ${name} format
@@ -4748,9 +4961,8 @@ export class SemanticAnalyzer {
                 const token_line = token.range.start.line;
                 if (
                     macro_name &&
-                    !this.is_macro_defined(
+                    !this.is_global_macro_defined(
                         macro_name,
-                        'global',
                         symbols,
                         undefined,
                         token_line,

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -1,4 +1,5 @@
 import { Range } from 'vscode-languageserver-textdocument';
+import { find_enclosing_scope } from '../utils/scope-position';
 import {
     format_undefined_macro_message,
     format_undefined_variable_message,
@@ -3631,54 +3632,17 @@ export class SemanticAnalyzer {
         return false;
     }
 
-    /** Is `position` within `range` (inclusive), comparing line then char? */
-    private position_within_range(
-        position: { line: number; character: number },
-        range: Range
-    ): boolean {
-        return (
-            this.compare_positions(position, range.start) >= 0 &&
-            this.compare_positions(position, range.end) <= 0
-        );
-    }
-
     /**
-     * THE single mechanism for "which scope owns this position" — shared
-     * by the token reference pass and the Mata setter pass (the AST pass
-     * threads scopes structurally). Returns the innermost program scope
-     * whose (character-precise, inclusive) range contains `position`,
-     * else the do-file scope (`scopes[0]`). Do not add a second way to
-     * answer this question.
-     *
-     * Limitation (pre-existing): the parser only builds `program` block
-     * nodes under `#delimit cr`, so under `#delimit ;` positions inside
-     * a program fall back to the do-file scope.
+     * Which scope owns this position — shared by the token reference
+     * pass and the Mata setter pass (the AST pass threads scopes
+     * structurally). Delegates to the shared resolver in
+     * utils/scope-position (also used by the diagnostics provider).
      */
     private find_enclosing_scope(
         scopes: ScopeInfo[],
         position: { line: number; character: number }
     ): ScopeInfo {
-        let innermost: ScopeInfo | undefined;
-        for (const my_scope of scopes) {
-            if (my_scope.type !== 'program') {
-                continue;
-            }
-            if (!this.position_within_range(position, my_scope.range)) {
-                continue;
-            }
-            // Nested program scopes start later than their enclosing
-            // scope, so the latest-starting match is the innermost.
-            if (
-                innermost === undefined ||
-                this.compare_positions(
-                    my_scope.range.start,
-                    innermost.range.start
-                ) > 0
-            ) {
-                innermost = my_scope;
-            }
-        }
-        return innermost ?? scopes[0];
+        return find_enclosing_scope(scopes, position);
     }
 
     /**

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -2942,6 +2942,18 @@ export class SemanticAnalyzer {
                 existing.definition_line = definition_line;
                 existing.definition_index = node_index;
                 existing.is_expanded = true;
+                // The promotion moved this symbol's source position
+                // earlier, so the flat slot must be re-arbitrated — a
+                // same-named symbol in another scope may hold it based
+                // on the pre-promotion position (mirrors the re-publish
+                // in register_mata_macro's promotion branch).
+                if (macro.scope === 'local') {
+                    this.publish_flat_local(
+                        symbols,
+                        current_scope,
+                        existing
+                    );
+                }
             } else {
                 existing.additional_definitions.push({
                     index: node_index,

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -4310,7 +4310,11 @@ export class SemanticAnalyzer {
      * scoped registration created (or promoted) a primary `symbol` in
      * `scope`. Ownership rules for the flat slot:
      *   1. a do-file-scope definition, if any exists, always owns it;
-     *   2. else the earliest-`definition_index` program-scope definition.
+     *   2. else the program-scope definition at the earliest source
+     *      position (location.range.start — the universal anchor;
+     *      definition_index is absent on Mata-created symbols and
+     *      definition_line can be a diagnostic sentinel, e.g. 0 for
+     *      `args` locals).
      * Pass `replaced` when a same-scope promotion demoted the previous
      * primary, so an occupied slot pointing at the demoted symbol is
      * updated. The flat view never merges cross-scope
@@ -4339,11 +4343,15 @@ export class SemanticAnalyzer {
             symbols.localMacros.set(symbol.name, symbol);
             return;
         }
-        // Both program-scoped: earliest definition wins (deterministic,
-        // matches the pre-split first-def-wins flat behavior).
-        const candidate_index = symbol.definition_index ?? Infinity;
-        const current_index = current_flat.definition_index ?? Infinity;
-        if (candidate_index < current_index) {
+        // Both program-scoped: earliest source position wins
+        // (deterministic regardless of registration order, and defined
+        // for every symbol kind — see the doc comment above).
+        if (
+            this.compare_positions(
+                symbol.location.range.start,
+                current_flat.location.range.start
+            ) < 0
+        ) {
             symbols.localMacros.set(symbol.name, symbol);
         }
     }

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -10,6 +10,7 @@ import {
   LexerError,
   ParseError,
   ScopeResolverConfig,
+  ScopeInfo,
 } from './types';
 import { undefined_symbol_data_fields } from './utils/undefined-symbol-diagnostic';
 import { diagnostic_code_description_fields } from './utils/diagnostic-code-description';
@@ -40,6 +41,11 @@ export interface DocumentState {
   tokens: Token[];
   ast: StataAST | null;
   symbols: SymbolTable;
+  // Per-scope local-macro maps from the analyzer (do-file scope first,
+  // then one per program body). Retained so position-aware features
+  // (issue #261 follow-ups) can query scope visibility without
+  // re-analyzing.
+  scopes: ScopeInfo[];
   diagnostics: Diagnostic[];
 
   // Context tracking (existing, but now single source of truth)
@@ -758,6 +764,7 @@ export class DocumentStore {
           scalars: new Map(),
           matrices: new Map(),
         },
+        scopes: [],
         diagnostics: [
           {
             severity: DiagnosticSeverity.Warning,
@@ -849,6 +856,7 @@ export class DocumentStore {
       tokens: lex_result.result!.tokens,
       ast: parse_result.result!.ast,
       symbols: analyze_result.result!.symbols,
+      scopes: analyze_result.result!.scopes,
       diagnostics,
       context_ranges,
       context_tracker: my_context_tracker,
@@ -916,6 +924,7 @@ export class DocumentStore {
         scalars: new Map(),
         matrices: new Map(),
       },
+      scopes: [],
       diagnostics: [
         {
           severity: DiagnosticSeverity.Error,

--- a/src/providers/__tests__/hover-suppression.test.ts
+++ b/src/providers/__tests__/hover-suppression.test.ts
@@ -8,6 +8,20 @@ import { CommandDatabase } from '../../command-database';
 import { DocumentState } from '../../document-store';
 import { Position, MarkupKind } from 'vscode-languageserver';
 import { ResolvedScope, SymbolTable, OutOfScopeSymbol } from '../../types';
+import { ContextTracker } from '../../context-tracker';
+
+// Shared required-field defaults so each fixture literal satisfies the
+// full DocumentState shape; individual tests override what they use.
+const DOCUMENT_STATE_DEFAULTS = {
+    version: 1,
+    scopes: [],
+    context_ranges: [],
+    context_tracker: new ContextTracker(),
+    line_offsets: [0],
+    forward_calls: [],
+    token_line_index: new Map(),
+    ignored_lines: new Set<number>(),
+};
 
 describe('HoverProvider Out-of-Scope Suppression', () => {
     let hover_provider: HoverProvider;
@@ -21,6 +35,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
     describe('get_reference_type_from_context', () => {
         it('should detect local macro reference', () => {
             const document: DocumentState = {
+                ...DOCUMENT_STATE_DEFAULTS,
                 uri: 'file:///test.do',
                 content: 'display `country_name\'',
                 symbols: { programs: new Map(), localMacros: new Map(), globalMacros: new Map(), variables: new Map(), scalars: new Map(), matrices: new Map() },
@@ -36,6 +51,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should detect global macro reference with $', () => {
             const document: DocumentState = {
+                ...DOCUMENT_STATE_DEFAULTS,
                 uri: 'file:///test.do',
                 content: 'display $country_name',
                 symbols: { programs: new Map(), localMacros: new Map(), globalMacros: new Map(), variables: new Map(), scalars: new Map(), matrices: new Map() },
@@ -51,6 +67,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should detect global macro reference with ${}', () => {
             const document: DocumentState = {
+                ...DOCUMENT_STATE_DEFAULTS,
                 uri: 'file:///test.do',
                 content: 'display ${country_name}',
                 symbols: { programs: new Map(), localMacros: new Map(), globalMacros: new Map(), variables: new Map(), scalars: new Map(), matrices: new Map() },
@@ -66,6 +83,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should detect other reference type for bare identifier', () => {
             const document: DocumentState = {
+                ...DOCUMENT_STATE_DEFAULTS,
                 uri: 'file:///test.do',
                 content: 'display country_name',
                 symbols: { programs: new Map(), localMacros: new Map(), globalMacros: new Map(), variables: new Map(), scalars: new Map(), matrices: new Map() },
@@ -144,6 +162,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
     describe('collect_all_symbol_matches with suppression', () => {
         it('should return out-of-scope match for out-of-scope local macro reference', () => {
             const document: DocumentState = {
+                ...DOCUMENT_STATE_DEFAULTS,
                 uri: 'file:///test.do',
                 content: 'display `country_name\'',
                 symbols: { 
@@ -191,6 +210,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should return out-of-scope match for out-of-scope global macro reference', () => {
             const document: DocumentState = {
+                ...DOCUMENT_STATE_DEFAULTS,
                 uri: 'file:///test.do',
                 content: 'display $country_name',
                 symbols: { 
@@ -238,6 +258,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should return normal matches for non-out-of-scope reference', () => {
             const document: DocumentState = {
+                ...DOCUMENT_STATE_DEFAULTS,
                 uri: 'file:///test.do',
                 content: 'display country_name',
                 symbols: { 
@@ -276,6 +297,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should return normal matches when reference type is other but local macro is out-of-scope', () => {
             const document: DocumentState = {
+                ...DOCUMENT_STATE_DEFAULTS,
                 uri: 'file:///test.do',
                 content: 'display country_name', // bare identifier, not `country_name'
                 symbols: { 
@@ -326,6 +348,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
     describe('integration with get_hover', () => {
         it('should return hover with out-of-scope indicator for out-of-scope local macro reference', async () => {
             const document: DocumentState = {
+                ...DOCUMENT_STATE_DEFAULTS,
                 uri: 'file:///test.do',
                 content: 'display `country_name\'',
                 symbols: { 
@@ -383,6 +406,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should return hover with out-of-scope indicator for out-of-scope global macro reference', async () => {
             const document: DocumentState = {
+                ...DOCUMENT_STATE_DEFAULTS,
                 uri: 'file:///test.do',
                 content: 'display $country_name',
                 symbols: { 

--- a/src/providers/__tests__/hover-suppression.test.ts
+++ b/src/providers/__tests__/hover-suppression.test.ts
@@ -10,18 +10,21 @@ import { Position, MarkupKind } from 'vscode-languageserver';
 import { ResolvedScope, SymbolTable, OutOfScopeSymbol } from '../../types';
 import { ContextTracker } from '../../context-tracker';
 
-// Shared required-field defaults so each fixture literal satisfies the
-// full DocumentState shape; individual tests override what they use.
-const DOCUMENT_STATE_DEFAULTS = {
-    version: 1,
-    scopes: [],
-    context_ranges: [],
-    context_tracker: new ContextTracker(),
-    line_offsets: [0],
-    forward_calls: [],
-    token_line_index: new Map(),
-    ignored_lines: new Set<number>(),
-};
+// Required-field defaults so each fixture literal satisfies the full
+// DocumentState shape. A factory (not a shared constant) so every
+// fixture gets fresh mutable instances - no state leaks across tests.
+function create_document_state_defaults() {
+    return {
+        version: 1,
+        scopes: [],
+        context_ranges: [],
+        context_tracker: new ContextTracker(),
+        line_offsets: [0],
+        forward_calls: [],
+        token_line_index: new Map(),
+        ignored_lines: new Set<number>(),
+    };
+}
 
 describe('HoverProvider Out-of-Scope Suppression', () => {
     let hover_provider: HoverProvider;
@@ -35,7 +38,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
     describe('get_reference_type_from_context', () => {
         it('should detect local macro reference', () => {
             const document: DocumentState = {
-                ...DOCUMENT_STATE_DEFAULTS,
+                ...create_document_state_defaults(),
                 uri: 'file:///test.do',
                 content: 'display `country_name\'',
                 symbols: { programs: new Map(), localMacros: new Map(), globalMacros: new Map(), variables: new Map(), scalars: new Map(), matrices: new Map() },
@@ -51,7 +54,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should detect global macro reference with $', () => {
             const document: DocumentState = {
-                ...DOCUMENT_STATE_DEFAULTS,
+                ...create_document_state_defaults(),
                 uri: 'file:///test.do',
                 content: 'display $country_name',
                 symbols: { programs: new Map(), localMacros: new Map(), globalMacros: new Map(), variables: new Map(), scalars: new Map(), matrices: new Map() },
@@ -67,7 +70,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should detect global macro reference with ${}', () => {
             const document: DocumentState = {
-                ...DOCUMENT_STATE_DEFAULTS,
+                ...create_document_state_defaults(),
                 uri: 'file:///test.do',
                 content: 'display ${country_name}',
                 symbols: { programs: new Map(), localMacros: new Map(), globalMacros: new Map(), variables: new Map(), scalars: new Map(), matrices: new Map() },
@@ -83,7 +86,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should detect other reference type for bare identifier', () => {
             const document: DocumentState = {
-                ...DOCUMENT_STATE_DEFAULTS,
+                ...create_document_state_defaults(),
                 uri: 'file:///test.do',
                 content: 'display country_name',
                 symbols: { programs: new Map(), localMacros: new Map(), globalMacros: new Map(), variables: new Map(), scalars: new Map(), matrices: new Map() },
@@ -162,7 +165,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
     describe('collect_all_symbol_matches with suppression', () => {
         it('should return out-of-scope match for out-of-scope local macro reference', () => {
             const document: DocumentState = {
-                ...DOCUMENT_STATE_DEFAULTS,
+                ...create_document_state_defaults(),
                 uri: 'file:///test.do',
                 content: 'display `country_name\'',
                 symbols: { 
@@ -210,7 +213,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should return out-of-scope match for out-of-scope global macro reference', () => {
             const document: DocumentState = {
-                ...DOCUMENT_STATE_DEFAULTS,
+                ...create_document_state_defaults(),
                 uri: 'file:///test.do',
                 content: 'display $country_name',
                 symbols: { 
@@ -258,7 +261,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should return normal matches for non-out-of-scope reference', () => {
             const document: DocumentState = {
-                ...DOCUMENT_STATE_DEFAULTS,
+                ...create_document_state_defaults(),
                 uri: 'file:///test.do',
                 content: 'display country_name',
                 symbols: { 
@@ -297,7 +300,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should return normal matches when reference type is other but local macro is out-of-scope', () => {
             const document: DocumentState = {
-                ...DOCUMENT_STATE_DEFAULTS,
+                ...create_document_state_defaults(),
                 uri: 'file:///test.do',
                 content: 'display country_name', // bare identifier, not `country_name'
                 symbols: { 
@@ -348,7 +351,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
     describe('integration with get_hover', () => {
         it('should return hover with out-of-scope indicator for out-of-scope local macro reference', async () => {
             const document: DocumentState = {
-                ...DOCUMENT_STATE_DEFAULTS,
+                ...create_document_state_defaults(),
                 uri: 'file:///test.do',
                 content: 'display `country_name\'',
                 symbols: { 
@@ -406,7 +409,7 @@ describe('HoverProvider Out-of-Scope Suppression', () => {
 
         it('should return hover with out-of-scope indicator for out-of-scope global macro reference', async () => {
             const document: DocumentState = {
-                ...DOCUMENT_STATE_DEFAULTS,
+                ...create_document_state_defaults(),
                 uri: 'file:///test.do',
                 content: 'display $country_name',
                 symbols: { 

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -14,7 +14,10 @@ import {
     DirectiveDiagnostic,
     UndefinedSymbolDiagnosticData
 } from '../types';
-import { find_enclosing_scope } from '../utils/scope-position';
+import {
+    find_enclosing_scope,
+    position_within_range,
+} from '../utils/scope-position';
 import {
     ScopeResolver,
     get_visible_forward_call_sites,
@@ -427,10 +430,34 @@ export class DiagnosticsProvider {
                 let do_excluded_source_file: string | undefined;
                 if (resolved_scope) {
                     const diag_line = my_diagnostic.range.start.line;
+                    const the_scopes = document.scopes ?? [];
+                    const reference_position = my_diagnostic.range.start;
                     for (const call_site of get_visible_forward_call_sites(
                         resolved_scope,
                         diag_line
                     )) {
+                        // Executable blame only: a call strictly inside a
+                        // program body runs when that program is called,
+                        // not at its textual position — so unless the
+                        // reference sits in that same body, the call has
+                        // not executed before the reference and must not
+                        // be blamed (a later in-program `do` would
+                        // otherwise shadow the real top-level one).
+                        const in_uncalled_program = the_scopes.some(
+                            my_scope =>
+                                my_scope.type === 'program' &&
+                                call_site.call_line >
+                                    my_scope.range.start.line &&
+                                call_site.call_line <
+                                    my_scope.range.end.line &&
+                                !position_within_range(
+                                    reference_position,
+                                    my_scope.range
+                                )
+                        );
+                        if (in_uncalled_program) {
+                            continue;
+                        }
                         if (this.is_symbol_excluded_by_forward_call(
                                 symbol_name,
                                 call_site,

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -418,12 +418,37 @@ export class DiagnosticsProvider {
             // behind the 2026-04-21 revert; see the guard comment on
             // is_symbol_defined_in_current_document).
             //
-            // Deliberate precedence: this also outranks the forward-call
-            // "use include" rewrite when a do-called child ALSO defines
-            // the name — same-file definedness beats that rewrite per the
-            // 2026-04-21 decision (main showed the generic message there;
-            // #145 upgrades it to the scope-isolation message).
+            // When a do-called child ALSO defines the name, the message
+            // refers to BOTH facts (the same-file program local and the
+            // child's do-excluded definition with its include remedy)
+            // rather than picking one. Same-file definedness still leads
+            // per the 2026-04-21 decision; the child half is appended.
             if (symbol_name && my_diagnostic.scope_isolation) {
+                let do_excluded_source_file: string | undefined;
+                if (resolved_scope) {
+                    const diag_line = my_diagnostic.range.start.line;
+                    for (const call_site of get_visible_forward_call_sites(
+                        resolved_scope,
+                        diag_line
+                    )) {
+                        if (this.is_symbol_excluded_by_forward_call(
+                                symbol_name,
+                                call_site,
+                                my_diagnostic.code,
+                                reference_kind,
+                                document.uri
+                            )) {
+                            const effective =
+                                call_site.excluded_locals?.get(symbol_name);
+                            const excluded_callee_uri = effective?.sourceUri
+                                ?? call_site.callee_uri;
+                            do_excluded_source_file =
+                                excluded_callee_uri.split('/').pop()
+                                || excluded_callee_uri;
+                            break;
+                        }
+                    }
+                }
                 const converted = this.create_out_of_scope_rewrite(
                     my_diagnostic,
                     symbol_name,
@@ -434,6 +459,9 @@ export class DiagnosticsProvider {
                             program_names:
                                 my_diagnostic.scope_isolation
                                     .defined_in_programs,
+                            ...(do_excluded_source_file !== undefined
+                                ? { do_excluded_source_file }
+                                : {}),
                         },
                     },
                     config,

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -417,6 +417,12 @@ export class DiagnosticsProvider {
             // same-file forward reference (the misleading behavior
             // behind the 2026-04-21 revert; see the guard comment on
             // is_symbol_defined_in_current_document).
+            //
+            // Deliberate precedence: this also outranks the forward-call
+            // "use include" rewrite when a do-called child ALSO defines
+            // the name — same-file definedness beats that rewrite per the
+            // 2026-04-21 decision (main showed the generic message there;
+            // #145 upgrades it to the scope-isolation message).
             if (symbol_name && my_diagnostic.scope_isolation) {
                 const converted = this.create_out_of_scope_rewrite(
                     my_diagnostic,

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -50,6 +50,9 @@ type SemanticDiagnostic = {
     // data, never by parsing the (now reworded) message prose.
     symbol_name?: string;
     reference_kind?: 'local' | 'global' | 'variable';
+    // Same-file program bodies that define this otherwise-undefined
+    // local; drives the scope-isolation rewrite (#145).
+    scope_isolation?: { defined_in_programs: string[] };
 };
 type ReferenceKind = 'local' | 'global' | 'variable' | null;
 type OutOfScopeRewriteMatch = {
@@ -400,6 +403,40 @@ export class DiagnosticsProvider {
                     continue;
                 }
             }
+
+            // Scope-isolated program local (#145): the analyzer determined
+            // the referenced local exists ONLY inside other program bodies
+            // in this same file. Rewrite with the specific message. This
+            // runs AFTER cross-file resolution has had its chance to
+            // suppress the diagnostic (a parent's genuine definition still
+            // wins above), and BEFORE the legacy same-file/backward
+            // matchers — which would otherwise misread the flat symbol
+            // table and e.g. rewrite a pre-program reference as a
+            // same-file forward reference (the misleading behavior
+            // behind the 2026-04-21 revert; see the guard comment on
+            // is_symbol_defined_in_current_document).
+            if (symbol_name && my_diagnostic.scope_isolation) {
+                const converted = this.create_out_of_scope_rewrite(
+                    my_diagnostic,
+                    symbol_name,
+                    {
+                        symbol_kind: 'local',
+                        reason: {
+                            kind: 'scope_isolated_in_program',
+                            program_names:
+                                my_diagnostic.scope_isolation
+                                    .defined_in_programs,
+                        },
+                    },
+                    config,
+                    document
+                );
+                if (converted) {
+                    the_diagnostics.push(converted);
+                }
+                continue;
+            }
+
             if (symbol_name) {
                 const same_file_match = this.find_same_file_out_of_scope_match(
                     symbol_name,
@@ -657,6 +694,7 @@ export class DiagnosticsProvider {
                     severity: severity_map[diag.severity ?? DiagnosticSeverity.Error],
                     symbol_name: data?.symbol_name,
                     reference_kind: data?.reference_kind,
+                    scope_isolation: data?.scope_isolation,
                 });
             }
         }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -9,10 +9,12 @@ import {
     StataDiagnosticCode,
     StataLSPConfig,
     SymbolTable,
+    ScopeInfo,
     ResolvedScope,
     DirectiveDiagnostic,
     UndefinedSymbolDiagnosticData
 } from '../types';
+import { find_enclosing_scope } from '../utils/scope-position';
 import {
     ScopeResolver,
     get_visible_forward_call_sites,
@@ -443,7 +445,9 @@ export class DiagnosticsProvider {
                     reference_kind,
                     document.symbols,
                     document.uri,
-                    my_diagnostic.range.start.line
+                    my_diagnostic.range.start.line,
+                    document.scopes ?? [],
+                    my_diagnostic.range.start
                 );
                 if (same_file_match) {
                     const converted = this.create_out_of_scope_rewrite(
@@ -939,10 +943,68 @@ export class DiagnosticsProvider {
         reference_kind: 'local' | 'global' | 'variable' | null,
         symbols: SymbolTable,
         current_document_uri: string,
-        reference_line: number
+        reference_line: number,
+        scopes: ScopeInfo[],
+        reference_position: Position
     ): OutOfScopeRewriteMatch | null {
         if (reference_kind !== 'local' && reference_kind !== 'global') {
             return null;
+        }
+
+        // Locals resolve the forward hint scope-aware: the flat view's
+        // slot prefers a do-file definition, which may be an unrelated
+        // later redefinition rather than the same-scope definition the
+        // user should be pointed at. Mirror lookup_local_macro's
+        // visibility (own scope + do-file scope) and pick the nearest
+        // definition after the reference across both. Falls back to the
+        // flat read when no scopes were provided (partial states).
+        if (reference_kind === 'local' && scopes.length > 0) {
+            const enclosing_scope = find_enclosing_scope(
+                scopes,
+                reference_position
+            );
+            const the_visible_scopes =
+                enclosing_scope.type !== 'dofile' &&
+                scopes[0] !== undefined &&
+                scopes[0] !== enclosing_scope
+                    ? [enclosing_scope, scopes[0]]
+                    : [enclosing_scope];
+            let nearest_forward_line: number | null = null;
+            for (const my_scope of the_visible_scopes) {
+                const my_symbol = my_scope.localMacros.get(symbol_name);
+                if (!my_symbol) {
+                    continue;
+                }
+                const the_lines: number[] = [];
+                const primary_line = my_symbol.definition_line
+                    ?? my_symbol.location?.range?.start?.line;
+                if (typeof primary_line === 'number') {
+                    the_lines.push(primary_line);
+                }
+                for (const my_extra of
+                    my_symbol.additional_definitions ?? []) {
+                    the_lines.push(my_extra.line);
+                }
+                for (const my_line of the_lines) {
+                    if (
+                        my_line > reference_line &&
+                        (nearest_forward_line === null ||
+                            my_line < nearest_forward_line)
+                    ) {
+                        nearest_forward_line = my_line;
+                    }
+                }
+            }
+            if (nearest_forward_line === null) {
+                return null;
+            }
+            return {
+                symbol_kind: 'local',
+                reason: {
+                    kind: 'same_file_forward',
+                    defined_line_0: nearest_forward_line,
+                },
+            };
         }
 
         const get_definition_line = (

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -442,10 +442,13 @@ export class DiagnosticsProvider {
                                 call_site.excluded_locals?.get(symbol_name);
                             const excluded_callee_uri = effective?.sourceUri
                                 ?? call_site.callee_uri;
+                            // No break: later visible call sites overwrite
+                            // earlier ones so the LAST one wins, matching
+                            // Stata execution order and the forward-call
+                            // rewrite's blame precedence below.
                             do_excluded_source_file =
                                 excluded_callee_uri.split('/').pop()
                                 || excluded_callee_uri;
-                            break;
                         }
                     }
                 }

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -305,6 +305,7 @@ export function create_completion_handler(
                             scalars: new Map(),
                             matrices: new Map(),
                         },
+                        scopes: [],
                         diagnostics: [],
                         context_ranges: [],
                         context_tracker: new ContextTracker(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -401,6 +401,12 @@ export interface MacroSymbol {
   value?: string;
   hasEquals?: boolean;  // True if defined with = sign (local x = expr) vs literal (local x a b)
   containingScope?: ScopeType;
+  // Owning scope's ScopeInfo.id. Distinguishes same-named locals defined
+  // in different scopes (issue #261). Absent only for flat-only writers.
+  scope_id?: number;
+  // Set iff containingScope === 'program': the defining program's name,
+  // for scope-isolation diagnostics (issue #145).
+  containing_program_name?: string;
   extendedFunction?: ExtendedMacroFunction;
   definition_index?: number;  // Preorder index where macro was defined
   definition_line?: number;   // Line number where macro was first defined
@@ -454,6 +460,11 @@ export interface ScopeInfo {
   type: ScopeType;
   range: Range;
   localMacros: Map<string, MacroSymbol>;
+  // Index of this scope in AnalysisResult.scopes; the do-file scope is
+  // always id 0. Gives local macros a stable owning-scope identity.
+  id: number;
+  // Program name for 'program' scopes; feeds scope-isolation messaging.
+  program_name?: string;
 }
 
 // Command Database Types
@@ -549,6 +560,9 @@ export enum StataDiagnosticCode {
 export interface UndefinedSymbolDiagnosticData {
   symbol_name?: string;
   reference_kind?: 'local' | 'global' | 'variable';
+  // Present when an undefined local has same-named definitions that
+  // exist only inside other program bodies in the same file (#145).
+  scope_isolation?: { defined_in_programs: string[] };
 }
 
 

--- a/src/utils/out-of-scope-message.ts
+++ b/src/utils/out-of-scope-message.ts
@@ -13,6 +13,10 @@ export type OutOfScopeReason =
     | {
         kind: 'same_file_forward';
         defined_line_0: number;
+    }
+    | {
+        kind: 'scope_isolated_in_program';
+        program_names: string[];
     };
 
 function format_symbol_display_name(
@@ -56,5 +60,21 @@ export function format_out_of_scope_message(
                 `${display_name} is used before it is defined ` +
                 `(line ${reason.defined_line_0 + 1})`
             );
+        case 'scope_isolated_in_program': {
+            const the_names = reason.program_names;
+            if (the_names.length === 1) {
+                return (
+                    `${display_name} is defined only inside ` +
+                    `program ${the_names[0]}`
+                );
+            }
+            const listed =
+                `${the_names.slice(0, -1).join(', ')} and ` +
+                `${the_names[the_names.length - 1]}`;
+            return (
+                `${display_name} is defined only inside ` +
+                `programs ${listed}`
+            );
+        }
     }
 }

--- a/src/utils/out-of-scope-message.ts
+++ b/src/utils/out-of-scope-message.ts
@@ -17,6 +17,10 @@ export type OutOfScopeReason =
     | {
         kind: 'scope_isolated_in_program';
         program_names: string[];
+        // When a do/run-called file ALSO defines the name (its locals
+        // excluded by do/run semantics), name it so the message refers
+        // to both facts instead of picking one.
+        do_excluded_source_file?: string;
     };
 
 function format_symbol_display_name(
@@ -62,18 +66,20 @@ export function format_out_of_scope_message(
             );
         case 'scope_isolated_in_program': {
             const the_names = reason.program_names;
-            if (the_names.length === 1) {
-                return (
-                    `${display_name} is defined only inside ` +
-                    `program ${the_names[0]}`
-                );
+            const listed = the_names.length === 1
+                ? `program ${the_names[0]}`
+                : 'programs ' +
+                    `${the_names.slice(0, -1).join(', ')} and ` +
+                    `${the_names[the_names.length - 1]}`;
+            const scope_part =
+                `${display_name} is defined only inside ${listed}`;
+            if (reason.do_excluded_source_file === undefined) {
+                return scope_part;
             }
-            const listed =
-                `${the_names.slice(0, -1).join(', ')} and ` +
-                `${the_names[the_names.length - 1]}`;
             return (
-                `${display_name} is defined only inside ` +
-                `programs ${listed}`
+                `${scope_part} in this file; it is also defined in ` +
+                `${reason.do_excluded_source_file} but local macros ` +
+                'are not inherited via do or run (use include instead)'
             );
         }
     }

--- a/src/utils/scope-position.ts
+++ b/src/utils/scope-position.ts
@@ -1,0 +1,63 @@
+// Position → owning-scope resolution over the analyzer's ScopeInfo
+// array (do-file scope first, then one entry per program body). THE
+// single mechanism for "which scope owns this position" — shared by
+// the analyzer's token/Mata passes and the diagnostics provider. Do
+// not add a second way to answer this question.
+//
+// Limitation (pre-existing): the parser only builds `program` block
+// nodes under `#delimit cr`, so under `#delimit ;` positions inside a
+// program fall back to the do-file scope.
+
+import { Range } from 'vscode-languageserver-textdocument';
+import { ScopeInfo } from '../types';
+
+interface Position {
+    line: number;
+    character: number;
+}
+
+function compare_positions(a: Position, b: Position): number {
+    if (a.line !== b.line) {
+        return a.line - b.line;
+    }
+    return a.character - b.character;
+}
+
+/** Is `position` within `range` (inclusive), comparing line then char? */
+export function position_within_range(
+    position: Position,
+    range: Range
+): boolean {
+    return (
+        compare_positions(position, range.start) >= 0 &&
+        compare_positions(position, range.end) <= 0
+    );
+}
+
+/**
+ * Innermost program scope whose (character-precise, inclusive) range
+ * contains `position`, else the do-file scope (`scopes[0]`).
+ */
+export function find_enclosing_scope(
+    scopes: ScopeInfo[],
+    position: Position
+): ScopeInfo {
+    let innermost: ScopeInfo | undefined;
+    for (const my_scope of scopes) {
+        if (my_scope.type !== 'program') {
+            continue;
+        }
+        if (!position_within_range(position, my_scope.range)) {
+            continue;
+        }
+        // Nested program scopes start later than their enclosing
+        // scope, so the latest-starting match is the innermost.
+        if (
+            innermost === undefined ||
+            compare_positions(my_scope.range.start, innermost.range.start) > 0
+        ) {
+            innermost = my_scope;
+        }
+    }
+    return innermost ?? scopes[0];
+}

--- a/src/utils/scope-position.ts
+++ b/src/utils/scope-position.ts
@@ -42,6 +42,12 @@ export function find_enclosing_scope(
     scopes: ScopeInfo[],
     position: Position
 ): ScopeInfo {
+    if (scopes.length === 0) {
+        // Every producer pushes the do-file scope first, so an empty
+        // array is a caller bug — fail loudly rather than return an
+        // undefined that NPEs at a distance.
+        throw new Error('find_enclosing_scope: scopes must be non-empty');
+    }
     let innermost: ScopeInfo | undefined;
     for (const my_scope of scopes) {
         if (my_scope.type !== 'program') {

--- a/src/utils/undefined-symbol-diagnostic.ts
+++ b/src/utils/undefined-symbol-diagnostic.ts
@@ -37,6 +37,7 @@ export function undefined_symbol_data_fields(
     diagnostic: {
         symbol_name?: string;
         reference_kind?: 'local' | 'global' | 'variable';
+        scope_isolation?: { defined_in_programs: string[] };
     }
 ): { data: UndefinedSymbolDiagnosticData } | Record<string, never> {
     if (
@@ -49,6 +50,9 @@ export function undefined_symbol_data_fields(
         data: {
             symbol_name: diagnostic.symbol_name,
             reference_kind: diagnostic.reference_kind,
+            ...(diagnostic.scope_isolation !== undefined
+                ? { scope_isolation: diagnostic.scope_isolation }
+                : {}),
         },
     };
 }

--- a/tests/test-context-helper.ts
+++ b/tests/test-context-helper.ts
@@ -1,14 +1,84 @@
 import { ContextTracker } from '../src/context-tracker';
 import { StataLexer } from '../src/lexer';
+import { StataParser } from '../src/parser';
+import { SemanticAnalyzer } from '../src/analyzer';
+import { DocumentState } from '../src/document-store';
+import { undefined_symbol_data_fields } from '../src/utils/undefined-symbol-diagnostic';
+import { DiagnosticSeverity } from 'vscode-languageserver';
 
 /**
  * Helper to initialize a ContextTracker from source code.
  * Lexes the source and calls initialize_from_tokens().
- * 
+ *
  * This replaces the removed initialize(string) method for tests.
  */
 export function init_tracker_from_source(tracker: ContextTracker, source: string): void {
     const lexer = new StataLexer();
     const lex_result = lexer.tokenize(source);
     tracker.initialize_from_tokens(lex_result.tokens, source);
+}
+
+/**
+ * Build a DocumentState from real lexer/parser/analyzer output,
+ * mirroring DocumentStore.build_diagnostics — including the structured
+ * `data` payload (symbol_name/reference_kind/scope_isolation) the
+ * diagnostics provider reads instead of parsing message prose.
+ */
+export function create_real_document_state(
+    content: string,
+    version: number = 1
+): DocumentState {
+    const my_lexer = new StataLexer();
+    const my_parser = new StataParser();
+    const my_analyzer = new SemanticAnalyzer();
+    const my_context_tracker = new ContextTracker();
+
+    const my_lex_result = my_lexer.tokenize(content);
+    const my_parse_result = my_parser.parse(my_lex_result.tokens);
+    const my_analysis_result = my_analyzer.analyze(
+        my_parse_result.ast,
+        'file:///test.do',
+        undefined,
+        undefined,
+        my_lex_result.tokens
+    );
+
+    my_context_tracker.initialize_from_tokens(my_lex_result.tokens, content);
+    const my_context_ranges = my_context_tracker.get_all_context_ranges();
+
+    const my_line_offsets: number[] = [0];
+    for (let i = 0; i < content.length; i++) {
+        if (content[i] === '\n') {
+            my_line_offsets.push(i + 1);
+        }
+    }
+
+    const diagnostics = my_analysis_result.diagnostics.map(diag => ({
+        range: diag.range,
+        message: diag.message,
+        severity: diag.severity === 'error' ? DiagnosticSeverity.Error
+            : diag.severity === 'warning' ? DiagnosticSeverity.Warning
+            : diag.severity === 'information' ? DiagnosticSeverity.Information
+            : DiagnosticSeverity.Hint,
+        code: diag.code,
+        source: 'sight',
+        ...undefined_symbol_data_fields(diag),
+    }));
+
+    return {
+        uri: 'file:///test.do',
+        version,
+        content,
+        tokens: my_lex_result.tokens,
+        ast: my_parse_result.ast,
+        symbols: my_analysis_result.symbols,
+        scopes: my_analysis_result.scopes,
+        diagnostics,
+        context_ranges: my_context_ranges,
+        context_tracker: my_context_tracker,
+        line_offsets: my_line_offsets,
+        forward_calls: my_analysis_result.forward_calls,
+        token_line_index: new Map(),
+        ignored_lines: my_analysis_result.ignored_lines,
+    };
 }

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { DiagnosticsProvider } from '../../src/providers/diagnostics';
 import { DocumentState } from '../../src/document-store';
 import { StataLSPConfig, StataDiagnosticCode, LexerErrorCode, ParseErrorCode, ResolvedScope, CrossFileCaseMismatchSeverity } from '../../src/types';
-import { DiagnosticSeverity } from 'vscode-languageserver';
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
 import { ContextTracker } from '../../src/context-tracker';
 import { create_empty_symbol_table } from '../../src/analyzer';
 import { ScopeResolver } from '../../src/scope-resolver';
@@ -62,7 +62,7 @@ function create_document_state(content: string, version: number = 1): DocumentSt
     const context_ranges = my_context_tracker.get_all_context_ranges();
     
     // Create sample diagnostics based on content
-    const diagnostics: any[] = [];
+    const diagnostics: Diagnostic[] = [];
     
     // Check for undefined macros (anywhere in the content)
     if (content.includes('`undefined') || content.includes('$undefined')) {
@@ -107,11 +107,17 @@ function create_document_state(content: string, version: number = 1): DocumentSt
             localMacros: new Map(),
             globalMacros: new Map(),
             variables: new Map(),
+            scalars: new Map(),
+            matrices: new Map(),
         },
+        scopes: [],
         diagnostics,
         context_ranges,
         context_tracker: my_context_tracker,
         line_offsets: [0],
+        forward_calls: [],
+        token_line_index: new Map(),
+        ignored_lines: new Set<number>(),
     };
 }
 

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -1,14 +1,13 @@
-import { init_tracker_from_source } from '../test-context-helper';
+import {
+    init_tracker_from_source,
+    create_real_document_state,
+} from '../test-context-helper';
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { DiagnosticsProvider } from '../../src/providers/diagnostics';
-import { undefined_symbol_data_fields } from '../../src/utils/undefined-symbol-diagnostic';
 import { DocumentState } from '../../src/document-store';
 import { StataLSPConfig, StataDiagnosticCode, LexerErrorCode, ParseErrorCode, ResolvedScope, CrossFileCaseMismatchSeverity } from '../../src/types';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { ContextTracker } from '../../src/context-tracker';
-import { StataLexer } from '../../src/lexer';
-import { StataParser } from '../../src/parser';
-import { SemanticAnalyzer } from '../../src/analyzer';
 import { create_empty_symbol_table } from '../../src/analyzer';
 import { ScopeResolver } from '../../src/scope-resolver';
 
@@ -113,72 +112,6 @@ function create_document_state(content: string, version: number = 1): DocumentSt
         context_ranges,
         context_tracker: my_context_tracker,
         line_offsets: [0],
-    };
-}
-
-/**
- * Create a document state with real lexer/parser/analyzer.
- * This properly detects undefined macros with case sensitivity.
- */
-function create_real_document_state(content: string, version: number = 1): DocumentState {
-    const my_lexer = new StataLexer();
-    const my_parser = new StataParser();
-    const my_analyzer = new SemanticAnalyzer();
-    const my_context_tracker = new ContextTracker();
-
-    // Tokenize
-    const my_lex_result = my_lexer.tokenize(content);
-
-    // Parse
-    const my_parse_result = my_parser.parse(my_lex_result.tokens);
-
-    // Analyze - returns AnalysisResult with symbols and diagnostics
-    const my_analysis_result = my_analyzer.analyze(
-        my_parse_result.ast,
-        'file:///test.do',
-        undefined,
-        undefined,
-        my_lex_result.tokens
-    );
-
-    // Track context
-    my_context_tracker.initialize_from_tokens(my_lex_result.tokens, content);
-    const my_context_ranges = my_context_tracker.get_all_context_ranges();
-
-    // Build line offsets
-    const my_line_offsets: number[] = [0];
-    for (let i = 0; i < content.length; i++) {
-        if (content[i] === '\n') {
-            my_line_offsets.push(i + 1);
-        }
-    }
-
-    // Convert analyzer diagnostics to LSP diagnostics. Mirrors
-    // DocumentStore.build_diagnostics, including the structured `data` payload
-    // (symbol_name/reference_kind) the provider reads instead of parsing prose.
-    const diagnostics = my_analysis_result.diagnostics.map(diag => ({
-        range: diag.range,
-        message: diag.message,
-        severity: diag.severity === 'error' ? DiagnosticSeverity.Error
-            : diag.severity === 'warning' ? DiagnosticSeverity.Warning
-            : diag.severity === 'information' ? DiagnosticSeverity.Information
-            : DiagnosticSeverity.Hint,
-        code: diag.code,
-        source: 'sight',
-        ...undefined_symbol_data_fields(diag),
-    }));
-
-    return {
-        uri: 'file:///test.do',
-        version,
-        content,
-        tokens: my_lex_result.tokens,
-        ast: my_parse_result.ast,
-        symbols: my_analysis_result.symbols,
-        diagnostics,
-        context_ranges: my_context_ranges,
-        context_tracker: my_context_tracker,
-        line_offsets: my_line_offsets,
     };
 }
 

--- a/tests/unit/scope-isolation-diagnostics.test.ts
+++ b/tests/unit/scope-isolation-diagnostics.test.ts
@@ -108,6 +108,27 @@ display \`shared'
         expect(the_matches[0].message).toContain('prog_b');
     });
 
+    it('forward hint points at the same-scope definition, not an unrelated dofile one', async () => {
+        // Reference at line 2, program-local definition at line 3,
+        // unrelated dofile-scope definition at line 5. The forward hint
+        // must name the program's own definition (1-based line 4), not
+        // the dofile redefinition the flat view prefers (line 6).
+        const document = create_real_document_state(`
+program define myprog
+    display \`x'
+    local x foo
+end
+local x bar
+`);
+        const provider = make_provider();
+        const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG);
+        const the_matches = the_diagnostics.filter(d =>
+            d.message.includes("`x'"));
+        expect(the_matches).toHaveLength(1);
+        expect(the_matches[0].message).toContain('before it is defined');
+        expect(the_matches[0].message).toContain('(line 4)');
+    });
+
     it('same-scope forward references keep the same-file-forward rewrite', async () => {
         const document = create_real_document_state(`
 display \`later'

--- a/tests/unit/scope-isolation-diagnostics.test.ts
+++ b/tests/unit/scope-isolation-diagnostics.test.ts
@@ -1,0 +1,193 @@
+import { create_real_document_state } from '../test-context-helper';
+import { describe, it, expect, mock } from 'bun:test';
+import { DiagnosticsProvider } from '../../src/providers/diagnostics';
+import {
+    StataLSPConfig,
+    StataDiagnosticCode,
+    ResolvedScope,
+} from '../../src/types';
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import { create_empty_symbol_table } from '../../src/analyzer';
+import { ScopeResolver } from '../../src/scope-resolver';
+
+function create_mock_connection() {
+    return {
+        sendDiagnostics: mock(() => {}),
+    };
+}
+
+const DEFAULT_CONFIG: StataLSPConfig = {
+    diagnostics: {
+        enabled: true,
+        severity: {
+            undefinedMacro: 'warning',
+            undefinedVariable: 'information',
+            styleWarnings: 'hint',
+        },
+    },
+    completion: {},
+    formatting: {
+        indentSize: 4,
+        indentStyle: 'spaces',
+    },
+    adoPaths: [],
+    indexWorkspace: true,
+};
+
+function make_stub_scope_resolver(resolved_scope: ResolvedScope): ScopeResolver {
+    const the_stub = new ScopeResolver();
+    (the_stub as unknown as { resolve: () => Promise<ResolvedScope> }).resolve =
+        async () => resolved_scope;
+    return the_stub;
+}
+
+// Issue #145: an undefined local that exists only inside another program
+// body gets a specific scope-isolation message, and the 2026-04-21
+// revert scenario (misleading rewrites) stays impossible.
+describe('scope-isolation diagnostics (#145)', () => {
+    function make_provider(): DiagnosticsProvider {
+        return new DiagnosticsProvider(
+            create_mock_connection() as unknown as ConstructorParameters<
+                typeof DiagnosticsProvider
+            >[0]
+        );
+    }
+
+    it('rewrites a program-only local reference after the program', async () => {
+        const document = create_real_document_state(`
+program define myprog
+    local inside_x 1
+end
+display \`inside_x'
+`);
+        const provider = make_provider();
+        const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG);
+        const the_matches = the_diagnostics.filter(d =>
+            d.message.includes('inside_x'));
+        expect(the_matches).toHaveLength(1);
+        expect(the_matches[0].code).toBe(StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL);
+        expect(the_matches[0].message).toBe(
+            "`inside_x' is defined only inside program myprog"
+        );
+    });
+
+    it('rewrites a reference before the program (not as same-file forward)', async () => {
+        const document = create_real_document_state(`
+display \`inside_x'
+program define myprog
+    local inside_x 1
+end
+`);
+        const provider = make_provider();
+        const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG);
+        const the_matches = the_diagnostics.filter(d =>
+            d.message.includes('inside_x'));
+        expect(the_matches).toHaveLength(1);
+        expect(the_matches[0].message).toBe(
+            "`inside_x' is defined only inside program myprog"
+        );
+        expect(the_matches[0].message).not.toContain('before it is defined');
+    });
+
+    it('names every program that defines the isolated local', async () => {
+        const document = create_real_document_state(`
+program define prog_a
+    local shared 1
+end
+program define prog_b
+    local shared 2
+end
+display \`shared'
+`);
+        const provider = make_provider();
+        const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG);
+        const the_matches = the_diagnostics.filter(d =>
+            d.message.includes('shared'));
+        expect(the_matches).toHaveLength(1);
+        expect(the_matches[0].message).toContain('prog_a');
+        expect(the_matches[0].message).toContain('prog_b');
+    });
+
+    it('same-scope forward references keep the same-file-forward rewrite', async () => {
+        const document = create_real_document_state(`
+display \`later'
+local later 1
+`);
+        const provider = make_provider();
+        const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG);
+        const the_matches = the_diagnostics.filter(d =>
+            d.message.includes('later'));
+        expect(the_matches).toHaveLength(1);
+        expect(the_matches[0].message).toContain('before it is defined');
+    });
+
+    it('genuine cross-file resolution still suppresses the diagnostic', async () => {
+        const document = create_real_document_state(`
+program define myprog
+    local inside_x 1
+end
+display \`inside_x'
+`);
+        // A parent scope (e.g. via @lsp-included-by) genuinely defines
+        // the local in another file: cross-file suppression must win
+        // over the scope-isolation rewrite.
+        const parent_symbols = create_empty_symbol_table();
+        parent_symbols.localMacros.set('inside_x', {
+            name: 'inside_x',
+            scope: 'local',
+            location: {
+                uri: 'file:///parent.do',
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 10 },
+                },
+            },
+            sourceUri: 'file:///parent.do',
+            containingScope: 'dofile',
+        });
+        const resolved_scope: ResolvedScope = {
+            chain: [],
+            symbols: parent_symbols,
+            out_of_scope_symbols: [],
+            diagnostics: [],
+            has_directives: true,
+            has_auto_parents: false,
+        };
+        const provider = make_provider();
+        const the_diagnostics = await provider.get_diagnostics(
+            document,
+            DEFAULT_CONFIG,
+            undefined,
+            make_stub_scope_resolver(resolved_scope)
+        );
+        const the_matches = the_diagnostics.filter(d =>
+            d.message.includes('inside_x'));
+        expect(the_matches).toHaveLength(0);
+    });
+
+    it('severity follows the undefinedMacro setting', async () => {
+        const document = create_real_document_state(`
+program define myprog
+    local inside_x 1
+end
+display \`inside_x'
+`);
+        const error_config: StataLSPConfig = {
+            ...DEFAULT_CONFIG,
+            diagnostics: {
+                enabled: true,
+                severity: {
+                    undefinedMacro: 'error',
+                    undefinedVariable: 'information',
+                    styleWarnings: 'hint',
+                },
+            },
+        };
+        const provider = make_provider();
+        const the_diagnostics = await provider.get_diagnostics(document, error_config);
+        const the_matches = the_diagnostics.filter(d =>
+            d.message.includes('inside_x'));
+        expect(the_matches).toHaveLength(1);
+        expect(the_matches[0].severity).toBe(DiagnosticSeverity.Error);
+    });
+});

--- a/tests/unit/scope-isolation-diagnostics.test.ts
+++ b/tests/unit/scope-isolation-diagnostics.test.ts
@@ -186,13 +186,13 @@ display \`inside_x'
         expect(the_matches).toHaveLength(0);
     });
 
-    it('scope isolation outranks the use-include rewrite (2026-04-21 decision)', async () => {
+    it('combined case mentions both the program local and the do-excluded child', async () => {
         // Combined case: the name exists in a same-file program body AND
-        // in a do-called child (excluded_locals). Per the 2026-04-21
-        // revert decision, same-file definedness beats the "use include"
-        // rewrite — pre-#145 that meant the generic message; now it means
-        // the scope-isolation message. Pins the precedence so a future
-        // reorder of the diagnostics pipeline cannot silently flip it.
+        // in a do-called child (excluded_locals). The message refers to
+        // BOTH facts instead of picking one: the scope-isolation part
+        // (same-file definedness, per the 2026-04-21 revert decision)
+        // plus the child definition and its include remedy. Pins the
+        // wording so a pipeline reorder cannot silently drop either half.
         const document = create_real_document_state(`
 program define p
     local x 1
@@ -239,9 +239,10 @@ display \`x'
             d.message.includes("`x'"));
         expect(the_matches).toHaveLength(1);
         expect(the_matches[0].message).toBe(
-            "`x' is defined only inside program p"
+            "`x' is defined only inside program p in this file; " +
+            'it is also defined in child.do but local macros are not ' +
+            'inherited via do or run (use include instead)'
         );
-        expect(the_matches[0].message).not.toContain('include');
     });
 
     it('severity follows the undefinedMacro setting', async () => {

--- a/tests/unit/scope-isolation-diagnostics.test.ts
+++ b/tests/unit/scope-isolation-diagnostics.test.ts
@@ -186,6 +186,71 @@ display \`inside_x'
         expect(the_matches).toHaveLength(0);
     });
 
+    it('combined case blames the LAST visible do-excluded child', async () => {
+        // With multiple visible do-called children defining the name,
+        // the last one wins — matching Stata execution order and the
+        // pre-existing forward-call rewrite's blame precedence (its
+        // loop deliberately lets later call sites overwrite earlier).
+        const document = create_real_document_state(`
+program define p
+    local x 1
+end
+do a.do
+do b.do
+display \`x'
+`);
+        const make_excluded = (uri: string) => new Map([
+            ['x', {
+                name: 'x',
+                scope: 'local' as const,
+                location: {
+                    uri,
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 9 },
+                    },
+                },
+                sourceUri: uri,
+            }],
+        ]);
+        const resolved_scope: ResolvedScope = {
+            chain: [],
+            symbols: create_empty_symbol_table(),
+            out_of_scope_symbols: [],
+            diagnostics: [],
+            has_directives: false,
+            has_auto_parents: true,
+            forward_call_symbols: [
+                {
+                    callee_uri: 'file:///a.do',
+                    call_line: 4,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'do',
+                    excluded_locals: make_excluded('file:///a.do'),
+                },
+                {
+                    callee_uri: 'file:///b.do',
+                    call_line: 5,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'do',
+                    excluded_locals: make_excluded('file:///b.do'),
+                },
+            ],
+        };
+        const provider = make_provider();
+        const the_diagnostics = await provider.get_diagnostics(
+            document,
+            DEFAULT_CONFIG,
+            undefined,
+            make_stub_scope_resolver(resolved_scope)
+        );
+        const the_matches = the_diagnostics.filter(d =>
+            d.message.includes("`x'"));
+        expect(the_matches).toHaveLength(1);
+        expect(the_matches[0].message).toContain('defined in b.do');
+        expect(the_matches[0].message).not.toContain('a.do');
+    });
+
     it('combined case mentions both the program local and the do-excluded child', async () => {
         // Combined case: the name exists in a same-file program body AND
         // in a do-called child (excluded_locals). The message refers to

--- a/tests/unit/scope-isolation-diagnostics.test.ts
+++ b/tests/unit/scope-isolation-diagnostics.test.ts
@@ -186,6 +186,74 @@ display \`inside_x'
         expect(the_matches).toHaveLength(0);
     });
 
+    it('combined case skips do calls inside uncalled program bodies', async () => {
+        // A later `do` that sits inside a program body has not executed
+        // when a top-level reference runs — only calls on the execution
+        // path to the reference are executable blame. Here `do b.do`
+        // lives inside program q (never called), so a.do must be blamed
+        // despite b.do being the later visible call site.
+        const document = create_real_document_state(`
+program define p
+    local x 1
+end
+do a.do
+program define q
+    do b.do
+end
+display \`x'
+`);
+        const make_excluded = (uri: string) => new Map([
+            ['x', {
+                name: 'x',
+                scope: 'local' as const,
+                location: {
+                    uri,
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 9 },
+                    },
+                },
+                sourceUri: uri,
+            }],
+        ]);
+        const resolved_scope: ResolvedScope = {
+            chain: [],
+            symbols: create_empty_symbol_table(),
+            out_of_scope_symbols: [],
+            diagnostics: [],
+            has_directives: false,
+            has_auto_parents: true,
+            forward_call_symbols: [
+                {
+                    callee_uri: 'file:///a.do',
+                    call_line: 4,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'do',
+                    excluded_locals: make_excluded('file:///a.do'),
+                },
+                {
+                    callee_uri: 'file:///b.do',
+                    call_line: 6,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'do',
+                    excluded_locals: make_excluded('file:///b.do'),
+                },
+            ],
+        };
+        const provider = make_provider();
+        const the_diagnostics = await provider.get_diagnostics(
+            document,
+            DEFAULT_CONFIG,
+            undefined,
+            make_stub_scope_resolver(resolved_scope)
+        );
+        const the_matches = the_diagnostics.filter(d =>
+            d.message.includes("`x'"));
+        expect(the_matches).toHaveLength(1);
+        expect(the_matches[0].message).toContain('defined in a.do');
+        expect(the_matches[0].message).not.toContain('b.do');
+    });
+
     it('combined case blames the LAST visible do-excluded child', async () => {
         // With multiple visible do-called children defining the name,
         // the last one wins — matching Stata execution order and the

--- a/tests/unit/scope-isolation-diagnostics.test.ts
+++ b/tests/unit/scope-isolation-diagnostics.test.ts
@@ -186,6 +186,64 @@ display \`inside_x'
         expect(the_matches).toHaveLength(0);
     });
 
+    it('scope isolation outranks the use-include rewrite (2026-04-21 decision)', async () => {
+        // Combined case: the name exists in a same-file program body AND
+        // in a do-called child (excluded_locals). Per the 2026-04-21
+        // revert decision, same-file definedness beats the "use include"
+        // rewrite — pre-#145 that meant the generic message; now it means
+        // the scope-isolation message. Pins the precedence so a future
+        // reorder of the diagnostics pipeline cannot silently flip it.
+        const document = create_real_document_state(`
+program define p
+    local x 1
+end
+do child.do
+display \`x'
+`);
+        const resolved_scope: ResolvedScope = {
+            chain: [],
+            symbols: create_empty_symbol_table(),
+            out_of_scope_symbols: [],
+            diagnostics: [],
+            has_directives: false,
+            has_auto_parents: true,
+            forward_call_symbols: [{
+                callee_uri: 'file:///child.do',
+                call_line: 4,
+                symbols: create_empty_symbol_table(),
+                effective_type: 'do',
+                excluded_locals: new Map([
+                    ['x', {
+                        name: 'x',
+                        scope: 'local' as const,
+                        location: {
+                            uri: 'file:///child.do',
+                            range: {
+                                start: { line: 0, character: 0 },
+                                end: { line: 0, character: 9 },
+                            },
+                        },
+                        sourceUri: 'file:///child.do',
+                    }],
+                ]),
+            }],
+        };
+        const provider = make_provider();
+        const the_diagnostics = await provider.get_diagnostics(
+            document,
+            DEFAULT_CONFIG,
+            undefined,
+            make_stub_scope_resolver(resolved_scope)
+        );
+        const the_matches = the_diagnostics.filter(d =>
+            d.message.includes("`x'"));
+        expect(the_matches).toHaveLength(1);
+        expect(the_matches[0].message).toBe(
+            "`x' is defined only inside program p"
+        );
+        expect(the_matches[0].message).not.toContain('include');
+    });
+
     it('severity follows the undefinedMacro setting', async () => {
         const document = create_real_document_state(`
 program define myprog

--- a/tests/unit/scoped-local-macro-identity.test.ts
+++ b/tests/unit/scoped-local-macro-identity.test.ts
@@ -115,6 +115,24 @@ end
         expect(undefined_macro_diagnostics(result, 'top_x')).toHaveLength(0);
     });
 
+    it('redeclared program bodies do not blame their own name', () => {
+        // A reference in body #2 of a redeclared program to a local
+        // defined only in body #1 must warn plainly — "defined only
+        // inside program foo" would be self-contradictory to a reader
+        // already inside program foo.
+        const result = analyze_code(`
+program define foo
+    local x 1
+end
+program define foo
+    display \`x'
+end
+`);
+        const the_diagnostics = undefined_macro_diagnostics(result, 'x');
+        expect(the_diagnostics).toHaveLength(1);
+        expect(the_diagnostics[0].scope_isolation).toBeUndefined();
+    });
+
     it('out-of-scope program-local diagnostics carry the defining program name', () => {
         const result = analyze_code(`
 program define myprog

--- a/tests/unit/scoped-local-macro-identity.test.ts
+++ b/tests/unit/scoped-local-macro-identity.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'bun:test';
+import { StataLexer } from '../../src/lexer';
+import { StataParser } from '../../src/parser';
+import { SemanticAnalyzer } from '../../src/analyzer';
+import { StataDiagnosticCode } from '../../src/types';
+
+function analyze_code(code: string) {
+    const lexer = new StataLexer();
+    const parser = new StataParser();
+    const analyzer = new SemanticAnalyzer();
+    const lexer_result = lexer.tokenize(code);
+    const parse_result = parser.parse(lexer_result.tokens);
+    return analyzer.analyze(
+        parse_result.ast,
+        'file:///test.do',
+        undefined,
+        { undefined_macro_enabled: true },
+        lexer_result.tokens
+    );
+}
+
+function undefined_macro_diagnostics(
+    result: ReturnType<typeof analyze_code>,
+    name: string
+) {
+    return result.diagnostics.filter(d =>
+        d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+        d.message.includes(`\`${name}'`)
+    );
+}
+
+// Issue #261: program-scoped locals must not suppress undefined-macro
+// warnings outside their defining program body.
+describe('scoped local macro identity (#261)', () => {
+    it('sanity: local defined and used inside the same program does not warn', () => {
+        const result = analyze_code(`
+program define myprog
+    local inside_x 1
+    display \`inside_x'
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'inside_x')).toHaveLength(0);
+    });
+
+    it('forward: top-level reference before top-level definition still warns', () => {
+        const result = analyze_code(`
+display \`later'
+local later 1
+`);
+        expect(undefined_macro_diagnostics(result, 'later')).toHaveLength(1);
+    });
+
+    it('forward: in-program reference before same-program definition still warns', () => {
+        const result = analyze_code(`
+program define myprog
+    display \`inner'
+    local inner 1
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'inner')).toHaveLength(1);
+    });
+
+    it('program-to-top-level: reference after the program warns', () => {
+        const result = analyze_code(`
+program define myprog
+    local inside_x 1
+end
+display \`inside_x'
+`);
+        expect(undefined_macro_diagnostics(result, 'inside_x')).toHaveLength(1);
+    });
+
+    it('program-to-top-level: reference before the program warns', () => {
+        const result = analyze_code(`
+display \`inside_x'
+program define myprog
+    local inside_x 1
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'inside_x')).toHaveLength(1);
+    });
+
+    it('cross-program: reference in a sibling program warns', () => {
+        const result = analyze_code(`
+program define prog_a
+    local from_a 1
+end
+program define prog_b
+    display \`from_a'
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'from_a')).toHaveLength(1);
+    });
+
+    it('cross-program: sibling with its own same-named local does not warn', () => {
+        const result = analyze_code(`
+program define prog_a
+    local shared 1
+end
+program define prog_b
+    local shared 2
+    display \`shared'
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'shared')).toHaveLength(0);
+    });
+
+    it('program reference still sees dofile-scope locals (permissive)', () => {
+        const result = analyze_code(`
+local top_x 1
+program define myprog
+    display \`top_x'
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'top_x')).toHaveLength(0);
+    });
+
+    it('out-of-scope program-local diagnostics carry the defining program name', () => {
+        const result = analyze_code(`
+program define myprog
+    local inside_x 1
+end
+display \`inside_x'
+`);
+        const the_diagnostics = undefined_macro_diagnostics(result, 'inside_x');
+        expect(the_diagnostics).toHaveLength(1);
+        expect(the_diagnostics[0].scope_isolation).toEqual({
+            defined_in_programs: ['myprog'],
+        });
+    });
+});
+
+// Identity split: same-named locals in different scopes are distinct
+// symbols with no cross-scope additional_definitions chains.
+describe('scoped local macro identity split', () => {
+    it('program-then-top-level: dofile definition owns the flat slot cleanly', () => {
+        const result = analyze_code(`
+program define myprog
+    local x 1
+end
+local x 2
+`);
+        const flat_x = result.symbols.localMacros.get('x');
+        expect(flat_x).toBeDefined();
+        expect(flat_x!.containingScope).toBe('dofile');
+        expect(flat_x!.additional_definitions ?? []).toHaveLength(0);
+    });
+
+    it('same-scope redefinitions still chain additional_definitions', () => {
+        const result = analyze_code(`
+local x 1
+local x 2
+`);
+        const flat_x = result.symbols.localMacros.get('x');
+        expect(flat_x).toBeDefined();
+        expect(flat_x!.containingScope).toBe('dofile');
+        expect(flat_x!.additional_definitions).toHaveLength(1);
+    });
+
+    it('cross-program same-named locals are distinct symbols', () => {
+        const result = analyze_code(`
+program define prog_a
+    local shared 1
+end
+program define prog_b
+    local shared 2
+end
+`);
+        const the_program_scopes = result.scopes.filter(s => s.type === 'program');
+        expect(the_program_scopes).toHaveLength(2);
+        const symbol_a = the_program_scopes[0].localMacros.get('shared');
+        const symbol_b = the_program_scopes[1].localMacros.get('shared');
+        expect(symbol_a).toBeDefined();
+        expect(symbol_b).toBeDefined();
+        expect(symbol_a).not.toBe(symbol_b);
+        expect(symbol_a!.additional_definitions ?? []).toHaveLength(0);
+        expect(symbol_b!.additional_definitions ?? []).toHaveLength(0);
+    });
+});
+
+// Flat-slot ownership must be deterministic by earliest definition even
+// when the earlier contender is a loop-expanded macro (whose symbol is
+// synthesized by inject_expanded_macro rather than register_local_macro).
+describe('flat view ownership with loop-expanded macros', () => {
+    it('an earlier loop-expanded local keeps the flat slot', () => {
+        const result = analyze_code(`
+program define prog_b
+    local helper 1
+    foreach v in 1 2 3 {
+        local x_\`v' \`helper'
+    }
+end
+program define prog_a
+    local x_2 99
+end
+`);
+        const flat_x2 = result.symbols.localMacros.get('x_2');
+        expect(flat_x2).toBeDefined();
+        expect(flat_x2!.containing_program_name).toBe('prog_b');
+    });
+});
+
+// Issue #263 limitation 6: an unrelated program-scoped local of the same
+// name must not poison static loop-macro expansion at the top level.
+describe('loop expansion unaffected by cross-scope collisions (#263)', () => {
+    it('top-level fold works despite same-named program-body local', () => {
+        const result = analyze_code(`
+program define helper
+    local list z
+end
+local list a b
+foreach v of local list {
+    local seen_\`v' 1
+}
+display \`seen_a'
+`);
+        expect(undefined_macro_diagnostics(result, 'seen_a')).toHaveLength(0);
+    });
+});

--- a/tests/unit/scoped-local-macro-identity.test.ts
+++ b/tests/unit/scoped-local-macro-identity.test.ts
@@ -240,6 +240,40 @@ end
     });
 });
 
+// Global-macro suppression inside programs must not cover the header or
+// end lines: Stata expands macros on the `program define` line at
+// definition time, so an undefined global there is a real warning.
+describe('global suppression excludes program header and end lines', () => {
+    function undefined_global_diagnostics(
+        result: ReturnType<typeof analyze_code>,
+        name: string
+    ) {
+        return result.diagnostics.filter(d =>
+            d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+            d.message.includes(`$${name}`)
+        );
+    }
+
+    it('warns for an undefined global on the program define line', () => {
+        const result = analyze_code(`
+program define myprog, rclass $extra
+end
+`);
+        expect(undefined_global_diagnostics(result, 'extra')).toHaveLength(1);
+    });
+
+    it('still suppresses undefined globals inside the program body', () => {
+        const result = analyze_code(`
+program define myprog
+    display $maybe_set_by_caller
+end
+`);
+        expect(
+            undefined_global_diagnostics(result, 'maybe_set_by_caller')
+        ).toHaveLength(0);
+    });
+});
+
 // Issue #263 limitation 6: an unrelated program-scoped local of the same
 // name must not poison static loop-macro expansion at the top level.
 describe('loop expansion unaffected by cross-scope collisions (#263)', () => {

--- a/tests/unit/scoped-local-macro-identity.test.ts
+++ b/tests/unit/scoped-local-macro-identity.test.ts
@@ -200,6 +200,22 @@ end
     });
 });
 
+describe('flat view ownership with Mata setters', () => {
+    it('an earlier Mata st_local program-local keeps the flat slot', () => {
+        const result = analyze_code(`
+program define prog_a
+    mata: st_local("x", "1")
+end
+program define prog_b
+    local x 2
+end
+`);
+        const flat_x = result.symbols.localMacros.get('x');
+        expect(flat_x).toBeDefined();
+        expect(flat_x!.containing_program_name).toBe('prog_a');
+    });
+});
+
 // Issue #263 limitation 6: an unrelated program-scoped local of the same
 // name must not poison static loop-macro expansion at the top level.
 describe('loop expansion unaffected by cross-scope collisions (#263)', () => {

--- a/tests/unit/scoped-local-macro-identity.test.ts
+++ b/tests/unit/scoped-local-macro-identity.test.ts
@@ -200,6 +200,30 @@ end
     });
 });
 
+describe('flat view ownership after in-place expanded promotion', () => {
+    it('re-arbitrates the flat slot when promotion moves a symbol earlier', () => {
+        // The literal `local x_1 3` registers in outer's scope after
+        // inner's `local x_1 2` took the flat slot. Loop expansion then
+        // promotes outer's symbol to the constructed-name statement
+        // (line 3), which is earlier than inner's definition — the flat
+        // slot must follow.
+        const result = analyze_code(`
+program define outer
+    foreach v in 1 {
+        local x_\`v' 1
+        program define inner
+            local x_1 2
+        end
+        local x_1 3
+    }
+end
+`);
+        const flat_x1 = result.symbols.localMacros.get('x_1');
+        expect(flat_x1).toBeDefined();
+        expect(flat_x1!.containing_program_name).toBe('outer');
+    });
+});
+
 describe('flat view ownership with Mata setters', () => {
     it('an earlier Mata st_local program-local keeps the flat slot', () => {
         const result = analyze_code(`


### PR DESCRIPTION
## Summary

Implements the **scoped environment model** for local macros in the analyzer — the architectural substrate identified after the v0.9–v0.11 review-convergence retrospective. Fixes #261, resolves #145, and fixes #263's limitation 6 as a side effect.

### What changes

**Identity.** Every local-macro definition site now decides first-definition-wins inside its owning `ScopeInfo.localMacros` (do-file scope, or one scope per `program` body) instead of the flat file-wide map. Same-named locals in unrelated scopes are distinct symbols; cross-scope `additional_definitions` chains no longer exist. The flat `symbols.localMacros` becomes a derived compatibility view maintained by a single function (`publish_flat_local`): a do-file definition owns the slot, else the program-scope definition at the earliest source position.

**Diagnostics (#261).** Reference checking resolves through `lookup_local_macro`, a single choke point: a local suppresses warnings in its own scope, do-file locals stay visible inside programs (permissive, per the issue's proposed semantics), and programs never see each other's locals — structurally, not by enumeration. Positional args and `@lsp-local` directives keep their existing file-wide semantics (directives now also seed the do-file scope).

**Messaging (#145).** When a referenced local exists only inside other program bodies, the diagnostic carries `scope_isolation` and the provider rewrites it to `` `x' is defined only inside program foo `` — inserted after cross-file suppression and before the legacy same-file/backward matchers, so the misleading rewrite reverted on 2026-04-21 is structurally unreachable (those functions are untouched). Severity config, `@lsp-ignore`, and `sight check` tallying are unaffected (code stays `UNDEFINED_MACRO`-based via the existing OUT_OF_SCOPE rewrite).

**Loop expansion (#263 item 6).** Cross-scope name collisions no longer chain into `additional_definitions`, so `fold_symbol`'s poisoning check fires only on genuine same-scope redefinitions — an unrelated program-body local no longer disables top-level folding.

**One mechanism for position→scope.** `find_enclosing_scope` (src/utils/scope-position.ts) replaces the `inside_program` boolean, `collect_program_ranges`, and `collect_program_position_ranges`; the AST pass, token pass, Mata `st_local` pass, and the diagnostics provider's forward-hint logic all share it. In-program global suppression keeps its pre-existing line-exclusive semantics (header/`end` lines still warn).

**Retained substrate.** `DocumentState.scopes` is kept (was discarded) so the provider position-awareness follow-up can query scope visibility without re-analysis; `MacroSymbol.scope_id`/`containing_program_name` are stamped for the same purpose.

### Review process

Beyond the internal design review (three architect variants + adversarial assessment by Codex, which picked the shipped hybrid), the diff went through eight adversarial review rounds (Codex + independent finder/verifier agents). Rounds 1–4 surfaced six shrinking-scope defects, all fixed with both-ways-verified regression tests: expanded-macro flat-slot `definition_index`, scope-aware same-file forward hints, source-position tie-break (Mata setters), promotion re-arbitration, header-line global suppression, and redeclared-program self-blame. Round 6 raised a message-precedence question, initially resolved by precedence (scope isolation outranks the use-include rewrite, per the 2026-04-21 precedent) and refined post-review in e32d078: the combined case (same-file program local + do-called child defining the name) now states BOTH facts - the scope-isolation half leads and the child definition with its "use include instead" remedy is appended. Pinned by test. Rounds 7 and 8 came back clean consecutively, the final round via a 12-file realistic-corpus differential in which every diagnostic difference vs main traced to an intended change.

### Deferred, tracked separately

- Provider position-awareness (hover/definition/references/completion still read the flat view): #270
- Cross-file `include` inheritance of program-body locals (pre-existing): #271

### Testing

- `bun run test` — full suite green (6,918+ tests), typecheck clean
- `bun run lint` — clean
- New: `tests/unit/scoped-local-macro-identity.test.ts` (analyzer-level: #261's four cases, identity split, flat-slot ownership permutations, header/end suppression, redeclared programs, #263 unpoisoning), `tests/unit/scope-isolation-diagnostics.test.ts` (provider-level: #145 messages, revert-scenario regression, cross-file suppression precedence, severity parity, scope-aware forward hints)

https://claude.ai/code/session_01T1B6kdubit8c7muBZj2Ktc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scope-aware handling for undefined local/global macros, including clearer “defined only inside program(s)” messaging.
  * Document analysis state and completion fallback now include populated scope information for downstream features.
* **Bug Fixes**
  * Fixed macro resolution across nested program bodies, Mata blocks, and scoped local definitions.
  * Improved undefined-symbol rewriting precedence and forward-definition hinting for same-file cases.
* **Tests**
  * Added new unit coverage for scope isolation diagnostics and scoped local macro identity.
  * Updated diagnostic and fixture helpers to use real document state where appropriate, plus expanded existing hover-suppression test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
