### PR TITLE
Filter program-body locals from cross-file include inheritance

### DIFF
--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -32,6 +32,8 @@ import {
     type PathCaseOutcome,
 } from '../utils/file-path-utils';
 import { get_workspace_root_for_path } from '../utils/workspace-roots';
+import { filter_dofile_locals, is_dofile_local } from '../utils/dofile-locals';
+import { clone_symbol_table } from '../scope-resolver/visible-symbols';
 
 export interface ForwardScopeConfig {
     max_forward_depth: number;
@@ -670,10 +672,14 @@ export class ForwardScopeResolver {
             // Apply inheritance rules
             let inherited_symbols: SymbolTable;
             if (decision.action === 'add_locals_only') {
-                // Only add locals from include after do
+                // Only add locals from include after do; program-body
+                // locals stay behind (issue #271), same as the
+                // apply_forward_inheritance include branch this bypasses.
                 inherited_symbols = {
                     programs: new Map(),
-                    localMacros: new Map(callee_result.symbols.localMacros),
+                    localMacros: filter_dofile_locals(
+                        callee_result.symbols.localMacros
+                    ),
                     globalMacros: new Map(),
                     variables: new Map(),
                     scalars: new Map(),
@@ -804,19 +810,21 @@ export class ForwardScopeResolver {
         callee_symbols: SymbolTable,
         effective_call_type: EffectiveCallType
     ): SymbolTable {
+        // Clone in both branches: `callee_symbols` is the shared
+        // file-cache entry and must not be aliased or mutated.
+        const inherited = clone_symbol_table(callee_symbols);
+
         if (effective_call_type === 'include') {
-            return callee_symbols;
+            // include: inherit everything except program-body locals,
+            // which never exist at the callee's do-file level (issue #271).
+            inherited.localMacros =
+                filter_dofile_locals(callee_symbols.localMacros);
+            return inherited;
         }
 
         // do/run: exclude local macros
-        return {
-            programs: new Map(callee_symbols.programs),
-            localMacros: new Map(),
-            globalMacros: new Map(callee_symbols.globalMacros),
-            variables: new Map(callee_symbols.variables),
-            scalars: new Map(callee_symbols.scalars),
-            matrices: new Map(callee_symbols.matrices),
-        };
+        inherited.localMacros = new Map();
+        return inherited;
     }
 
     /**
@@ -961,7 +969,7 @@ export class ForwardScopeResolver {
 
             const the_events: WalkEvent[] = [];
             for (const [my_name, my_symbol] of callee_result.symbols.localMacros) {
-                if (my_symbol.containingScope !== 'dofile') continue;
+                if (!is_dofile_local(my_symbol)) continue;
                 // Emit one event per definition: the primary plus each entry
                 // in `additional_definitions`. `SemanticAnalyzer` implements
                 // first-def-wins, so every later `local X` in the same file

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -48,6 +48,7 @@ import * as path from 'path';
 import { URI } from 'vscode-uri';
 import { resolve_path_rich, resolve_forward_call_rich } from '../utils/file-path-utils';
 import { get_line_text } from '../utils/line-utils';
+import { is_cross_file_hidden_local } from '../utils/dofile-locals';
 import { is_cursor_in_comment, is_cursor_in_block_comment } from '../utils/comment-utils';
 import {
     BACKWARD_DIRECTIVE_KEYWORDS,
@@ -1065,6 +1066,7 @@ export class DefinitionProvider {
         )) {
             if (my_def.sourceUri === document_uri) continue;
             if (!related_uris.has(my_def.sourceUri)) continue;
+            if (is_cross_file_hidden_local(symbol_type, my_def)) continue;
             out.push(...this.symbol_to_locations(my_def));
         }
         return out;
@@ -1109,6 +1111,14 @@ export class DefinitionProvider {
                 continue;
             }
             if (!related_uris.has(my_def.sourceUri)) continue;
+            // Same-file hits stay unfiltered: a program-body local is
+            // navigable within its own file.
+            if (
+                my_def.sourceUri !== document_uri &&
+                is_cross_file_hidden_local(symbol_type, my_def)
+            ) {
+                continue;
+            }
             out.push(...this.symbol_to_locations(my_def));
         }
         return out;

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -52,6 +52,7 @@ import {
 } from '../utils/token-utils';
 import { is_cursor_in_comment } from '../utils/comment-utils';
 import { is_cursor_in_string_literal } from '../utils/string-literal-utils';
+import { is_cross_file_hidden_local } from '../utils/dofile-locals';
 
 const MARKDOWN_TEXT_ESCAPE_PATTERN =
     /([\\`*_{}\[\]()#+\-.!|])/g;
@@ -792,6 +793,14 @@ export class HoverProvider {
         }
         const the_hits = workspace_indexer.find_symbol_definitions(name, symbol_type);
         for (const my_hit of the_hits) {
+            // Skips the hit and its extras. Same-file hits stay:
+            // redefinitions within the current file are real.
+            if (
+                my_hit.sourceUri !== current_uri &&
+                is_cross_file_hidden_local(symbol_type, my_hit)
+            ) {
+                continue;
+            }
             const my_location = my_hit.location as
                 | { uri: string; range: Range }
                 | undefined;

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -15,6 +15,7 @@ import {
 import { DocumentState } from '../document-store';
 import { LanguageContext, Token, ContextRange } from '../types';
 import { get_line_text } from '../utils/line-utils';
+import { is_cross_file_hidden_local } from '../utils/dofile-locals';
 import type { WorkspaceIndexer } from '../indexer';
 import type { IContextTracker } from '../context-tracker/types';
 import type { ScopeResolver } from '../scope-resolver';
@@ -328,6 +329,7 @@ export class ReferencesProvider {
             // already holds the authoritative fresh declaration.
             for (const my_def of workspace_indexer.find_symbol_definitions(symbol_name, ws_type)) {
                 if (my_def.sourceUri === document.uri) continue;
+                if (is_cross_file_hidden_local(ws_type, my_def)) continue;
                 if (the_allowed_uris) {
                     const range = the_allowed_uris.get(my_def.sourceUri);
                     if (!range) continue;

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -41,6 +41,7 @@ import { StataParser } from '../parser';
 import { SemanticAnalyzer, create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 import { logger } from '../utils/logger';
 import { error_message } from '../utils/error-message';
+import { filter_dofile_locals, is_dofile_local } from '../utils/dofile-locals';
 import { get_line_text, get_line_count, compute_line_offsets } from '../utils/line-utils';
 import {
     get_workspace_root_for_uri,
@@ -65,8 +66,10 @@ export {
     get_visible_forward_call_sites,
     collect_visible_reference_uris,
     filter_forward_site_symbols,
+    clone_symbol_table,
 } from './visible-symbols';
 export type { ReferenceScanRange } from './visible-symbols';
+import { clone_symbol_table } from './visible-symbols';
 
 const DEFAULT_CONFIG: ScopeResolverConfig = {
     assume_call_site: 'end',
@@ -855,8 +858,17 @@ export class ScopeResolver {
             the_parts.push(`g:${my_name}`);
         }
 
-        // Local macros (included for include callees)
-        const local_names = Array.from(symbols.localMacros.keys()).sort();
+        // Local macros (included for include callees). Only do-file-level
+        // locals are include-visible (issue #271); hashing the raw flat map
+        // would miss scope moves (program <-> dofile keeps the name set
+        // unchanged) and skip caller revalidation.
+        const local_names: string[] = [];
+        for (const [my_name, my_symbol] of symbols.localMacros) {
+            if (is_dofile_local(my_symbol)) {
+                local_names.push(my_name);
+            }
+        }
+        local_names.sort();
         for (const my_name of local_names) {
             the_parts.push(`l:${my_name}`);
         }
@@ -2403,21 +2415,33 @@ export class ScopeResolver {
     /**
      * Apply inheritance rules based on directive type.
      * done-by: excludes locals
-     * included-by: includes all symbols
+     * included-by: includes all symbols except program-body locals
      * Returns both filtered symbols and locals excluded due to inheritance rules.
+     *
+     * Program-body locals never exist at the do-file level of the boundary
+     * (issue #271): `included-by` drops them silently (references get the
+     * plain undefined warning), and `done-by` omits them from
+     * excluded_locals because the "use include instead" remedy would be
+     * false advice for them.
      */
     apply_inheritance_rules(
         symbols: SymbolTable,
         directive_type: 'done-by' | 'included-by',
         source_uri: string
     ): { filtered: SymbolTable; excluded_locals: OutOfScopeSymbol[] } {
+        // Clone in both branches: `symbols` is the shared file-cache
+        // entry and must not be aliased or mutated.
+        const filtered = clone_symbol_table(symbols);
+
         if (directive_type === 'included-by') {
-            return { filtered: symbols, excluded_locals: [] };
+            filtered.localMacros = filter_dofile_locals(symbols.localMacros);
+            return { filtered, excluded_locals: [] };
         }
 
         // done-by: exclude locals and track them
         const excluded_locals: OutOfScopeSymbol[] = [];
         for (const [name, symbol] of symbols.localMacros) {
+            if (!is_dofile_local(symbol)) continue;
             excluded_locals.push({
                 name,
                 type: 'local',
@@ -2428,17 +2452,8 @@ export class ScopeResolver {
             });
         }
 
-        return {
-            filtered: {
-                programs: new Map(symbols.programs),
-                localMacros: new Map(), // Exclude locals
-                globalMacros: new Map(symbols.globalMacros),
-                variables: new Map(symbols.variables),
-                scalars: new Map(symbols.scalars),
-                matrices: new Map(symbols.matrices),
-            },
-            excluded_locals,
-        };
+        filtered.localMacros = new Map(); // Exclude locals
+        return { filtered, excluded_locals };
     }
 
     /**

--- a/src/scope-resolver/visible-symbols.ts
+++ b/src/scope-resolver/visible-symbols.ts
@@ -235,7 +235,7 @@ function symbol_table_matches_active_reference(
     ) === active_symbol_identity;
 }
 
-function clone_symbol_table(symbols: SymbolTable): SymbolTable {
+export function clone_symbol_table(symbols: SymbolTable): SymbolTable {
     return {
         programs: new Map(symbols.programs),
         localMacros: new Map(symbols.localMacros),

--- a/src/utils/dofile-locals.ts
+++ b/src/utils/dofile-locals.ts
@@ -1,0 +1,62 @@
+/**
+ * Scope gate for local macros crossing file boundaries (issue #271).
+ *
+ * A local macro is inheritable across an `include` boundary only when it
+ * is genuine do-file-level state. Locals defined inside `program ... end`
+ * bodies (`containingScope: 'program'`) die with their program's scope
+ * frame — merely defining the program does not execute it — so they never
+ * exist at the do-file level that `include` splices into.
+ *
+ * The flat `SymbolTable.localMacros` view can carry a program-body local
+ * when a name has no do-file-level definition (see the analyzer's
+ * `publish_flat_local`), so every cross-file consumer of that map must
+ * apply this gate.
+ */
+
+import {
+    MacroSymbol,
+    MatrixSymbol,
+    ProgramSymbol,
+    ScalarSymbol,
+    VariableSymbol,
+} from '../types';
+
+export function is_dofile_local(
+    symbol: Pick<MacroSymbol, 'containingScope'>
+): boolean {
+    return symbol.containingScope === 'dofile';
+}
+
+export function filter_dofile_locals(
+    locals: Map<string, MacroSymbol>
+): Map<string, MacroSymbol> {
+    const filtered = new Map<string, MacroSymbol>();
+    for (const [my_name, my_symbol] of locals) {
+        if (is_dofile_local(my_symbol)) {
+            filtered.set(my_name, my_symbol);
+        }
+    }
+    return filtered;
+}
+
+/**
+ * True when a workspace-indexed symbol hit from ANOTHER file must be
+ * hidden because it is a program-body local. Providers that fall back
+ * to the raw indexer tables (definition/hover/references) share this
+ * gate; non-local symbol kinds are never hidden by it. Callers exempt
+ * same-file hits themselves where same-file redefinitions are wanted.
+ */
+export function is_cross_file_hidden_local(
+    symbol_kind: string,
+    symbol:
+        | ProgramSymbol
+        | MacroSymbol
+        | VariableSymbol
+        | ScalarSymbol
+        | MatrixSymbol
+): boolean {
+    // The indexer's find_symbol_definitions only yields MacroSymbols
+    // for the 'local' kind, so the narrowing cast is safe.
+    return symbol_kind === 'local' &&
+        !is_dofile_local(symbol as MacroSymbol);
+}

--- a/tests/integration/program-local-include-inheritance.test.ts
+++ b/tests/integration/program-local-include-inheritance.test.ts
@@ -7,7 +7,10 @@
  */
 
 import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
-import { DiagnosticsProvider } from '../../src/providers/diagnostics';
+import {
+    DiagnosticsConnection,
+    DiagnosticsProvider,
+} from '../../src/providers/diagnostics';
 import { DocumentStore } from '../../src/document-store';
 import { ScopeResolver } from '../../src/scope-resolver';
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
@@ -15,7 +18,6 @@ import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
 import { join } from 'path';
 import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
 import { URI } from 'vscode-uri';
-import { Connection } from 'vscode-languageserver';
 
 describe('Program-body locals across include boundaries (issue #271)', () => {
     const test_temp_dir = join(process.cwd(), 'temp_program_local_include_test');
@@ -23,7 +25,7 @@ describe('Program-body locals across include boundaries (issue #271)', () => {
     let document_store: DocumentStore;
     let scope_resolver: ScopeResolver;
     let forward_scope_resolver: ForwardScopeResolver;
-    let mock_connection: Connection;
+    let mock_connection: DiagnosticsConnection;
     let config: StataLSPConfig;
 
     beforeEach(() => {
@@ -34,7 +36,7 @@ describe('Program-body locals across include boundaries (issue #271)', () => {
 
         mock_connection = {
             sendDiagnostics: () => {},
-        } as any;
+        };
 
         document_store = new DocumentStore();
         scope_resolver = new ScopeResolver();

--- a/tests/integration/program-local-include-inheritance.test.ts
+++ b/tests/integration/program-local-include-inheritance.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Integration tests for issue #271: locals defined inside `program ... end`
+ * bodies must not be inherited across `include` boundaries, in either
+ * direction (backward `@lsp-included-by`/`@lsp-done-by` directives and
+ * forward `include`/`do` commands), while genuine do-file-level locals
+ * keep flowing through `include`.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
+import { DiagnosticsProvider } from '../../src/providers/diagnostics';
+import { DocumentStore } from '../../src/document-store';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
+import { join } from 'path';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { URI } from 'vscode-uri';
+import { Connection } from 'vscode-languageserver';
+
+describe('Program-body locals across include boundaries (issue #271)', () => {
+    const test_temp_dir = join(process.cwd(), 'temp_program_local_include_test');
+    let diagnostics_provider: DiagnosticsProvider;
+    let document_store: DocumentStore;
+    let scope_resolver: ScopeResolver;
+    let forward_scope_resolver: ForwardScopeResolver;
+    let mock_connection: Connection;
+    let config: StataLSPConfig;
+
+    beforeEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+        mkdirSync(test_temp_dir);
+
+        mock_connection = {
+            sendDiagnostics: () => {},
+        } as any;
+
+        document_store = new DocumentStore();
+        scope_resolver = new ScopeResolver();
+        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+        diagnostics_provider = new DiagnosticsProvider(mock_connection);
+
+        config = {
+            diagnostics: {
+                enabled: true,
+                severity: {
+                    undefinedMacro: 'warning',
+                    undefinedVariable: 'information',
+                    styleWarnings: 'hint',
+                },
+            },
+            adoPaths: [],
+            cross_file: {
+                assume_call_site: 'end',
+                max_forward_depth: 10,
+            },
+        };
+    });
+
+    afterAll(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function get_diagnostics_for(main_path: string, main_content: string) {
+        const main_uri = URI.file(main_path).toString();
+        await document_store.open(main_uri, main_content, 1);
+        const document_state = document_store.get(main_uri)!;
+        return diagnostics_provider.get_diagnostics(
+            document_state,
+            config,
+            undefined,
+            scope_resolver
+        );
+    }
+
+    describe('backward @lsp-included-by', () => {
+        it('does not suppress a parent program-body local (issue #271 repro)', async () => {
+            const parent_path = join(test_temp_dir, 'parent1.do');
+            const parent_content = `program define p
+    local hidden 1
+end
+include child1.do`;
+            writeFileSync(parent_path, parent_content);
+
+            const child_path = join(test_temp_dir, 'child1.do');
+            const child_content = `// @lsp-included-by: "parent1.do"
+display \`hidden'`;
+            writeFileSync(child_path, child_content);
+
+            const diagnostics = await get_diagnostics_for(child_path, child_content);
+
+            const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(true);
+        });
+
+        it('still suppresses a parent dofile-level local', async () => {
+            const parent_path = join(test_temp_dir, 'parent2.do');
+            const parent_content = `local visible 1
+include child2.do`;
+            writeFileSync(parent_path, parent_content);
+
+            const child_path = join(test_temp_dir, 'child2.do');
+            const child_content = `// @lsp-included-by: "parent2.do"
+display \`visible'`;
+            writeFileSync(child_path, child_content);
+
+            const diagnostics = await get_diagnostics_for(child_path, child_content);
+
+            const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(false);
+        });
+    });
+
+    describe('backward @lsp-done-by excluded-locals messaging', () => {
+        it('program-body parent local gets the plain undefined warning, not use-include advice', async () => {
+            const parent_path = join(test_temp_dir, 'parent3.do');
+            const parent_content = `program define q
+    local hidden 1
+end
+do child3.do`;
+            writeFileSync(parent_path, parent_content);
+
+            const child_path = join(test_temp_dir, 'child3.do');
+            const child_content = `// @lsp-done-by: "parent3.do"
+display \`hidden'`;
+            writeFileSync(child_path, child_content);
+
+            const diagnostics = await get_diagnostics_for(child_path, child_content);
+
+            const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+            // "use include instead" would be false advice: include does not
+            // surface program-body locals either.
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+            )).toBe(false);
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(true);
+        });
+
+        it('dofile-level parent local still gets the use-include out-of-scope message', async () => {
+            const parent_path = join(test_temp_dir, 'parent4.do');
+            const parent_content = `local veggie 1
+do child4.do`;
+            writeFileSync(parent_path, parent_content);
+
+            const child_path = join(test_temp_dir, 'child4.do');
+            const child_content = `// @lsp-done-by: "parent4.do"
+display \`veggie'`;
+            writeFileSync(child_path, child_content);
+
+            const diagnostics = await get_diagnostics_for(child_path, child_content);
+
+            const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+            const informative = line1_diags.find(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes('veggie')
+            );
+            expect(informative).toBeDefined();
+            expect(informative!.message).toContain('use include instead');
+        });
+    });
+
+    describe('forward include command', () => {
+        it('does not suppress a callee program-body local (mirror of the do-path test)', async () => {
+            const helper_path = join(test_temp_dir, 'helper5.do');
+            const helper_content = `program define myprog
+    local veggie potato
+    di "\`veggie'"
+end`;
+            writeFileSync(helper_path, helper_content);
+
+            const main_path = join(test_temp_dir, 'main5.do');
+            const main_content = `include helper5.do
+di \`veggie'`;
+            writeFileSync(main_path, main_content);
+
+            const diagnostics = await get_diagnostics_for(main_path, main_content);
+
+            const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+            )).toBe(false);
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(true);
+        });
+
+        it('still suppresses a callee dofile-level local', async () => {
+            const helper_path = join(test_temp_dir, 'helper6.do');
+            writeFileSync(helper_path, 'local veggie potato');
+
+            const main_path = join(test_temp_dir, 'main6.do');
+            const main_content = `include helper6.do
+di \`veggie'`;
+            writeFileSync(main_path, main_content);
+
+            const diagnostics = await get_diagnostics_for(main_path, main_content);
+
+            const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(false);
+        });
+
+        it('include after do adds only dofile-level locals (add_locals_only path)', async () => {
+            const helper_path = join(test_temp_dir, 'helper7.do');
+            const helper_content = `local filelevel 1
+program define hp
+    local progonly 2
+end`;
+            writeFileSync(helper_path, helper_content);
+
+            const main_path = join(test_temp_dir, 'main7.do');
+            const main_content = `do helper7.do
+include helper7.do
+di \`filelevel'
+di \`progonly'`;
+            writeFileSync(main_path, main_content);
+
+            const diagnostics = await get_diagnostics_for(main_path, main_content);
+
+            const line2_diags = diagnostics.filter(d => d.range.start.line === 2);
+            expect(line2_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(false);
+
+            const line3_diags = diagnostics.filter(d => d.range.start.line === 3);
+            expect(line3_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(true);
+        });
+
+        it('filters program-body locals at every hop of a multi-level include chain', async () => {
+            const leaf_path = join(test_temp_dir, 'leaf8.do');
+            const leaf_content = `local deep_ok 1
+program define leafp
+    local deep_hidden 2
+end`;
+            writeFileSync(leaf_path, leaf_content);
+
+            const mid_path = join(test_temp_dir, 'mid8.do');
+            writeFileSync(mid_path, 'include leaf8.do');
+
+            const main_path = join(test_temp_dir, 'main8.do');
+            const main_content = `include mid8.do
+di \`deep_ok'
+di \`deep_hidden'`;
+            writeFileSync(main_path, main_content);
+
+            const diagnostics = await get_diagnostics_for(main_path, main_content);
+
+            const line1_diags = diagnostics.filter(d => d.range.start.line === 1);
+            expect(line1_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(false);
+
+            const line2_diags = diagnostics.filter(d => d.range.start.line === 2);
+            expect(line2_diags.some(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            )).toBe(true);
+        });
+    });
+});

--- a/tests/integration/program-local-index-fallback.test.ts
+++ b/tests/integration/program-local-index-fallback.test.ts
@@ -336,4 +336,97 @@ di \`shared'`;
             expect(hover_text(hover!.contents)).toContain('child_hover_ok.do');
         });
     });
+
+    describe('same-file exemption branches of the gate (direct)', () => {
+        // The gate call sites exempt same-file hits so a program-body
+        // local stays visible within its own file. Same-file answers
+        // normally arrive via earlier provider paths (document symbols,
+        // resolved scope), so the end-to-end controls above cannot fail
+        // on a broken exemption. These tests hit the two exempting
+        // helpers directly with a stub indexer whose only source of the
+        // same-file answer is the gated loop.
+        const MAIN_URI = 'file:///gate/main.do';
+        const OTHER_URI = 'file:///gate/other.do';
+        const PRIMARY_URI = 'file:///gate/primary.do';
+
+        function make_program_local_hit(uri: string, line: number) {
+            return {
+                name: 'shared',
+                scope: 'local' as const,
+                location: {
+                    uri,
+                    range: {
+                        start: { line, character: 4 },
+                        end: { line, character: 10 },
+                    },
+                },
+                sourceUri: uri,
+                containingScope: 'program' as const,
+                containing_program_name: 'p',
+            };
+        }
+
+        it('hover footer keeps same-file program-body hits and drops cross-file ones', () => {
+            const hover_provider = new HoverProvider(new CommandDatabase());
+            const the_hits = [
+                make_program_local_hit(MAIN_URI, 5),
+                make_program_local_hit(OTHER_URI, 7),
+            ];
+            const stub_indexer = {
+                find_symbol_definitions: () => the_hits,
+                // No get_related_uris: hover treats that as "no
+                // reachability gate", leaving only the #271 gate active.
+            };
+            const primary = {
+                location: {
+                    uri: PRIMARY_URI,
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 6 },
+                    },
+                },
+            };
+
+            const entries = (hover_provider as any)
+                .collect_workspace_additional_definitions(
+                    'shared',
+                    'local',
+                    primary,
+                    stub_indexer,
+                    MAIN_URI,
+                );
+
+            const the_entry_uris = entries.map(
+                (my_entry: { location: { uri: string } }) =>
+                    my_entry.location.uri
+            );
+            expect(the_entry_uris).toContain(MAIN_URI);
+            expect(the_entry_uris).not.toContain(OTHER_URI);
+        });
+
+        it('definition workspace lookup keeps same-file program-body hits when include_current_uri is set', () => {
+            const definition_provider = new DefinitionProvider();
+            const the_hits = [
+                make_program_local_hit(MAIN_URI, 5),
+                make_program_local_hit(OTHER_URI, 7),
+            ];
+            const stub_indexer = {
+                find_symbol_definitions: () => the_hits,
+                get_related_uris: () => new Set([MAIN_URI, OTHER_URI]),
+            };
+
+            const locations: Location[] = (definition_provider as any)
+                .collect_workspace_definition_locations(
+                    MAIN_URI,
+                    'shared',
+                    'local',
+                    stub_indexer,
+                    { include_only: true, include_current_uri: true },
+                );
+
+            const the_location_uris = locations.map(my_loc => my_loc.uri);
+            expect(the_location_uris).toContain(MAIN_URI);
+            expect(the_location_uris).not.toContain(OTHER_URI);
+        });
+    });
 });

--- a/tests/integration/program-local-index-fallback.test.ts
+++ b/tests/integration/program-local-index-fallback.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Integration tests for issue #271, indexer-fallback surface: the
+ * workspace-indexer paths in definition / references / hover must not
+ * surface program-body locals from include-related files. These paths
+ * bypass the scope resolvers (they read the indexer's flat symbol
+ * tables directly), so they need their own containingScope gate.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { DefinitionProvider } from '../../src/providers/definition';
+import { ReferencesProvider } from '../../src/providers/references';
+import { HoverProvider } from '../../src/providers/hover';
+import { CommandDatabase } from '../../src/command-database';
+import { DocumentStore } from '../../src/document-store';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { join } from 'path';
+import { writeFileSync, mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { URI } from 'vscode-uri';
+import { Location, MarkupContent } from 'vscode-languageserver';
+
+function build_pipeline() {
+    const the_indexer = new WorkspaceIndexer();
+    const the_dep_graph = new DependencyGraph();
+    the_indexer.set_dependency_graph(the_dep_graph);
+
+    const the_scope_resolver = new ScopeResolver();
+    the_scope_resolver.set_dependency_graph(the_dep_graph);
+
+    const the_forward_resolver = new ForwardScopeResolver(the_scope_resolver, {
+        max_forward_depth: 10,
+    });
+    the_scope_resolver.set_forward_scope_resolver(the_forward_resolver);
+
+    return {
+        indexer: the_indexer,
+        dependency_graph: the_dep_graph,
+        scope_resolver: the_scope_resolver,
+        forward_scope_resolver: the_forward_resolver,
+        definition_provider: new DefinitionProvider(),
+        references_provider: new ReferencesProvider(the_scope_resolver),
+        hover_provider: new HoverProvider(new CommandDatabase()),
+        document_store: new DocumentStore(),
+    };
+}
+
+function as_locations(
+    result: Location | Location[] | null
+): Location[] {
+    return Array.isArray(result) ? result : (result ? [result] : []);
+}
+
+function hover_text(contents: unknown): string {
+    if (typeof contents === 'string') return contents;
+    if (contents && typeof contents === 'object' && 'value' in contents) {
+        return String((contents as MarkupContent).value);
+    }
+    return JSON.stringify(contents);
+}
+
+describe('Indexer fallbacks - program-body locals in include-related files (issue #271)', () => {
+    let test_temp_dir: string;
+    let pipeline: ReturnType<typeof build_pipeline>;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'prog-local-fallback-'));
+        pipeline = build_pipeline();
+    });
+
+    afterEach(() => {
+        try { pipeline?.scope_resolver?.dispose(); } catch { /* ignore */ }
+        try { pipeline?.forward_scope_resolver?.dispose(); } catch { /* ignore */ }
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_main(main_path: string, main_content: string) {
+        await pipeline.indexer.initialize([test_temp_dir]);
+        const main_uri = URI.file(main_path).toString();
+        await pipeline.document_store.open(main_uri, main_content, 1);
+        return pipeline.document_store.get(main_uri)!;
+    }
+
+    describe('go-to-definition', () => {
+        it('does not navigate to a program-body local in an included file', async () => {
+            const child_path = join(test_temp_dir, 'child.do');
+            writeFileSync(child_path, `program define p
+    local hidden 1
+end`);
+
+            const main_path = join(test_temp_dir, 'main.do');
+            const main_content = `include "child.do"
+di \`hidden'`;
+            writeFileSync(main_path, main_content);
+
+            const document_state = await open_main(main_path, main_content);
+            const hidden_char = main_content.split('\n')[1].indexOf('hidden');
+
+            const result = await pipeline.definition_provider.get_definition(
+                document_state,
+                { line: 1, character: hidden_char },
+                pipeline.indexer.get_all_symbols(),
+                document_state.context_tracker,
+                pipeline.scope_resolver,
+                pipeline.indexer,
+            );
+
+            const child_uri = URI.file(child_path).toString();
+            const uris = new Set(as_locations(result).map(loc => loc.uri));
+            expect(uris.has(child_uri)).toBe(false);
+        });
+
+        it('still navigates to a dofile-level local in an included file (control)', async () => {
+            const child_path = join(test_temp_dir, 'child_ok.do');
+            writeFileSync(child_path, 'local visible 1');
+
+            const main_path = join(test_temp_dir, 'main_ok.do');
+            const main_content = `include "child_ok.do"
+di \`visible'`;
+            writeFileSync(main_path, main_content);
+
+            const document_state = await open_main(main_path, main_content);
+            const visible_char = main_content.split('\n')[1].indexOf('visible');
+
+            const result = await pipeline.definition_provider.get_definition(
+                document_state,
+                { line: 1, character: visible_char },
+                pipeline.indexer.get_all_symbols(),
+                document_state.context_tracker,
+                pipeline.scope_resolver,
+                pipeline.indexer,
+            );
+
+            const child_uri = URI.file(child_path).toString();
+            const uris = new Set(as_locations(result).map(loc => loc.uri));
+            expect(uris.has(child_uri)).toBe(true);
+        });
+    });
+
+    describe('find references', () => {
+        it('does not pool a program-body local declaration from an include-related file', async () => {
+            // The child contains ONLY the program-body declaration (no
+            // backtick references), so any child location in the result
+            // can only come from the cross-file declaration pooling path.
+            const child_path = join(test_temp_dir, 'child_refs.do');
+            writeFileSync(child_path, `program define p
+    local hidden 1
+end`);
+
+            const main_path = join(test_temp_dir, 'main_refs.do');
+            const main_content = `include "child_refs.do"
+di \`hidden'`;
+            writeFileSync(main_path, main_content);
+
+            const document_state = await open_main(main_path, main_content);
+            const line1 = main_content.split('\n')[1];
+            const hidden_char = line1.indexOf('hidden');
+
+            const locations = await pipeline.references_provider.get_references(
+                document_state,
+                { line: 1, character: hidden_char },
+                { includeDeclaration: true },
+                pipeline.indexer,
+                document_state.context_tracker
+            );
+
+            const child_uri = URI.file(child_path).toString();
+            expect(locations.some(loc => loc.uri === child_uri)).toBe(false);
+        });
+
+        it('still pools a dofile-level local declaration from an included file (control)', async () => {
+            const child_path = join(test_temp_dir, 'child_refs_ok.do');
+            writeFileSync(child_path, 'local visible 1');
+
+            const main_path = join(test_temp_dir, 'main_refs_ok.do');
+            const main_content = `include "child_refs_ok.do"
+di \`visible'`;
+            writeFileSync(main_path, main_content);
+
+            const document_state = await open_main(main_path, main_content);
+            const visible_char = main_content.split('\n')[1].indexOf('visible');
+
+            const locations = await pipeline.references_provider.get_references(
+                document_state,
+                { line: 1, character: visible_char },
+                { includeDeclaration: true },
+                pipeline.indexer,
+                document_state.context_tracker
+            );
+
+            const child_uri = URI.file(child_path).toString();
+            expect(locations.some(loc => loc.uri === child_uri)).toBe(true);
+        });
+    });
+
+    describe('hover redefinition footer', () => {
+        it('omits program-body locals from include-related files', async () => {
+            const child_path = join(test_temp_dir, 'child_hover.do');
+            writeFileSync(child_path, `program define p
+    local shared 2
+end`);
+
+            const main_path = join(test_temp_dir, 'main_hover.do');
+            const main_content = `local shared 1
+include "child_hover.do"
+di \`shared'`;
+            writeFileSync(main_path, main_content);
+
+            const document_state = await open_main(main_path, main_content);
+            const shared_char = main_content.split('\n')[2].indexOf('shared');
+
+            const hover = await pipeline.hover_provider.get_hover(
+                document_state,
+                { line: 2, character: shared_char },
+                pipeline.indexer.get_all_symbols(),
+                pipeline.scope_resolver,
+                undefined,
+                undefined,
+                test_temp_dir,
+                pipeline.indexer,
+            );
+
+            expect(hover).not.toBeNull();
+            expect(hover_text(hover!.contents)).not.toContain('child_hover.do');
+        });
+
+        it('still lists dofile-level redefinitions from included files (control)', async () => {
+            const child_path = join(test_temp_dir, 'child_hover_ok.do');
+            writeFileSync(child_path, 'local shared 2');
+
+            const main_path = join(test_temp_dir, 'main_hover_ok.do');
+            const main_content = `local shared 1
+include "child_hover_ok.do"
+di \`shared'`;
+            writeFileSync(main_path, main_content);
+
+            const document_state = await open_main(main_path, main_content);
+            const shared_char = main_content.split('\n')[2].indexOf('shared');
+
+            const hover = await pipeline.hover_provider.get_hover(
+                document_state,
+                { line: 2, character: shared_char },
+                pipeline.indexer.get_all_symbols(),
+                pipeline.scope_resolver,
+                undefined,
+                undefined,
+                test_temp_dir,
+                pipeline.indexer,
+            );
+
+            expect(hover).not.toBeNull();
+            expect(hover_text(hover!.contents)).toContain('child_hover_ok.do');
+        });
+    });
+});

--- a/tests/integration/program-local-index-fallback.test.ts
+++ b/tests/integration/program-local-index-fallback.test.ts
@@ -197,6 +197,86 @@ di \`visible'`;
         });
     });
 
+    describe('same-file program-body locals (control)', () => {
+        // The cross-file gate must not block ordinary navigation for a
+        // program-body local declared and used in the SAME document.
+        const same_file_content = `program define p
+    local hidden 1
+    di "\`hidden'"
+end`;
+
+        it('go-to-definition still resolves within the defining file', async () => {
+            const main_path = join(test_temp_dir, 'same_def.do');
+            writeFileSync(main_path, same_file_content);
+
+            const document_state = await open_main(main_path, same_file_content);
+            const hidden_char = same_file_content.split('\n')[2].indexOf('hidden');
+
+            const result = await pipeline.definition_provider.get_definition(
+                document_state,
+                { line: 2, character: hidden_char },
+                pipeline.indexer.get_all_symbols(),
+                document_state.context_tracker,
+                pipeline.scope_resolver,
+                pipeline.indexer,
+            );
+
+            const main_uri = URI.file(main_path).toString();
+            const locations = as_locations(result);
+            expect(locations.some(
+                loc => loc.uri === main_uri && loc.range.start.line === 1
+            )).toBe(true);
+        });
+
+        it('find references still works within the defining file', async () => {
+            const main_path = join(test_temp_dir, 'same_refs.do');
+            writeFileSync(main_path, same_file_content);
+
+            const document_state = await open_main(main_path, same_file_content);
+            const hidden_char = same_file_content.split('\n')[2].indexOf('hidden');
+
+            const locations = await pipeline.references_provider.get_references(
+                document_state,
+                { line: 2, character: hidden_char },
+                { includeDeclaration: true },
+                pipeline.indexer,
+                document_state.context_tracker
+            );
+
+            const main_uri = URI.file(main_path).toString();
+            // The declaration (line 1) is pooled and the reference
+            // (line 2) is found — the gate only hides cross-file hits.
+            expect(locations.some(
+                loc => loc.uri === main_uri && loc.range.start.line === 1
+            )).toBe(true);
+            expect(locations.some(
+                loc => loc.uri === main_uri && loc.range.start.line === 2
+            )).toBe(true);
+        });
+
+        it('hover still works within the defining file', async () => {
+            const main_path = join(test_temp_dir, 'same_hover.do');
+            writeFileSync(main_path, same_file_content);
+
+            const document_state = await open_main(main_path, same_file_content);
+            const hidden_char = same_file_content.split('\n')[2].indexOf('hidden');
+
+            const hover = await pipeline.hover_provider.get_hover(
+                document_state,
+                { line: 2, character: hidden_char },
+                pipeline.indexer.get_all_symbols(),
+                pipeline.scope_resolver,
+                undefined,
+                undefined,
+                test_temp_dir,
+                pipeline.indexer,
+            );
+
+            expect(hover).not.toBeNull();
+            expect(hover_text(hover!.contents)).toContain('hidden');
+        });
+    });
+
     describe('hover redefinition footer', () => {
         it('omits program-body locals from include-related files', async () => {
             const child_path = join(test_temp_dir, 'child_hover.do');

--- a/tests/unit/scope-resolver/program-local-inheritance-filter.test.ts
+++ b/tests/unit/scope-resolver/program-local-inheritance-filter.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for issue #271: program-body locals must not cross file
+ * boundaries via `include` inheritance.
+ *
+ * Covers the resolver-level filters directly:
+ * - ScopeResolver.apply_inheritance_rules (included-by / done-by)
+ * - ForwardScopeResolver.apply_forward_inheritance (include / do)
+ * - ScopeResolver.compute_dual_interface_hash (include hash must reflect
+ *   the filtered do-file-local interface, not the raw flat map)
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { ScopeResolver } from '../../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../../src/forward-scope-resolver';
+import { MacroSymbol, ScopeType, SymbolTable } from '../../../src/types';
+
+const PARENT_URI = 'file:///parent.do';
+
+function make_local(
+    name: string,
+    containing_scope: ScopeType,
+    line: number = 0
+): MacroSymbol {
+    return {
+        name,
+        scope: 'local',
+        location: {
+            uri: PARENT_URI,
+            range: {
+                start: { line, character: 0 },
+                end: { line, character: name.length },
+            },
+        },
+        sourceUri: PARENT_URI,
+        containingScope: containing_scope,
+        ...(containing_scope === 'program'
+            ? { containing_program_name: 'p' }
+            : {}),
+    };
+}
+
+function make_table(the_locals: MacroSymbol[]): SymbolTable {
+    const table: SymbolTable = {
+        programs: new Map(),
+        localMacros: new Map(),
+        globalMacros: new Map(),
+        variables: new Map(),
+        scalars: new Map(),
+        matrices: new Map(),
+    };
+    for (const my_local of the_locals) {
+        table.localMacros.set(my_local.name, my_local);
+    }
+    return table;
+}
+
+describe('ScopeResolver.apply_inheritance_rules - program-body locals', () => {
+    let resolver: ScopeResolver;
+
+    beforeEach(() => {
+        resolver = new ScopeResolver();
+    });
+
+    it('included-by keeps dofile locals and drops program-body locals', () => {
+        const symbols = make_table([
+            make_local('visible', 'dofile', 0),
+            make_local('hidden', 'program', 2),
+        ]);
+
+        const result = resolver.apply_inheritance_rules(
+            symbols,
+            'included-by',
+            PARENT_URI
+        );
+
+        expect(result.filtered.localMacros.has('visible')).toBe(true);
+        expect(result.filtered.localMacros.has('hidden')).toBe(false);
+    });
+
+    it('included-by silently drops program-body locals (no excluded_locals entry)', () => {
+        const symbols = make_table([make_local('hidden', 'program', 2)]);
+
+        const result = resolver.apply_inheritance_rules(
+            symbols,
+            'included-by',
+            PARENT_URI
+        );
+
+        // Per the issue-#271 decision, references to a program-body local
+        // get the plain undefined warning: no out-of-scope rewrite entry.
+        expect(result.excluded_locals).toHaveLength(0);
+    });
+
+    it('included-by does not mutate or alias the (cached) input table', () => {
+        const symbols = make_table([
+            make_local('visible', 'dofile', 0),
+            make_local('hidden', 'program', 2),
+        ]);
+
+        const result = resolver.apply_inheritance_rules(
+            symbols,
+            'included-by',
+            PARENT_URI
+        );
+
+        // The input table is the shared file-cache entry; filtering must
+        // not remove entries from it, and the filtered map must not be
+        // the same object (a later consumer of the cache would otherwise
+        // see the filtered view).
+        expect(symbols.localMacros.has('hidden')).toBe(true);
+        expect(result.filtered.localMacros).not.toBe(symbols.localMacros);
+    });
+
+    it('included-by preserves non-local symbol kinds', () => {
+        const symbols = make_table([make_local('hidden', 'program', 2)]);
+        symbols.globalMacros.set('G', {
+            name: 'G',
+            scope: 'global',
+            location: {
+                uri: PARENT_URI,
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 1 },
+                },
+            },
+            sourceUri: PARENT_URI,
+        });
+
+        const result = resolver.apply_inheritance_rules(
+            symbols,
+            'included-by',
+            PARENT_URI
+        );
+
+        expect(result.filtered.globalMacros.has('G')).toBe(true);
+    });
+
+    it('done-by excluded_locals omits program-body locals but keeps dofile locals', () => {
+        const symbols = make_table([
+            make_local('veggie', 'dofile', 0),
+            make_local('hidden', 'program', 2),
+        ]);
+
+        const result = resolver.apply_inheritance_rules(
+            symbols,
+            'done-by',
+            PARENT_URI
+        );
+
+        // All locals stay excluded from the inherited table.
+        expect(result.filtered.localMacros.size).toBe(0);
+
+        // Only the dofile local earns the "use include instead" rewrite:
+        // promoting the call to `include` would NOT surface a program-body
+        // local, so advertising it would be false advice.
+        const the_excluded_names = result.excluded_locals.map(s => s.name);
+        expect(the_excluded_names).toContain('veggie');
+        expect(the_excluded_names).not.toContain('hidden');
+    });
+});
+
+describe('ForwardScopeResolver.apply_forward_inheritance - program-body locals', () => {
+    let scope_resolver: ScopeResolver;
+    let forward_resolver: ForwardScopeResolver;
+
+    beforeEach(() => {
+        scope_resolver = new ScopeResolver();
+        forward_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+    });
+
+    it('include keeps dofile locals and drops program-body locals', () => {
+        const callee_symbols = make_table([
+            make_local('visible', 'dofile', 0),
+            make_local('hidden', 'program', 2),
+        ]);
+
+        const inherited = forward_resolver.apply_forward_inheritance(
+            callee_symbols,
+            'include'
+        );
+
+        expect(inherited.localMacros.has('visible')).toBe(true);
+        expect(inherited.localMacros.has('hidden')).toBe(false);
+    });
+
+    it('include does not mutate or alias the (cached) callee table', () => {
+        const callee_symbols = make_table([
+            make_local('visible', 'dofile', 0),
+            make_local('hidden', 'program', 2),
+        ]);
+
+        const inherited = forward_resolver.apply_forward_inheritance(
+            callee_symbols,
+            'include'
+        );
+
+        expect(callee_symbols.localMacros.has('hidden')).toBe(true);
+        expect(inherited.localMacros).not.toBe(callee_symbols.localMacros);
+    });
+
+    it('do still drops all locals regardless of containing scope', () => {
+        const callee_symbols = make_table([
+            make_local('visible', 'dofile', 0),
+            make_local('hidden', 'program', 2),
+        ]);
+
+        const inherited = forward_resolver.apply_forward_inheritance(
+            callee_symbols,
+            'do'
+        );
+
+        expect(inherited.localMacros.size).toBe(0);
+    });
+});
+
+describe('ScopeResolver.compute_dual_interface_hash - include hash scope sensitivity', () => {
+    let resolver: ScopeResolver;
+
+    beforeEach(() => {
+        resolver = new ScopeResolver();
+    });
+
+    it('include hash changes when a local moves between program and dofile scope', () => {
+        // Same name set, different containing scope: the include-visible
+        // interface differs (a dofile local is inherited via include, a
+        // program-body local is not), so the hash must differ or callee
+        // revalidation gets skipped after such an edit.
+        const program_scoped = make_table([make_local('hidden', 'program', 1)]);
+        const dofile_scoped = make_table([make_local('hidden', 'dofile', 1)]);
+
+        const hash_program = resolver.compute_dual_interface_hash(program_scoped);
+        const hash_dofile = resolver.compute_dual_interface_hash(dofile_scoped);
+
+        expect(hash_program.include_hash).not.toBe(hash_dofile.include_hash);
+    });
+
+    it('include hash ignores program-body locals entirely', () => {
+        // A program-body local is invisible across every boundary type, so
+        // adding/removing one must not change the include interface.
+        const with_program_local = make_table([
+            make_local('visible', 'dofile', 0),
+            make_local('hidden', 'program', 2),
+        ]);
+        const without_program_local = make_table([
+            make_local('visible', 'dofile', 0),
+        ]);
+
+        const hash_with = resolver.compute_dual_interface_hash(with_program_local);
+        const hash_without = resolver.compute_dual_interface_hash(without_program_local);
+
+        expect(hash_with.include_hash).toBe(hash_without.include_hash);
+    });
+});


### PR DESCRIPTION
Closes #271.

## Problem

A `local` defined inside `program ... end` in a parent/callee file suppressed undefined-macro warnings in the including/included file, even though it never exists at the do-file level of the boundary. Both cross-file resolvers passed the flat `localMacros` map through unfiltered for `include`.

## Fix

New shared predicate `src/utils/dofile-locals.ts` (`is_dofile_local`, `filter_dofile_locals`, `is_cross_file_hidden_local`), applied at every cross-file consumer of the flat local view:

- **`ScopeResolver.apply_inheritance_rules`** — `included-by` now clones the cached table (it previously returned it by reference) and filters locals to dofile scope; `done-by` omits program-scoped locals from `excluded_locals`, so the "use include instead" rewrite no longer promises a remedy that would not work.
- **`ForwardScopeResolver`** — `apply_forward_inheritance` (include branch), the `add_locals_only` include-after-do branch (which bypasses `apply_forward_inheritance` entirely), and `compute_effective_end_state_locals` (refactored onto the shared predicate it already implemented inline).
- **`compute_include_interface_hash`** — hashes only dofile-scope local names. Under the old name-only hash, moving a local between program and do-file scope left the hash unchanged and skipped caller revalidation; verified live over stdio that the scope-move edit now revalidates callers.
- **Indexer fallbacks** — definition (two collect helpers), hover redefinition footers, and references declaration pooling gate cross-file `local` hits; same-file hits stay unfiltered (a program-body local remains navigable within its own file).

References to a no-longer-inherited program-body local get the plain undefined-macro warning (matches the pinned do-path test for the same scenario).

## Caching

No cache-key or invalidation changes needed: the filters are pure per-request transforms applied after cache reads, and parent edits already cascade-invalidate dependents by URI. The interface-hash change above is the one caching-adjacent fix, and it is content-derived (covered by existing keys).

## Testing

- `tests/unit/scope-resolver/program-local-inheritance-filter.test.ts` — resolver branches, aliasing contract, hash scope-sensitivity (typechecked suite).
- `tests/integration/program-local-include-inheritance.test.ts` — issue repro (backward `@lsp-included-by`), done-by messaging both ways, forward include, include-after-do, multi-hop chains, with dofile-local controls.
- `tests/integration/program-local-index-fallback.test.ts` — definition/references/hover indexer-fallback gates with controls.
- Full suite (6961 pass) + lint clean. End-to-end verified by driving the LSP server over stdio against the repro, including a baseline run on main showing the old leaks (silent repros; go-to-definition jumping into the program body).

## Review gate

Codex adversarially reviewed the plan pre-implementation (its findings — interface-hash staleness, indexer-side leaks in definition/hover/references — are fixed here). Final diff reviewed clean by codex task-mode plus opus and sonnet reviewer subagents.

## Deferred (pre-existing, tracked)

- References' textual occurrence scan can still match `` `name' `` tokens inside program bodies of include-related files; per-occurrence scope classification in remote files is the flat-view precision work tracked in #270.

https://claude.ai/code/session_018BgS6bki3YbAp9hVLF78KB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of “local macros” across `include` and inheritance so only do-file locals propagate correctly (program-body locals are filtered out where appropriate).
  * Go-to-definition, hover, and references now ignore hidden cross-file local hits, reducing incorrect navigation and extra hover footer entries.
  * Prevented cached symbol-table mutation/aliasing during forward inheritance to keep results consistent.
* **Tests**
  * Added integration and unit coverage for program-body/dofile-level local behavior across include chains and indexer fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->