### PR TITLE
Implement forward-closure cache store/serve (#234)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,13 @@ call directives (`@lsp-do`, `@lsp-run`, `@lsp-include`) and auto-detected
 - Backward directives resolved first, then forward calls processed in order
 - Cycle detection and configurable max depth (`cross_file.max_backward_depth`, `cross_file.max_forward_depth`, `cross_file.max_chain_depth`, defaults 10, 10, 20; user-facing `crossFile.maxBackwardDepth`, `crossFile.maxForwardDepth`, `crossFile.maxChainDepth`)
 - Paths containing macro references are skipped
+- Caller-independent forward-closure memo (#234, on by default): nested
+  closures cached keyed by content hash / effective call type / WD / depth /
+  caps / dep-graph version; only standalone, diagnostic-free closures are
+  stored, served only when disjoint from the caller's dedup state (the
+  visited-delta is replayed on serve), and evicted in lockstep with
+  ScopeResolver's scope cache. See docs/cross-file.md "Forward-Closure
+  Caching Semantics"
 
 ### LSP Features
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -776,7 +776,9 @@ file's forward closure is identical across distinct callers given the same input
 > recursion stack and visited map, replaying the closure's visited-delta into
 > the caller on serve. Any closure that would emit a diagnostic — including a
 > depth-cap truncation suppressed by `maxDepth = "off"` — is recomputed live
-> and never stored. Entries are evicted in lockstep with the scope cache
+> and never stored (the key is marked unservable so the doomed standalone
+> build is not re-attempted on later traversals). Entries are evicted in
+> lockstep with the scope cache
 > (content changes, transitive dependents, dependency-graph version changes,
 > workspace resets), the memo only populates once the workspace scan is
 > complete, and closures built while an invalidation or cancellation landed

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -769,10 +769,19 @@ on; it is enforced by the memo correctness gate
 (`tests/integration/forward-closure-memo-gate.test.ts`), which checks that a
 file's forward closure is identical across distinct callers given the same inputs.
 
-> Implementation status: the cache *key contract* and an enable/disable toggle
-> (`set_forward_closure_memo_enabled`, default **off**) are in place; the cache
-> store/serve path is deferred to a follow-up. The toggle is a behavioral no-op
-> until then, guarded by the on/off correctness gate.
+> Implementation status: the forward-closure memo is fully implemented and
+> **on by default** (`set_forward_closure_memo_enabled` can disable it). The
+> memo caches only standalone, owner-suppressed, diagnostic-free closures and
+> serves an entry only when its reachable set is disjoint from the caller's
+> recursion stack and visited map, replaying the closure's visited-delta into
+> the caller on serve. Any closure that would emit a diagnostic — including a
+> depth-cap truncation suppressed by `maxDepth = "off"` — is recomputed live
+> and never stored. Entries are evicted in lockstep with the scope cache
+> (content changes, transitive dependents, dependency-graph version changes,
+> workspace resets), the memo only populates once the workspace scan is
+> complete, and closures built while an invalidation or cancellation landed
+> mid-build are discarded. All of this is guarded by the memo-on/off
+> correctness gate above.
 
 ## Configuration
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -762,34 +762,12 @@ sibling in execution order — see
 if it had no parents (a *backward* concern). It does **not** introduce caller-dependence
 into the *forward* closure: standalone can change the file's *inherited working
 directory* and the *effective call type* it is entered under, but both are inputs
-the closure already depends on (and would key on, were the closure cached).
+the closure already depends on.
 Standalone introduces no other forward-closure variation, and never caller
 identity. This is the assumption a caller-independent forward-closure cache relies
 on; it is enforced by the memo correctness gate
 (`tests/integration/forward-closure-memo-gate.test.ts`), which checks that a
 file's forward closure is identical across distinct callers given the same inputs.
-
-> Implementation status: the forward-closure memo is fully implemented and
-> **on by default** (`set_forward_closure_memo_enabled` can disable it). The
-> memo caches only standalone, owner-suppressed, diagnostic-free closures and
-> serves an entry only when its reachable set is disjoint from the caller's
-> recursion stack and visited map, replaying the closure's visited-delta into
-> the caller on serve. Any closure that would emit a diagnostic — including a
-> depth-cap truncation suppressed by `maxDepth = "off"` — is recomputed live
-> and never stored (the key is marked unservable so the doomed standalone
-> build is not re-attempted on later traversals). Entries are evicted in
-> lockstep with the scope cache
-> (content changes, transitive dependents, dependency-graph version changes,
-> workspace resets), the memo only populates once the workspace scan is
-> complete, and closures built while an invalidation or cancellation landed
-> mid-build are discarded. Closures that resolved a call through a fallback
-> tier (a missing working-directory candidate, or the `.do`-extension
-> fallback) also record the probed-and-missing paths as dependents, so
-> creating a file at a higher-priority path evicts them. (Creating an
-> *extensionless* file cannot be observed — the file watcher only covers
-> `*.do`/`*.ado`/`*.doh`/`*.mata` — a pre-existing platform constraint that
-> equally affects the file parse cache.) All of this is guarded by the
-> memo-on/off correctness gate above.
 
 ## Configuration
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -782,8 +782,14 @@ file's forward closure is identical across distinct callers given the same input
 > (content changes, transitive dependents, dependency-graph version changes,
 > workspace resets), the memo only populates once the workspace scan is
 > complete, and closures built while an invalidation or cancellation landed
-> mid-build are discarded. All of this is guarded by the memo-on/off
-> correctness gate above.
+> mid-build are discarded. Closures that resolved a call through a fallback
+> tier (a missing working-directory candidate, or the `.do`-extension
+> fallback) also record the probed-and-missing paths as dependents, so
+> creating a file at a higher-priority path evicts them. (Creating an
+> *extensionless* file cannot be observed — the file watcher only covers
+> `*.do`/`*.ado`/`*.doh`/`*.mata` — a pre-existing platform constraint that
+> equally affects the file parse cache.) All of this is guarded by the
+> memo-on/off correctness gate above.
 
 ## Configuration
 

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -401,6 +401,9 @@ export async function build_check_context(
     // files get the same callee keys here as in the LSP server.
     workspace_indexer.set_scope_resolver(scope_resolver);
     scope_resolver.set_dependency_graph(dependency_graph);
+    // Supplies dep_graph_version + the scan_complete population gate for
+    // the forward-closure memo (#234) — parity with the LSP server wiring.
+    forward_scope_resolver.set_dependency_graph(dependency_graph);
     scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
     diagnostics_provider.set_dependency_graph(dependency_graph);
     dependency_graph.set_workspace_roots([workspace_root]);

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -109,27 +109,6 @@ export function build_forward_closure_key(
 }
 
 /**
- * Build the version-independent prefix of the forward-closure key: the same
- * JSON tuple as `build_forward_closure_key` MINUS `dep_graph_version`. Used
- * to evict the previous entry for the same closure identity when the graph
- * version rotates — otherwise every graph edit would strand one dead entry
- * per key (the memo analog of scope_cache's same-URI stale graph-key
- * eviction at write time).
- */
-function build_forward_closure_base_key(
-    inputs: Omit<ForwardClosureKeyInputs, 'dep_graph_version'>
-): string {
-    return JSON.stringify([
-        inputs.callee_uri,
-        inputs.content_hash,
-        inputs.effective_call_type,
-        inputs.working_directory ?? null,
-        inputs.depth,
-        inputs.max_forward_depth,
-    ]);
-}
-
-/**
  * Metrics for the forward-closure memo (#234). Counting semantics:
  * - `misses`         standalone closure computations performed (each one is
  *                    a full first-visit walk — the recomputation the memo
@@ -137,8 +116,8 @@ function build_forward_closure_base_key(
  * - `hits`           serves from a PRE-existing entry. Serving an entry that
  *                    was stored earlier in the same call counts only as the
  *                    miss that built it.
- * - `invalidations`  entries evicted (by URI invalidation, base-key rotation,
- *                    or a full clear).
+ * - `invalidations`  entries evicted (by URI invalidation, a graph-version
+ *                    change, or a full clear).
  */
 export interface ForwardClosureMemoMetrics {
     hits: number;
@@ -162,8 +141,6 @@ interface ForwardClosureMemoClosureEntry {
     /** callee_uri + every reachable URI: any of these changing must evict
      *  this entry (same contract as ScopeCacheEntry.dependent_uris). */
     dependent_uris: Set<string>;
-    /** Version-independent key, for base-key rotation cleanup on delete. */
-    base_key: string;
 }
 
 /**
@@ -186,7 +163,6 @@ interface ForwardClosureMemoClosureEntry {
 interface ForwardClosureMemoUnservableEntry {
     kind: 'unservable';
     dependent_uris: Set<string>;
-    base_key: string;
 }
 
 type ForwardClosureMemoEntry =
@@ -220,9 +196,12 @@ export class ForwardScopeResolver {
     // keys that depend on it.
     private forward_closure_memo = new Map<string, ForwardClosureMemoEntry>();
     private memo_uri_to_keys = new Map<string, Set<string>>();
-    // Version-independent identity → current key, so a dep-graph version
-    // bump replaces (not strands) the previous entry at store time.
-    private memo_base_key_to_key = new Map<string, string>();
+    // The dep-graph version the memo's entries were built against. A
+    // version change makes EVERY existing entry dead by construction (all
+    // keys embed an older version), so the first memo access after a
+    // change clears the whole store — losing nothing servable and leaving
+    // no unreachable entries behind (PR #278 review).
+    private last_seen_graph_version: number | undefined;
     // Monotonic counter bumped by EVERY memo invalidation (even ones that
     // delete nothing). A standalone build snapshots it before its awaits and
     // refuses to store if it moved — otherwise an invalidation landing
@@ -286,6 +265,9 @@ export class ForwardScopeResolver {
     ): void {
         this.dependency_graph = graph;
         this.clear_forward_closure_memo();
+        // Adopt the new graph's version numbering fresh at the next memo
+        // access (a different graph could reuse the same version value).
+        this.last_seen_graph_version = undefined;
     }
 
     /** Detached snapshot of the memo metrics (#234). */
@@ -330,7 +312,6 @@ export class ForwardScopeResolver {
         this.memo_metrics.invalidations += this.forward_closure_memo.size;
         this.forward_closure_memo.clear();
         this.memo_uri_to_keys.clear();
-        this.memo_base_key_to_key.clear();
     }
 
     /**
@@ -351,9 +332,6 @@ export class ForwardScopeResolver {
                     this.memo_uri_to_keys.delete(my_dep_uri);
                 }
             }
-        }
-        if (this.memo_base_key_to_key.get(my_entry.base_key) === key) {
-            this.memo_base_key_to_key.delete(my_entry.base_key);
         }
         return true;
     }
@@ -1127,14 +1105,18 @@ export class ForwardScopeResolver {
         token?: CancellationToken,
     ): Promise<ForwardResolvedScope | undefined> {
         const dep_graph_version = this.dependency_graph?.get_version() ?? 0;
-        const base_key = build_forward_closure_base_key({
-            callee_uri,
-            content_hash,
-            effective_call_type,
-            working_directory,
-            depth: caller_context.depth + 1,
-            max_forward_depth: resolved_config.max_forward_depth,
-        });
+
+        // A graph-version change makes EVERY existing entry dead by
+        // construction (all stored keys embed an older version), so clear
+        // the whole store at the first access under the new version —
+        // losing nothing servable and stranding no unreachable entries
+        // (PR #278 review).
+        if (this.last_seen_graph_version !== undefined &&
+            this.last_seen_graph_version !== dep_graph_version) {
+            this.clear_forward_closure_memo();
+        }
+        this.last_seen_graph_version = dep_graph_version;
+
         const key = build_forward_closure_key({
             callee_uri,
             content_hash,
@@ -1163,7 +1145,6 @@ export class ForwardScopeResolver {
             }
             entry = await this.compute_and_store_standalone_closure(
                 key,
-                base_key,
                 callee_uri,
                 forward_calls,
                 cd_commands,
@@ -1225,7 +1206,6 @@ export class ForwardScopeResolver {
      */
     private async compute_and_store_standalone_closure(
         key: string,
-        base_key: string,
         callee_uri: string,
         forward_calls: ForwardCall[],
         cd_commands: CdCommand[],
@@ -1320,7 +1300,6 @@ export class ForwardScopeResolver {
             return this.store_memo_entry(key, {
                 kind: 'unservable',
                 dependent_uris,
-                base_key,
             });
         }
 
@@ -1330,28 +1309,20 @@ export class ForwardScopeResolver {
             call_sites: standalone.call_sites,
             visited_delta: fresh_visited,
             dependent_uris,
-            base_key,
         });
     }
 
     /**
-     * Insert a memo entry, maintaining the dependent-URI reverse index and
-     * evicting the previous entry for the same base key (a dep-graph
-     * version rotation must never strand dead entries). Returns the entry.
+     * Insert a memo entry, maintaining the dependent-URI reverse index.
+     * All live entries share one graph version (a version change clears the
+     * whole memo at the next access), so no per-identity version rotation
+     * is needed here. Returns the entry.
      */
     private store_memo_entry(
         key: string,
         entry: ForwardClosureMemoEntry
     ): ForwardClosureMemoEntry {
-        const old_key = this.memo_base_key_to_key.get(entry.base_key);
-        if (old_key !== undefined && old_key !== key) {
-            if (this.delete_memo_entry(old_key)) {
-                this.memo_metrics.invalidations++;
-            }
-        }
-
         this.forward_closure_memo.set(key, entry);
-        this.memo_base_key_to_key.set(entry.base_key, key);
         for (const my_dep_uri of entry.dependent_uris) {
             let my_key_set = this.memo_uri_to_keys.get(my_dep_uri);
             if (!my_key_set) {

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -71,10 +71,10 @@ export interface ForwardClosureKeyInputs {
 }
 
 /**
- * Build the caller-independent forward-closure cache key (#209). The cache
- * STORE/SERVE write-path is deferred to a follow-up; this contract ships now
- * so the follow-up — and the #208 standalone work — can rely on it, guarded
- * by the memo-on/off correctness gate.
+ * Build the caller-independent forward-closure cache key (#209/#234) used
+ * by the memo store/serve path in `memo_serve_or_compute`. The #208
+ * standalone work relies on this contract, guarded by the memo-on/off
+ * correctness gate.
  *
  * Encoded as a JSON tuple rather than a delimiter-joined string so the key
  * is collision-free: a `callee_uri` or `working_directory` containing a
@@ -83,7 +83,7 @@ export interface ForwardClosureKeyInputs {
  *
  * NOTE: the key intentionally OMITS the caller's `visited` map and the
  * `diagnostic_owner_uri`. These vary `resolve()`'s output but are NOT keyed,
- * because the deferred store/serve path handles them OUTSIDE the key (encoding
+ * because the store/serve path handles them OUTSIDE the key (encoding
  * `visited` would make the key caller-dependent, defeating the whole point):
  *  - duplicate-call (`visited`) divergence is prevented by serving only when
  *    the cached closure's reachable set is DISJOINT from the caller's
@@ -92,7 +92,7 @@ export interface ForwardClosureKeyInputs {
  *    owner-suppressed closures (any closure that would emit a diagnostic is
  *    recomputed live).
  * See docs/cross-file.md "Forward-closure caching semantics" for the full
- * deferred design and the memo-on/off correctness gate that enforces it.
+ * design and the memo-on/off correctness gate that enforces it.
  */
 export function build_forward_closure_key(
     inputs: ForwardClosureKeyInputs
@@ -151,7 +151,8 @@ export interface ForwardClosureMemoMetrics {
  * owner-suppressed, diagnostic-free result of walking `callee_uri`'s forward
  * calls from a clean self-seeded stack.
  */
-interface ForwardClosureMemoEntry {
+interface ForwardClosureMemoClosureEntry {
+    kind: 'closure';
     symbols: SymbolTable;
     call_sites: ForwardCallSite[];
     /** The (uri → effective type) pairs the standalone walk marked visited —
@@ -164,6 +165,30 @@ interface ForwardClosureMemoEntry {
     /** Version-independent key, for base-key rotation cleanup on delete. */
     base_key: string;
 }
+
+/**
+ * Negative entry (#234): this key's standalone build emitted diagnostics —
+ * a KEY-DETERMINED outcome (same inputs reproduce the same diagnostics), so
+ * re-attempting the build on every traversal would be wasted work. Without
+ * this, a chain that trips the depth cap re-attempts a doomed standalone
+ * build at every level of every live retry — O(2^depth) sub-resolutions.
+ * The marker sends the hook straight to the live path (which emits the
+ * diagnostics with the caller's own call-chain prefixes). Transient
+ * failures (cancellation, invalidation-epoch or graph-version races) are
+ * NOT negative-cached. Evicted by the same dependent-URI machinery; note a
+ * missing callee file that later APPEARS does not evict (it was never
+ * visited, so it is not a dependent) — the subtree just stays on the
+ * always-correct live path until a dependent changes.
+ */
+interface ForwardClosureMemoUnservableEntry {
+    kind: 'unservable';
+    dependent_uris: Set<string>;
+    base_key: string;
+}
+
+type ForwardClosureMemoEntry =
+    | ForwardClosureMemoClosureEntry
+    | ForwardClosureMemoUnservableEntry;
 
 const DEFAULT_CONFIG: ForwardScopeConfig = {
     max_forward_depth: 10,
@@ -206,6 +231,14 @@ export class ForwardScopeResolver {
         misses: 0,
         invalidations: 0,
     };
+    // URIs whose standalone closure build is currently in flight. A memo
+    // hook firing for one of these is a guaranteed re-entry (the build's
+    // own subtree cycled back to it), so it must go straight to the live
+    // path — which cycle-skips against the real stack — instead of
+    // launching a fresh-stack standalone build. Without this, a mutual
+    // do/run cycle cascades fresh-stack builds to max_forward_depth on
+    // warm-up (each one blind to the ancestry the previous discarded).
+    private standalone_in_flight = new Set<string>();
     private dependency_graph?: import('../dependency-graph').DependencyGraph;
 
     constructor(scope_resolver: ScopeResolver, config: Partial<ForwardScopeConfig> = {}) {
@@ -214,9 +247,9 @@ export class ForwardScopeResolver {
     }
 
     /**
-     * Enable/disable the forward-closure memo (#209/#234). Default OFF.
-     * Guarded by the memo-on/off correctness gate
-     * (tests/integration/forward-closure-memo-gate.test.ts).
+     * Enable/disable the forward-closure memo (#209/#234). Default ON
+     * (#234 acceptance decision). Guarded by the memo-on/off correctness
+     * gate (tests/integration/forward-closure-memo-gate.test.ts).
      */
     set_forward_closure_memo_enabled(enabled: boolean): void {
         this.forward_closure_memo_enabled = enabled;
@@ -231,11 +264,15 @@ export class ForwardScopeResolver {
      * memo key and the `scan_complete` population gate. When no graph is
      * wired (standalone/test usage) the gate is vacuously open and the
      * version is 0 — there is no scan whose partial state could be cached.
+     * Clears the memo: entries keyed against a previous graph's version
+     * numbering must not survive a graph swap (a different graph could
+     * reuse the same version value).
      */
     set_dependency_graph(
         graph: import('../dependency-graph').DependencyGraph
     ): void {
         this.dependency_graph = graph;
+        this.clear_forward_closure_memo();
     }
 
     /** Detached snapshot of the memo metrics (#234). */
@@ -1074,6 +1111,14 @@ export class ForwardScopeResolver {
         const entry_preexisted = entry !== undefined;
 
         if (!entry) {
+            // Re-entry guard: this callee's own standalone build is already
+            // in flight below us, so this hook is inside a cycle back to
+            // it. A fresh-stack build here would be blind to that ancestry
+            // and recurse to the depth cap; the live path cycle-skips
+            // against the real stack instead.
+            if (this.standalone_in_flight.has(callee_uri)) {
+                return undefined;
+            }
             entry = await this.compute_and_store_standalone_closure(
                 key,
                 base_key,
@@ -1090,6 +1135,13 @@ export class ForwardScopeResolver {
             if (!entry) {
                 return undefined;
             }
+        }
+
+        // Known diagnostic-producing key: always recompute live (the live
+        // walk emits the diagnostics with the caller's own call-chain
+        // prefixes and truncation anchors).
+        if (entry.kind === 'unservable') {
+            return undefined;
         }
 
         // Serve gate: the cached reachable set must be disjoint from the
@@ -1150,44 +1202,51 @@ export class ForwardScopeResolver {
         // memo exists to collapse — whether or not the result is storable.
         this.memo_metrics.misses++;
 
-        const standalone = await this.resolve(
-            callee_uri,
-            forward_calls,
-            effective_call_type,
-            {
-                visited: fresh_visited,
+        this.standalone_in_flight.add(callee_uri);
+        let standalone: ForwardResolvedScope;
+        try {
+            standalone = await this.resolve(
+                callee_uri,
+                forward_calls,
                 effective_call_type,
-                depth,
-                diagnostics: fresh_diagnostics,
-                working_directory,
-                cd_commands,
-                call_chain: [],
-                diagnostic_owner_uri: undefined,
-            },
-            new Set(),
-            token,
-            {
-                max_forward_depth: resolved_config.max_forward_depth,
-                // Force a non-'off' truncation severity: a cap-truncated
-                // closure is shaped by the cap but the SEVERITY setting is
-                // not in the key, so under 'off' it would look
-                // diagnostic-free and get stored, then be served to callers
-                // whose setting expects the truncation diagnostic. The
-                // fresh_diagnostics array is only an eligibility signal —
-                // it is discarded, so the forced severity never surfaces.
-                diagnostics: { max_depth: 'warning' },
-            },
-        );
+                {
+                    visited: fresh_visited,
+                    effective_call_type,
+                    depth,
+                    diagnostics: fresh_diagnostics,
+                    working_directory,
+                    cd_commands,
+                    call_chain: [],
+                    diagnostic_owner_uri: undefined,
+                },
+                new Set(),
+                token,
+                {
+                    max_forward_depth: resolved_config.max_forward_depth,
+                    // Force a non-'off' truncation severity: a cap-truncated
+                    // closure is shaped by the cap but the SEVERITY setting
+                    // is not in the key, so under 'off' it would look
+                    // diagnostic-free and get stored, then be served to
+                    // callers whose setting expects the truncation
+                    // diagnostic. The fresh_diagnostics array is only an
+                    // eligibility signal — it is discarded, so the forced
+                    // severity never surfaces.
+                    diagnostics: { max_depth: 'warning' },
+                },
+            );
+        } finally {
+            this.standalone_in_flight.delete(callee_uri);
+        }
 
+        // Transient failures — never stored (not key-determined): the next
+        // traversal may legitimately succeed.
         if (token?.isCancellationRequested) {
             return undefined;
         }
-        if (fresh_diagnostics.length > 0) {
-            return undefined;
-        }
         // An invalidation or graph change landed during the awaits above:
-        // the closure may already be stale, and the invalidation could not
-        // have evicted a not-yet-stored entry. Neither store nor serve.
+        // the build may have read mid-change state, and the invalidation
+        // could not have evicted a not-yet-stored entry. Neither store nor
+        // serve.
         if (this.memo_invalidation_epoch !== epoch_before) {
             return undefined;
         }
@@ -1195,18 +1254,40 @@ export class ForwardScopeResolver {
             return undefined;
         }
 
-        const entry: ForwardClosureMemoEntry = {
+        const dependent_uris = new Set([callee_uri, ...fresh_visited.keys()]);
+
+        // Key-determined failure: the same inputs reproduce the same
+        // diagnostics, so mark the key unservable instead of re-attempting
+        // a doomed standalone build on every future traversal (O(2^depth)
+        // blowup on cap-tripping chains otherwise).
+        if (fresh_diagnostics.length > 0) {
+            return this.store_memo_entry(key, {
+                kind: 'unservable',
+                dependent_uris,
+                base_key,
+            });
+        }
+
+        return this.store_memo_entry(key, {
+            kind: 'closure',
             symbols: standalone.symbols,
             call_sites: standalone.call_sites,
             visited_delta: fresh_visited,
-            dependent_uris: new Set([callee_uri, ...fresh_visited.keys()]),
+            dependent_uris,
             base_key,
-        };
+        });
+    }
 
-        // Base-key rotation: replace the previous entry for the same
-        // closure identity under an older graph version, so version bumps
-        // never strand dead entries.
-        const old_key = this.memo_base_key_to_key.get(base_key);
+    /**
+     * Insert a memo entry, maintaining the dependent-URI reverse index and
+     * evicting the previous entry for the same base key (a dep-graph
+     * version rotation must never strand dead entries). Returns the entry.
+     */
+    private store_memo_entry(
+        key: string,
+        entry: ForwardClosureMemoEntry
+    ): ForwardClosureMemoEntry {
+        const old_key = this.memo_base_key_to_key.get(entry.base_key);
         if (old_key !== undefined && old_key !== key) {
             if (this.delete_memo_entry(old_key)) {
                 this.memo_metrics.invalidations++;
@@ -1214,7 +1295,7 @@ export class ForwardScopeResolver {
         }
 
         this.forward_closure_memo.set(key, entry);
-        this.memo_base_key_to_key.set(base_key, key);
+        this.memo_base_key_to_key.set(entry.base_key, key);
         for (const my_dep_uri of entry.dependent_uris) {
             let my_key_set = this.memo_uri_to_keys.get(my_dep_uri);
             if (!my_key_set) {

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -242,6 +242,16 @@ export class ForwardScopeResolver {
     // do/run cycle cascades fresh-stack builds to max_forward_depth on
     // warm-up (each one blind to the ancestry the previous discarded).
     private standalone_in_flight = new Set<string>();
+    // Missing-probe collectors for in-flight standalone builds (#234): the
+    // URIs of higher-priority path candidates that resolved MISSING before
+    // a fallback tier won, plus .do-fallback originals. Recorded into every
+    // active collector (nested builds embed their inner builds' results, so
+    // inner probes belong to outer entries too) and folded into
+    // dependent_uris — creating a file at one of these paths would change
+    // what a fresh walk resolves, so it must evict the entry. Cross-
+    // contamination between concurrent unrelated builds only ADDS
+    // dependents (safe over-invalidation).
+    private active_probe_collectors: Set<string>[] = [];
     private dependency_graph?: import('../dependency-graph').DependencyGraph;
 
     constructor(scope_resolver: ScopeResolver, config: Partial<ForwardScopeConfig> = {}) {
@@ -359,6 +369,22 @@ export class ForwardScopeResolver {
     }
 
     /**
+     * Record missing-probe filesystem paths (as URIs) into every active
+     * standalone-build collector (#234). No-op when no build is in flight.
+     */
+    private record_missing_probes(fs_paths: string[]): void {
+        if (this.active_probe_collectors.length === 0) {
+            return;
+        }
+        for (const my_fs_path of fs_paths) {
+            const my_probe_uri = URI.file(my_fs_path).toString();
+            for (const my_collector of this.active_probe_collectors) {
+                my_collector.add(my_probe_uri);
+            }
+        }
+    }
+
+    /**
      * Set workspace roots (filesystem paths) for cache-first mode guarding.
      * Clears the forward-closure memo: roots steer path/cd resolution and
      * cache-first fetching but are not part of the memo key, so entries
@@ -422,6 +448,11 @@ export class ForwardScopeResolver {
         seed_dir?: string;
     } {
         const my_caller_dir = path.dirname(URI.parse(caller_uri).fsPath);
+        // Collect probed-and-missing higher-priority candidates only when a
+        // standalone memo build is in flight (live walks don't cache, so
+        // they have nothing to invalidate).
+        const my_missed_candidates: string[] | undefined =
+            this.active_probe_collectors.length > 0 ? [] : undefined;
         const my_outcome: PathCaseOutcome = resolve_forward_call_rich(
             raw_path,
             my_caller_dir,
@@ -431,8 +462,12 @@ export class ForwardScopeResolver {
                     ? this.workspace_roots
                     : undefined,
                 fs: this.resolve_fs,
+                missed_candidates: my_missed_candidates,
             },
         );
+        if (my_missed_candidates && my_missed_candidates.length > 0) {
+            this.record_missing_probes(my_missed_candidates);
+        }
 
         if (my_outcome.kind === 'exact') {
             return {
@@ -1210,6 +1245,8 @@ export class ForwardScopeResolver {
         this.memo_metrics.misses++;
 
         this.standalone_in_flight.add(callee_uri);
+        const my_probe_collector = new Set<string>();
+        this.active_probe_collectors.push(my_probe_collector);
         let standalone: ForwardResolvedScope;
         try {
             standalone = await this.resolve(
@@ -1243,6 +1280,11 @@ export class ForwardScopeResolver {
             );
         } finally {
             this.standalone_in_flight.delete(callee_uri);
+            const my_collector_index =
+                this.active_probe_collectors.indexOf(my_probe_collector);
+            if (my_collector_index >= 0) {
+                this.active_probe_collectors.splice(my_collector_index, 1);
+            }
         }
 
         // Transient failures — never stored (not key-determined): the next
@@ -1261,7 +1303,14 @@ export class ForwardScopeResolver {
             return undefined;
         }
 
-        const dependent_uris = new Set([callee_uri, ...fresh_visited.keys()]);
+        // Dependents: the callee, everything the walk reached, and every
+        // probed-and-missing higher-priority path candidate — creating a
+        // file at one of those would change what a fresh walk resolves.
+        const dependent_uris = new Set([
+            callee_uri,
+            ...fresh_visited.keys(),
+            ...my_probe_collector,
+        ]);
 
         // Key-determined failure: the same inputs reproduce the same
         // diagnostics, so mark the key unservable instead of re-attempting
@@ -1625,6 +1674,11 @@ export class ForwardScopeResolver {
                 if (fs.existsSync(do_path)) {
                     final_fs_path = do_path;
                     final_uri = URI.file(do_path).toString();
+                    // A file created later at the extensionless path would
+                    // win over the .do fallback — record the miss so memo
+                    // entries built through this fallback get evicted
+                    // (#234; no-op outside standalone builds).
+                    this.record_missing_probes([fs_path]);
                 }
             }
         }

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -18,6 +18,7 @@ import {
     ForwardCallSite,
     ForwardResolvedScope,
     DuplicateCallDecision,
+    DirectiveDiagnostic,
     MacroSymbol,
     StataDiagnosticCode,
 } from '../types';
@@ -107,6 +108,63 @@ export function build_forward_closure_key(
     ]);
 }
 
+/**
+ * Build the version-independent prefix of the forward-closure key: the same
+ * JSON tuple as `build_forward_closure_key` MINUS `dep_graph_version`. Used
+ * to evict the previous entry for the same closure identity when the graph
+ * version rotates — otherwise every graph edit would strand one dead entry
+ * per key (the memo analog of scope_cache's same-URI stale graph-key
+ * eviction at write time).
+ */
+function build_forward_closure_base_key(
+    inputs: Omit<ForwardClosureKeyInputs, 'dep_graph_version'>
+): string {
+    return JSON.stringify([
+        inputs.callee_uri,
+        inputs.content_hash,
+        inputs.effective_call_type,
+        inputs.working_directory ?? null,
+        inputs.depth,
+        inputs.max_forward_depth,
+    ]);
+}
+
+/**
+ * Metrics for the forward-closure memo (#234). Counting semantics:
+ * - `misses`         standalone closure computations performed (each one is
+ *                    a full first-visit walk — the recomputation the memo
+ *                    exists to collapse).
+ * - `hits`           serves from a PRE-existing entry. Serving an entry that
+ *                    was stored earlier in the same call counts only as the
+ *                    miss that built it.
+ * - `invalidations`  entries evicted (by URI invalidation, base-key rotation,
+ *                    or a full clear).
+ */
+export interface ForwardClosureMemoMetrics {
+    hits: number;
+    misses: number;
+    invalidations: number;
+}
+
+/**
+ * One cached caller-independent forward closure (#234): the standalone,
+ * owner-suppressed, diagnostic-free result of walking `callee_uri`'s forward
+ * calls from a clean self-seeded stack.
+ */
+interface ForwardClosureMemoEntry {
+    symbols: SymbolTable;
+    call_sites: ForwardCallSite[];
+    /** The (uri → effective type) pairs the standalone walk marked visited —
+     *  the closure's reachable set. Replayed into the caller's visited map
+     *  on serve so later siblings dedup identically to a live recompute. */
+    visited_delta: Map<string, EffectiveCallType>;
+    /** callee_uri + every reachable URI: any of these changing must evict
+     *  this entry (same contract as ScopeCacheEntry.dependent_uris). */
+    dependent_uris: Set<string>;
+    /** Version-independent key, for base-key rotation cleanup on delete. */
+    base_key: string;
+}
+
 const DEFAULT_CONFIG: ForwardScopeConfig = {
     max_forward_depth: 10,
 };
@@ -119,12 +177,36 @@ export class ForwardScopeResolver {
     // When undefined, resolve_path_rich uses the real Node fs.
     private resolve_fs?: RichResolveFs;
 
-    // #209: switch for the (deferred) caller-independent forward-closure
-    // memo. Default OFF — the cache store/serve write-path lands in a
-    // follow-up. The memo-on/off correctness gate flips this to prove the
-    // future cache is behaviorally identical to the live walk; #208's
-    // caller-independence assumption rides on that gate, not on the cache.
-    private forward_closure_memo_enabled = false;
+    // #209/#234: switch for the caller-independent forward-closure memo.
+    // Default ON (#234 acceptance decision: memo-on/off gate green, ~2.4×
+    // on the shared-chain N-callers shape with no added I/O). The
+    // memo-on/off correctness gate proves the cache is behaviorally
+    // identical to the live walk; #208's caller-independence assumption
+    // rides on that gate.
+    private forward_closure_memo_enabled = true;
+
+    // #234: forward-closure memo store (key → standalone closure) plus the
+    // reverse index used for O(affected) cascade eviction. Unlike
+    // scope_cache's index (which covers only each entry's OWN uri and needs
+    // an O(N) scan for cascades), this index maps EVERY dependent URI to the
+    // keys that depend on it.
+    private forward_closure_memo = new Map<string, ForwardClosureMemoEntry>();
+    private memo_uri_to_keys = new Map<string, Set<string>>();
+    // Version-independent identity → current key, so a dep-graph version
+    // bump replaces (not strands) the previous entry at store time.
+    private memo_base_key_to_key = new Map<string, string>();
+    // Monotonic counter bumped by EVERY memo invalidation (even ones that
+    // delete nothing). A standalone build snapshots it before its awaits and
+    // refuses to store if it moved — otherwise an invalidation landing
+    // mid-build would miss the not-yet-stored entry and a stale closure
+    // would be published right after (codex finding #1 on the #234 plan).
+    private memo_invalidation_epoch = 0;
+    private memo_metrics: ForwardClosureMemoMetrics = {
+        hits: 0,
+        misses: 0,
+        invalidations: 0,
+    };
+    private dependency_graph?: import('../dependency-graph').DependencyGraph;
 
     constructor(scope_resolver: ScopeResolver, config: Partial<ForwardScopeConfig> = {}) {
         this.scope_resolver = scope_resolver;
@@ -132,9 +214,9 @@ export class ForwardScopeResolver {
     }
 
     /**
-     * Enable/disable the forward-closure memo (#209). Default OFF. The
-     * store/serve write-path is deferred; until it lands, toggling this is a
-     * behavioral no-op — guarded by the memo-on/off correctness gate.
+     * Enable/disable the forward-closure memo (#209/#234). Default OFF.
+     * Guarded by the memo-on/off correctness gate
+     * (tests/integration/forward-closure-memo-gate.test.ts).
      */
     set_forward_closure_memo_enabled(enabled: boolean): void {
         this.forward_closure_memo_enabled = enabled;
@@ -145,19 +227,118 @@ export class ForwardScopeResolver {
     }
 
     /**
+     * Set the dependency graph (#234). Supplies `dep_graph_version` for the
+     * memo key and the `scan_complete` population gate. When no graph is
+     * wired (standalone/test usage) the gate is vacuously open and the
+     * version is 0 — there is no scan whose partial state could be cached.
+     */
+    set_dependency_graph(
+        graph: import('../dependency-graph').DependencyGraph
+    ): void {
+        this.dependency_graph = graph;
+    }
+
+    /** Detached snapshot of the memo metrics (#234). */
+    get_forward_closure_metrics(): ForwardClosureMemoMetrics {
+        return { ...this.memo_metrics };
+    }
+
+    reset_forward_closure_metrics(): void {
+        this.memo_metrics = { hits: 0, misses: 0, invalidations: 0 };
+    }
+
+    /**
+     * Evict every memo entry that depends on `uri` (its own closure or any
+     * closure that transitively reached it). Called by ScopeResolver from
+     * the same funnels that invalidate scope_cache (didChange, watcher,
+     * rename, cascade, workspace reset), so the memo inherits scope_cache's
+     * invalidation triggers without new server wiring.
+     *
+     * ALWAYS bumps the invalidation epoch, even when nothing is deleted:
+     * an in-flight standalone build for this URI has no stored entry yet,
+     * and the epoch is what stops it from storing a stale closure.
+     */
+    invalidate_forward_closure_for_uri(uri: string): number {
+        this.memo_invalidation_epoch++;
+        const the_keys = this.memo_uri_to_keys.get(uri);
+        if (!the_keys) {
+            return 0;
+        }
+        let count = 0;
+        for (const my_key of [...the_keys]) {
+            if (this.delete_memo_entry(my_key)) {
+                count++;
+            }
+        }
+        this.memo_metrics.invalidations += count;
+        return count;
+    }
+
+    /** Drop the whole memo (workspace reset / clear_cache / dispose). */
+    clear_forward_closure_memo(): void {
+        this.memo_invalidation_epoch++;
+        this.memo_metrics.invalidations += this.forward_closure_memo.size;
+        this.forward_closure_memo.clear();
+        this.memo_uri_to_keys.clear();
+        this.memo_base_key_to_key.clear();
+    }
+
+    /**
+     * Remove one memo entry and every index reference to it.
+     * Returns true when the key existed.
+     */
+    private delete_memo_entry(key: string): boolean {
+        const my_entry = this.forward_closure_memo.get(key);
+        if (!my_entry) {
+            return false;
+        }
+        this.forward_closure_memo.delete(key);
+        for (const my_dep_uri of my_entry.dependent_uris) {
+            const my_key_set = this.memo_uri_to_keys.get(my_dep_uri);
+            if (my_key_set) {
+                my_key_set.delete(key);
+                if (my_key_set.size === 0) {
+                    this.memo_uri_to_keys.delete(my_dep_uri);
+                }
+            }
+        }
+        if (this.memo_base_key_to_key.get(my_entry.base_key) === key) {
+            this.memo_base_key_to_key.delete(my_entry.base_key);
+        }
+        return true;
+    }
+
+    /**
+     * Population/serve gate (#234): only use the memo once the workspace
+     * scan has completed — closures computed against a partial dependency
+     * graph must never be cached. Vacuously open when no graph is wired.
+     */
+    private is_memo_usable(): boolean {
+        return this.dependency_graph === undefined ||
+            this.dependency_graph.is_scan_complete();
+    }
+
+    /**
      * Set workspace roots (filesystem paths) for cache-first mode guarding.
+     * Clears the forward-closure memo: roots steer path/cd resolution and
+     * cache-first fetching but are not part of the memo key, so entries
+     * built under the old roots must not survive (#234).
      */
     set_workspace_roots(roots: string[]): void {
         this.workspace_roots = roots.map(r => path.resolve(r));
+        this.clear_forward_closure_memo();
     }
 
     /**
      * Inject a filesystem implementation for `resolve_path_rich`.
      * For testing only — production code leaves this undefined so
      * `resolve_path_rich` uses the real Node `fs`.
+     * Clears the forward-closure memo for the same reason as
+     * `set_workspace_roots` (the fs steers path resolution, unkeyed).
      */
     set_resolve_fs(injected_fs: RichResolveFs): void {
         this.resolve_fs = injected_fs;
+        this.clear_forward_closure_memo();
     }
 
     /**
@@ -731,39 +912,71 @@ export class ForwardScopeResolver {
 
             // Recursively resolve callee's forward calls
             if (callee_result.forward_calls.length > 0) {
-                const nested_result = await this.resolve(
-                    callee_uri,
-                    callee_result.forward_calls,
-                    my_effective_type,
-                    {
-                        visited: my_context.visited,
-                        effective_call_type: my_effective_type,
-                        depth: my_context.depth + 1,
-                        diagnostics: my_context.diagnostics,
-                        working_directory: callee_result.working_directory ?? effective_call_wd,
-                        // The callee's own in-script cd commands drive its
-                        // frame's timeline (issue #252).
-                        cd_commands: callee_result.cd_commands,
-                        call_chain: [...(my_context.call_chain ?? []), my_call.raw_path],
-                        // Pass the original owner through unchanged so the
-                        // single-emission guard remains correct: nested
-                        // callee calls are at depth > 0 relative to the
-                        // owner and therefore suppress their own
-                        // path_case_mismatch emission.
-                        diagnostic_owner_uri: my_context.diagnostic_owner_uri,
-                        // Anchor nested cap-truncations to the owner file's
-                        // depth-0 call site (#209). Established once, on the
-                        // first owner-rooted recursion, then propagated. Only
-                        // set when an owner is present (not ancestor builds).
-                        root_call_range: my_context.root_call_range ??
-                            (my_context.diagnostic_owner_uri !== undefined
-                                ? my_call.range
-                                : undefined),
-                    },
-                    my_stack,
-                    token,
-                    resolved_config,
-                );
+                const nested_wd =
+                    callee_result.working_directory ?? effective_call_wd;
+
+                // #234: the forward-closure memo hooks HERE and only here.
+                // Nested calls run at depth >= 1, where the owner-gated
+                // diagnostics (cd timeline, path_case_mismatch) structurally
+                // cannot fire — so "owner-suppressed" holds by construction
+                // — and callee content always came through get_parsed_file,
+                // so content_hash identifies exactly what was parsed.
+                // Returns undefined when the caller must recompute live
+                // (memo off, scan gate closed, unstorable closure, or the
+                // caller's dedup state intersects the cached reachable set).
+                let nested_result =
+                    this.forward_closure_memo_enabled &&
+                    this.is_memo_usable() &&
+                    typeof callee_result.content_hash === 'string'
+                        ? await this.memo_serve_or_compute(
+                            callee_uri,
+                            callee_result.content_hash,
+                            callee_result.forward_calls,
+                            callee_result.cd_commands,
+                            my_effective_type,
+                            nested_wd,
+                            my_context,
+                            my_stack,
+                            resolved_config,
+                            token,
+                        )
+                        : undefined;
+
+                if (nested_result === undefined) {
+                    nested_result = await this.resolve(
+                        callee_uri,
+                        callee_result.forward_calls,
+                        my_effective_type,
+                        {
+                            visited: my_context.visited,
+                            effective_call_type: my_effective_type,
+                            depth: my_context.depth + 1,
+                            diagnostics: my_context.diagnostics,
+                            working_directory: nested_wd,
+                            // The callee's own in-script cd commands drive its
+                            // frame's timeline (issue #252).
+                            cd_commands: callee_result.cd_commands,
+                            call_chain: [...(my_context.call_chain ?? []), my_call.raw_path],
+                            // Pass the original owner through unchanged so the
+                            // single-emission guard remains correct: nested
+                            // callee calls are at depth > 0 relative to the
+                            // owner and therefore suppress their own
+                            // path_case_mismatch emission.
+                            diagnostic_owner_uri: my_context.diagnostic_owner_uri,
+                            // Anchor nested cap-truncations to the owner file's
+                            // depth-0 call site (#209). Established once, on the
+                            // first owner-rooted recursion, then propagated. Only
+                            // set when an owner is present (not ancestor builds).
+                            root_call_range: my_context.root_call_range ??
+                                (my_context.diagnostic_owner_uri !== undefined
+                                    ? my_call.range
+                                    : undefined),
+                        },
+                        my_stack,
+                        token,
+                        resolved_config,
+                    );
+                }
 
                 // Check cancellation after recursive call
                 if (token?.isCancellationRequested) {
@@ -801,6 +1014,217 @@ export class ForwardScopeResolver {
             call_sites: the_call_sites,
             diagnostics: my_context.diagnostics,
         };
+    }
+
+    /**
+     * Memo store/serve for one nested forward closure (#234).
+     *
+     * MISS: compute the callee's closure STANDALONE — fresh visited map,
+     * clean self-seeded stack, fresh diagnostics array, no diagnostic
+     * owner — at the same depth/config the live recursion would use. Store
+     * it only when it is diagnostic-free, was not cancelled, and no memo
+     * invalidation or dep-graph version change landed during the build.
+     *
+     * SERVE: only when the closure's reachable set (visited_delta) is
+     * disjoint from the caller's recursion stack and visited map — i.e.
+     * when the caller's dedup state cannot change what a live walk of this
+     * subtree would produce. On serve, replay the visited_delta into the
+     * caller's visited map so later siblings dedup identically to a live
+     * recompute.
+     *
+     * Returns undefined whenever the caller must recompute live: the
+     * closure was unstorable (diagnostics — whose call-chain prefixes and
+     * truncation anchors are caller-dependent — or a cancellation/epoch
+     * race), or the disjointness gate failed. Store-eligibility and
+     * serve-eligibility are independent: a stored entry may still be
+     * unservable to THIS caller while serving future disjoint callers.
+     */
+    private async memo_serve_or_compute(
+        callee_uri: string,
+        content_hash: string,
+        forward_calls: ForwardCall[],
+        cd_commands: CdCommand[],
+        effective_call_type: EffectiveCallType,
+        working_directory: string | undefined,
+        caller_context: ForwardResolveContext,
+        caller_stack: Set<string>,
+        resolved_config: ForwardScopeConfig,
+        token?: CancellationToken,
+    ): Promise<ForwardResolvedScope | undefined> {
+        const dep_graph_version = this.dependency_graph?.get_version() ?? 0;
+        const base_key = build_forward_closure_base_key({
+            callee_uri,
+            content_hash,
+            effective_call_type,
+            working_directory,
+            depth: caller_context.depth + 1,
+            max_forward_depth: resolved_config.max_forward_depth,
+        });
+        const key = build_forward_closure_key({
+            callee_uri,
+            content_hash,
+            effective_call_type,
+            working_directory,
+            depth: caller_context.depth + 1,
+            max_forward_depth: resolved_config.max_forward_depth,
+            dep_graph_version,
+        });
+
+        let entry = this.forward_closure_memo.get(key);
+        const entry_preexisted = entry !== undefined;
+
+        if (!entry) {
+            entry = await this.compute_and_store_standalone_closure(
+                key,
+                base_key,
+                callee_uri,
+                forward_calls,
+                cd_commands,
+                effective_call_type,
+                working_directory,
+                caller_context.depth + 1,
+                dep_graph_version,
+                resolved_config,
+                token,
+            );
+            if (!entry) {
+                return undefined;
+            }
+        }
+
+        // Serve gate: the cached reachable set must be disjoint from the
+        // caller's stack and visited map, or dedup decisions would diverge
+        // from a live walk (duplicate suppression, cycle skips).
+        for (const my_uri of entry.visited_delta.keys()) {
+            if (caller_stack.has(my_uri) ||
+                caller_context.visited.has(my_uri)) {
+                return undefined;
+            }
+        }
+
+        if (entry_preexisted) {
+            this.memo_metrics.hits++;
+        }
+
+        // Replay the visited-delta so later siblings dedup exactly as they
+        // would after a live recompute of this subtree.
+        for (const [my_uri, my_type] of entry.visited_delta) {
+            caller_context.visited.set(my_uri, my_type);
+        }
+
+        // The caller's flattening loop spread-copies each site and the
+        // symbol merge builds new maps, so the cached tables are never
+        // mutated (same sharing discipline as scope_cache serves).
+        return {
+            symbols: entry.symbols,
+            call_sites: entry.call_sites,
+            diagnostics: [],
+        };
+    }
+
+    /**
+     * Compute a callee's standalone closure and store it when eligible
+     * (#234). Returns undefined when the closure must not be cached:
+     * it emitted a diagnostic, the build was cancelled, or an invalidation
+     * epoch / dep-graph version change raced the build (in which case the
+     * result may already be stale, so it is not served either).
+     */
+    private async compute_and_store_standalone_closure(
+        key: string,
+        base_key: string,
+        callee_uri: string,
+        forward_calls: ForwardCall[],
+        cd_commands: CdCommand[],
+        effective_call_type: EffectiveCallType,
+        working_directory: string | undefined,
+        depth: number,
+        dep_graph_version: number,
+        resolved_config: ForwardScopeConfig,
+        token?: CancellationToken,
+    ): Promise<ForwardClosureMemoEntry | undefined> {
+        const epoch_before = this.memo_invalidation_epoch;
+        const fresh_visited = new Map<string, EffectiveCallType>();
+        const fresh_diagnostics: DirectiveDiagnostic[] = [];
+
+        // Every standalone computation is a "miss" — the recomputation the
+        // memo exists to collapse — whether or not the result is storable.
+        this.memo_metrics.misses++;
+
+        const standalone = await this.resolve(
+            callee_uri,
+            forward_calls,
+            effective_call_type,
+            {
+                visited: fresh_visited,
+                effective_call_type,
+                depth,
+                diagnostics: fresh_diagnostics,
+                working_directory,
+                cd_commands,
+                call_chain: [],
+                diagnostic_owner_uri: undefined,
+            },
+            new Set(),
+            token,
+            {
+                max_forward_depth: resolved_config.max_forward_depth,
+                // Force a non-'off' truncation severity: a cap-truncated
+                // closure is shaped by the cap but the SEVERITY setting is
+                // not in the key, so under 'off' it would look
+                // diagnostic-free and get stored, then be served to callers
+                // whose setting expects the truncation diagnostic. The
+                // fresh_diagnostics array is only an eligibility signal —
+                // it is discarded, so the forced severity never surfaces.
+                diagnostics: { max_depth: 'warning' },
+            },
+        );
+
+        if (token?.isCancellationRequested) {
+            return undefined;
+        }
+        if (fresh_diagnostics.length > 0) {
+            return undefined;
+        }
+        // An invalidation or graph change landed during the awaits above:
+        // the closure may already be stale, and the invalidation could not
+        // have evicted a not-yet-stored entry. Neither store nor serve.
+        if (this.memo_invalidation_epoch !== epoch_before) {
+            return undefined;
+        }
+        if ((this.dependency_graph?.get_version() ?? 0) !== dep_graph_version) {
+            return undefined;
+        }
+
+        const entry: ForwardClosureMemoEntry = {
+            symbols: standalone.symbols,
+            call_sites: standalone.call_sites,
+            visited_delta: fresh_visited,
+            dependent_uris: new Set([callee_uri, ...fresh_visited.keys()]),
+            base_key,
+        };
+
+        // Base-key rotation: replace the previous entry for the same
+        // closure identity under an older graph version, so version bumps
+        // never strand dead entries.
+        const old_key = this.memo_base_key_to_key.get(base_key);
+        if (old_key !== undefined && old_key !== key) {
+            if (this.delete_memo_entry(old_key)) {
+                this.memo_metrics.invalidations++;
+            }
+        }
+
+        this.forward_closure_memo.set(key, entry);
+        this.memo_base_key_to_key.set(base_key, key);
+        for (const my_dep_uri of entry.dependent_uris) {
+            let my_key_set = this.memo_uri_to_keys.get(my_dep_uri);
+            if (!my_key_set) {
+                my_key_set = new Set();
+                this.memo_uri_to_keys.set(my_dep_uri, my_key_set);
+            }
+            my_key_set.add(key);
+        }
+
+        return entry;
     }
 
     /**
@@ -1099,7 +1523,7 @@ export class ForwardScopeResolver {
         fs_path: string,
         uri: string,
         working_directory?: string
-    ): Promise<{ symbols: SymbolTable; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string } | { error: string }> {
+    ): Promise<{ symbols: SymbolTable; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; content_hash?: string } | { error: string }> {
         let final_fs_path = fs_path;
         let final_uri = uri;
         const paths_tried: string[] = [fs_path];
@@ -1131,17 +1555,22 @@ export class ForwardScopeResolver {
             // Defensive default: older/mocked parse results may omit cd_commands.
             cd_commands: parsed_result.cd_commands ?? [],
             working_directory: parsed_result.working_directory,
+            // Identifies exactly the content that was parsed (editor buffer
+            // or disk) — the memo key input (#234). Optional because
+            // JS-level mocks of get_parsed_file may omit it; the memo hook
+            // skips caching when it is absent.
+            content_hash: parsed_result.content_hash,
         };
     }
 
     /**
      * Dispose the forward scope resolver.
      * Called during server shutdown to release resources.
-     * The ForwardScopeResolver delegates caching to ScopeResolver,
-     * so there are no internal caches to clear here.
+     * File/parse caching is delegated to ScopeResolver; the forward-closure
+     * memo (#234) is the one cache owned here.
      */
     dispose(): void {
-        // No internal caches to clear — caching is delegated to ScopeResolver
+        this.clear_forward_closure_memo();
     }
 
 }

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -1114,11 +1114,15 @@ export class ForwardScopeResolver {
         const entry_preexisted = entry !== undefined;
 
         if (!entry) {
-            // Re-entry guard: this callee's own standalone build is already
-            // in flight below us, so this hook is inside a cycle back to
-            // it. A fresh-stack build here would be blind to that ancestry
-            // and recurse to the depth cap; the live path cycle-skips
-            // against the real stack instead.
+            // Re-entry guard: within one resolution chain, a hook firing
+            // for a callee whose standalone build is already in flight is
+            // a cycle back into it — a fresh-stack build here would be
+            // blind to that ancestry and recurse to the depth cap; the
+            // live path cycle-skips against the real stack instead. Under
+            // concurrent resolutions sharing this resolver (sight check
+            // workers), an overlap can also trip this for an unrelated
+            // caller — a conservative live fallback (lost caching, never
+            // wrong output).
             if (this.standalone_in_flight.has(callee_uri)) {
                 return undefined;
             }

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -167,9 +167,12 @@ interface ForwardClosureMemoClosureEntry {
 }
 
 /**
- * Negative entry (#234): this key's standalone build emitted diagnostics —
- * a KEY-DETERMINED outcome (same inputs reproduce the same diagnostics), so
- * re-attempting the build on every traversal would be wasted work. Without
+ * Negative entry (#234): this key's standalone build emitted diagnostics.
+ * For cap truncations the outcome is fully key-determined; for missing/
+ * ambiguous files it also depends on the filesystem, which can change
+ * without rotating the key — the marker stays conservative either way
+ * (unservable entries never serve, they only skip re-attempting the
+ * build). Re-attempting on every traversal would be wasted work: without
  * this, a chain that trips the depth cap re-attempts a doomed standalone
  * build at every level of every live retry — O(2^depth) sub-resolutions.
  * The marker sends the hook straight to the live path (which emits the

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -2318,6 +2318,14 @@ export class ScopeResolver {
                                 forward_calls: fallback_cached.forward_calls,
                                 cd_commands: fallback_cached.cd_commands,
                                 working_directory: fallback_cached.working_directory,
+                                // Was missing from this HIT return alone
+                                // (coderabbit on PR #278): without it,
+                                // discover_working_directory cannot see a
+                                // parent's own WD directive when the parent
+                                // is served from this branch, and WD
+                                // inheritance falls through to deeper
+                                // ancestors.
+                                working_directory_directive: fallback_cached.working_directory_directive,
                                 diagnostics: fallback_cached.diagnostics
                             };
                         }

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -2758,8 +2758,15 @@ export class ScopeResolver {
      * @param options - Invalidation options
      * @param options.preserve_forward_call_relationships - If true, do not clear forward call relationships.
      *   Use this when the file cache is being invalidated during an update where relationships were just refreshed.
+     * @param options.preserve_backward_directive_dependencies - If true, do
+     *   not clear the parent→child backward-directive map for this URI. Use
+     *   this on document CLOSE (#278): the file still exists on disk and
+     *   nothing re-syncs the map until its next parse, so clearing it would
+     *   break get_transitive_backward_directive_children for parent edits
+     *   until then. The next parse re-syncs (and corrects buffer-era
+     *   registrations) via sync_backward_directive_dependencies.
      */
-    invalidate_file_cache(uri: string, options?: { preserve_forward_call_relationships?: boolean }): void {
+    invalidate_file_cache(uri: string, options?: { preserve_forward_call_relationships?: boolean; preserve_backward_directive_dependencies?: boolean }): void {
         this.log(`[invalidate_file_cache] Invalidating file cache for ${uri}`);
         // Keep the forward-closure memo in lockstep with scope_cache (#234).
         this.forward_scope_resolver?.invalidate_forward_closure_for_uri?.(uri);
@@ -2777,7 +2784,9 @@ export class ScopeResolver {
 
         // Clear backward directive dependencies for this file
         // This maintains consistency between file cache and backward directive map
-        this.clear_backward_directive_dependencies(uri);
+        if (!options?.preserve_backward_directive_dependencies) {
+            this.clear_backward_directive_dependencies(uri);
+        }
 
         // Clear forward call relationships for this file
         // This maintains consistency between file cache and callee_to_callers map

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -2057,6 +2057,18 @@ export class ScopeResolver {
             return { symbols: cached.symbols, directives: cached.directives, forward_calls: cached.forward_calls, cd_commands: cached.cd_commands, diagnostics: cached.diagnostics };
         }
 
+        // New content observed for this URI: any forward-closure memo entry
+        // built from the PREVIOUS content is stale. The eager didChange
+        // invalidation cannot cover entries built DURING the debounce window
+        // (after the invalidation, before this parse) from the then-stale
+        // file_cache — they are keyed by ancestor hashes that this edit does
+        // not rotate, so purge them now that the new content lands (#278
+        // review). No-op when nothing was cached before.
+        if (cached) {
+            this.forward_scope_resolver
+                ?.invalidate_forward_closure_for_uri?.(uri);
+        }
+
         try {
             const my_parse_result = this.parse_content(uri, content);
 
@@ -2370,6 +2382,11 @@ export class ScopeResolver {
             };
         } else if (actual_cached) {
             this.log(`[get_parsed_file] File cache STALE for ${actual_uri} (cached hash=${actual_cached.content_hash}, disk hash=${disk_hash})`);
+            // New content observed without an invalidation event having
+            // reached us: purge memo entries that embedded the previous
+            // content (same rationale as the parse_file hash-change purge).
+            this.forward_scope_resolver
+                ?.invalidate_forward_closure_for_uri?.(actual_uri);
         } else {
             this.log(`[get_parsed_file] File cache MISS for ${actual_uri} (no entry)`);
         }

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -130,7 +130,7 @@ export function scope_resolver_config_for(
  * Cache for file parsing results within a single resolution request.
  * Ensures we only read/parse each file once per request.
  */
-type ParsedFileResult = { content: string; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] } | { error: string };
+type ParsedFileResult = { content: string; content_hash: string; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] } | { error: string };
 type RequestCache = Map<string, Promise<ParsedFileResult>>;
 
 /**
@@ -164,6 +164,13 @@ interface ForwardScopeResolverInterface {
             };
         }
     ): Promise<ForwardResolvedScope>;
+    /**
+     * Evict forward-closure memo entries depending on `uri` (#234).
+     * Optional so lightweight test doubles need not implement it.
+     */
+    invalidate_forward_closure_for_uri?(uri: string): number;
+    /** Drop the whole forward-closure memo (#234). Optional as above. */
+    clear_forward_closure_memo?(): void;
 }
 
 export class ScopeResolver {
@@ -2239,6 +2246,7 @@ export class ScopeResolver {
             this.cache_metrics.file.hits++;
             return {
                 content: cached.content,
+                content_hash: cached.content_hash,
                 symbols: cached.symbols,
                 directives: cached.directives,
                 forward_calls: cached.forward_calls,
@@ -2265,6 +2273,7 @@ export class ScopeResolver {
                 this.log(`[get_parsed_file] File cache HIT for ${uri} (mtime match, skipped read)`);
                 return {
                     content: cached.content,
+                    content_hash: cached.content_hash,
                     symbols: cached.symbols,
                     directives: cached.directives,
                     forward_calls: cached.forward_calls,
@@ -2303,6 +2312,7 @@ export class ScopeResolver {
                             this.log(`[get_parsed_file] File cache HIT for ${fallback_uri} (mtime match, skipped read)`);
                             return {
                                 content: fallback_cached.content,
+                                content_hash: fallback_cached.content_hash,
                                 symbols: fallback_cached.symbols,
                                 directives: fallback_cached.directives,
                                 forward_calls: fallback_cached.forward_calls,
@@ -2341,6 +2351,7 @@ export class ScopeResolver {
             // Return cached results with current content - don't mutate cache entry
             return {
                 content,
+                content_hash: disk_hash,
                 symbols: actual_cached.symbols,
                 directives: actual_cached.directives,
                 forward_calls: actual_cached.forward_calls,
@@ -2390,7 +2401,7 @@ export class ScopeResolver {
             // not just open documents, enabling proper revalidation when callees change
             this.register_forward_call_relationships_from_cache(actual_uri, parse_result.forward_calls, parse_result.symbols);
 
-            return { content, ...parse_result };
+            return { content, content_hash: disk_hash, ...parse_result };
         } catch (error) {
             this.warn(`ScopeResolver: Parse error for ${actual_uri}: ${error_message(error)}`);
 
@@ -2398,6 +2409,7 @@ export class ScopeResolver {
             const empty_symbols = create_empty_symbol_table();
             return {
                 content,
+                content_hash: disk_hash,
                 symbols: empty_symbols,
                 directives: [],
                 forward_calls: [],
@@ -2704,6 +2716,10 @@ export class ScopeResolver {
      * Also invalidates scope caches for all callers (files that call this file via do/run/include).
      */
     invalidate_scope_cache(uri: string): void {
+        // Keep the forward-closure memo in lockstep with scope_cache (#234):
+        // any memoized closure that reached this URI is stale with it.
+        this.forward_scope_resolver?.invalidate_forward_closure_for_uri?.(uri);
+
         // Fast path: directly invalidate scope cache for the target URI using secondary index (spec 6.2)
         let num_removed = this.invalidate_scope_cache_for_uri(uri);
 
@@ -2737,6 +2753,8 @@ export class ScopeResolver {
      */
     invalidate_file_cache(uri: string, options?: { preserve_forward_call_relationships?: boolean }): void {
         this.log(`[invalidate_file_cache] Invalidating file cache for ${uri}`);
+        // Keep the forward-closure memo in lockstep with scope_cache (#234).
+        this.forward_scope_resolver?.invalidate_forward_closure_for_uri?.(uri);
         // Delete all file cache entries that start with this URI
         // (handles composite keys like "uri|working_directory")
         let num_deleted = 0;
@@ -3063,6 +3081,8 @@ export class ScopeResolver {
         this.scope_cache.clear();
         this.uri_to_cache_keys.clear();
         this.file_cache.clear();
+        // Keep the forward-closure memo in lockstep (#234).
+        this.forward_scope_resolver?.clear_forward_closure_memo?.();
 
         this.cache_metrics.scope.invalidations += scope_cache_size;
         this.cache_metrics.file.invalidations += file_cache_size;
@@ -3158,6 +3178,9 @@ export class ScopeResolver {
      */
     private invalidate_callee_scope_caches(uris: Set<string>): void {
         for (const my_uri of uris) {
+            // Keep the forward-closure memo in lockstep (#234).
+            this.forward_scope_resolver
+                ?.invalidate_forward_closure_for_uri?.(my_uri);
             // Find and remove all scope cache entries that depend on this URI
             const keys_to_remove: string[] = [];
             for (const [cache_key, entry] of this.scope_cache) {

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1495,9 +1495,14 @@ export async function create_server(options: ServerOptions): Promise<void> {
             // forward-closure memo entries embedding the buffer's symbols)
             // must not survive, or they keep serving the discarded edits
             // (#278 review). Preserve forward-call relationships so the
-            // anti-flicker rationale below still holds.
+            // anti-flicker rationale below still holds, and preserve the
+            // backward-directive map — the file still exists on disk and
+            // nothing re-syncs that map until its next parse, so clearing
+            // it here would make parent edits miss this file's descendants
+            // (#278 review, round 2).
             scope_resolver.invalidate_file_cache(e.document.uri, {
                 preserve_forward_call_relationships: true,
+                preserve_backward_directive_dependencies: true,
             });
         }
         // On close, the buffer's in-memory edges/symbols are discarded, so

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1488,6 +1488,17 @@ export async function create_server(options: ServerOptions): Promise<void> {
         }
         if (scope_resolver) {
             scope_resolver.remove_caller_from_reverse_deps(e.document.uri);
+            // Closing discards the buffer: effective content reverts to
+            // disk with NO didChange/watcher event. Caches built from the
+            // buffer (a file_cache entry parsed from unsaved content but
+            // stamped with the unchanged DISK mtime, scope entries, and
+            // forward-closure memo entries embedding the buffer's symbols)
+            // must not survive, or they keep serving the discarded edits
+            // (#278 review). Preserve forward-call relationships so the
+            // anti-flicker rationale below still holds.
+            scope_resolver.invalidate_file_cache(e.document.uri, {
+                preserve_forward_call_relationships: true,
+            });
         }
         // On close, the buffer's in-memory edges/symbols are discarded, so
         // callees that inherited from this file must re-resolve against its

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1293,6 +1293,9 @@ export async function create_server(options: ServerOptions): Promise<void> {
             forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
                 max_forward_depth: DEFAULT_SETTINGS.cross_file.max_forward_depth,
             });
+            // Supplies dep_graph_version + the scan_complete population gate
+            // for the forward-closure memo (#234).
+            forward_scope_resolver.set_dependency_graph(dependency_graph);
 
             scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
 

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -662,13 +662,18 @@ export function outcome_fs_path(outcome: PathCaseOutcome): string {
  * @param working_directory - Effective WD at the call site, or undefined.
  * @param options           - workspace_roots and optional fs override.
  *                            `missed_candidates`, when provided, receives
- *                            every higher-priority candidate path that
- *                            resolved MISSING before the winning candidate
- *                            (empty when the first candidate wins). The
- *                            forward-closure memo (#234) records these as
- *                            dependents so that creating a file at a
- *                            higher-priority path evicts closures that
- *                            resolved through a fallback tier.
+ *                            every path that was probed and MISSED before
+ *                            the winning resolution: each losing
+ *                            candidate, its implicit `.do`-fallback
+ *                            variant (when the leaf has no extension —
+ *                            mirroring resolve_path_rich's internal
+ *                            fallback), and the winning candidate's own
+ *                            as-written form when the winner resolved
+ *                            through the internal fallback or case
+ *                            correction. The forward-closure memo (#234)
+ *                            records these as dependents so that creating
+ *                            a file at a higher-priority path evicts
+ *                            closures that resolved through a fallback.
  */
 export function resolve_forward_call_rich(
     raw_path: string,
@@ -730,6 +735,30 @@ export function resolve_forward_call_rich(
         fs: options?.fs,
     };
 
+    // Report every probe variant of `candidate` that the winning path did
+    // not satisfy: the candidate as written, plus its implicit
+    // `.do`-fallback variant when the leaf has no extension (the same
+    // fallback resolve_path_rich applies internally). A file appearing at
+    // any of these would change what a fresh resolution returns.
+    const push_missed_probes = (
+        candidate: string,
+        winning_path: string | undefined,
+    ): void => {
+        const collector = options?.missed_candidates;
+        if (!collector) {
+            return;
+        }
+        const the_variants = [candidate];
+        if (!has_extension(node_path.basename(candidate))) {
+            the_variants.push(candidate + '.do');
+        }
+        for (const my_variant of the_variants) {
+            if (my_variant !== winning_path) {
+                collector.push(my_variant);
+            }
+        }
+    };
+
     // ── Resolution loop ───────────────────────────────────────────────────
     let my_first_outcome: PathCaseOutcome | undefined;
     for (const my_candidate of the_candidates) {
@@ -738,15 +767,19 @@ export function resolve_forward_call_rich(
             my_first_outcome = my_outcome;
         }
         if (my_outcome.kind === 'exact' || my_outcome.kind === 'case_only') {
+            // The winner may have resolved through the internal `.do`
+            // fallback or case correction — its as-written variants that
+            // did NOT match are still misses worth reporting.
+            push_missed_probes(my_candidate, my_outcome.path);
             return my_outcome;
         }
         // Ambiguous: STOP — never fall through (round-A fix preserved).
         if (my_outcome.kind === 'ambiguous') {
             return my_outcome;
         }
-        // missing: continue to next candidate, reporting the miss so
-        // callers can invalidate cached resolutions if this path appears.
-        options?.missed_candidates?.push(my_candidate);
+        // missing: continue to next candidate, reporting the misses so
+        // callers can invalidate cached resolutions if a file appears.
+        push_missed_probes(my_candidate, undefined);
     }
 
     // All candidates missing (or list was somehow empty): return the first

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -661,12 +661,24 @@ export function outcome_fs_path(outcome: PathCaseOutcome): string {
  * @param caller_dir        - dirname of the caller file's fsPath.
  * @param working_directory - Effective WD at the call site, or undefined.
  * @param options           - workspace_roots and optional fs override.
+ *                            `missed_candidates`, when provided, receives
+ *                            every higher-priority candidate path that
+ *                            resolved MISSING before the winning candidate
+ *                            (empty when the first candidate wins). The
+ *                            forward-closure memo (#234) records these as
+ *                            dependents so that creating a file at a
+ *                            higher-priority path evicts closures that
+ *                            resolved through a fallback tier.
  */
 export function resolve_forward_call_rich(
     raw_path: string,
     caller_dir: string,
     working_directory: string | undefined,
-    options?: { workspace_roots?: string[]; fs?: RichResolveFs },
+    options?: {
+        workspace_roots?: string[];
+        fs?: RichResolveFs;
+        missed_candidates?: string[];
+    },
 ): PathCaseOutcome {
     const my_normalized_raw = raw_path.replace(/\\/g, '/');
     const my_is_abs =
@@ -732,7 +744,9 @@ export function resolve_forward_call_rich(
         if (my_outcome.kind === 'ambiguous') {
             return my_outcome;
         }
-        // missing: continue to next candidate.
+        // missing: continue to next candidate, reporting the miss so
+        // callers can invalidate cached resolutions if this path appears.
+        options?.missed_candidates?.push(my_candidate);
     }
 
     // All candidates missing (or list was somehow empty): return the first

--- a/src/utils/file-path-utils.ts
+++ b/src/utils/file-path-utils.ts
@@ -748,6 +748,14 @@ export function resolve_forward_call_rich(
         if (!collector) {
             return;
         }
+        // The candidate won exactly as written: resolve_path_rich
+        // short-circuits before probing the `.do` variant, so nothing
+        // about this candidate was missed. (On Windows a separator-
+        // normalization mismatch can skip this guard — that degrades to
+        // recording the variants, i.e. harmless over-invalidation.)
+        if (winning_path === candidate) {
+            return;
+        }
         const the_variants = [candidate];
         if (!has_extension(node_path.basename(candidate))) {
             the_variants.push(candidate + '.do');

--- a/tests/integration/forward-closure-memo-gate.test.ts
+++ b/tests/integration/forward-closure-memo-gate.test.ts
@@ -5,11 +5,10 @@
  *  (1) CALLER-INDEPENDENCE (the assumption #208 relies on): a file's forward-call
  *      closure is identical regardless of which caller triggered it, given the
  *      same keyed inputs (effective call type, working directory, depth, content).
- *      This holds TODAY and is the contract the deferred cache will exploit.
- *  (2) MEMO ON/OFF EQUIVALENCE: flipping the (default-OFF) memo toggle must not
- *      change any caller-observable output. The cache store/serve write-path is
- *      deferred, so this is currently a no-op equivalence — it becomes the
- *      regression gate the follow-up must keep green.
+ *      This is the contract the memo cache exploits (#234).
+ *  (2) MEMO ON/OFF EQUIVALENCE: flipping the (default-ON) memo toggle must not
+ *      change any caller-observable output. With the store/serve write-path
+ *      live (#234), this is the regression gate it must keep green.
  *
  * See docs/cross-file.md "Forward-closure caching semantics".
  */
@@ -52,8 +51,8 @@ describe('issue #209/#208 — forward-closure memo gate', () => {
         pathToFileURL(file_path).toString();
 
     // Build a fresh resolver pair so two caller-independence runs cannot share
-    // cache state (when the deferred memo store/serve lands, a shared instance
-    // could serve caller 2 from caller 1's cached closure and mask a
+    // cache state (with the memo store/serve live, a shared instance could
+    // serve caller 2 from caller 1's cached closure and mask a
     // caller-DEPENDENT closure).
     const make_resolver = (): {
         scope: ScopeResolver; forward: ForwardScopeResolver;
@@ -120,8 +119,8 @@ describe('issue #209/#208 — forward-closure memo gate', () => {
         const hub = create_file('hub.do', `run "${helper}"\nglobal hub_g 1\n`);
         const hub_uri = to_uri(hub);
 
-        // Each caller gets its OWN resolver instance (separate cache), so the
-        // gate stays honest once the deferred memo store/serve lands.
+        // Each caller gets its OWN resolver instance (separate cache), so
+        // the gate stays honest with the memo store/serve live.
         const resolve_from = async (caller_uri: string) => {
             const { scope, forward } = make_resolver();
             const parsed = await scope.get_parsed_file(hub_uri, hub);

--- a/tests/integration/forward-closure-memo-store-serve.test.ts
+++ b/tests/integration/forward-closure-memo-store-serve.test.ts
@@ -274,6 +274,39 @@ describe('issue #234 — forward-closure memo store/serve', () => {
             d.message.includes('Maximum forward resolution'))).toBe(true);
     });
 
+    it('evicts entries when a file appears at a higher-priority path candidate', async () => {
+        // inner.do lives in sub/ and calls "child.do". With the working
+        // directory at the temp root (via the caller's `cd`), the WD-join
+        // candidate <temp>/child.do is probed FIRST and misses, so
+        // resolution falls back to the script-relative <temp>/sub/child.do.
+        // Creating <temp>/child.do later changes what a fresh walk
+        // resolves — the memoized closure that resolved through the
+        // fallback must be evicted by the creation event, or memo-on would
+        // keep serving the stale fallback closure (codex round-4 finding).
+        fs.mkdirSync(path.join(temp_dir, 'sub'));
+        create_file(path.join('sub', 'child.do'), 'global g_old 1\n');
+        create_file(path.join('sub', 'inner.do'),
+            'do "child.do"\nglobal inner_g 1\n');
+        const root = create_file('probe_root.do',
+            `cd "${temp_dir}"\ndo "sub/inner.do"\ndisplay "\${g_old}"\n`);
+
+        const before = await scope_resolver.resolve(to_uri(root), read(root));
+        expect(site_has_global(before, 'g_old')).toBe(true);
+
+        // The file appears at the higher-priority WD-join candidate; the
+        // watcher reports it via invalidate_file_cache.
+        const promoted = create_file('child.do', 'global g_new 1\n');
+        scope_resolver.invalidate_file_cache(to_uri(promoted));
+
+        // A root edit (didChange) forces a fresh top-level resolution; the
+        // memoized inner closure must NOT survive to serve the old
+        // fallback resolution.
+        scope_resolver.invalidate_scope_cache(to_uri(root));
+        const after = await scope_resolver.resolve(to_uri(root), read(root));
+        expect(site_has_global(after, 'g_new')).toBe(true);
+        expect(site_has_global(after, 'g_old')).toBe(false);
+    });
+
     it('evicts transitively dependent entries on didChange and on-disk change', async () => {
         const { chain, roots } = build_chain_workspace(2);
         const [, , chain_3] = chain;

--- a/tests/integration/forward-closure-memo-store-serve.test.ts
+++ b/tests/integration/forward-closure-memo-store-serve.test.ts
@@ -307,6 +307,34 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         expect(site_has_global(after, 'g_old')).toBe(false);
     });
 
+    it('evicts entries when a .do file appears for an extension-omitted call', async () => {
+        // Same shape as above but with the common extension-omitted idiom
+        // `do "childx"`: the WD-join candidate <temp>/childx misses BOTH
+        // as-written and via the internal .do fallback, and resolution
+        // falls back to <temp>/subx/childx.do. Creating <temp>/childx.do
+        // (the natural way to satisfy the call at the WD tier — and a
+        // watchable *.do path) must evict the memoized closure, which
+        // requires the probe set to include the .do-fallback VARIANT of
+        // the missed candidate, not just its as-written form.
+        fs.mkdirSync(path.join(temp_dir, 'subx'));
+        create_file(path.join('subx', 'childx.do'), 'global gx_old 1\n');
+        create_file(path.join('subx', 'innerx.do'),
+            'do "childx"\nglobal innerx_g 1\n');
+        const root = create_file('probe_root_x.do',
+            `cd "${temp_dir}"\ndo "subx/innerx.do"\ndisplay "\${gx_old}"\n`);
+
+        const before = await scope_resolver.resolve(to_uri(root), read(root));
+        expect(site_has_global(before, 'gx_old')).toBe(true);
+
+        const promoted = create_file('childx.do', 'global gx_new 1\n');
+        scope_resolver.invalidate_file_cache(to_uri(promoted));
+
+        scope_resolver.invalidate_scope_cache(to_uri(root));
+        const after = await scope_resolver.resolve(to_uri(root), read(root));
+        expect(site_has_global(after, 'gx_new')).toBe(true);
+        expect(site_has_global(after, 'gx_old')).toBe(false);
+    });
+
     it('evicts transitively dependent entries on didChange and on-disk change', async () => {
         const { chain, roots } = build_chain_workspace(2);
         const [, , chain_3] = chain;

--- a/tests/integration/forward-closure-memo-store-serve.test.ts
+++ b/tests/integration/forward-closure-memo-store-serve.test.ts
@@ -420,7 +420,7 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         expect(metrics.hits).toBe(1);
     });
 
-    it('a dep-graph version bump rotates keys without stranding old entries', async () => {
+    it('a dep-graph version bump clears the memo at the next access', async () => {
         const graph = new DependencyGraph();
         graph.mark_scan_complete();
         forward_resolver.set_dependency_graph(graph);
@@ -429,9 +429,10 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         await scope_resolver.resolve(to_uri(roots[0]), read(roots[0]));
         expect(forward_resolver.get_forward_closure_metrics().misses).toBe(2);
 
-        // Bump the graph version (unrelated edge change): old keys are
-        // unreachable, so the next resolution recomputes — and the base-key
-        // rotation must evict the two stranded entries at store time.
+        // Bump the graph version (unrelated edge change): every stored key
+        // embeds the old version, so the whole memo is dead by
+        // construction — the first access under the new version clears it
+        // (2 invalidations) and recomputes fresh (2 more misses).
         const version_before = graph.get_version();
         graph.update_caller('file:///unrelated/x.do', [{
             type: 'do',
@@ -449,5 +450,47 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         const metrics = forward_resolver.get_forward_closure_metrics();
         expect(metrics.misses).toBe(4);
         expect(metrics.invalidations).toBe(2);
+    });
+
+    it('version churn reclaims dead entries even when their closures are never revisited', async () => {
+        // PR #278 review (pullfrog): entries whose closure identity is
+        // never traversed again must not linger unreachably after a graph
+        // change. Build entries over chain A, bump the version, then
+        // resolve a DIFFERENT workspace shape (chain B) — A's dead entries
+        // must be reclaimed by the version-change clear, not stranded.
+        const graph = new DependencyGraph();
+        graph.mark_scan_complete();
+        forward_resolver.set_dependency_graph(graph);
+        const { roots } = build_chain_workspace(1);
+
+        const b3 = create_file('b3.do', 'global b3_g 1\n');
+        const b2 = create_file('b2.do', `do "${b3}"\nglobal b2_g 1\n`);
+        const b1 = create_file('b1.do', `do "${b2}"\nglobal b1_g 1\n`);
+        const b_root = create_file('b_root.do',
+            `do "${b1}"\ndisplay "\${b3_g}"\n`);
+
+        await scope_resolver.resolve(to_uri(roots[0]), read(roots[0]));
+        expect(forward_resolver.get_forward_closure_metrics().misses).toBe(2);
+        expect(forward_resolver.get_forward_closure_metrics().invalidations)
+            .toBe(0);
+
+        graph.update_caller('file:///unrelated/x.do', [{
+            type: 'do',
+            raw_path: 'y.do',
+            call_site_line: 0,
+            range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 10 },
+            },
+            source: 'command',
+            is_static: true,
+        }]);
+
+        // Chain A is never revisited; resolving chain B alone must still
+        // reclaim A's two dead entries via the version-change clear.
+        await scope_resolver.resolve(to_uri(b_root), read(b_root));
+        const metrics = forward_resolver.get_forward_closure_metrics();
+        expect(metrics.invalidations).toBe(2);
+        expect(metrics.misses).toBe(4);
     });
 });

--- a/tests/integration/forward-closure-memo-store-serve.test.ts
+++ b/tests/integration/forward-closure-memo-store-serve.test.ts
@@ -503,6 +503,7 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         scope.remove_caller_from_reverse_deps(x_uri);
         scope.invalidate_file_cache(x_uri, {
             preserve_forward_call_relationships: true,
+            preserve_backward_directive_dependencies: true,
         });
 
         // A root edit forces a fresh top-level resolution; the memo must
@@ -511,6 +512,43 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         const after_close = await scope.resolve(root_uri, root_content);
         expect(site_has_global(after_close, 'x_old')).toBe(true);
         expect(site_has_global(after_close, 'x_new')).toBe(false);
+    });
+
+    it('close-path invalidation keeps backward-directive links intact', async () => {
+        // codex round-2 on the close fix: invalidate_file_cache used to
+        // unconditionally clear the closed file's parent→child backward-
+        // directive registrations, and nothing re-syncs them until the
+        // file's next parse — so after closing a directive-chain child, a
+        // parent edit could miss invalidating/revalidating descendants
+        // (get_transitive_backward_directive_children came up empty). The
+        // close path must preserve the map (pre-#278 behavior).
+        const parent = create_file('bd_parent.do',
+            'global bd_g 1\ndo "bd_child.do"\n');
+        const child_content =
+            `// @lsp-done-by: "${parent}" match="bd_child.do"\n` +
+            'display "${bd_g}"\n';
+        const child = create_file('bd_child.do', child_content);
+        const child_uri = to_uri(child);
+        const parent_uri = to_uri(parent);
+
+        // Resolving the child registers the parent→child backward link.
+        await scope_resolver.resolve(child_uri, child_content);
+        expect([...scope_resolver
+            .get_transitive_backward_directive_children(parent_uri)])
+            .toContain(child_uri);
+
+        // Simulate closing the child (the onDidClose handler's sequence).
+        scope_resolver.remove_caller_from_reverse_deps(child_uri);
+        scope_resolver.invalidate_file_cache(child_uri, {
+            preserve_forward_call_relationships: true,
+            preserve_backward_directive_dependencies: true,
+        });
+
+        // The link must survive so a subsequent parent edit still reaches
+        // the (now closed) child and its descendants.
+        expect([...scope_resolver
+            .get_transitive_backward_directive_children(parent_uri)])
+            .toContain(child_uri);
     });
 
     it('version churn reclaims dead entries even when their closures are never revisited', async () => {

--- a/tests/integration/forward-closure-memo-store-serve.test.ts
+++ b/tests/integration/forward-closure-memo-store-serve.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Issue #234 — forward-closure memo store/serve semantics.
+ *
+ * The memo-on/off correctness gate (forward-closure-memo-gate.test.ts)
+ * proves the memo never changes caller-observable output. This file pins the
+ * memo's own mechanics instead:
+ *  - the N→1 collapse (misses stay flat across callers, hits grow);
+ *  - the disjointness serve gate (a caller whose visited/stack intersects a
+ *    cached closure's reachable set is recomputed live);
+ *  - the visited-delta replay (later siblings dedup identically to a live
+ *    walk after a serve);
+ *  - store-eligibility (diagnostic-producing closures are never stored —
+ *    including cap truncations suppressed by `max_depth: 'off'`);
+ *  - invalidation parity with scope_cache (didChange + on-disk change +
+ *    transitive dependents + clear_cache), the in-flight epoch guard, and
+ *    the dependency-graph scan/version gates.
+ *
+ * See docs/cross-file.md "Forward-closure caching semantics".
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { pathToFileURL } from 'node:url';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { DependencyGraph } from '../../src/dependency-graph';
+import type { ForwardCallSite, ResolvedScope } from '../../src/types';
+import { create_test_scope_resolver_logger } from '../test-logger';
+
+describe('issue #234 — forward-closure memo store/serve', () => {
+    let scope_resolver: ScopeResolver;
+    let forward_resolver: ForwardScopeResolver;
+    let temp_dir: string;
+
+    beforeEach(() => {
+        scope_resolver = new ScopeResolver(create_test_scope_resolver_logger());
+        forward_resolver = new ForwardScopeResolver(scope_resolver);
+        scope_resolver.set_forward_scope_resolver(forward_resolver);
+        forward_resolver.set_forward_closure_memo_enabled(true);
+        temp_dir = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'memo-store-serve-234-'));
+    });
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    const create_file = (name: string, content: string): string => {
+        const file_path = path.join(temp_dir, name);
+        fs.writeFileSync(file_path, content);
+        return file_path;
+    };
+    const to_uri = (file_path: string): string =>
+        pathToFileURL(file_path).toString();
+    const read = (file_path: string): string =>
+        fs.readFileSync(file_path, 'utf8');
+
+    /** Do any of the file's own forward-call sites carry this global? */
+    const site_has_global = (r: ResolvedScope, name: string): boolean =>
+        (r.forward_call_symbols ?? []).some(
+            (s: ForwardCallSite) => s.symbols.globalMacros.has(name));
+
+    /** chain_1 → chain_2 → chain_3 (leaf), plus N roots that `do` chain_1. */
+    const build_chain_workspace = (n_roots: number): {
+        chain: string[]; roots: string[];
+    } => {
+        const chain_3 = create_file('chain_3.do', 'global g3 1\n');
+        const chain_2 = create_file(
+            'chain_2.do', `do "${chain_3}"\nglobal g2 1\n`);
+        const chain_1 = create_file(
+            'chain_1.do', `do "${chain_2}"\nglobal g1 1\n`);
+        const the_roots = Array.from({ length: n_roots }, (_unused, i) =>
+            create_file(
+                `root_${i}.do`, `do "${chain_1}"\ndisplay "\${g3}"\n`));
+        return { chain: [chain_1, chain_2, chain_3], roots: the_roots };
+    };
+
+    it('collapses shared-chain recomputation across callers (N→1)', async () => {
+        const { roots } = build_chain_workspace(5);
+
+        for (const my_root of roots) {
+            const resolved = await scope_resolver.resolve(
+                to_uri(my_root), read(my_root));
+            expect(site_has_global(resolved, 'g3')).toBe(true);
+        }
+
+        const metrics = forward_resolver.get_forward_closure_metrics();
+        // chain_1 and chain_2 have forward calls (chain_3 is a leaf): their
+        // closures are computed exactly once, on the first root.
+        expect(metrics.misses).toBe(2);
+        // Every later root serves chain_1's cached closure.
+        expect(metrics.hits).toBe(roots.length - 1);
+    });
+
+    it('replays the visited-delta: a later sibling dedups against a served hub', async () => {
+        // parent runs a then b; both source the same hub. Serving a's
+        // closure must replay hub into visited so b's walk boundary-skips
+        // the hub exactly as a live walk would (no duplicate hub site).
+        const hub = create_file('hub.do', 'global hub_g 1\n');
+        const a = create_file('a.do', `run "${hub}"\nglobal a_g 1\n`);
+        const b = create_file('b.do', `run "${hub}"\nglobal b_g 1\n`);
+        const parent = create_file(
+            'parent.do', `run "${a}"\nrun "${b}"\ndisplay 1\n`);
+
+        // Resolve the parent twice: the second pass serves a's closure from
+        // the memo (hit) and must produce the identical call-site surface.
+        const surface_of = (r: ResolvedScope): string[] =>
+            (r.forward_call_symbols ?? []).map((s: ForwardCallSite) =>
+                `${path.basename(s.callee_uri)}@${s.call_line}:` +
+                `${s.effective_type}`).sort();
+
+        const first = await scope_resolver.resolve(
+            to_uri(parent), read(parent));
+        // Force a fresh top-level resolution without touching the memo.
+        scope_resolver.invalidate_scope_cache(to_uri(parent));
+        const second = await scope_resolver.resolve(
+            to_uri(parent), read(parent));
+
+        expect(surface_of(second)).toEqual(surface_of(first));
+        const hub_sites = (second.forward_call_symbols ?? []).filter(
+            (s: ForwardCallSite) => s.callee_uri === to_uri(hub) &&
+                s.symbols.globalMacros.has('hub_g'));
+        // The hub's symbols must be contributed exactly once (a's subtree);
+        // b's re-visit is a dedup'd boundary, not a second contribution.
+        expect(hub_sites.length).toBe(1);
+    });
+
+    it('never serves a closure into a caller whose state intersects it', async () => {
+        // cycle: a → b → a. Resolving a's own scope walks b, whose closure
+        // reaches back to a (in the caller's stack) — so b's cached entry
+        // must NOT be served (a live walk cycle-skips a; the standalone
+        // closure contains it).
+        const a_path = path.join(temp_dir, 'cyc_a.do');
+        const b_path = path.join(temp_dir, 'cyc_b.do');
+        fs.writeFileSync(a_path, `do "${b_path}"\nglobal a_g 1\n`);
+        fs.writeFileSync(b_path, `do "${a_path}"\nglobal b_g 1\n`);
+
+        const resolved = await scope_resolver.resolve(
+            to_uri(a_path), read(a_path));
+        // b's contribution must include b_g but NOT re-walk a into a
+        // duplicate site (live cycle-skip semantics preserved).
+        expect(site_has_global(resolved, 'b_g')).toBe(true);
+        const a_sites = (resolved.forward_call_symbols ?? []).filter(
+            (s: ForwardCallSite) => s.callee_uri === to_uri(a_path));
+        expect(a_sites.length).toBe(0);
+    });
+
+    it('does not store diagnostic-producing closures (missing file)', async () => {
+        const broken = create_file(
+            'broken.do', `do "${path.join(temp_dir, 'missing.do')}"\n`);
+        const root = create_file(
+            'diag_root.do', `do "${broken}"\ndisplay 1\n`);
+
+        const first = await scope_resolver.resolve(
+            to_uri(root), read(root));
+        const first_missing = first.diagnostics.filter(d =>
+            d.message.includes('Cannot read file'));
+        expect(first_missing.length).toBeGreaterThan(0);
+
+        // Nothing may be cached for broken.do: a second resolution (fresh
+        // scope-cache entry) must re-emit the same diagnostics.
+        scope_resolver.invalidate_scope_cache(to_uri(root));
+        const second = await scope_resolver.resolve(
+            to_uri(root), read(root));
+        const second_missing = second.diagnostics.filter(d =>
+            d.message.includes('Cannot read file'));
+        expect(second_missing.map(d => d.message))
+            .toEqual(first_missing.map(d => d.message));
+        expect(forward_resolver.get_forward_closure_metrics().hits).toBe(0);
+    });
+
+    it("does not store cap-truncated closures even under max_depth 'off'", async () => {
+        // deep chain long enough to exceed max_forward_depth = 2
+        const d3 = create_file('deep_3.do', 'global d3 1\n');
+        const d2 = create_file('deep_2.do', `do "${d3}"\nglobal d2 1\n`);
+        const d1 = create_file('deep_1.do', `do "${d2}"\nglobal d1 1\n`);
+        const root = create_file('deep_root.do', `do "${d1}"\ndisplay 1\n`);
+
+        const scope = new ScopeResolver(create_test_scope_resolver_logger());
+        const forward = new ForwardScopeResolver(scope, {
+            max_forward_depth: 2,
+            diagnostics: { max_depth: 'off' },
+        });
+        scope.set_forward_scope_resolver(forward);
+        forward.set_forward_closure_memo_enabled(true);
+
+        const resolved = await scope.resolve(to_uri(root), read(root), {
+            max_forward_depth: 2,
+            diagnostics: { max_depth: 'off' },
+        });
+        // 'off' suppresses the truncation diagnostic for the user...
+        expect(resolved.diagnostics.filter(d =>
+            d.message.includes('Maximum forward resolution')).length).toBe(0);
+        // ...but the truncated closure must never have been stored: the
+        // truncation-shaped subtree (d1 at depth 1 truncates at depth 2)
+        // is recomputed live every time.
+        const metrics = forward.get_forward_closure_metrics();
+        expect(metrics.hits).toBe(0);
+    });
+
+    it('evicts transitively dependent entries on didChange and on-disk change', async () => {
+        const { chain, roots } = build_chain_workspace(2);
+        const [, , chain_3] = chain;
+
+        for (const my_root of roots) {
+            await scope_resolver.resolve(to_uri(my_root), read(my_root));
+        }
+        expect(forward_resolver.get_forward_closure_metrics().misses).toBe(2);
+
+        // Edit the LEAF: both memoized closures (chain_1's and chain_2's)
+        // transitively depend on it and must be evicted together.
+        fs.writeFileSync(chain_3, 'global g3_renamed 1\n');
+        scope_resolver.invalidate_file_cache(to_uri(chain_3));
+        expect(forward_resolver.get_forward_closure_metrics().invalidations)
+            .toBe(2);
+
+        scope_resolver.invalidate_scope_cache(to_uri(roots[0]));
+        const after = await scope_resolver.resolve(
+            to_uri(roots[0]), read(roots[0]));
+        expect(site_has_global(after, 'g3')).toBe(false);
+        expect(site_has_global(after, 'g3_renamed')).toBe(true);
+    });
+
+    it('clear_cache drops the memo (workspace reset parity)', async () => {
+        const { roots } = build_chain_workspace(2);
+        await scope_resolver.resolve(to_uri(roots[0]), read(roots[0]));
+        const before = forward_resolver.get_forward_closure_metrics();
+        expect(before.misses).toBe(2);
+
+        scope_resolver.clear_cache();
+
+        await scope_resolver.resolve(to_uri(roots[1]), read(roots[1]));
+        const after = forward_resolver.get_forward_closure_metrics();
+        // Fully recomputed — nothing served across the clear.
+        expect(after.hits).toBe(0);
+        expect(after.misses).toBe(4);
+    });
+
+    it('open-buffer edits invalidate through invalidate_scope_cache (didChange path)', async () => {
+        // Production didChange calls invalidate_scope_cache (NOT
+        // invalidate_file_cache); the memo must be evicted through that
+        // funnel too — codex finding #4 on the #234 plan.
+        const { chain, roots } = build_chain_workspace(1);
+        const [, chain_2] = chain;
+        await scope_resolver.resolve(to_uri(roots[0]), read(roots[0]));
+        expect(forward_resolver.get_forward_closure_metrics().misses).toBe(2);
+
+        fs.writeFileSync(chain_2, 'global g2_only 1\n');
+        scope_resolver.invalidate_scope_cache(to_uri(chain_2));
+        // chain_1's closure depends on chain_2 → evicted; chain_2's own
+        // entry likewise. (invalidate_scope_cache deliberately leaves
+        // file_cache alone; evict it here so the re-read sees the new
+        // content, standing in for the didChange buffer overlay.)
+        expect(forward_resolver.get_forward_closure_metrics().invalidations)
+            .toBe(2);
+        scope_resolver.invalidate_file_cache(to_uri(chain_2));
+
+        scope_resolver.invalidate_scope_cache(to_uri(roots[0]));
+        const after = await scope_resolver.resolve(
+            to_uri(roots[0]), read(roots[0]));
+        expect(site_has_global(after, 'g3')).toBe(false);
+        expect(site_has_global(after, 'g2_only')).toBe(true);
+    });
+
+    it('does not populate while the dependency-graph scan is incomplete', async () => {
+        const graph = new DependencyGraph();
+        forward_resolver.set_dependency_graph(graph);
+        const { roots } = build_chain_workspace(3);
+
+        // Scan not complete → gate closed → no stores, no serves.
+        await scope_resolver.resolve(to_uri(roots[0]), read(roots[0]));
+        let metrics = forward_resolver.get_forward_closure_metrics();
+        expect(metrics.misses).toBe(0);
+        expect(metrics.hits).toBe(0);
+
+        // Scan complete → gate open.
+        graph.mark_scan_complete();
+        scope_resolver.invalidate_scope_cache(to_uri(roots[0]));
+        await scope_resolver.resolve(to_uri(roots[1]), read(roots[1]));
+        await scope_resolver.resolve(to_uri(roots[2]), read(roots[2]));
+        metrics = forward_resolver.get_forward_closure_metrics();
+        expect(metrics.misses).toBe(2);
+        expect(metrics.hits).toBe(1);
+    });
+
+    it('a dep-graph version bump rotates keys without stranding old entries', async () => {
+        const graph = new DependencyGraph();
+        graph.mark_scan_complete();
+        forward_resolver.set_dependency_graph(graph);
+        const { roots } = build_chain_workspace(2);
+
+        await scope_resolver.resolve(to_uri(roots[0]), read(roots[0]));
+        expect(forward_resolver.get_forward_closure_metrics().misses).toBe(2);
+
+        // Bump the graph version (unrelated edge change): old keys are
+        // unreachable, so the next resolution recomputes — and the base-key
+        // rotation must evict the two stranded entries at store time.
+        const version_before = graph.get_version();
+        graph.update_caller('file:///unrelated/x.do', [{
+            type: 'do',
+            raw_path: 'y.do',
+            call_site_line: 0,
+            range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 10 },
+            },
+            source: 'command',
+            is_static: true,
+        }]);
+        expect(graph.get_version()).toBeGreaterThan(version_before);
+        await scope_resolver.resolve(to_uri(roots[1]), read(roots[1]));
+        const metrics = forward_resolver.get_forward_closure_metrics();
+        expect(metrics.misses).toBe(4);
+        expect(metrics.invalidations).toBe(2);
+    });
+});

--- a/tests/integration/forward-closure-memo-store-serve.test.ts
+++ b/tests/integration/forward-closure-memo-store-serve.test.ts
@@ -514,6 +514,78 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         expect(site_has_global(after_close, 'x_new')).toBe(false);
     });
 
+    it('a debounce-window rebuild cannot pin stale content past the next parse', async () => {
+        // codex final-round P1: on didChange the server invalidates
+        // eagerly, but the file_cache is only updated by the DEBOUNCED
+        // parse. A resolution landing in that window rebuilds an
+        // ancestor's closure from the stale cached callee — keyed by the
+        // ancestor's UNCHANGED hash, so the edit never rotates it, and if
+        // the edit doesn't change the interface hash no later event purges
+        // it. Fix: parse_file purges memo entries for a URI whenever it
+        // observes new content for it. Sequence modeled: root→a→x; edit x;
+        // eager invalidation; window resolution re-poisons from stale
+        // file_cache; debounced parse of x lands; a later resolution must
+        // see the new content.
+        const x_v1 = 'global x_v1 1\n';
+        const x_v2 = 'global x_v2 1\n';
+        let x_content = x_v1;
+
+        const the_contents = new Map<string, string>();
+        const content_for = (uri: string): string =>
+            uri.endsWith('x.do') ? x_content : (the_contents.get(uri) ?? '');
+        const provider = {
+            read_file: async (uri: string) => content_for(uri),
+            exists: async () => true,
+            // Constant stat: the mtime fast path keeps serving the cached
+            // (stale) entry during the window, like an unsaved buffer edit
+            // whose disk file is untouched.
+            stat: async (uri: string) => ({
+                mtimeMs: 1000,
+                size: Buffer.byteLength(content_for(uri), 'utf8'),
+            }),
+        };
+        const scope = new ScopeResolver(
+            create_test_scope_resolver_logger(), provider);
+        const forward = new ForwardScopeResolver(scope);
+        scope.set_forward_scope_resolver(forward);
+        forward.set_forward_closure_memo_enabled(true);
+
+        const x_uri = 'file:///ws/x.do';
+        const a_uri = 'file:///ws/a.do';
+        const root1_uri = 'file:///ws/root1.do';
+        const root2_uri = 'file:///ws/root2.do';
+        the_contents.set(a_uri, 'do "x.do"\nglobal a_g 1\n');
+        const root_content = 'do "a.do"\ndisplay "${x_v1}"\n';
+        the_contents.set(root1_uri, root_content);
+        the_contents.set(root2_uri, root_content);
+
+        // Warm: a's closure embeds x v1.
+        await scope.resolve(root1_uri, root_content);
+
+        // The user edits x (v2). Eager didChange invalidation runs now;
+        // the parse is debounced, so file_cache still holds v1. Note the
+        // constant stat means size must stay comparable — use same-length
+        // contents.
+        x_content = x_v2;
+        scope.invalidate_scope_cache(x_uri);
+
+        // A resolution lands INSIDE the window: it rebuilds a's closure
+        // from the stale cached x (mtime fast path serves v1).
+        const in_window = await scope.resolve(root2_uri, root_content);
+        expect(site_has_global(in_window, 'x_v1')).toBe(true);
+
+        // The debounced parse of x lands (resolve() calls parse_file with
+        // the new buffer content) — this must purge the window-built
+        // entries that embedded v1.
+        await scope.resolve(x_uri, x_v2);
+
+        // A later resolution must see v2, not the window-pinned v1.
+        scope.invalidate_scope_cache(root1_uri);
+        const after = await scope.resolve(root1_uri, root_content);
+        expect(site_has_global(after, 'x_v2')).toBe(true);
+        expect(site_has_global(after, 'x_v1')).toBe(false);
+    });
+
     it('close-path invalidation keeps backward-directive links intact', async () => {
         // codex round-2 on the close fix: invalidate_file_cache used to
         // unconditionally clear the closed file's parent→child backward-

--- a/tests/integration/forward-closure-memo-store-serve.test.ts
+++ b/tests/integration/forward-closure-memo-store-serve.test.ts
@@ -211,9 +211,13 @@ describe('issue #234 — forward-closure memo store/serve', () => {
 
         await scope_resolver.resolve(to_uri(a_path), read(a_path));
         // ≤ 2 standalone attempts for one traversal of a 2-cycle — a
-        // cascade would burn ~max_forward_depth (10) per traversal.
-        expect(forward_resolver.get_forward_closure_metrics().misses)
-            .toBeLessThanOrEqual(2);
+        // cascade would burn ~max_forward_depth (10) per traversal. The
+        // floor proves the memo actually engaged (a silently-disabled memo
+        // would report 0 and satisfy any ceiling vacuously).
+        const first_cycle_misses =
+            forward_resolver.get_forward_closure_metrics().misses;
+        expect(first_cycle_misses).toBeGreaterThan(0);
+        expect(first_cycle_misses).toBeLessThanOrEqual(2);
 
         // invalidate_scope_cache(a) also evicts both memo entries (a is in
         // their dependent sets), so the second traversal legitimately
@@ -245,6 +249,9 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         await scope_resolver.resolve(to_uri(root), read(root), config);
         const first_misses =
             forward_resolver.get_forward_closure_metrics().misses;
+        // Floor: the memo must actually have attempted builds (a
+        // silently-disabled memo would report 0 and pass any ceiling).
+        expect(first_misses).toBeGreaterThan(0);
         expect(first_misses).toBeLessThanOrEqual(4);
 
         // Re-resolving must not re-attempt the doomed builds.

--- a/tests/integration/forward-closure-memo-store-serve.test.ts
+++ b/tests/integration/forward-closure-memo-store-serve.test.ts
@@ -199,6 +199,65 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         expect(metrics.hits).toBe(0);
     });
 
+    it('keeps standalone-build work bounded on a mutual do-cycle', async () => {
+        // a → b → a. A memo miss launches a fresh-stack standalone build
+        // that cannot see the caller's ancestry; without the in-flight
+        // re-entry guard the builds cascade to max_forward_depth on every
+        // traversal. Bounded misses prove the guard works.
+        const a_path = path.join(temp_dir, 'bounded_a.do');
+        const b_path = path.join(temp_dir, 'bounded_b.do');
+        fs.writeFileSync(a_path, `do "${b_path}"\nglobal a_g 1\n`);
+        fs.writeFileSync(b_path, `do "${a_path}"\nglobal b_g 1\n`);
+
+        await scope_resolver.resolve(to_uri(a_path), read(a_path));
+        // ≤ 2 standalone attempts for one traversal of a 2-cycle — a
+        // cascade would burn ~max_forward_depth (10) per traversal.
+        expect(forward_resolver.get_forward_closure_metrics().misses)
+            .toBeLessThanOrEqual(2);
+
+        // invalidate_scope_cache(a) also evicts both memo entries (a is in
+        // their dependent sets), so the second traversal legitimately
+        // recomputes the same bounded set — still no cascade.
+        scope_resolver.invalidate_scope_cache(to_uri(a_path));
+        await scope_resolver.resolve(to_uri(a_path), read(a_path));
+        expect(forward_resolver.get_forward_closure_metrics().misses)
+            .toBeLessThanOrEqual(4);
+    });
+
+    it('does not re-attempt doomed standalone builds on cap-tripping chains', async () => {
+        // deep_1 → … → deep_6 with max_forward_depth 3: every standalone
+        // build in the truncated region is doomed (truncation diagnostic).
+        // Each key must be attempted ONCE (negative-cached), not once per
+        // level of every live retry (O(2^depth)).
+        const the_chain: string[] = [];
+        for (let i = 6; i >= 1; i--) {
+            const my_path = path.join(temp_dir, `cap_${i}.do`);
+            const my_next = the_chain.length > 0
+                ? `do "${the_chain[the_chain.length - 1]}"\n`
+                : '';
+            fs.writeFileSync(my_path, `${my_next}global cap_${i}_g 1\n`);
+            the_chain.push(my_path);
+        }
+        const head = the_chain[the_chain.length - 1];
+        const root = create_file('cap_root.do', `do "${head}"\ndisplay 1\n`);
+
+        const config = { max_forward_depth: 3 };
+        await scope_resolver.resolve(to_uri(root), read(root), config);
+        const first_misses =
+            forward_resolver.get_forward_closure_metrics().misses;
+        expect(first_misses).toBeLessThanOrEqual(4);
+
+        // Re-resolving must not re-attempt the doomed builds.
+        scope_resolver.invalidate_scope_cache(to_uri(root));
+        const again = await scope_resolver.resolve(
+            to_uri(root), read(root), config);
+        expect(forward_resolver.get_forward_closure_metrics().misses)
+            .toBe(first_misses);
+        // ...and the truncation diagnostic still reaches the user.
+        expect(again.diagnostics.some(d =>
+            d.message.includes('Maximum forward resolution'))).toBe(true);
+    });
+
     it('evicts transitively dependent entries on didChange and on-disk change', async () => {
         const { chain, roots } = build_chain_workspace(2);
         const [, , chain_3] = chain;

--- a/tests/integration/forward-closure-memo-store-serve.test.ts
+++ b/tests/integration/forward-closure-memo-store-serve.test.ts
@@ -185,18 +185,27 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         scope.set_forward_scope_resolver(forward);
         forward.set_forward_closure_memo_enabled(true);
 
-        const resolved = await scope.resolve(to_uri(root), read(root), {
+        const config = {
             max_forward_depth: 2,
-            diagnostics: { max_depth: 'off' },
-        });
+            diagnostics: { max_depth: 'off' as const },
+        };
+        const resolved = await scope.resolve(to_uri(root), read(root), config);
         // 'off' suppresses the truncation diagnostic for the user...
         expect(resolved.diagnostics.filter(d =>
             d.message.includes('Maximum forward resolution')).length).toBe(0);
-        // ...but the truncated closure must never have been stored: the
-        // truncation-shaped subtree (d1 at depth 1 truncates at depth 2)
-        // is recomputed live every time.
-        const metrics = forward.get_forward_closure_metrics();
-        expect(metrics.hits).toBe(0);
+        // The memo must have engaged (floor: a disabled memo would make
+        // the assertions below vacuous).
+        expect(forward.get_forward_closure_metrics().misses)
+            .toBeGreaterThan(0);
+
+        // ...but the truncated closure must never have been stored as
+        // SERVABLE. Only a second resolution can prove that: if the
+        // standalone build inherited the caller's 'off' severity (instead
+        // of forcing a non-'off' one), the cap-truncated closure would
+        // look diagnostic-free, get stored, and be SERVED here — hits > 0.
+        scope.invalidate_scope_cache(to_uri(root));
+        await scope.resolve(to_uri(root), read(root), config);
+        expect(forward.get_forward_closure_metrics().hits).toBe(0);
     });
 
     it('keeps standalone-build work bounded on a mutual do-cycle', async () => {

--- a/tests/integration/forward-closure-memo-store-serve.test.ts
+++ b/tests/integration/forward-closure-memo-store-serve.test.ts
@@ -452,6 +452,67 @@ describe('issue #234 — forward-closure memo store/serve', () => {
         expect(metrics.invalidations).toBe(2);
     });
 
+    it('closing a dirty buffer does not leave the memo serving discarded content', async () => {
+        // codex P1 on PR #278: root → a → x, with x OPEN and edited but
+        // unsaved. The memoized closure of `a` embeds x's buffer symbols.
+        // Closing x reverts effective content to disk with NO didChange or
+        // watcher event, so the server's onDidClose handler must invalidate
+        // the closed URI (invalidate_file_cache with forward-call
+        // relationships preserved) — otherwise memo-on keeps serving the
+        // discarded buffer symbols while memo-off recomputes from disk.
+        // This test drives the resolver through that exact handler
+        // sequence and asserts memo-on output matches disk afterward.
+        const x_disk = 'global x_old 1\n';
+        const x_buffer = 'global x_new 1\n';
+        let x_open = true;
+
+        const the_contents = new Map<string, string>();
+        const content_for = (uri: string): string => {
+            if (uri.endsWith('x.do')) {
+                return x_open ? x_buffer : x_disk;
+            }
+            return the_contents.get(uri) ?? '';
+        };
+        const provider = {
+            read_file: async (uri: string) => content_for(uri),
+            exists: async () => true,
+            // No stat(): forces the hash-validation path, where file_cache
+            // self-heals on read — isolating the memo as the only cache
+            // that could serve stale content without the close-time
+            // invalidation.
+        };
+        const scope = new ScopeResolver(
+            create_test_scope_resolver_logger(), provider);
+        const forward = new ForwardScopeResolver(scope);
+        scope.set_forward_scope_resolver(forward);
+        forward.set_forward_closure_memo_enabled(true);
+
+        const x_uri = 'file:///ws/x.do';
+        const a_uri = 'file:///ws/a.do';
+        const root_uri = 'file:///ws/root.do';
+        the_contents.set(a_uri, 'do "x.do"\nglobal a_g 1\n');
+        const root_content = 'do "a.do"\ndisplay "${x_new}"\n';
+        the_contents.set(root_uri, root_content);
+
+        const while_open = await scope.resolve(root_uri, root_content);
+        expect(site_has_global(while_open, 'x_new')).toBe(true);
+
+        // Close x: buffer discarded, disk content becomes effective.
+        // Mirror the onDidClose handler's cache invalidation.
+        x_open = false;
+        scope.remove_caller_from_reverse_deps(x_uri);
+        scope.invalidate_file_cache(x_uri, {
+            preserve_forward_call_relationships: true,
+        });
+
+        // A root edit forces a fresh top-level resolution; the memo must
+        // not serve a's buffer-era closure.
+        scope.invalidate_scope_cache(root_uri);
+        const after_close = await scope.resolve(root_uri, root_content);
+        expect(site_has_global(after_close, 'x_old')).toBe(true);
+        expect(site_has_global(after_close, 'x_new')).toBe(false);
+    });
+
     it('version churn reclaims dead entries even when their closures are never revisited', async () => {
         // PR #278 review (pullfrog): entries whose closure identity is
         // never traversed again must not linger unreachably after a graph

--- a/tests/performance/forward-closure-hub.test.ts
+++ b/tests/performance/forward-closure-hub.test.ts
@@ -1,19 +1,20 @@
 /**
- * Issue #209 — hub-heavy forward-call performance coverage.
+ * Issue #209/#234 — hub-heavy forward-call performance coverage.
  *
  * A parent runs N sibling files before its child; every sibling sources one
- * shared hub. This is the dense shape that motivated the (deferred) forward-
- * closure memo. The guard here is a REGRESSION guard, not a timing benchmark:
+ * shared hub. This is the dense shape that motivated the forward-closure
+ * memo. The guards here are REGRESSION guards, not timing benchmarks:
  * resolving the child must keep file reads BOUNDED (no accidental O(N^2)
- * blowup in full-workspace `sight check`), and the memo toggle must not change
- * read counts today (write-path deferred → ON ≡ OFF).
+ * blowup in full-workspace `sight check`), and enabling the memo must never
+ * ADD reads.
  *
- * Note: the request-scoped `file_cache` already dedupes disk READS (the shared
+ * Note: the persistent `file_cache` already dedupes disk READS (the shared
  * hub is read once even with N siblings), so reads are a cache-busting
- * regression guard, not where the memo's win shows. The deferred memo targets
- * closure RE-COMPUTATION across callers (CPU, not I/O); the follow-up that adds
- * the cache store/serve will add a recomputation counter and assert the N→1
- * collapse here.
+ * regression guard, not where the memo's win shows. The memo targets closure
+ * RE-COMPUTATION across callers (CPU, not I/O): the N→1 scenario below
+ * resolves N root files that all traverse one shared chain and asserts, via
+ * the memo's recomputation counter (#234), that the chain's closures are
+ * computed once and served to every later caller.
  */
 
 import { ScopeResolver } from '../../src/scope-resolver';
@@ -98,7 +99,7 @@ describe('hub-heavy forward-call performance (#209)', () => {
         expect(reads).toBeLessThanOrEqual(2 * N_SIBLINGS);
     });
 
-    it('memo ON ≡ OFF read counts today (cache write-path deferred)', async () => {
+    it('memo ON never reads more than OFF (standalone walks reuse file_cache)', async () => {
         const off = build_hub_workspace();
         off.forward.set_forward_closure_memo_enabled(false);
         await off.resolver.resolve(off.child_uri, off.child_content);
@@ -107,9 +108,74 @@ describe('hub-heavy forward-call performance (#209)', () => {
         on.forward.set_forward_closure_memo_enabled(true);
         await on.resolver.resolve(on.child_uri, on.child_content);
 
-        // No cache yet → enabling the memo must not change reads. When the
-        // follow-up lands its store/serve, the ON hub read count should drop.
+        // The memo's standalone closure builds go through the same
+        // file_cache as live walks, so enabling it must not add I/O.
         expect(total_reads(on.read_counts))
-            .toBe(total_reads(off.read_counts));
+            .toBeLessThanOrEqual(total_reads(off.read_counts));
+    });
+
+    it('collapses shared-chain closure recomputation to ~1 across N callers (#234)', async () => {
+        // N root files all `do` chain_1; chain_1 → chain_2 → … → chain_K
+        // (the last link is a leaf). This is the `sight check` shape: every
+        // root's resolution traverses the same chain, and without the memo
+        // each traversal recomputes every chain closure from scratch.
+        const N_ROOTS = 10;
+        const CHAIN_LINKS = 5; // chain_1..chain_5; chain_5 is a leaf
+        const chain_content = (i: number): string =>
+            i < CHAIN_LINKS
+                ? `do "chain_${i + 1}.do"\nglobal chain_${i}_g 1\n`
+                : `global chain_${i}_g 1\n`;
+        const root_content = `do "chain_1.do"\ndisplay "\${chain_${CHAIN_LINKS}_g}"\n`;
+
+        const content_for = (uri: string): string => {
+            const m = uri.match(/chain_(\d+)\.do$/);
+            if (m) return chain_content(Number(m[1]));
+            if (/root_\d+\.do$/.test(uri)) return root_content;
+            return '';
+        };
+        const build = (memo_on: boolean) => {
+            const read_counts = new Map<string, number>();
+            const content_provider: ContentProvider = {
+                read_file: async (uri: string) => {
+                    read_counts.set(uri, (read_counts.get(uri) || 0) + 1);
+                    return content_for(uri);
+                },
+                exists: async () => true,
+                stat: async (uri: string) => ({
+                    mtimeMs: 1000,
+                    size: Buffer.byteLength(content_for(uri), 'utf8'),
+                }),
+            };
+            const resolver = new ScopeResolver(undefined, content_provider);
+            const forward = new ForwardScopeResolver(resolver);
+            resolver.set_forward_scope_resolver(forward);
+            forward.set_forward_closure_memo_enabled(memo_on);
+            return { resolver, forward, read_counts };
+        };
+        const resolve_all_roots = async (
+            ws: ReturnType<typeof build>
+        ): Promise<void> => {
+            for (let i = 0; i < N_ROOTS; i++) {
+                const my_uri = URI.file(`/ws/root_${i}.do`).toString();
+                await ws.resolver.resolve(my_uri, root_content);
+            }
+        };
+
+        const on = build(true);
+        await resolve_all_roots(on);
+        const metrics = on.forward.get_forward_closure_metrics();
+
+        // The N→1 collapse: chain_1..chain_{K-1} have forward calls (the
+        // leaf does not), so exactly K-1 closures are ever computed —
+        // regardless of N — and every later root serves chain_1's cached
+        // closure instead of re-walking the chain.
+        expect(metrics.misses).toBe(CHAIN_LINKS - 1);
+        expect(metrics.hits).toBe(N_ROOTS - 1);
+
+        // And the memo must not add I/O relative to OFF.
+        const off = build(false);
+        await resolve_all_roots(off);
+        expect(total_reads(on.read_counts))
+            .toBeLessThanOrEqual(total_reads(off.read_counts));
     });
 });

--- a/tests/unit/forward-closure-memo-plumbing.test.ts
+++ b/tests/unit/forward-closure-memo-plumbing.test.ts
@@ -1,11 +1,11 @@
 /**
- * Issue #209 — forward-closure memo plumbing (gate + toggle).
+ * Issue #209/#234 — forward-closure memo plumbing (gate + toggle).
  *
- * The cache STORE/SERVE write-path is deferred to a follow-up; this PR ships the
- * toggle and the caller-independent key contract that the follow-up implements.
  * The key must capture every input that varies a file's forward closure and
  * NOTHING about the calling file's identity (the #208 caller-independence
  * assumption). See docs/cross-file.md "Forward-closure caching semantics".
+ * The store/serve write-path itself is covered by
+ * tests/integration/forward-closure-memo-store-serve.test.ts.
  */
 
 import { describe, it, expect, beforeEach } from 'bun:test';
@@ -24,8 +24,8 @@ describe('forward-closure memo toggle', () => {
         scope_resolver.set_forward_scope_resolver(forward_resolver);
     });
 
-    it('is disabled by default (write-path deferred)', () => {
-        expect(forward_resolver.is_forward_closure_memo_enabled()).toBe(false);
+    it('is enabled by default (#234 acceptance decision)', () => {
+        expect(forward_resolver.is_forward_closure_memo_enabled()).toBe(true);
     });
 
     it('reflects the toggle', () => {

--- a/tests/unit/get-parsed-file-do-fallback-wd-directive.test.ts
+++ b/tests/unit/get-parsed-file-do-fallback-wd-directive.test.ts
@@ -1,0 +1,65 @@
+/**
+ * PR #278 review (coderabbit) — the `.do`-fallback mtime-match cache-HIT
+ * return in `_get_parsed_file_impl` was the only success return that
+ * dropped `working_directory_directive`. `discover_working_directory`
+ * relies on that field to detect a parent's OWN working-directory
+ * directive; a parent served from that branch silently lost its directive
+ * and WD inheritance fell through to deeper ancestors.
+ *
+ * This drives `get_parsed_file` through that exact branch: the file is
+ * referenced WITHOUT its `.do` extension (read of the extensionless URI
+ * throws), the `.do` fallback is read and cached on the first call, and
+ * the second call hits the fallback stat/mtime fast path.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ScopeResolver } from '../../src/scope-resolver';
+import type { ContentProvider } from '../../src/types';
+import { create_test_scope_resolver_logger } from '../test-logger';
+
+describe('get_parsed_file .do-fallback mtime HIT (#278)', () => {
+    it('preserves working_directory_directive across the fallback cache hit', async () => {
+        const do_uri = 'file:///ws/parent.do';
+        const content = '// @lsp-cd: "/data"\nglobal p_g 1\n';
+
+        const provider: ContentProvider = {
+            read_file: async (uri: string) => {
+                if (uri === do_uri) {
+                    return content;
+                }
+                // The extensionless URI does not exist on "disk".
+                throw new Error('ENOENT');
+            },
+            exists: async (uri: string) => uri === do_uri,
+            stat: async (uri: string) =>
+                uri === do_uri
+                    ? {
+                        mtimeMs: 1000,
+                        size: Buffer.byteLength(content, 'utf8'),
+                    }
+                    : undefined,
+        };
+        const scope_resolver = new ScopeResolver(
+            create_test_scope_resolver_logger(), provider);
+        // A leading-slash @lsp-cd path is workspace-relative; a root must
+        // be set for `working_directory` to resolve.
+        scope_resolver.set_workspace_roots(['/ws']);
+
+        // First call: extensionless read throws → .do fallback read,
+        // parsed, and cached under the .do URI.
+        const first = await scope_resolver.get_parsed_file(
+            'file:///ws/parent', '/ws/parent');
+        if ('error' in first) throw new Error(first.error);
+        expect(first.working_directory_directive).toBeDefined();
+        expect(first.working_directory).toBeDefined();
+
+        // Second call: extensionless read throws again → the fallback
+        // stat matches the cached entry → the fallback mtime-HIT return.
+        // It must carry the directive like every other success return.
+        const second = await scope_resolver.get_parsed_file(
+            'file:///ws/parent', '/ws/parent');
+        if ('error' in second) throw new Error(second.error);
+        expect(second.working_directory_directive).toBeDefined();
+        expect(second.working_directory).toBe(first.working_directory);
+    });
+});


### PR DESCRIPTION
Implements the forward-closure memo write-path deferred from #209 (PR #233 shipped the key contract, toggle, and correctness gate). Closes #234.

## What landed

- **Store**: only standalone, owner-suppressed, diagnostic-free closures, computed at the nested-recursion hook (depth ≥ 1, where owner-gated diagnostics structurally cannot fire) from a clean self-seeded stack. Cap truncations are detected even under `maxDepth = "off"` by forcing a non-off severity in the discarded standalone diagnostics (fault-injection-verified test).
- **Serve**: only when the entry's visited-delta is disjoint from the caller's recursion stack ∪ visited map; the delta is replayed on serve so later siblings dedup identically to a live walk.
- **Negative caching**: diagnostic-producing keys get an `unservable` marker (always live path — with the caller's own call-chain prefixes) so doomed standalone builds are attempted once per key, not once per level of every live retry (the O(2^depth) cascade two reviewers found). An in-flight re-entry guard bounds mutual-cycle warm-up.
- **Invalidation parity with scope_cache**: `dependent_uris` per entry + a reverse index covering *every* dependent URI; eviction wired into `invalidate_scope_cache` / `invalidate_file_cache` / `cascade_invalidate` / `clear_cache`; base-key rotation on dep-graph version bumps; an invalidation epoch vetoes stores raced by mid-build changes; population gated on `scan_complete` (vacuously open with no graph — test/CLI-standalone semantics); memo cleared on `set_workspace_roots` / `set_resolve_fs` / `set_dependency_graph` / `dispose`.
- **Fallback-path healing**: standalone builds record probed-and-missing higher-priority path candidates (including the implicit `.do`-fallback variants) as dependents, so a file created at a higher-priority path evicts closures that resolved through a fallback tier.
- **Plumbing**: `content_hash` exposed through `ParsedFileResult`; `ForwardScopeResolver.set_dependency_graph` wired in both `server-factory` and the `sight check` CLI; `hits`/`misses`/`invalidations` metrics.

## Default: ON

Per the issue's acceptance criteria (green gate + perf numbers): the memo-on/off gate is green, and the shared-chain N-callers benchmark (60 roots × 8-link chain) runs **~2.4× faster** (median 14.7ms → 6.1ms) with the expected N→1 collapse (7 misses regardless of caller count, 59 hits) and no added file reads.

## Tests

- Memo-on/off correctness gate and key-contract tests stay green (now exercising a real cache).
- New store/serve suite: N→1 collapse, disjointness gate, visited-delta replay, diagnostic/truncation store rejection (fault-injection-verified), bounded work on cycles and cap-tripping chains, transitive + didChange eviction, higher-priority-path creation healing (both explicit-extension and extension-omitted idioms, fault-injection-verified), scan/version gates.
- Hub perf test extended with the recomputation-counter N→1 assertion.
- Full suite: 6989 pass / 0 fail; `bun run lint` clean.

## Review provenance

Plan adversarially reviewed by codex before implementation. Six subsequent review rounds (codex + independent reviewer subagents: correctness, cache-lifecycle, conventions, cold un-primed, invariant-refutation) surfaced and fixed: the O(2^depth) standalone cascade, a mid-build invalidation store race, dep-graph-version key stranding, missing CLI wiring, fallback-path staleness (two rounds: as-written candidates, then `.do` variants), vacuous test assertions, and stale comments. The final diff passed **two consecutive fully-clean rounds** from both codex and the subagent reviewers.

## Considered and declined (reviewer advisories, with rationale)

- `ScopeResolver.set_dependency_graph` does not auto-propagate to an attached `ForwardScopeResolver`: both production construction sites (server-factory, CLI) wire the graph explicitly; auto-propagation would add ordering-sensitive coupling for no production gain.
- Extensionless file creations cannot heal caches via the watcher: the client glob covers only `*.do/*.ado/*.doh/*.mata` — a pre-existing platform constraint that equally affects the file parse cache; documented in docs/cross-file.md.
- `unservable` entries may outlive a missing/ambiguous file's later change: conservative by construction (they never serve; the live path stays correct), matching the scope_cache-parity posture the issue specifies.
- In-flight guard is URI-granular: under concurrent `sight check` workers an overlap forces a conservative live fallback (lost caching only, never wrong output).
- No LRU/size cap and the transitive inner-served-entry dependent gap: explicit scope_cache parity per the issue ("out of scope here, same parity").

Refs #209, #208, PR #233.

https://claude.ai/code/session_01GuEAExKHEYeFW3N5qAN9yU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled forward-closure memoization by default to improve reuse of nested resolution work.
  * Added forward-closure metrics and memo governance for safer serving.

* **Bug Fixes**
  * Strengthened cache invalidation when file content changes, dependency-graph versions update, or documents close/discard buffers.
  * Ensured diagnostics-producing and truncated closures are not cached/served.

* **Documentation**
  * Updated caching semantics docs and gate/store-serve behavior documentation.

* **Tests**
  * Expanded integration, performance, and unit coverage for memo correctness, eviction, and default-on behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->