### PR TITLE
Resolve header/end-line local references against the enclosing scope

### DIFF
--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -3663,9 +3663,10 @@ export class SemanticAnalyzer {
      */
     private find_enclosing_scope(
         scopes: ScopeInfo[],
-        position: { line: number; character: number }
+        position: { line: number; character: number },
+        options?: { body_only?: boolean }
     ): ScopeInfo {
-        return find_enclosing_scope(scopes, position);
+        return find_enclosing_scope(scopes, position, options);
     }
 
     /**
@@ -4917,9 +4918,13 @@ export class SemanticAnalyzer {
                 
                 const token_line = token.range.start.line;
                 if (macro_name) {
+                    // Header/end lines expand at definition time in the
+                    // enclosing frame, so body locals never satisfy a
+                    // reference there (issue #273) — resolve body-only.
                     const reference_scope = this.find_enclosing_scope(
                         scopes,
-                        token.range.start
+                        token.range.start,
+                        { body_only: true }
                     );
                     const result = this.lookup_local_macro(
                         macro_name,

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -3372,7 +3372,11 @@ export class SemanticAnalyzer {
         reference_scope: ScopeInfo,
         reference_index?: number,
         reference_line?: number,
-        reference_range?: Range
+        reference_range?: Range,
+        // Program whose header/end line the reference sits on (its
+        // body was skipped by body_only resolution); never blamed in
+        // scope-isolation hints — see the redeclared-bodies rule below.
+        header_program_name?: string
     ): LocalMacroLookupResult {
         // Positional arguments (`1', `2', ...) are always potentially
         // defined — they represent command-line arguments.
@@ -3444,10 +3448,14 @@ export class SemanticAnalyzer {
                 // reference's own program name — blaming them would
                 // read as self-contradictory ("defined only inside
                 // program foo" while inside program foo). Skip them;
-                // the plain undefined message is correct there.
+                // the plain undefined message is correct there. The
+                // same rule covers a reference on a program's own
+                // header/end line (issue #273).
                 if (
-                    reference_scope.type === 'program' &&
-                    my_scope.program_name === reference_scope.program_name
+                    my_scope.program_name === header_program_name ||
+                    (reference_scope.type === 'program' &&
+                        my_scope.program_name ===
+                            reference_scope.program_name)
                 ) {
                     continue;
                 }
@@ -4863,15 +4871,16 @@ export class SemanticAnalyzer {
             // lines are excluded: Stata expands macros on the header at
             // definition time, so an undefined global there is a real
             // warning (matches the pre-split line-exclusive ranges).
+            // body_only also sends a NESTED header to the enclosing
+            // program's body — it expands while the outer program runs,
+            // the same caller-may-set frame as outer body code.
             if (token.type === 'MACRO_REF_GLOBAL') {
-                const enclosing_scope =
-                    this.find_enclosing_scope(scopes, token.range.start);
-                const token_line = token.range.start.line;
-                if (
-                    enclosing_scope.type === 'program' &&
-                    token_line > enclosing_scope.range.start.line &&
-                    token_line < enclosing_scope.range.end.line
-                ) {
+                const enclosing_scope = this.find_enclosing_scope(
+                    scopes,
+                    token.range.start,
+                    { body_only: true }
+                );
+                if (enclosing_scope.type === 'program') {
                     continue;
                 }
             }
@@ -4926,13 +4935,27 @@ export class SemanticAnalyzer {
                         token.range.start,
                         { body_only: true }
                     );
+                    // When body_only skipped a program (the token sits
+                    // on its header/end line), that program's name must
+                    // not be blamed in scope-isolation hints — same
+                    // self-contradiction rule as redeclared bodies.
+                    const positional_scope = this.find_enclosing_scope(
+                        scopes,
+                        token.range.start
+                    );
+                    const header_program_name =
+                        positional_scope !== reference_scope &&
+                        positional_scope.type === 'program'
+                            ? positional_scope.program_name
+                            : undefined;
                     const result = this.lookup_local_macro(
                         macro_name,
                         symbols,
                         reference_scope,
                         undefined,
                         token_line,
-                        token.range
+                        token.range,
+                        header_program_name
                     );
                     this.emit_undefined_local_diagnostic(
                         result,

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -1,5 +1,8 @@
 import { Range } from 'vscode-languageserver-textdocument';
-import { find_enclosing_scope } from '../utils/scope-position';
+import {
+    find_enclosing_scope,
+    program_body_start_line,
+} from '../utils/scope-position';
 import {
     format_undefined_macro_message,
     format_undefined_variable_message,
@@ -314,6 +317,10 @@ export class SemanticAnalyzer {
     // lookups can reach the do-file scope (index 0) and the scope-
     // isolation scan without threading it through every signature.
     private current_scopes: ScopeInfo[] = [];
+    // Lines whose statement ///-continues onto the next physical line,
+    // from the in-flight analyze() call's token stream. Lets program
+    // scopes record where a continued header actually ends (#273).
+    private continued_lines = new Set<number>();
 
     /**
      * Analyze an AST and build symbol tables.
@@ -343,6 +350,14 @@ export class SemanticAnalyzer {
         this.nonexec_conditional_depth = 0;
         this.workspace_symbols = workspace_symbols; // Store workspace symbols
         this.tokens = tokens; // Keep tokens for command-level pattern checks
+        this.continued_lines = new Set<number>();
+        if (tokens) {
+            for (const my_token of tokens) {
+                if (my_token.type === 'CONTINUATION') {
+                    this.continued_lines.add(my_token.range.start.line);
+                }
+            }
+        }
 
         // Initialize symbol table
         const symbols: SymbolTable = create_empty_symbol_table();
@@ -899,12 +914,20 @@ export class SemanticAnalyzer {
 
         // Create a new scope for the program body — unconditional so that
         // each redeclaration's body gets its own scope for per-body diagnostics.
+        // A ///-continued header spans several physical lines that are
+        // all still header — walk the continuation run so body-only
+        // scope resolution excludes the whole logical header (#273).
+        let my_header_line = node.range.start.line;
+        while (this.continued_lines.has(my_header_line)) {
+            my_header_line++;
+        }
         const program_scope: ScopeInfo = {
             type: 'program',
             range: node.range,
             localMacros: new Map(),
             id: all_scopes.length,
             program_name: node.name,
+            body_start_line: my_header_line + 1,
         };
         all_scopes.push(program_scope);
 
@@ -4867,8 +4890,9 @@ export class SemanticAnalyzer {
             }
 
             // Suppress ALL global-token checks inside program BODIES.
-            // The header (`program define ...`) and `end` lines are
-            // excluded: Stata expands macros on the header at
+            // The header (`program define ...`, including every
+            // physical line of a ///-continued header) and `end` lines
+            // are excluded: Stata expands macros on the header at
             // definition time, so an undefined global there is a real
             // warning (matches the pre-split line-exclusive ranges).
             // Kept char-precise and innermost-only (NOT body_only): a
@@ -4882,7 +4906,8 @@ export class SemanticAnalyzer {
                 const token_line = token.range.start.line;
                 if (
                     enclosing_scope.type === 'program' &&
-                    token_line > enclosing_scope.range.start.line &&
+                    token_line >=
+                        program_body_start_line(enclosing_scope) &&
                     token_line < enclosing_scope.range.end.line
                 ) {
                     continue;

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -4866,21 +4866,25 @@ export class SemanticAnalyzer {
                 continue;
             }
 
-            // Suppress undefined global macro warnings inside program
-            // BODIES only. The header (`program define ...`) and `end`
-            // lines are excluded: Stata expands macros on the header at
+            // Suppress ALL global-token checks inside program BODIES.
+            // The header (`program define ...`) and `end` lines are
+            // excluded: Stata expands macros on the header at
             // definition time, so an undefined global there is a real
             // warning (matches the pre-split line-exclusive ranges).
-            // body_only also sends a NESTED header to the enclosing
-            // program's body — it expands while the outer program runs,
-            // the same caller-may-set frame as outer body code.
+            // Kept char-precise and innermost-only (NOT body_only): a
+            // nested header must fall through so its syntax checks
+            // (e.g. invalid macro chars) still run — only its
+            // undefined-global check is frame-suppressed, at the push
+            // site below.
             if (token.type === 'MACRO_REF_GLOBAL') {
-                const enclosing_scope = this.find_enclosing_scope(
-                    scopes,
-                    token.range.start,
-                    { body_only: true }
-                );
-                if (enclosing_scope.type === 'program') {
+                const enclosing_scope =
+                    this.find_enclosing_scope(scopes, token.range.start);
+                const token_line = token.range.start.line;
+                if (
+                    enclosing_scope.type === 'program' &&
+                    token_line > enclosing_scope.range.start.line &&
+                    token_line < enclosing_scope.range.end.line
+                ) {
                     continue;
                 }
             }
@@ -5001,6 +5005,18 @@ export class SemanticAnalyzer {
                         token.range
                     )
                 ) {
+                    // A NESTED program's header/end line expands while
+                    // the outer program runs — the same caller-may-set
+                    // frame as outer body code, so the undefined-global
+                    // warning (and only it) is suppressed there.
+                    const frame_scope = this.find_enclosing_scope(
+                        scopes,
+                        token.range.start,
+                        { body_only: true }
+                    );
+                    if (frame_scope.type === 'program') {
+                        continue;
+                    }
                     diagnostics.push({
                         message: format_undefined_macro_message(
                             'global',

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -33,7 +33,9 @@ import {
     ScalarSymbol,
     MatrixSymbol,
     StataLSPConfig,
+    ScopeInfo,
 } from '../types';
+import { program_body_start_line } from '../utils/scope-position';
 import { IContextTracker, LanguageContext } from '../context-tracker/types';
 import { CompletionPrefixCache } from '../utils/lru-cache';
 import { SymbolIndexCache } from '../utils/symbol-index-cache';
@@ -3243,7 +3245,11 @@ export class CompletionProvider {
             return null;
         }
 
-        return this.find_program_containing_position(document.ast.nodes, position);
+        return this.find_program_containing_position(
+            document.ast.nodes,
+            position,
+            document.scopes
+        );
     }
 
     /**
@@ -3251,42 +3257,59 @@ export class CompletionProvider {
      */
     private find_program_containing_position(
         nodes: StataNode[],
-        position: Position
+        position: Position,
+        scopes?: ScopeInfo[]
     ): ProgramNode | null {
         for (const node of nodes) {
             if (node.type === 'program') {
                 // Check if position is within program body (not just the program declaration)
-                if (this.is_position_in_program_body(position, node)) {
+                if (this.is_position_in_program_body(position, node, scopes)) {
                     return node;
                 }
             }
-            
+
             // Recurse into nested structures
-            if (node.type === 'if' || node.type === 'else' || 
-                node.type === 'foreach' || node.type === 'forvalues' || 
+            if (node.type === 'if' || node.type === 'else' ||
+                node.type === 'foreach' || node.type === 'forvalues' ||
                 node.type === 'while' || node.type === 'frame') {
-                const result = this.find_program_containing_position(node.body, position);
+                const result = this.find_program_containing_position(node.body, position, scopes);
                 if (result) return result;
             }
         }
-        
+
         return null;
     }
 
     /**
-     * Check if position is within a program's body (not the declaration line).
+     * Check if position is within a program's BODY. The whole logical
+     * header — every physical line of a ///-continued one — and the
+     * `end` line expand at definition time in the enclosing frame
+     * (issue #273), so body completions are not offered there. The
+     * analyzer's matching scope carries the continued header's extent;
+     * without scopes, fall back to the single-line-header boundary.
      */
-    private is_position_in_program_body(position: Position, program: ProgramNode): boolean {
+    private is_position_in_program_body(
+        position: Position,
+        program: ProgramNode,
+        scopes?: ScopeInfo[]
+    ): boolean {
         // Position must be within program range
         if (!is_position_in_range(position, program.range)) {
             return false;
         }
-        
-        // Position must be after the program declaration line
-        if (position.line <= program.range.start.line) {
-            return false;
-        }
-        
-        return true;
+
+        const matching_scope = scopes?.find(
+            my_scope =>
+                my_scope.type === 'program' &&
+                my_scope.range.start.line === program.range.start.line &&
+                my_scope.range.end.line === program.range.end.line
+        );
+        const body_start = matching_scope
+            ? program_body_start_line(matching_scope)
+            : program.range.start.line + 1;
+        return (
+            position.line >= body_start &&
+            position.line < program.range.end.line
+        );
     }
 }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -1832,7 +1832,8 @@ export class CompletionProvider {
                 if (macro_pos) {
                     const containing_program = this.find_program_containing_position(
                         document.ast.nodes,
-                        macro_pos
+                        macro_pos,
+                        document.scopes
                     );
 
                     if (current_program) {

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -1023,9 +1023,13 @@ export class DiagnosticsProvider {
         // definition after the reference across both. Falls back to the
         // flat read when no scopes were provided (partial states).
         if (reference_kind === 'local' && scopes.length > 0) {
+            // body_only: a reference on a program's header/end line
+            // expands in the enclosing frame, so the hint must never
+            // name a body local (issue #273).
             const enclosing_scope = find_enclosing_scope(
                 scopes,
-                reference_position
+                reference_position,
+                { body_only: true }
             );
             const the_visible_scopes =
                 enclosing_scope.type !== 'dofile' &&

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -465,6 +465,10 @@ export interface ScopeInfo {
   id: number;
   // Program name for 'program' scopes; feeds scope-isolation messaging.
   program_name?: string;
+  // First line of the program BODY, one past the header's last
+  // physical line. Set when a ///-continued header spans several
+  // lines; absent, the body starts after range.start.line.
+  body_start_line?: number;
 }
 
 // Command Database Types

--- a/src/utils/scope-position.ts
+++ b/src/utils/scope-position.ts
@@ -37,10 +37,17 @@ export function position_within_range(
 /**
  * Innermost program scope whose (character-precise, inclusive) range
  * contains `position`, else the do-file scope (`scopes[0]`).
+ *
+ * With `body_only`, a program scope matches only on its strictly
+ * interior lines: the `program define` header and `end` lines are
+ * excluded, because Stata expands macros there at definition time in
+ * the enclosing frame (issue #273). A nested program's header still
+ * resolves to its enclosing program's body, not the do-file scope.
  */
 export function find_enclosing_scope(
     scopes: ScopeInfo[],
-    position: Position
+    position: Position,
+    options?: { body_only?: boolean }
 ): ScopeInfo {
     if (scopes.length === 0) {
         // Every producer pushes the do-file scope first, so an empty
@@ -54,6 +61,13 @@ export function find_enclosing_scope(
             continue;
         }
         if (!position_within_range(position, my_scope.range)) {
+            continue;
+        }
+        if (
+            options?.body_only === true &&
+            (position.line <= my_scope.range.start.line ||
+                position.line >= my_scope.range.end.line)
+        ) {
             continue;
         }
         // Nested program scopes start later than their enclosing

--- a/src/utils/scope-position.ts
+++ b/src/utils/scope-position.ts
@@ -35,14 +35,25 @@ export function position_within_range(
 }
 
 /**
+ * First line of a program scope's BODY. The analyzer records
+ * `body_start_line` when a `program define` header is ///-continued
+ * across several physical lines; absent, the body starts on the line
+ * after the header line.
+ */
+export function program_body_start_line(scope: ScopeInfo): number {
+    return scope.body_start_line ?? scope.range.start.line + 1;
+}
+
+/**
  * Innermost program scope whose (character-precise, inclusive) range
  * contains `position`, else the do-file scope (`scopes[0]`).
  *
- * With `body_only`, a program scope matches only on its strictly
- * interior lines: the `program define` header and `end` lines are
- * excluded, because Stata expands macros there at definition time in
- * the enclosing frame (issue #273). A nested program's header still
- * resolves to its enclosing program's body, not the do-file scope.
+ * With `body_only`, a program scope matches only on its body lines:
+ * the `program define` header (all physical lines of it, when
+ * ///-continued) and the `end` line are excluded, because Stata
+ * expands macros there at definition time in the enclosing frame
+ * (issue #273). A nested program's header still resolves to its
+ * enclosing program's body, not the do-file scope.
  */
 export function find_enclosing_scope(
     scopes: ScopeInfo[],
@@ -65,7 +76,7 @@ export function find_enclosing_scope(
         }
         if (
             options?.body_only === true &&
-            (position.line <= my_scope.range.start.line ||
+            (position.line < program_body_start_line(my_scope) ||
                 position.line >= my_scope.range.end.line)
         ) {
             continue;

--- a/tests/property/helpers/document-utils.ts
+++ b/tests/property/helpers/document-utils.ts
@@ -100,6 +100,7 @@ export function create_document_state(my_source: string): DocumentState {
     tokens: my_lex_result.tokens,
     ast: my_parse_result.ast,
     symbols: my_analysis_result.symbols,
+    scopes: my_analysis_result.scopes,
     diagnostics: my_lsp_diagnostics,
     context_ranges: my_context_ranges,
     context_tracker: my_context_tracker,

--- a/tests/property/program-arguments.test.ts
+++ b/tests/property/program-arguments.test.ts
@@ -196,21 +196,83 @@ program define test_prog
     local result \`varlist'
 end
 `;
-            
+
             const document = create_test_document(program_code);
             const parsed = parse_and_analyze(program_code);
             document.ast = parsed.ast;
-            
+
             const provider = new CompletionProvider(new CommandDatabase());
-            
+
             // Position on program declaration line
             const declaration_position: Position = { line: 1, character: 15 };
             const result = (provider as any).detect_cursor_in_program_body(document, declaration_position);
             expect(result).toBeNull();
         });
+
+        it('should not detect program on a ///-continued header line (#273)', () => {
+            // Line 2 is still the header — it expands at definition
+            // time in the enclosing frame, so body completions must
+            // not be offered there.
+            const program_code = `
+program define test_prog, ///
+    rclass
+    syntax varlist
+end
+`;
+            const document = parse_and_analyze(program_code);
+            const provider = new CompletionProvider(new CommandDatabase());
+
+            const continuation_position: Position = { line: 2, character: 10 };
+            const continuation_result = (provider as any)
+                .detect_cursor_in_program_body(document, continuation_position);
+            expect(continuation_result).toBeNull();
+
+            // The first true body line still detects the program.
+            const body_position: Position = { line: 3, character: 10 };
+            const body_result = (provider as any)
+                .detect_cursor_in_program_body(document, body_position);
+            expect(body_result?.name).toBe('test_prog');
+        });
+
+        it('should not detect program on the end line', () => {
+            const program_code = `
+program define test_prog
+    syntax varlist
+end
+`;
+            const document = parse_and_analyze(program_code);
+            const provider = new CompletionProvider(new CommandDatabase());
+
+            const end_position: Position = { line: 3, character: 2 };
+            const result = (provider as any)
+                .detect_cursor_in_program_body(document, end_position);
+            expect(result).toBeNull();
+        });
     });
 
     describe('program argument completions in macro context', () => {
+        it('should not offer program arguments on a continued header line (#273)', async () => {
+            const program_code = `
+program define test_prog, ///
+    rclass \`
+    syntax varlist
+end
+`;
+            const document = parse_and_analyze(program_code);
+            const provider = new CompletionProvider(new CommandDatabase());
+
+            // Inside the backtick on the continuation line — still
+            // the header, so `varlist` (a body argument) must not be
+            // offered as a program argument there.
+            const position: Position = { line: 2, character: 12 };
+            const completions = await provider.get_completions(document, position);
+
+            const the_argument_labels = completions
+                .filter(c => c.detail === 'Program argument')
+                .map(c => c.label);
+            expect(the_argument_labels).not.toContain('varlist');
+        });
+
         it('should include program arguments in local macro completions', async () => {
             const program_code = `
 program define test_prog

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -1437,6 +1437,35 @@ display \`result'
             );
         });
 
+        it('should not point continued-header forward hints at body locals (#273)', async () => {
+            // The reference sits on the second physical line of a
+            // ///-continued header — still the header, so the hint
+            // must name the do-file definition (line 5), not the body
+            // local (line 3).
+            const content = [
+                'program define p, ///',
+                "    rclass `x'",
+                'local x 1',
+                'end',
+                'local x 2',
+            ].join('\n');
+            const document = create_real_document_state(content);
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG
+            );
+
+            const out_of_scope_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.range.start.line === 1
+            );
+            expect(out_of_scope_diag).toBeDefined();
+            expect(out_of_scope_diag?.message).toBe(
+                "`x' is used before it is defined (line 5)"
+            );
+        });
+
         it('should rewrite same-file global forward references', async () => {
             const content = [
                 'display $after_global',

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -1410,6 +1410,33 @@ display \`result'
             expect(undefined_diag).toBeUndefined();
         });
 
+        it('should not point header-line forward hints at program-body locals (#273)', async () => {
+            // The header reference expands at definition time in the
+            // do-file frame, so the hint must name the later do-file
+            // definition (line 4), never the body local (line 2).
+            const content = [
+                "program define p, rclass `x'",
+                'local x 1',
+                'end',
+                'local x 2',
+            ].join('\n');
+            const document = create_real_document_state(content);
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG
+            );
+
+            const out_of_scope_diag = the_diagnostics.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.range.start.line === 0
+            );
+            expect(out_of_scope_diag).toBeDefined();
+            expect(out_of_scope_diag?.message).toBe(
+                "`x' is used before it is defined (line 4)"
+            );
+        });
+
         it('should rewrite same-file global forward references', async () => {
             const content = [
                 'display $after_global',

--- a/tests/unit/scoped-local-macro-identity.test.ts
+++ b/tests/unit/scoped-local-macro-identity.test.ts
@@ -436,6 +436,69 @@ end
     });
 });
 
+// A ///-continued `program define` header spans several physical
+// lines; every one of them is still the header and expands at
+// definition time in the enclosing frame, so the body-only treatment
+// must cover the whole logical header, not just its first line.
+describe('continued program headers are header, not body (#273)', () => {
+    it('warns for a continued-header local even when args defines it in the body', () => {
+        const result = analyze_code(`
+program define p, ///
+    rclass \`x'
+    args x
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'x')).toHaveLength(1);
+    });
+
+    it('warns for an undefined global on a continued header line', () => {
+        const result = analyze_code(`
+program define p, ///
+    rclass $extra
+end
+`);
+        expect(result.diagnostics.filter(d =>
+            d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+            d.message.includes('$extra')
+        )).toHaveLength(1);
+    });
+
+    it('reports invalid macro chars on a continued header line', () => {
+        const result = analyze_code(`
+program define p, ///
+    rclass \${bad.name}
+end
+`);
+        expect(result.diagnostics.filter(d =>
+            d.code === StataDiagnosticCode.INVALID_MACRO_CHAR
+        )).toHaveLength(1);
+    });
+
+    it('body lines after a continued header still suppress globals', () => {
+        const result = analyze_code(`
+program define p, ///
+    rclass
+    display $maybe_set_by_caller
+end
+`);
+        expect(result.diagnostics.filter(d =>
+            d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+            d.message.includes('$maybe_set_by_caller')
+        )).toHaveLength(0);
+    });
+
+    it('body references after a continued header still see body locals', () => {
+        const result = analyze_code(`
+program define p, ///
+    rclass
+    args x
+    display \`x'
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'x')).toHaveLength(0);
+    });
+});
+
 // Issue #263 limitation 6: an unrelated program-scoped local of the same
 // name must not poison static loop-macro expansion at the top level.
 describe('loop expansion unaffected by cross-scope collisions (#263)', () => {

--- a/tests/unit/scoped-local-macro-identity.test.ts
+++ b/tests/unit/scoped-local-macro-identity.test.ts
@@ -290,6 +290,20 @@ end
             undefined_global_diagnostics(result, 'maybe_set_by_caller')
         ).toHaveLength(0);
     });
+
+    it('suppresses undefined globals on a nested program header', () => {
+        // The inner header expands while OUTER runs — the same frame
+        // as outer body code, whose globals may be set by the caller.
+        const result = analyze_code(`
+program define outer
+    program define inner, rclass $maybe_set
+    end
+end
+`);
+        expect(
+            undefined_global_diagnostics(result, 'maybe_set')
+        ).toHaveLength(0);
+    });
 });
 
 // Issue #273: local-macro references on a `program define` header line
@@ -307,7 +321,9 @@ end
         expect(undefined_macro_diagnostics(result, 'x')).toHaveLength(1);
     });
 
-    it('header local matched only by a body local reports scope isolation', () => {
+    it('header local matched only by an own-body local warns plainly', () => {
+        // Blaming the program whose header the reference sits on would
+        // be self-contradictory, same as the redeclared-bodies rule.
         const result = analyze_code(`
 program define p, rclass \`x'
     local x 1
@@ -315,8 +331,34 @@ end
 `);
         const the_diagnostics = undefined_macro_diagnostics(result, 'x');
         expect(the_diagnostics).toHaveLength(1);
+        expect(the_diagnostics[0].scope_isolation).toBeUndefined();
+    });
+
+    it('redeclared program headers do not blame their own name', () => {
+        const result = analyze_code(`
+program define foo
+    local x 1
+end
+program define foo, rclass \`x'
+end
+`);
+        const the_diagnostics = undefined_macro_diagnostics(result, 'x');
+        expect(the_diagnostics).toHaveLength(1);
+        expect(the_diagnostics[0].scope_isolation).toBeUndefined();
+    });
+
+    it('header locals still blame other programs that define the name', () => {
+        const result = analyze_code(`
+program define helper
+    local x 1
+end
+program define p, rclass \`x'
+end
+`);
+        const the_diagnostics = undefined_macro_diagnostics(result, 'x');
+        expect(the_diagnostics).toHaveLength(1);
         expect(the_diagnostics[0].scope_isolation).toEqual({
-            defined_in_programs: ['p'],
+            defined_in_programs: ['helper'],
         });
     });
 

--- a/tests/unit/scoped-local-macro-identity.test.ts
+++ b/tests/unit/scoped-local-macro-identity.test.ts
@@ -292,6 +292,80 @@ end
     });
 });
 
+// Issue #273: local-macro references on a `program define` header line
+// expand at definition time in the enclosing frame, so body locals can
+// never satisfy them. They must resolve against the enclosing scope
+// (do-file, or the outer program body for nested definitions), the same
+// body-only treatment global suppression got above.
+describe('header-line local references resolve against the enclosing scope (#273)', () => {
+    it('warns for a header local even when args defines it in the body', () => {
+        const result = analyze_code(`
+program define p, rclass \`x'
+    args x
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'x')).toHaveLength(1);
+    });
+
+    it('header local matched only by a body local reports scope isolation', () => {
+        const result = analyze_code(`
+program define p, rclass \`x'
+    local x 1
+end
+`);
+        const the_diagnostics = undefined_macro_diagnostics(result, 'x');
+        expect(the_diagnostics).toHaveLength(1);
+        expect(the_diagnostics[0].scope_isolation).toEqual({
+            defined_in_programs: ['p'],
+        });
+    });
+
+    it('header local defined earlier at do-file scope does not warn', () => {
+        const result = analyze_code(`
+local x 1
+program define p, rclass \`x'
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'x')).toHaveLength(0);
+    });
+
+    it('nested header local resolves against the outer program body', () => {
+        const result = analyze_code(`
+program define outer
+    local x 1
+    program define inner, rclass \`x'
+    end
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'x')).toHaveLength(0);
+    });
+
+    it('end-line local references resolve against the do-file scope', () => {
+        // Trailing text after `end` already sits outside the program's
+        // char-inclusive range; guard that it stays do-file-resolved.
+        const result = analyze_code(`
+program define p
+    local x 1
+end \`x'
+`);
+        const the_diagnostics = undefined_macro_diagnostics(result, 'x');
+        expect(the_diagnostics).toHaveLength(1);
+        expect(the_diagnostics[0].scope_isolation).toEqual({
+            defined_in_programs: ['p'],
+        });
+    });
+
+    it('body references still see body locals', () => {
+        const result = analyze_code(`
+program define p
+    args x
+    display \`x'
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'x')).toHaveLength(0);
+    });
+});
+
 // Issue #263 limitation 6: an unrelated program-scoped local of the same
 // name must not poison static loop-macro expansion at the top level.
 describe('loop expansion unaffected by cross-scope collisions (#263)', () => {

--- a/tests/unit/scoped-local-macro-identity.test.ts
+++ b/tests/unit/scoped-local-macro-identity.test.ts
@@ -304,6 +304,34 @@ end
             undefined_global_diagnostics(result, 'maybe_set')
         ).toHaveLength(0);
     });
+
+    it('still reports invalid macro chars on a nested program header', () => {
+        // Frame suppression covers only the undefined-global check —
+        // \${bad.name} is a syntax error no caller can make valid.
+        const result = analyze_code(`
+program define outer
+    program define inner, rclass \${bad.name}
+    end
+end
+`);
+        expect(result.diagnostics.filter(d =>
+            d.code === StataDiagnosticCode.INVALID_MACRO_CHAR
+        )).toHaveLength(1);
+    });
+
+    it('body-line invalid macro chars stay suppressed (parity with main)', () => {
+        // Pre-existing behavior: program-body global tokens skip ALL
+        // checks, including syntax ones. Pinned so changes are
+        // deliberate, not incidental.
+        const result = analyze_code(`
+program define myprog
+    display \${bad.name}
+end
+`);
+        expect(result.diagnostics.filter(d =>
+            d.code === StataDiagnosticCode.INVALID_MACRO_CHAR
+        )).toHaveLength(0);
+    });
 });
 
 // Issue #273: local-macro references on a `program define` header line


### PR DESCRIPTION
## Summary

Local-macro references on a `program define` header line (and `end` line) expand at definition time in the enclosing frame, so program-body locals can never satisfy them. This gives them the same body-only treatment global suppression got in PR #272 (9ec12e9), and extends that treatment to `///`-continued headers, which previously counted as body from their second physical line on.

Fixes #273

## How

- `find_enclosing_scope` (`src/utils/scope-position.ts`) gains a `body_only` mode: a program scope matches only on its body lines. A nested program's header resolves to the *enclosing program's body*, not straight to the do-file scope.
- Program `ScopeInfo` records `body_start_line`, computed in the analyzer by walking the run of lexer `CONTINUATION` tokens from the header line — the parser drops continuation content into the body, so the scope range alone cannot reveal the header extent. The shared `program_body_start_line` helper feeds every consumer.
- The analyzer token pass (`MACRO_REF_LOCAL`), the global-suppression sites, the diagnostics provider's same-file forward hint, and completion's cursor-in-body detection all use the shared boundary.

## Behavior changes (all stricter-or-equal except noted)

- `` program define p, rclass `x' `` + `args x` body → now warns (the `args` visible-from-scope-start sentinel silently masked it).
- Header local matched only by an own-body local → warns plainly, with no forward hint naming a body local the header can never see, and no self-contradictory "defined only inside program p" blame (extends the redeclared-bodies rule). Other programs defining the name are still blamed.
- All of the above also on every physical line of a `///`-continued header, for locals and globals, including `${bad.name}` syntax checks.
- Nested program headers: undefined-global warnings are now *suppressed* there (the inner header expands while the outer program runs — the same caller-may-set frame as outer body code), while syntax checks still run.
- Completion no longer offers program-body arguments on continued header lines or the `end` line.

## Review gate

Five rounds of Codex (task mode) + independently-spawned Claude reviewer subagents (cold correctness, pattern sweep, conventions/test-quality). Each round's findings were fixed with regression tests or dismissed with evidence; final rounds returned NO ISSUES FOUND on the diff. Full suite: 6,942 tests green; eslint clean.

## Known pre-existing gaps deliberately not addressed here (all verified identical on main)

- The parser does not bridge `///` on program headers, so continuation content still parses as a bogus body statement; signature extraction can therefore pick up a `syntax` written on a continuation line (pathological input; principled fix is parser-level bridging).
- Completion's program scoping is flat-by-name: nested program bodies detect as the outer program, and redeclared programs share locals in completion while diagnostics keep them distinct (the completion analog of #270/#271).
- Program-body global tokens skip all checks including `${bad.name}` syntax errors (now pinned by a parity test so any change is deliberate).
- Mata setter attribution stays char-precise: a setter cannot syntactically share a header/`end` line.

https://claude.ai/code/session_013Uqggu37Q8Lxk1A5hMswXn