### PR TITLE
Apply the executable-blame filter to all diagnostic forward-call scans

### DIFF
--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -17,7 +17,6 @@ import {
 } from '../types';
 import {
     find_enclosing_scope,
-    position_within_range,
 } from '../utils/scope-position';
 import {
     ScopeResolver,
@@ -89,24 +88,60 @@ function is_stata_diagnostic_code(code: unknown): code is StataDiagnosticCode {
 }
 
 /**
- * Executable blame only (#274): a forward call strictly inside a program
- * body runs when that program is called, not at its textual position — so
- * unless the reference sits in that same body, the call has not executed
- * before the reference and must not be blamed (a later in-program `do`
- * would otherwise shadow the real top-level one).
+ * Innermost program scope whose BODY contains `line`. Header lines
+ * (including ///-continued headers, via body_start_line, #273) and the
+ * `end` line belong to the enclosing scope, matching the analyzer's
+ * body-only scope resolution.
+ */
+function innermost_program_body_scope(
+    line: number,
+    the_scopes: ScopeInfo[]
+): ScopeInfo | undefined {
+    let innermost: ScopeInfo | undefined;
+    for (const my_scope of the_scopes) {
+        if (my_scope.type !== 'program') {
+            continue;
+        }
+        const body_start_line =
+            my_scope.body_start_line ?? my_scope.range.start.line + 1;
+        if (line < body_start_line || line >= my_scope.range.end.line) {
+            continue;
+        }
+        if (!innermost
+            || my_scope.range.start.line > innermost.range.start.line) {
+            innermost = my_scope;
+        }
+    }
+    return innermost;
+}
+
+/**
+ * Executable blame only (#274): a forward call inside a program body runs
+ * when that program is called, not at its textual position — and its
+ * effects land in that program's own frame. So the call counts as
+ * executed-before-the-reference only when the reference's innermost
+ * program body is the SAME scope as the call site's: a later in-program
+ * `do` must not shadow the real top-level one, and full-range containment
+ * would wrongly cover references inside nested programs, which run in a
+ * fresh frame.
  */
 function call_site_in_uncalled_program_body(
     call_site: ForwardCallSite,
     the_scopes: ScopeInfo[],
     reference_position: Position
 ): boolean {
-    return the_scopes.some(
-        my_scope =>
-            my_scope.type === 'program' &&
-            call_site.call_line > my_scope.range.start.line &&
-            call_site.call_line < my_scope.range.end.line &&
-            !position_within_range(reference_position, my_scope.range)
+    const call_scope = innermost_program_body_scope(
+        call_site.call_line,
+        the_scopes
     );
+    if (!call_scope) {
+        return false;
+    }
+    const reference_scope = innermost_program_body_scope(
+        reference_position.line,
+        the_scopes
+    );
+    return reference_scope !== call_scope;
 }
 
 // ─── Testability seam for host_is_case_sensitive ─────────────────────────────

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -88,58 +88,36 @@ function is_stata_diagnostic_code(code: unknown): code is StataDiagnosticCode {
 }
 
 /**
- * Innermost program scope whose BODY contains `line`. Header lines
- * (including ///-continued headers, via body_start_line, #273) and the
- * `end` line belong to the enclosing scope, matching the analyzer's
- * body-only scope resolution.
- */
-function innermost_program_body_scope(
-    line: number,
-    the_scopes: ScopeInfo[]
-): ScopeInfo | undefined {
-    let innermost: ScopeInfo | undefined;
-    for (const my_scope of the_scopes) {
-        if (my_scope.type !== 'program') {
-            continue;
-        }
-        const body_start_line =
-            my_scope.body_start_line ?? my_scope.range.start.line + 1;
-        if (line < body_start_line || line >= my_scope.range.end.line) {
-            continue;
-        }
-        if (!innermost
-            || my_scope.range.start.line > innermost.range.start.line) {
-            innermost = my_scope;
-        }
-    }
-    return innermost;
-}
-
-/**
  * Executable blame only (#274): a forward call inside a program body runs
  * when that program is called, not at its textual position — and its
  * effects land in that program's own frame. So the call counts as
  * executed-before-the-reference only when the reference's innermost
- * program body is the SAME scope as the call site's: a later in-program
- * `do` must not shadow the real top-level one, and full-range containment
- * would wrongly cover references inside nested programs, which run in a
- * fresh frame.
+ * program body (body-only per #273: header and `end` lines belong to the
+ * enclosing frame) is the SAME scope as the call site's: a later
+ * in-program `do` must not shadow the real top-level one, and full-range
+ * containment would wrongly cover references inside nested programs,
+ * which run in a fresh frame.
  */
 function call_site_in_uncalled_program_body(
     call_site: ForwardCallSite,
     the_scopes: ScopeInfo[],
     reference_position: Position
 ): boolean {
-    const call_scope = innermost_program_body_scope(
-        call_site.call_line,
-        the_scopes
-    );
-    if (!call_scope) {
+    if (the_scopes.length === 0) {
         return false;
     }
-    const reference_scope = innermost_program_body_scope(
-        reference_position.line,
-        the_scopes
+    const call_scope = find_enclosing_scope(
+        the_scopes,
+        { line: call_site.call_line, character: 0 },
+        { body_only: true }
+    );
+    if (call_scope.type !== 'program') {
+        return false;
+    }
+    const reference_scope = find_enclosing_scope(
+        the_scopes,
+        reference_position,
+        { body_only: true }
     );
     return reference_scope !== call_scope;
 }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -10,6 +10,7 @@ import {
     StataLSPConfig,
     SymbolTable,
     ScopeInfo,
+    ForwardCallSite,
     ResolvedScope,
     DirectiveDiagnostic,
     UndefinedSymbolDiagnosticData
@@ -85,6 +86,27 @@ function is_parser_error_code(code: unknown): code is ParseErrorCode {
 
 function is_stata_diagnostic_code(code: unknown): code is StataDiagnosticCode {
     return typeof code === 'string' && STATA_DIAGNOSTIC_CODES.has(code);
+}
+
+/**
+ * Executable blame only (#274): a forward call strictly inside a program
+ * body runs when that program is called, not at its textual position — so
+ * unless the reference sits in that same body, the call has not executed
+ * before the reference and must not be blamed (a later in-program `do`
+ * would otherwise shadow the real top-level one).
+ */
+function call_site_in_uncalled_program_body(
+    call_site: ForwardCallSite,
+    the_scopes: ScopeInfo[],
+    reference_position: Position
+): boolean {
+    return the_scopes.some(
+        my_scope =>
+            my_scope.type === 'program' &&
+            call_site.call_line > my_scope.range.start.line &&
+            call_site.call_line < my_scope.range.end.line &&
+            !position_within_range(reference_position, my_scope.range)
+    );
 }
 
 // ─── Testability seam for host_is_case_sensitive ─────────────────────────────
@@ -392,6 +414,22 @@ export class DiagnosticsProvider {
                     resolved_scope,
                     diag_line
                 )) {
+                    // Local suppression only comes from `include` call
+                    // sites, and an include inside a program body binds
+                    // its locals into that program's frame — they never
+                    // reach a reference outside the body even when the
+                    // program runs. Globals/variables are left alone: a
+                    // do/run inside a program body DOES define them once
+                    // the program is called, which a textual filter
+                    // cannot see (see #274).
+                    if (reference_kind === 'local'
+                        && call_site_in_uncalled_program_body(
+                            call_site,
+                            document.scopes ?? [],
+                            my_diagnostic.range.start
+                        )) {
+                        continue;
+                    }
                     if (this.is_symbol_in_forward_call(
                             symbol_name,
                             call_site.symbols,
@@ -436,26 +474,11 @@ export class DiagnosticsProvider {
                         resolved_scope,
                         diag_line
                     )) {
-                        // Executable blame only: a call strictly inside a
-                        // program body runs when that program is called,
-                        // not at its textual position — so unless the
-                        // reference sits in that same body, the call has
-                        // not executed before the reference and must not
-                        // be blamed (a later in-program `do` would
-                        // otherwise shadow the real top-level one).
-                        const in_uncalled_program = the_scopes.some(
-                            my_scope =>
-                                my_scope.type === 'program' &&
-                                call_site.call_line >
-                                    my_scope.range.start.line &&
-                                call_site.call_line <
-                                    my_scope.range.end.line &&
-                                !position_within_range(
-                                    reference_position,
-                                    my_scope.range
-                                )
-                        );
-                        if (in_uncalled_program) {
+                        if (call_site_in_uncalled_program_body(
+                                call_site,
+                                the_scopes,
+                                reference_position
+                            )) {
                             continue;
                         }
                         if (this.is_symbol_excluded_by_forward_call(
@@ -554,6 +577,13 @@ export class DiagnosticsProvider {
                     resolved_scope,
                     diag_line
                 )) {
+                    if (call_site_in_uncalled_program_body(
+                            call_site,
+                            document.scopes ?? [],
+                            my_diagnostic.range.start
+                        )) {
+                        continue;
+                    }
                     if (this.is_symbol_excluded_by_forward_call(
                             symbol_name,
                             call_site,

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -1410,6 +1410,415 @@ display \`result'
             expect(undefined_diag).toBeUndefined();
         });
 
+        it('use-include rewrite skips do calls inside uncalled program bodies (#274)', async () => {
+            // Mirror of the combined-message test in
+            // scope-isolation-diagnostics.test.ts: a later `do` inside a
+            // program body has not executed when a top-level reference
+            // runs, so the pure use-include rewrite must blame a.do, not
+            // b.do (the later visible call site).
+            const content = [
+                'do a.do',
+                'program define q',
+                '    do b.do',
+                'end',
+                "display `x'",
+            ].join('\n');
+            const document = create_real_document_state(content);
+
+            const make_excluded = (uri: string) => new Map([
+                ['x', {
+                    name: 'x',
+                    scope: 'local' as const,
+                    location: {
+                        uri,
+                        range: {
+                            start: { line: 0, character: 0 },
+                            end: { line: 0, character: 9 },
+                        },
+                    },
+                    sourceUri: uri,
+                }],
+            ]);
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: true,
+                forward_call_symbols: [
+                    {
+                        callee_uri: 'file:///a.do',
+                        call_line: 0,
+                        symbols: create_empty_symbol_table(),
+                        effective_type: 'do',
+                        excluded_locals: make_excluded('file:///a.do'),
+                    },
+                    {
+                        callee_uri: 'file:///b.do',
+                        call_line: 2,
+                        symbols: create_empty_symbol_table(),
+                        effective_type: 'do',
+                        excluded_locals: make_excluded('file:///b.do'),
+                    },
+                ],
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                make_stub_scope_resolver(resolved_scope)
+            );
+
+            const the_matches = the_diagnostics.filter(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes("`x'")
+            );
+            expect(the_matches).toHaveLength(1);
+            expect(the_matches[0].message).toContain('defined in a.do');
+            expect(the_matches[0].message).not.toContain('b.do');
+        });
+
+        it('use-include rewrite keeps blaming do calls in the reference\'s own body (#274)', async () => {
+            // A call in the reference's own program body IS executable
+            // blame: it ran on the path to the reference, so the filter
+            // must not skip it.
+            const content = [
+                'program define q',
+                '    do b.do',
+                "    display `x'",
+                'end',
+            ].join('\n');
+            const document = create_real_document_state(content);
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: true,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///b.do',
+                    call_line: 1,
+                    symbols: create_empty_symbol_table(),
+                    effective_type: 'do',
+                    excluded_locals: new Map([
+                        ['x', {
+                            name: 'x',
+                            scope: 'local' as const,
+                            location: {
+                                uri: 'file:///b.do',
+                                range: {
+                                    start: { line: 0, character: 0 },
+                                    end: { line: 0, character: 9 },
+                                },
+                            },
+                            sourceUri: 'file:///b.do',
+                        }],
+                    ]),
+                }],
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                make_stub_scope_resolver(resolved_scope)
+            );
+
+            const the_matches = the_diagnostics.filter(
+                d => d.code === StataDiagnosticCode.OUT_OF_SCOPE_SYMBOL
+                    && d.message.includes("`x'")
+            );
+            expect(the_matches).toHaveLength(1);
+            expect(the_matches[0].message).toContain('defined in b.do');
+        });
+
+        it('suppression scan skips include calls inside uncalled program bodies (#274)', async () => {
+            // An `include` inside a program body contributes its locals
+            // to the PROGRAM's frame, never to the top level — so it
+            // must not suppress a genuine undefined-local diagnostic for
+            // a top-level reference.
+            const content = [
+                'program define q',
+                '    include b.do',
+                'end',
+                "display `x'",
+            ].join('\n');
+            const document = create_real_document_state(content);
+            const forward_symbols = create_empty_symbol_table();
+            forward_symbols.localMacros.set('x', {
+                name: 'x',
+                scope: 'local',
+                location: {
+                    uri: 'file:///b.do',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 9 },
+                    },
+                },
+                sourceUri: 'file:///b.do',
+            });
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: true,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///b.do',
+                    call_line: 1,
+                    symbols: forward_symbols,
+                    effective_type: 'include',
+                }],
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                make_stub_scope_resolver(resolved_scope)
+            );
+
+            const undefined_diag = the_diagnostics.find(
+                d => (d.data as { symbol_name?: string } | undefined)
+                    ?.symbol_name === 'x'
+            );
+            expect(undefined_diag).toBeDefined();
+        });
+
+        it('suppression via include in the reference\'s own program body still applies (#274)', async () => {
+            // Same include, but the reference sits in the same program
+            // body: both run in the same frame, so the callee's local
+            // genuinely resolves and the diagnostic stays suppressed.
+            const content = [
+                'program define q',
+                '    include b.do',
+                "    display `x'",
+                'end',
+            ].join('\n');
+            const document = create_real_document_state(content);
+            const forward_symbols = create_empty_symbol_table();
+            forward_symbols.localMacros.set('x', {
+                name: 'x',
+                scope: 'local',
+                location: {
+                    uri: 'file:///b.do',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 9 },
+                    },
+                },
+                sourceUri: 'file:///b.do',
+            });
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: true,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///b.do',
+                    call_line: 1,
+                    symbols: forward_symbols,
+                    effective_type: 'include',
+                }],
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                make_stub_scope_resolver(resolved_scope)
+            );
+
+            const the_matches = the_diagnostics.filter(
+                d => (d.data as { symbol_name?: string } | undefined)
+                    ?.symbol_name === 'x'
+                    || d.message.includes("`x'")
+            );
+            expect(the_matches).toHaveLength(0);
+        });
+
+        it('top-level include suppression is not over-guarded (#274)', async () => {
+            // The guard only targets call sites inside program bodies; a
+            // plain top-level include keeps suppressing its locals.
+            const content = [
+                'include b.do',
+                "display `x'",
+            ].join('\n');
+            const document = create_real_document_state(content);
+            const forward_symbols = create_empty_symbol_table();
+            forward_symbols.localMacros.set('x', {
+                name: 'x',
+                scope: 'local',
+                location: {
+                    uri: 'file:///b.do',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 9 },
+                    },
+                },
+                sourceUri: 'file:///b.do',
+            });
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: true,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///b.do',
+                    call_line: 0,
+                    symbols: forward_symbols,
+                    effective_type: 'include',
+                }],
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                make_stub_scope_resolver(resolved_scope)
+            );
+
+            const the_matches = the_diagnostics.filter(
+                d => (d.data as { symbol_name?: string } | undefined)
+                    ?.symbol_name === 'x'
+                    || d.message.includes("`x'")
+            );
+            expect(the_matches).toHaveLength(0);
+        });
+
+        it('global suppression via do in an uncalled program body is unchanged (#274)', async () => {
+            // Scope lock for the #274 guard: globals defined by a do/run
+            // inside a program body DO become visible once the program
+            // is called, which a textual filter cannot see — so global
+            // suppression deliberately keeps its lenient pre-#274
+            // behavior. If this test breaks, that trade-off changed.
+            const content = [
+                'program define q',
+                '    do b.do',
+                'end',
+                'display "$G"',
+            ].join('\n');
+            const document = create_real_document_state(content);
+            const forward_symbols = create_empty_symbol_table();
+            forward_symbols.globalMacros.set('G', {
+                name: 'G',
+                scope: 'global',
+                location: {
+                    uri: 'file:///b.do',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 9 },
+                    },
+                },
+                sourceUri: 'file:///b.do',
+            });
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: true,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///b.do',
+                    call_line: 1,
+                    symbols: forward_symbols,
+                    effective_type: 'do',
+                }],
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                make_stub_scope_resolver(resolved_scope)
+            );
+
+            const the_matches = the_diagnostics.filter(
+                d => (d.data as { symbol_name?: string } | undefined)
+                    ?.symbol_name === 'G'
+            );
+            expect(the_matches).toHaveLength(0);
+        });
+
+        it('variable suppression via do in an uncalled program body is unchanged (#274)', async () => {
+            // Same scope lock as the global case, for dataset variables
+            // (data loaded by a called program is global state).
+            const document = create_document_state([
+                'program define q',
+                '    do b.do',
+                'end',
+                'summarize y',
+            ].join('\n'));
+            document.diagnostics = [{
+                range: {
+                    start: { line: 3, character: 10 },
+                    end: { line: 3, character: 11 },
+                },
+                message: 'y may not be defined',
+                severity: DiagnosticSeverity.Warning,
+                code: StataDiagnosticCode.UNDEFINED_VARIABLE,
+                source: 'sight',
+                data: { symbol_name: 'y', reference_kind: 'variable' },
+            }];
+            document.symbols = create_empty_symbol_table();
+
+            const forward_symbols = create_empty_symbol_table();
+            forward_symbols.variables.set('y', {
+                name: 'y',
+                location: {
+                    uri: 'file:///b.do',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 5 },
+                    },
+                },
+                sourceUri: 'file:///b.do',
+                source: 'gen',
+            });
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: true,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///b.do',
+                    call_line: 1,
+                    symbols: forward_symbols,
+                    effective_type: 'do',
+                }],
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                make_stub_scope_resolver(resolved_scope)
+            );
+
+            const the_matches = the_diagnostics.filter(
+                d => (d.data as { symbol_name?: string } | undefined)
+                    ?.symbol_name === 'y'
+            );
+            expect(the_matches).toHaveLength(0);
+        });
+
         it('should not point header-line forward hints at program-body locals (#273)', async () => {
             // The header reference expands at definition time in the
             // do-file frame, so the hint must name the later do-file

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -1646,6 +1646,64 @@ display \`result'
             expect(the_matches).toHaveLength(0);
         });
 
+        it('suppression scan skips include calls from an enclosing program body for nested-program references (#274)', async () => {
+            // An include in `outer` binds its locals into OUTER's frame;
+            // `inner` runs later in a fresh frame, so a reference inside
+            // inner must still warn. Full-range containment would treat
+            // the reference as "same body" and wrongly suppress — the
+            // guard must compare innermost program-body scopes.
+            const content = [
+                'program define outer',
+                '    include b.do',
+                '    program define inner',
+                "        display `x'",
+                '    end',
+                'end',
+            ].join('\n');
+            const document = create_real_document_state(content);
+            const forward_symbols = create_empty_symbol_table();
+            forward_symbols.localMacros.set('x', {
+                name: 'x',
+                scope: 'local',
+                location: {
+                    uri: 'file:///b.do',
+                    range: {
+                        start: { line: 0, character: 0 },
+                        end: { line: 0, character: 9 },
+                    },
+                },
+                sourceUri: 'file:///b.do',
+            });
+
+            const resolved_scope: ResolvedScope = {
+                chain: [],
+                symbols: create_empty_symbol_table(),
+                out_of_scope_symbols: [],
+                diagnostics: [],
+                has_directives: false,
+                has_auto_parents: true,
+                forward_call_symbols: [{
+                    callee_uri: 'file:///b.do',
+                    call_line: 1,
+                    symbols: forward_symbols,
+                    effective_type: 'include',
+                }],
+            };
+
+            const the_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                make_stub_scope_resolver(resolved_scope)
+            );
+
+            const undefined_diag = the_diagnostics.find(
+                d => (d.data as { symbol_name?: string } | undefined)
+                    ?.symbol_name === 'x'
+            );
+            expect(undefined_diag).toBeDefined();
+        });
+
         it('top-level include suppression is not over-guarded (#274)', async () => {
             // The guard only targets call sites inside program bodies; a
             // plain top-level include keeps suppressing its locals.


### PR DESCRIPTION
Closes #274.

## What

A `do`/`run`/`include` sitting inside a program body executes when that program is called, not at its textual position — and its effects land in that program's own frame. Commit `3e734bc` filtered such call sites out of the combined scope-isolation message only. This PR:

- Extracts that filter into a shared helper, `call_site_in_uncalled_program_body`, and applies it to the pure "use include instead" rewrite loop (#274's original scope), so a never-executed in-program `do` no longer steals blame from the real top-level call.
- Applies the same guard to the **suppression scan** (found during review): an `include` inside an uncalled program body was silently swallowing genuine undefined-local diagnostics. Guarded for local references only — include-inherited locals bind into the program's frame and never reach references outside its body, even when the program *is* called.
- Compares **innermost program-body scopes** (body-only per #273: header and `end` lines belong to the enclosing frame) rather than full-range containment, so references inside *nested* programs — which run in a fresh frame — are not treated as same-body (found by review on the interim diff).
- Reuses `find_enclosing_scope(…, {body_only: true})` per `scope-position.ts`'s single-mechanism contract instead of a parallel implementation.

Eight regression tests pin the behavior: uncalled-body skip and same-body blame for the pure rewrite; suppression-scan uncalled-body skip, same-body suppression, nested-program warning, and top-level include not over-guarded; plus scope-lock tests pinning the global/variable trade-off below.

## Deliberate deferrals (pre-existing, out of scope)

- **Globals/variables via `do`/`run` in a program body keep lenient suppression.** They genuinely become visible once the program is called, which a textual filter cannot see; guarding them would warn on the common "setup program wraps `do globals.do`, then is called" idiom. The precise eventual fix is invocation-aware suppression (the `is_c_local_from_resolved_program` pattern). Scope-lock tests pin this so any future change is deliberate.
- **`#delimit ;` bodies:** the parser builds program scopes only under `#delimit cr`, so the filter no-ops there (degrades to prior behavior). Pre-existing parser limitation documented in `scope-position.ts`.
- **Completion/hover** still surface include-locals from uncalled program bodies — consistent with the documented asymmetry that only diagnostics suppression is held to execution-order precision.

## Review gate

Codex + independently-spawned Claude reviewers (opus/sonnet), iterated to a clean round on the final diff: round 1 surfaced the suppression-scan hole (codex live-verified), round 2 surfaced the nested-program frame bug (codex live-verified) and the duplicate-mechanism cleanup; final round — codex and an opus replaced-primitive contract check — both clean. `bun run test` (typecheck + 6974 tests) and `bun run lint` pass.

https://claude.ai/code/session_01Hcow3KywLNYgTFoacUoqL6