### PR TITLE
Span @lsp-ignore-next across whole statements; flag assert literal-macro adjacency

### DIFF
--- a/docs/declaration-directives.md
+++ b/docs/declaration-directives.md
@@ -16,6 +16,11 @@ and declaration directives may also appear as trailing `//` comments;
 Block comments (`/* ... */`) do not carry directives. The older `@lsp-` forms
 remain permanent aliases, so `// @lsp-ignore` still works.
 
+"The next statement" means every physical line that statement spans:
+a statement continued with `///` (or spanning lines under `#delimit ;`)
+is covered on all of its lines. A statement that opens a `{` block is
+covered through the header line only, never the block body.
+
 ```stata
 // Suppress warning on the next line
 // sight: ignore-next

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -137,9 +137,14 @@ turned off independently.
 These operator/expression rules are heuristic token-stream checks: they do not
 parse per-command semantics, so they can fire inside text-storing commands
 (e.g. `notes`, `char`, `local x <text>`) and do not cover every
-bare-expression command. This matches the scope of the existing operator
-diagnostics; see [#268](https://github.com/jbearak/sight/issues/268) for the
-known edge cases and the command-context improvement tracked for later.
+bare-expression command. `LITERAL_MACRO_ADJACENCY` additionally recognizes
+`assert` as a bare-boolean-expression command when it appears in command
+position (optionally after `capture` / `quietly` / `noisily` prefixes and
+their colons), so `assert 1\`b'` is flagged like `if 1\`b'`; other
+bare-expression commands remain uncovered. This matches the scope of the
+existing operator diagnostics; see
+[#268](https://github.com/jbearak/sight/issues/268) for the known edge cases
+and the command-context improvement tracked for later.
 
 ## Indentation diagnostics
 
@@ -278,6 +283,16 @@ Each severity key accepts `"error"`, `"warning"`, `"information"`,
 |---|---|
 | `// sight: ignore` | On its own comment line, suppresses undefined-symbol and operator-style diagnostics on the next non-trivia statement. As a trailing `//` comment, suppresses those diagnostics on the same line. Does not silence lexer, parser / brace-style, or indentation diagnostics. |
 | `// sight: ignore-next` | Suppresses undefined-symbol and operator-style diagnostics on the next non-trivia statement. It does not suppress diagnostics on its own source line. |
+
+When the next statement spans several physical lines — via `///`
+continuations, or under `#delimit ;` — a standalone `sight: ignore` /
+`sight: ignore-next` covers every line the statement spans, wherever in
+the statement the flagged construct sits. A statement that opens a block
+is covered through its header line (up to and including the `{`), but
+never the block body: to suppress a diagnostic inside a block, put the
+directive on the offending statement inside the block. A trailing
+`// sight: ignore` on any physical line an operator-style diagnostic
+spans also suppresses it.
 | `// sight: local name [name ...]` | Declares one or more local macros from the directive line forward. |
 | `// sight: global name [name ...]` | Same, for globals. |
 | `// sight: variables var [var ...]` | Declares variables (e.g., loaded from a `.dta` file). |

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -47,6 +47,8 @@ import {
     has_ignore_directive,
     has_ignore_next_directive,
 } from '../utils/directives';
+import { next_statement_line_span } from '../utils/statement-span';
+import { is_swallowed_continuation_terminator } from '../utils/continuation';
 
 // Diagnostic interface for semantic errors
 export interface SemanticDiagnostic {
@@ -521,17 +523,24 @@ export class SemanticAnalyzer {
             .filter(name => name.length > 0 && is_valid_identifier(name));
     }
 
+    /**
+     * Suppress diagnostics on every physical line the next logical
+     * statement spans — not just its first line — so `@lsp-ignore-next`
+     * covers `///`-continued statements and multi-line `#delimit ;`
+     * statements (issue #268 item 2). A `{` block header is covered up
+     * to the opener; the block body is not.
+     */
     private ignore_next_non_trivia_line(tokens: Token[], directive_index: number): void {
-        for (let j = directive_index + 1; j < tokens.length; j++) {
-            const next_token = tokens[j];
-            if (next_token.type !== 'WHITESPACE' &&
-                next_token.type !== 'COMMENT_LINE' &&
-                next_token.type !== 'COMMENT_BLOCK' &&
-                next_token.type !== 'CONTINUATION' &&
-                next_token.type !== 'STATEMENT_TERMINATOR') {
-                this.config.ignored_lines.add(next_token.range.start.line);
-                break;
-            }
+        const my_span = next_statement_line_span(tokens, directive_index);
+        if (!my_span) {
+            return;
+        }
+        for (
+            let my_line = my_span.start_line;
+            my_line <= my_span.end_line;
+            my_line++
+        ) {
+            this.config.ignored_lines.add(my_line);
         }
     }
 
@@ -713,6 +722,19 @@ export class SemanticAnalyzer {
         }
     }
 
+    /**
+     * AST-trivia fallback for comment directives. Ignore directives here
+     * add only the following node's FIRST line, by design: a control-flow
+     * node's range spans its whole block body, so marking the full range
+     * would over-suppress everything inside the block. Every production
+     * caller of analyze() passes tokens, making the token path
+     * (extract_comment_directives_from_tokens ->
+     * ignore_next_non_trivia_line) authoritative with full statement-span
+     * suppression; this narrower single-line contribution is a redundant
+     * subset when tokens are present, never a source of over-suppression.
+     * If a caller ever stops passing tokens, `@lsp-ignore-next` regresses
+     * to single-line suppression for that caller — keep tokens flowing.
+     */
     private parse_directive(trivia: TriviaNode, following_node: StataNode): void {
         const content = trivia.content.trim();
 
@@ -3822,8 +3844,11 @@ export class SemanticAnalyzer {
                     continue;
                 }
                 if (
-                    token.type === 'STATEMENT_TERMINATOR' &&
-                    (after_continuation || skip_terminators)
+                    is_swallowed_continuation_terminator(
+                        token,
+                        after_continuation
+                    ) ||
+                    (token.type === 'STATEMENT_TERMINATOR' && skip_terminators)
                 ) {
                     after_continuation = false;
                     j++;
@@ -4617,7 +4642,8 @@ export class SemanticAnalyzer {
      * Is the STATEMENT_TERMINATOR at `index` a `///` line continuation
      * (rather than a real end of statement)? True when the previous
      * significant token — skipping whitespace and comments — is a
-     * CONTINUATION.
+     * CONTINUATION, and the terminator is the newline the `///`
+     * swallows (a `;` under `#delimit ;` is always a real end).
      */
     private is_continuation_terminator_at(
         tokens: Token[],
@@ -4627,7 +4653,10 @@ export class SemanticAnalyzer {
         while (j >= 0 && MATA_TRIVIA_TOKENS.has(tokens[j].type)) {
             j--;
         }
-        return j >= 0 && tokens[j].type === 'CONTINUATION';
+        return is_swallowed_continuation_terminator(
+            tokens[index],
+            j >= 0 && tokens[j].type === 'CONTINUATION'
+        );
     }
 
     /**

--- a/src/providers/chained-comparison-diagnostics.ts
+++ b/src/providers/chained-comparison-diagnostics.ts
@@ -8,6 +8,7 @@ import {
     LOGICAL_OPERATORS,
     collect_significant_tokens,
     is_adjacent,
+    is_diagnostic_range_ignored,
 } from './diagnostic-token-stream';
 import { is_invalid_operator_sequence_pair } from './operator-sequence-diagnostics';
 
@@ -264,20 +265,15 @@ export class ChainedComparisonAnalyzer {
         for (const my_chain of the_chains) {
             // A chain can span multiple lines via `///`; honor an @lsp-ignore
             // on any line the chain covers, not just its first.
-            if (
-                this.is_range_ignored(
-                    my_chain.first.range.start.line,
-                    my_chain.last.range.end.line,
-                    my_ignored_lines
-                )
-            ) {
+            const my_range = Range.create(
+                my_chain.first.range.start,
+                my_chain.last.range.end
+            );
+            if (is_diagnostic_range_ignored(my_range, my_ignored_lines)) {
                 continue;
             }
             the_diagnostics.push({
-                range: Range.create(
-                    my_chain.first.range.start,
-                    my_chain.last.range.end
-                ),
+                range: my_range,
                 message: my_chain.incomplete_tail
                     ? 'Incomplete chained comparison. A later comparison ' +
                       'operator has no right-hand operand; complete the ' +
@@ -300,20 +296,4 @@ export class ChainedComparisonAnalyzer {
         return the_diagnostics;
     }
 
-    /**
-     * Whether any line in the inclusive range [start_line, end_line] is
-     * suppressed by an @lsp-ignore directive.
-     */
-    private is_range_ignored(
-        start_line: number,
-        end_line: number,
-        ignored_lines: Set<number>
-    ): boolean {
-        for (let my_line = start_line; my_line <= end_line; my_line++) {
-            if (ignored_lines.has(my_line)) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/src/providers/command-position.ts
+++ b/src/providers/command-position.ts
@@ -1,0 +1,106 @@
+import { Token } from '../types';
+import { SINGLE_LINE_PREFIX_COMMANDS } from '../utils/stata-prefix-commands';
+
+/**
+ * Keywords that syntactically introduce a boolean condition wherever
+ * they appear. Exact case; Stata is case-sensitive.
+ */
+export const CONTROL_FLOW_EXPRESSION_KEYWORDS: ReadonlySet<string> =
+    new Set(['if', 'while']);
+
+/**
+ * Commands whose whole (non-prefix) argument is a bare boolean
+ * expression but which are ordinary WORD tokens, not parser keywords —
+ * recognizing them safely requires knowing they are in COMMAND
+ * POSITION. `assert` is the only case Sight special-cases (#268 item 3):
+ * folding it into CONTROL_FLOW_EXPRESSION_KEYWORDS was rejected on
+ * review because that set is also consulted by call-opener detection,
+ * and `assert` is a valid callee/subscript-target WORD in non-command
+ * positions (`display assert(1`b')`, `gen y = assert[1`b']`).
+ *
+ * SEAM FOR THE DEFERRED FIX: issue #268 defers a general
+ * position-to-context resolver (AST expression regions with ranges +
+ * command-database expression-vs-text argument metadata) that would let
+ * any command declare "this argument is an evaluated expression"
+ * without a hardcoded set. When that lands, replace this set and
+ * `is_bare_expression_command_at` with a query against that resolver —
+ * this module is the only file that should need to change.
+ *
+ * Module-private on purpose: external callers must go through
+ * `is_bare_expression_command_at`, which adds the command-position
+ * check that makes the classification safe.
+ */
+const BARE_EXPRESSION_COMMANDS: ReadonlySet<string> =
+    new Set(['assert']);
+
+/**
+ * Token types after which the next significant token is in command
+ * position. A `#delimit` line ends any statement, so the token after a
+ * DELIMIT_DIRECTIVE starts a new one.
+ */
+const STATEMENT_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
+    'STATEMENT_TERMINATOR',
+    'LBRACE',
+    'RBRACE',
+    'DELIMIT_DIRECTIVE',
+]);
+
+/**
+ * Whether `the_significant[index]` is a BARE_EXPRESSION_COMMANDS word
+ * used as a command: the first significant token of a statement,
+ * optionally preceded by single-line prefix commands, each optionally
+ * followed by a colon (`capture assert ...`, `cap: assert ...`,
+ * `qui noi assert ...`). False for every non-command use.
+ *
+ * Precondition: `the_significant` has already been filtered by
+ * `collect_significant_tokens` (src/providers/diagnostic-token-stream.ts),
+ * so trivia and `///` continuations are gone and statement boundaries
+ * are real STATEMENT_TERMINATOR tokens.
+ */
+export function is_bare_expression_command_at(
+    the_significant: Token[],
+    index: number
+): boolean {
+    const my_token = the_significant[index];
+    if (my_token === undefined || my_token.type !== 'WORD') {
+        return false;
+    }
+    if (!BARE_EXPRESSION_COMMANDS.has(my_token.value)) {
+        return false;
+    }
+    return is_command_position(the_significant, index);
+}
+
+/**
+ * Whether the token at `index` starts a command: scanning backward,
+ * only prefix commands (each optionally followed by their colon) may
+ * sit between it and the start of input or a statement boundary. This
+ * is the backward version of the forward prefix-skipping grammar in
+ * src/analyzer/loop-expander/name-expander.ts (parse_macro_def_head).
+ */
+function is_command_position(
+    the_significant: Token[],
+    index: number
+): boolean {
+    let my_i = index - 1;
+    while (my_i >= 0) {
+        let my_token = the_significant[my_i];
+        // A prefix command's optional colon, e.g. `cap:` / `qui noi:`.
+        if (my_token.type === 'COLON') {
+            my_i--;
+            if (my_i < 0) {
+                return false;
+            }
+            my_token = the_significant[my_i];
+        }
+        if (
+            my_token.type === 'WORD' &&
+            SINGLE_LINE_PREFIX_COMMANDS.has(my_token.value)
+        ) {
+            my_i--;
+            continue;
+        }
+        return STATEMENT_BOUNDARY_TYPES.has(my_token.type);
+    }
+    return true;
+}

--- a/src/providers/diagnostic-token-stream.ts
+++ b/src/providers/diagnostic-token-stream.ts
@@ -1,4 +1,6 @@
+import { Range } from 'vscode-languageserver/node';
 import { Token } from '../types';
+import { is_swallowed_continuation_terminator } from '../utils/continuation';
 
 /**
  * Comparison operators. Stata evaluates these left-to-right, each yielding 0/1;
@@ -84,7 +86,9 @@ export function collect_significant_tokens(tokens: Token[]): Token[] {
     let my_in_continuation = false;
 
     for (const my_token of tokens) {
-        if (my_token.type === 'STATEMENT_TERMINATOR' && my_in_continuation) {
+        if (
+            is_swallowed_continuation_terminator(my_token, my_in_continuation)
+        ) {
             my_in_continuation = false;
             continue;
         }
@@ -139,4 +143,43 @@ export function is_adjacent(first: Token, second: Token): boolean {
         first.range.end.line === second.range.start.line &&
         first.range.end.character === second.range.start.character
     );
+}
+
+/**
+ * Whether any physical line in `[range.start.line, range.end.line]` is
+ * suppressed by an `@lsp-ignore` / `@lsp-ignore-next` directive.
+ *
+ * Token-stream diagnostics can span multiple physical lines via `///`
+ * continuation, so checking only the first token's line under-suppresses
+ * when the ignore comment sits on a later line the diagnostic covers.
+ * Originally ChainedComparisonAnalyzer's private check (#268);
+ * centralized here so the sibling analyzers apply suppression
+ * identically and cannot drift apart on this rule.
+ */
+export function is_diagnostic_range_ignored(
+    range: Range,
+    ignored_lines: Set<number>
+): boolean {
+    // Iterate the smaller side: spans are usually 1-2 lines, but a
+    // chain in a long `#delimit ;` statement can span many; the ignored
+    // set is typically a handful of entries.
+    const my_span_lines = range.end.line - range.start.line + 1;
+    if (my_span_lines > ignored_lines.size) {
+        for (const my_line of ignored_lines) {
+            if (my_line >= range.start.line && my_line <= range.end.line) {
+                return true;
+            }
+        }
+        return false;
+    }
+    for (
+        let my_line = range.start.line;
+        my_line <= range.end.line;
+        my_line++
+    ) {
+        if (ignored_lines.has(my_line)) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/providers/literal-macro-adjacency-diagnostics.ts
+++ b/src/providers/literal-macro-adjacency-diagnostics.ts
@@ -8,7 +8,12 @@ import {
     LOGICAL_OPERATORS,
     collect_significant_tokens,
     is_adjacent,
+    is_diagnostic_range_ignored,
 } from './diagnostic-token-stream';
+import {
+    CONTROL_FLOW_EXPRESSION_KEYWORDS,
+    is_bare_expression_command_at,
+} from './command-position';
 
 /**
  * Macro reference token types.
@@ -19,12 +24,26 @@ const MACRO_REF_TYPES: Set<string> = new Set([
 ]);
 
 /**
- * Keywords that introduce a boolean condition (exact case; Stata is
- * case-sensitive). A literal that is the leading operand of one of these is
- * suspicious, where a number-macro concatenation is a footgun even with no
- * comparison operator adjacent to the pair.
+ * Keywords/commands that introduce a boolean condition: `if`/`while`
+ * anywhere (CONTROL_FLOW_EXPRESSION_KEYWORDS), plus bare-expression
+ * commands like `assert` in command position only (see
+ * command-position.ts). A literal that is the leading operand of one of
+ * these is suspicious, where a number-macro concatenation is a footgun
+ * even with no comparison operator adjacent to the pair.
  */
-const CONDITION_KEYWORDS: Set<string> = new Set(['if', 'while']);
+function is_condition_introducer(
+    the_significant: Token[],
+    index: number
+): boolean {
+    const my_token = the_significant[index];
+    if (my_token === undefined || my_token.type !== 'WORD') {
+        return false;
+    }
+    if (CONTROL_FLOW_EXPRESSION_KEYWORDS.has(my_token.value)) {
+        return true;
+    }
+    return is_bare_expression_command_at(the_significant, index);
+}
 
 /**
  * Grouping-open token types skipped when scanning backward for the operator
@@ -112,18 +131,20 @@ function is_expression_operator(my_token: Token | undefined): boolean {
 function governing_before(
     the_significant: Token[],
     index: number
-): { token: Token | undefined; group_opens: number } {
+): { token: Token | undefined; index: number; group_opens: number } {
     let my_group_opens = 0;
     for (let my_i = index - 1; my_i >= 0; my_i--) {
         const my_token = the_significant[my_i];
         if (GROUP_OPEN_TYPES.has(my_token.type)) {
-            const my_before_paren =
-                my_i - 1 >= 0 ? the_significant[my_i - 1] : undefined;
-            if (is_call_opener(my_before_paren, my_token)) {
+            const my_before_paren_index = my_i - 1;
+            if (
+                is_call_opener(the_significant, my_before_paren_index, my_token)
+            ) {
                 // Function-call / subscript opener: the operand is an
                 // argument, not a wrapped operand. Stop at the callee.
                 return {
-                    token: my_before_paren,
+                    token: the_significant[my_before_paren_index],
+                    index: my_before_paren_index,
                     group_opens: my_group_opens,
                 };
             }
@@ -136,9 +157,9 @@ function governing_before(
         ) {
             continue;
         }
-        return { token: my_token, group_opens: my_group_opens };
+        return { token: my_token, index: my_i, group_opens: my_group_opens };
     }
-    return { token: undefined, group_opens: my_group_opens };
+    return { token: undefined, index: -1, group_opens: my_group_opens };
 }
 
 /**
@@ -149,12 +170,19 @@ function governing_before(
  * `strlen(1`x')` is a call, but `assert (1`b')` / `display (1`b')` are commands
  * with a grouped expression, where Stata's own disambiguator is the space. A
  * call opener is a non-keyword WORD (callee name) or a preceding call/subscript
- * result (`)`/`]`). `if`/`while` before the paren is a condition, not a call.
+ * result (`)`/`]`). A condition introducer before the paren is not a
+ * call: `if`/`while` anywhere, or a bare-expression command such as
+ * `assert` in command position — `assert(1`b')` at statement start is
+ * the command with a grouped expression, while `display assert(1`b')`
+ * stays a call.
  */
 function is_call_opener(
-    my_token: Token | undefined,
+    the_significant: Token[],
+    token_index: number,
     my_paren: Token
 ): boolean {
+    const my_token =
+        token_index >= 0 ? the_significant[token_index] : undefined;
     if (my_token === undefined) {
         return false;
     }
@@ -165,7 +193,8 @@ function is_call_opener(
         return true;
     }
     return (
-        my_token.type === 'WORD' && !CONDITION_KEYWORDS.has(my_token.value)
+        my_token.type === 'WORD' &&
+        !is_condition_introducer(the_significant, token_index)
     );
 }
 
@@ -257,7 +286,8 @@ export class LiteralMacroAdjacencyAnalyzer {
             // such an operator governs it before or after — looking past
             // grouping parentheses and unary prefixes, so `if (1`b')` and
             // `a == -1`b'` read the same as their bare forms — or when the
-            // literal is the leading operand of an `if`/`while` condition.
+            // literal is the leading operand of an `if`/`while` condition
+            // or of a bare-expression command such as `assert`.
             const before = governing_before(the_significant, i - 1);
             const governor_after = governing_after(
                 the_significant,
@@ -267,20 +297,21 @@ export class LiteralMacroAdjacencyAnalyzer {
 
             const operator_before = is_expression_operator(before.token);
             const operator_after = is_expression_operator(governor_after);
-            const leads_condition =
-                before.token !== undefined &&
-                before.token.type === 'WORD' &&
-                CONDITION_KEYWORDS.has(before.token.value);
+            const leads_condition = is_condition_introducer(
+                the_significant,
+                before.index
+            );
 
+            const my_range = Range.create(
+                my_literal.range.start,
+                my_macro.range.end
+            );
             if (
                 (operator_before || operator_after || leads_condition) &&
-                !my_ignored_lines.has(my_literal.range.start.line)
+                !is_diagnostic_range_ignored(my_range, my_ignored_lines)
             ) {
                 the_diagnostics.push({
-                    range: Range.create(
-                        my_literal.range.start,
-                        my_macro.range.end
-                    ),
+                    range: my_range,
                     message:
                         'Literal adjacent to macro reference in an ' +
                         'expression. Stata concatenates these during macro ' +

--- a/src/providers/mixed-logical-diagnostics.ts
+++ b/src/providers/mixed-logical-diagnostics.ts
@@ -3,6 +3,8 @@ import { DocumentState } from '../document-store';
 import { StataDiagnosticCode, StataLSPConfig, Token } from '../types';
 import { diagnostic_code_description_fields } from '../utils/diagnostic-code-description';
 import { resolve_diagnostic_severity } from '../utils/diagnostic-severity';
+import { is_swallowed_continuation_terminator } from '../utils/continuation';
+import { is_diagnostic_range_ignored } from './diagnostic-token-stream';
 
 /**
  * Logical operator values tracked for mixed-operator detection.
@@ -105,7 +107,12 @@ export class MixedLogicalOperatorAnalyzer {
         for (let i = 0; i < the_tokens.length; i++) {
             const my_token = the_tokens[i];
 
-            if (my_token.type === 'STATEMENT_TERMINATOR' && my_in_continuation) {
+            if (
+                is_swallowed_continuation_terminator(
+                    my_token,
+                    my_in_continuation
+                )
+            ) {
                 my_in_continuation = false;
                 continue;
             }
@@ -228,7 +235,12 @@ export class MixedLogicalOperatorAnalyzer {
                 my_in_continuation = true;
                 continue;
             }
-            if (my_next_token.type === 'STATEMENT_TERMINATOR' && my_in_continuation) {
+            if (
+                is_swallowed_continuation_terminator(
+                    my_next_token,
+                    my_in_continuation
+                )
+            ) {
                 my_in_continuation = false;
                 continue;
             }
@@ -262,12 +274,18 @@ export class MixedLogicalOperatorAnalyzer {
             const my_first_token = is_before(my_first_and, my_first_or) ? my_first_and : my_first_or;
             const my_last_token = is_before(my_last_and, my_last_or) ? my_last_or : my_last_and;
 
-            if (my_ignored_lines.has(my_first_token.range.start.line)) {
+            // The flagged mix can span lines via `///`; honor an
+            // @lsp-ignore on any line the diagnostic covers.
+            const my_range = Range.create(
+                my_first_token.range.start,
+                my_last_token.range.end
+            );
+            if (is_diagnostic_range_ignored(my_range, my_ignored_lines)) {
                 continue;
             }
 
             my_diagnostics.push({
-                range: Range.create(my_first_token.range.start, my_last_token.range.end),
+                range: my_range,
                 message: "Mixed '&' and '|' without parentheses. "
                     + "Use parentheses to clarify precedence "
                     + "(e.g., '(x & y) | z' or 'x & (y | z)')",

--- a/src/providers/operator-sequence-diagnostics.ts
+++ b/src/providers/operator-sequence-diagnostics.ts
@@ -3,6 +3,8 @@ import { DocumentState } from '../document-store';
 import { StataDiagnosticCode, StataLSPConfig, Token, StataAST, StataNode } from '../types';
 import { diagnostic_code_description_fields } from '../utils/diagnostic-code-description';
 import { resolve_diagnostic_severity } from '../utils/diagnostic-severity';
+import { is_swallowed_continuation_terminator } from '../utils/continuation';
+import { is_diagnostic_range_ignored } from './diagnostic-token-stream';
 
 /**
  * Spaced compound operators that Stata accepts as their compact form.
@@ -217,9 +219,14 @@ export class OperatorSequenceAnalyzer {
                 continue;
             }
 
-            // Check for suppression via @lsp-ignore directives
-            const diagnostic_line = first_token.range.start.line;
-            if (ignored_lines.has(diagnostic_line)) {
+            // Check for suppression via @lsp-ignore directives. The pair
+            // can span lines via `///`; honor an @lsp-ignore on any line
+            // the diagnostic covers.
+            const my_pair_range = Range.create(
+                first_token.range.start,
+                second_token.range.end
+            );
+            if (is_diagnostic_range_ignored(my_pair_range, ignored_lines)) {
                 // Suppressed by directive, advance past second token
                 i = next_index;
                 continue;
@@ -251,10 +258,7 @@ export class OperatorSequenceAnalyzer {
             // Build the diagnostic
             const severity = this.resolve_severity(config_severity, pair_result.default_severity);
             const diagnostic: Diagnostic = {
-                range: Range.create(
-                    first_token.range.start,
-                    second_token.range.end
-                ),
+                range: my_pair_range,
                 message: pair_result.message,
                 severity,
                 source: 'sight',
@@ -301,11 +305,10 @@ export class OperatorSequenceAnalyzer {
                 continue;
             }
 
-            // Special case: STATEMENT_TERMINATOR after CONTINUATION is part of the
-            // continuation and should NOT break adjacency. The newline after ///
-            // is tokenized as STATEMENT_TERMINATOR but is semantically part of the
-            // continuation.
-            if (my_token.type === 'STATEMENT_TERMINATOR' && in_continuation) {
+            // The newline terminator swallowed by a `///` continuation
+            // does NOT break adjacency; a real terminator (a `;` under
+            // `#delimit ;`, or a plain newline) does.
+            if (is_swallowed_continuation_terminator(my_token, in_continuation)) {
                 // Reset continuation flag and continue scanning
                 in_continuation = false;
                 j++;

--- a/src/utils/continuation.ts
+++ b/src/utils/continuation.ts
@@ -1,0 +1,27 @@
+import { Token } from '../types';
+
+/**
+ * Whether `my_token` is the STATEMENT_TERMINATOR swallowed by a
+ * preceding `///` continuation — trivia, not a real statement end.
+ *
+ * Only a newline terminator qualifies: `///` consumes exactly the line
+ * break that follows it. Under `#delimit cr` that line break lexes as a
+ * STATEMENT_TERMINATOR with value '\n'; under `#delimit ;` it lexes as
+ * WHITESPACE, so any STATEMENT_TERMINATOR seen mid-continuation there
+ * is a literal `;` — always a real statement end.
+ *
+ * Shared by every token scan that tracks an in-continuation flag
+ * (statement spans, significant-token collection, operator adjacency,
+ * mixed-logical grouping, Mata setter scanning) so the rule cannot
+ * drift between them.
+ */
+export function is_swallowed_continuation_terminator(
+    my_token: Token,
+    in_continuation: boolean
+): boolean {
+    return (
+        my_token.type === 'STATEMENT_TERMINATOR' &&
+        in_continuation &&
+        my_token.value === '\n'
+    );
+}

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -1,0 +1,137 @@
+import { Token } from '../types';
+import { is_swallowed_continuation_terminator } from './continuation';
+
+/**
+ * Inclusive physical-line span, zero-based LSP line numbers.
+ */
+export interface LineSpan {
+    start_line: number;
+    end_line: number;
+}
+
+/**
+ * Token types skipped while searching for the first token of the "next
+ * statement" after a directive comment: surrounding whitespace, other
+ * comments, a `///` continuation and the newline it swallows, blank
+ * statement terminators, and a `#delimit` mode switch — so an
+ * `@lsp-ignore-next` immediately followed by `#delimit ;` targets the
+ * first real statement under the new mode, not the mode-switch line.
+ */
+const LEADING_TRIVIA_TYPES: ReadonlySet<string> = new Set([
+    'WHITESPACE',
+    'COMMENT_LINE',
+    'COMMENT_BLOCK',
+    'CONTINUATION',
+    'STATEMENT_TERMINATOR',
+    'DELIMIT_DIRECTIVE',
+]);
+
+/**
+ * Token types that open a body the span walk must never enter: a `{`
+ * block header, or a `mata`/`python` block start. The header line up to
+ * and including the opener is part of the statement's span; the body is
+ * not. (`MATA_INLINE`/`PYTHON_INLINE` are single-statement forms with no
+ * persistent body, so they are ordinary statement tokens.)
+ */
+const BODY_OPENER_TYPES: ReadonlySet<string> = new Set([
+    'LBRACE',
+    'MATA_START',
+    'PYTHON_START',
+]);
+
+/**
+ * Trivia that does not disturb `///` continuation state while walking a
+ * statement (mirrors collect_significant_tokens in
+ * src/providers/diagnostic-token-stream.ts).
+ */
+const CONTINUATION_NEUTRAL_TYPES: ReadonlySet<string> = new Set([
+    'WHITESPACE',
+    'COMMENT_LINE',
+    'COMMENT_BLOCK',
+]);
+
+/**
+ * Compute the inclusive physical-line span of the next logical statement
+ * after `tokens[from_index]` (typically the index of a directive comment
+ * token such as `// @lsp-ignore-next`).
+ *
+ * The walk is continuation-aware: a `///` CONTINUATION and the
+ * STATEMENT_TERMINATOR immediately after it are part of the statement,
+ * not a break (same rule as collect_significant_tokens in
+ * src/providers/diagnostic-token-stream.ts). The statement ends at the
+ * first real STATEMENT_TERMINATOR — a newline under `#delimit cr`, or
+ * `;` under `#delimit ;` — or at a body opener (`{`, `mata`, `python`),
+ * so a block header's lines are covered but its body never is.
+ *
+ * Lines are extended using each token's `range.start.line`, never
+ * `range.end.line`: in `#delimit cr` mode a STATEMENT_TERMINATOR is the
+ * `\n` character and its range ends at column 0 of the FOLLOWING line
+ * (the lexer builds the range after advancing past the newline), so
+ * `end.line` would drag an unrelated next line into the span. Any token
+ * that spans lines has its later lines covered by the start lines of
+ * the tokens that follow it.
+ *
+ * Returns undefined when no statement follows `from_index`.
+ */
+export function next_statement_line_span(
+    tokens: Token[],
+    from_index: number
+): LineSpan | undefined {
+    let my_first_index = from_index + 1;
+    while (
+        my_first_index < tokens.length &&
+        LEADING_TRIVIA_TYPES.has(tokens[my_first_index].type)
+    ) {
+        my_first_index++;
+    }
+    if (
+        my_first_index >= tokens.length ||
+        tokens[my_first_index].type === 'EOF'
+    ) {
+        return undefined;
+    }
+
+    const start_line = tokens[my_first_index].range.start.line;
+    let end_line = start_line;
+    let my_in_continuation = false;
+
+    for (let my_i = my_first_index; my_i < tokens.length; my_i++) {
+        const my_token = tokens[my_i];
+
+        if (my_token.type === 'EOF') {
+            break;
+        }
+
+        if (my_token.type === 'STATEMENT_TERMINATOR') {
+            end_line = Math.max(end_line, my_token.range.start.line);
+            if (
+                is_swallowed_continuation_terminator(
+                    my_token,
+                    my_in_continuation
+                )
+            ) {
+                my_in_continuation = false;
+                continue;
+            }
+            break;
+        }
+
+        if (my_token.type === 'CONTINUATION') {
+            my_in_continuation = true;
+            end_line = Math.max(end_line, my_token.range.start.line);
+            continue;
+        }
+
+        end_line = Math.max(end_line, my_token.range.start.line);
+
+        if (BODY_OPENER_TYPES.has(my_token.type)) {
+            break;
+        }
+
+        if (!CONTINUATION_NEUTRAL_TYPES.has(my_token.type)) {
+            my_in_continuation = false;
+        }
+    }
+
+    return { start_line, end_line };
+}

--- a/tests/property/command-position.prop.test.ts
+++ b/tests/property/command-position.prop.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Property tests for bare-expression command detection in
+ * LITERAL_MACRO_ADJACENCY (issue #268 item 3).
+ *
+ * `assert` in command position (with any prefix-command chain) always
+ * flags a leading literal-macro pair; `assert` as a callee or subscript
+ * target never does.
+ */
+
+import { describe, it, beforeEach } from 'bun:test';
+import * as fc from 'fast-check';
+import { LiteralMacroAdjacencyAnalyzer } from '../../src/providers/literal-macro-adjacency-diagnostics';
+import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
+import { DEFAULT_SETTINGS } from '../../src/server-handlers';
+import { create_document_state } from './helpers/document-utils';
+import { arbitrary_non_reserved_identifier } from './generators';
+
+describe('Command-position property tests', () => {
+    let analyzer: LiteralMacroAdjacencyAnalyzer;
+    let default_config: StataLSPConfig;
+
+    beforeEach(() => {
+        analyzer = new LiteralMacroAdjacencyAnalyzer();
+        default_config = {
+            ...DEFAULT_SETTINGS,
+            diagnostics: {
+                ...DEFAULT_SETTINGS.diagnostics,
+                severity: {
+                    ...DEFAULT_SETTINGS.diagnostics.severity,
+                },
+            },
+        };
+    });
+
+    const found = (source: string) =>
+        analyzer
+            .analyze(create_document_state(source), default_config)
+            .filter(
+                (d) => d.code === StataDiagnosticCode.LITERAL_MACRO_ADJACENCY
+            );
+
+    const arbitrary_prefix_chain = () =>
+        fc.array(
+            fc.constantFrom(
+                'capture', 'cap', 'quietly', 'qui', 'noisily', 'noi'
+            ),
+            { minLength: 0, maxLength: 2 }
+        ).chain((the_prefixes) =>
+            fc.boolean().map((use_colon) => {
+                if (the_prefixes.length === 0) {
+                    return '';
+                }
+                return the_prefixes.join(' ') + (use_colon ? ': ' : ' ');
+            })
+        );
+
+    it('always flags a leading literal-macro pair after (prefixed) assert', async () => {
+        await fc.assert(
+            fc.asyncProperty(
+                arbitrary_prefix_chain(),
+                arbitrary_non_reserved_identifier(),
+                fc.integer({ min: 0, max: 99 }),
+                async (prefix_chain, macro_name, literal_value) => {
+                    const content =
+                        `${prefix_chain}assert ${literal_value}\`${macro_name}'`;
+                    return found(content).length === 1;
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    it('never flags assert used as a callee or subscript target', async () => {
+        await fc.assert(
+            fc.asyncProperty(
+                fc.constantFrom(
+                    "display assert(1`MACRO')",
+                    "gen y = assert[1`MACRO']",
+                    "list assert 1`MACRO'"
+                ),
+                arbitrary_non_reserved_identifier(),
+                async (template, macro_name) => {
+                    const content = template.replace('MACRO', macro_name);
+                    return found(content).length === 0;
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+});

--- a/tests/property/diagnostic-suppression.test.ts
+++ b/tests/property/diagnostic-suppression.test.ts
@@ -114,6 +114,88 @@ describe('Diagnostic Suppression Property Tests', () => {
     });
 
     /**
+     * Property: @lsp-ignore-next covers every line of a ///-continued
+     * statement, wherever in the statement the reference lands (#268).
+     */
+    it('should suppress across /// continuations regardless of which line holds the reference', async () => {
+        await fc.assert(
+            fc.asyncProperty(
+                arbitrary_non_reserved_identifier(),
+                fc.integer({ min: 0, max: 2 }),
+                async (macro_name: string, ref_line_offset: number) => {
+                    // Build a 3-line continued statement placing the
+                    // undefined reference on line 1, 2, or 3 of it.
+                    const the_operands = ['1', '2', '3'];
+                    the_operands[ref_line_offset] = `\`${macro_name}'`;
+                    const content =
+                        '// @lsp-ignore-next\n' +
+                        `local result = ${the_operands[0]} + ///\n` +
+                        `    ${the_operands[1]} + ///\n` +
+                        `    ${the_operands[2]}`;
+                    const my_document = create_document_state(content);
+
+                    const the_diagnostics = await my_diagnostics_provider.get_diagnostics(
+                        my_document,
+                        my_config
+                    );
+
+                    const undefined_macro_diags = the_diagnostics.filter(
+                        d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    );
+
+                    return undefined_macro_diags.length === 0;
+                }
+            ),
+            { numRuns: 50 }
+        );
+    });
+
+    /**
+     * Property: @lsp-ignore-next before a block header never suppresses
+     * diagnostics inside the block body (#268).
+     */
+    it('should not suppress block-body diagnostics via a header @lsp-ignore-next', async () => {
+        await fc.assert(
+            fc.asyncProperty(
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                async (header_macro: string, body_macro: string) => {
+                    fc.pre(header_macro !== body_macro);
+
+                    const content =
+                        '// @lsp-ignore-next\n' +
+                        `if \`${header_macro}' == 1 {\n` +
+                        `    display \`${body_macro}'\n` +
+                        '}';
+                    const my_document = create_document_state(content);
+
+                    const the_diagnostics = await my_diagnostics_provider.get_diagnostics(
+                        my_document,
+                        my_config
+                    );
+
+                    const undefined_macro_diags = the_diagnostics.filter(
+                        d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+                    );
+
+                    // Header reference suppressed; body reference not.
+                    // Match the quoted `name' form, not a raw substring:
+                    // short names like `n' also occur in message prose.
+                    return (
+                        !undefined_macro_diags.some(
+                            d => d.message.includes(`\`${header_macro}'`)
+                        ) &&
+                        undefined_macro_diags.some(
+                            d => d.message.includes(`\`${body_macro}'`)
+                        )
+                    );
+                }
+            ),
+            { numRuns: 50 }
+        );
+    });
+
+    /**
      * Property: Suppression works for undefined variables too
      */
     it('should suppress undefined variable diagnostics with suppression comments', async () => {

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -642,6 +642,66 @@ display \`bare_directive_macro'
             expect(undefined_diags.some(d => d.message.includes('bare_directive_macro'))).toBe(true);
         });
 
+        it('should suppress with @lsp-ignore-next across a /// continuation', () => {
+            const result = analyze(`
+// @lsp-ignore-next
+local x = 1 + ///
+    \`undefined_macro'
+`, { undefined_macro_enabled: true });
+
+            const undefined_diags = result.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(undefined_diags.length).toBe(0);
+        });
+
+        it('@lsp-ignore-next covers a { block header but not the body', () => {
+            const result = analyze(`
+// @lsp-ignore-next
+if \`header_macro' == 1 {
+    display \`body_macro'
+}
+`, { undefined_macro_enabled: true });
+
+            const undefined_diags = result.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(undefined_diags.some(d => d.message.includes('header_macro'))).toBe(false);
+            expect(undefined_diags.some(d => d.message.includes('body_macro'))).toBe(true);
+        });
+
+        it('@lsp-ignore-next does not leak past a ; after a /// (semicolon mode)', () => {
+            const result = analyze(`
+#delimit ;
+// @lsp-ignore-next
+local x = \`alpha_macro' ///
+;
+display \`bravo_macro' ;
+`, { undefined_macro_enabled: true });
+
+            const undefined_diags = result.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(undefined_diags.some(d => d.message.includes('alpha_macro'))).toBe(false);
+            expect(undefined_diags.some(d => d.message.includes('bravo_macro'))).toBe(true);
+        });
+
+        it('@lsp-ignore-next spans a multi-line #delimit ; statement', () => {
+            const result = analyze(`
+#delimit ;
+// @lsp-ignore-next
+local x = 1 +
+    \`undefined_macro' ;
+display \`unignored_macro' ;
+`, { undefined_macro_enabled: true });
+
+            const undefined_diags = result.diagnostics.filter(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
+            );
+            expect(undefined_diags.some(d => d.message.includes('undefined_macro'))).toBe(false);
+            expect(undefined_diags.some(d => d.message.includes('unignored_macro'))).toBe(true);
+        });
+
         it('should declare variables with @lsp-variables', () => {
             const result = analyze(`
 // @lsp-variables age income status

--- a/tests/unit/command-position.test.ts
+++ b/tests/unit/command-position.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for the bare-expression command-position classifier
+ * (issue #268 item 3).
+ *
+ * `assert` is only a bare-expression command when it is in command
+ * position (statement start, optionally after single-line prefix
+ * commands and their colons); everywhere else it is an ordinary WORD
+ * (variable, callee, subscript target) and must not be classified.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { StataLexer } from '../../src/lexer';
+import { collect_significant_tokens } from '../../src/providers/diagnostic-token-stream';
+import { is_bare_expression_command_at } from '../../src/providers/command-position';
+
+const lexer = new StataLexer();
+
+/**
+ * Tokenize `source`, collect significant tokens, and report whether the
+ * WORD token equal to `word` at occurrence `occurrence` (0-based) is
+ * classified as a bare-expression command.
+ */
+function classify(source: string, word: string, occurrence = 0): boolean {
+    const { tokens } = lexer.tokenize(source);
+    const the_significant = collect_significant_tokens(tokens);
+    let my_seen = 0;
+    for (let i = 0; i < the_significant.length; i++) {
+        const my_token = the_significant[i];
+        if (my_token.type === 'WORD' && my_token.value === word) {
+            if (my_seen === occurrence) {
+                return is_bare_expression_command_at(the_significant, i);
+            }
+            my_seen++;
+        }
+    }
+    throw new Error(`word ${word} (occurrence ${occurrence}) not found`);
+}
+
+describe('is_bare_expression_command_at', () => {
+    it('classifies assert at start of file', () => {
+        expect(classify("assert 1`b'", 'assert')).toBe(true);
+    });
+
+    it('classifies assert after a statement terminator', () => {
+        expect(classify("display x\nassert 1`b'", 'assert')).toBe(true);
+    });
+
+    it('classifies assert after an opening brace', () => {
+        expect(classify("if ok {\nassert 1`b'\n}", 'assert')).toBe(true);
+    });
+
+    it('classifies assert after a closing brace', () => {
+        expect(classify("if ok {\n}\nassert 1`b'", 'assert')).toBe(true);
+    });
+
+    it('classifies assert after each single-line prefix command', () => {
+        for (const my_prefix of ['capture', 'cap', 'quietly', 'qui', 'quie', 'noisily', 'noi']) {
+            expect(classify(`${my_prefix} assert 1\`b'`, 'assert')).toBe(true);
+        }
+    });
+
+    it('classifies assert after a prefix command with colon', () => {
+        expect(classify("cap: assert 1`b'", 'assert')).toBe(true);
+    });
+
+    it('classifies assert after stacked prefixes with colon', () => {
+        expect(classify("cap noi: assert 1`b'", 'assert')).toBe(true);
+    });
+
+    it('rejects assert after a non-prefix word', () => {
+        expect(classify("list assert 1`b'", 'assert')).toBe(false);
+    });
+
+    it('rejects assert after an operator (assignment RHS)', () => {
+        expect(classify("gen y = assert[1`b']", 'assert')).toBe(false);
+    });
+
+    it('rejects assert after a non-prefix word with colon', () => {
+        // `foo:` is a program prefix Sight does not model as a
+        // single-line prefix command; stay conservative (a miss, never
+        // a false classification).
+        expect(classify("foo: assert 1`b'", 'assert')).toBe(false);
+    });
+
+    it('rejects a non-listed word even in command position', () => {
+        expect(classify('display x', 'display')).toBe(false);
+    });
+
+    it('rejects wrong-case Assert (Stata is case-sensitive)', () => {
+        expect(classify("Assert 1`b'", 'Assert')).toBe(false);
+    });
+
+    it('classifies per-statement independently', () => {
+        const source = "cap assert 1`b'\ngen y = assert[2`c']";
+        expect(classify(source, 'assert', 0)).toBe(true);
+        expect(classify(source, 'assert', 1)).toBe(false);
+    });
+
+    it('classifies assert in command position under #delimit ;', () => {
+        expect(
+            classify("#delimit ;\ndisplay x ;\nassert 1`b' ;", 'assert')
+        ).toBe(true);
+    });
+
+    it('classifies assert immediately after a #delimit line', () => {
+        expect(classify("#delimit ;\nassert 1`b' ;", 'assert')).toBe(true);
+    });
+});

--- a/tests/unit/diagnostic-token-stream.test.ts
+++ b/tests/unit/diagnostic-token-stream.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the shared token-stream diagnostic helpers.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { Range } from 'vscode-languageserver/node';
+import { StataLexer } from '../../src/lexer';
+import {
+    collect_significant_tokens,
+    is_diagnostic_range_ignored,
+} from '../../src/providers/diagnostic-token-stream';
+
+const lexer = new StataLexer();
+
+describe('is_diagnostic_range_ignored', () => {
+    it('hits a single-line range whose line is ignored', () => {
+        expect(
+            is_diagnostic_range_ignored(Range.create(3, 0, 3, 5), new Set([3]))
+        ).toBe(true);
+    });
+
+    it('misses a single-line range whose line is not ignored', () => {
+        expect(
+            is_diagnostic_range_ignored(Range.create(3, 0, 3, 5), new Set([2, 4]))
+        ).toBe(false);
+    });
+
+    it('hits a multi-line range when only an interior line is ignored', () => {
+        expect(
+            is_diagnostic_range_ignored(Range.create(1, 0, 4, 5), new Set([3]))
+        ).toBe(true);
+    });
+
+    it('misses a multi-line range with no ignored line inside', () => {
+        expect(
+            is_diagnostic_range_ignored(Range.create(1, 0, 4, 5), new Set([0, 5]))
+        ).toBe(false);
+    });
+});
+
+describe('collect_significant_tokens', () => {
+    it('drops the newline terminator swallowed by a /// continuation', () => {
+        const { tokens } = lexer.tokenize('local x = 1 + ///\n    2\nlocal y');
+        const the_significant = collect_significant_tokens(tokens);
+        const the_terminators = the_significant.filter(
+            (my_token) => my_token.type === 'STATEMENT_TERMINATOR'
+        );
+        // Only the real newline after `2` remains (no trailing newline
+        // after `local y`, so no final terminator).
+        expect(the_terminators.every((my_token) => my_token.value === '\n')).toBe(true);
+        expect(the_terminators.length).toBe(1);
+    });
+
+    it('keeps a real ; terminator on the line after a /// (semicolon mode)', () => {
+        // In `#delimit ;` mode the newline after `///` lexes as
+        // WHITESPACE, so a `;` on the following line is a real
+        // statement terminator — it must survive filtering, or two
+        // statements merge in the significant stream.
+        const { tokens } = lexer.tokenize(
+            '#delimit ;\nlocal x = 1 ///\n;\nlocal y = 2 ;'
+        );
+        const the_significant = collect_significant_tokens(tokens);
+        const the_semicolons = the_significant.filter(
+            (my_token) =>
+                my_token.type === 'STATEMENT_TERMINATOR' &&
+                my_token.value === ';'
+        );
+        expect(the_semicolons.length).toBe(2);
+    });
+});

--- a/tests/unit/literal-macro-adjacency-diagnostics.test.ts
+++ b/tests/unit/literal-macro-adjacency-diagnostics.test.ts
@@ -109,6 +109,50 @@ describe('LiteralMacroAdjacencyAnalyzer Unit Tests', () => {
         });
     });
 
+    describe('Bare-expression commands (#268 item 3)', () => {
+        it("detects a bare assert condition: assert 1`b'", () => {
+            expect(found("assert 1`b'")).toHaveLength(1);
+        });
+        it("detects an adjacent-paren assert (command, not call): assert(1`b') == 10", () => {
+            expect(found("assert(1`b') == 10")).toHaveLength(1);
+        });
+        it("detects a parenthesized bare assert condition: assert (1`b')", () => {
+            expect(found("assert (1`b')")).toHaveLength(1);
+        });
+        it("detects assert after a prefix command: capture assert 1`b'", () => {
+            expect(found("capture assert 1`b'")).toHaveLength(1);
+        });
+        it("detects assert after an abbreviated prefix: cap assert 1`b'", () => {
+            expect(found("cap assert 1`b'")).toHaveLength(1);
+        });
+        it("detects assert after a prefix with colon: quietly: assert 1`b'", () => {
+            expect(found("quietly: assert 1`b'")).toHaveLength(1);
+        });
+        it("detects assert after stacked prefixes: cap noi assert 1`b'", () => {
+            expect(found("cap noi assert 1`b'")).toHaveLength(1);
+        });
+        it("detects assert on a later statement: display x\\nassert 1`b'", () => {
+            expect(found("display x\nassert 1`b'")).toHaveLength(1);
+        });
+        it("does not flag wrong-case Assert (Stata is case-sensitive)", () => {
+            expect(found("Assert 1`b'")).toHaveLength(0);
+        });
+        it("does not flag assert as a subscript target: gen y = assert[1`b']", () => {
+            expect(found("gen y = assert[1`b']")).toHaveLength(0);
+        });
+        it("does not flag assert as a callee: display assert(1`b')", () => {
+            expect(found("display assert(1`b')")).toHaveLength(0);
+        });
+        it("does not treat a mid-statement assert word as a command: list assert 1`b'", () => {
+            // `assert` here is (unusually) a variable name in a varlist,
+            // not the command; command-position detection must not fire.
+            expect(found("list assert 1`b'")).toHaveLength(0);
+        });
+        it("treats statements independently: cap assert 1`b'\\ngen y = assert[2`c']", () => {
+            expect(found("cap assert 1`b'\ngen y = assert[2`c']")).toHaveLength(1);
+        });
+    });
+
     describe('Non-detection (false-positive guards)', () => {
         it("does not flag varname-macro: generate x`i' = 1", () => {
             expect(found("generate x`i' = 1")).toHaveLength(0);

--- a/tests/unit/mixed-logical-diagnostics.test.ts
+++ b/tests/unit/mixed-logical-diagnostics.test.ts
@@ -428,6 +428,20 @@ describe('MixedLogicalOperatorAnalyzer Unit Tests', () => {
             );
             expect(mixed).toHaveLength(0);
         });
+
+        it('respects @lsp-ignore on the trailing line of a /// mix', () => {
+            // The `&` sits on line 1 and the `|` on line 2; the ignore
+            // comment is on line 2 only. The diagnostic spans both lines,
+            // so it must be suppressed (#268).
+            const doc = create_document_state(
+                'keep if x & /// \n y | z // @lsp-ignore'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const mixed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+            expect(mixed).toHaveLength(0);
+        });
     });
 
     describe('Continuation Lines', () => {
@@ -438,6 +452,22 @@ describe('MixedLogicalOperatorAnalyzer Unit Tests', () => {
                 d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
             );
             expect(mixed).toHaveLength(1);
+        });
+
+        it('does not merge statements across a ; after a /// (semicolon mode)', () => {
+            // The newline after `///` is WHITESPACE under `#delimit ;`,
+            // so the `;` on the next line is a real terminator. The `&`
+            // and `|` belong to different statements and must not be
+            // reported as a mix. (No `if` qualifier here: that would
+            // flush state on its own and mask the terminator handling.)
+            const doc = create_document_state(
+                '#delimit ;\ngen z = x & y ///\n;\ngen w = a | b ;'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const mixed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+            expect(mixed).toHaveLength(0);
         });
 
         it('does not warn for same operator across /// continuation', () => {

--- a/tests/unit/operator-sequence-diagnostics.test.ts
+++ b/tests/unit/operator-sequence-diagnostics.test.ts
@@ -80,6 +80,57 @@ describe('OperatorSequenceAnalyzer Unit Tests', () => {
         });
     });
 
+    describe('@lsp-ignore Suppression', () => {
+        it('@lsp-ignore-next suppresses a malformed pair on the next line', () => {
+            const doc = create_document_state(
+                '// @lsp-ignore-next\nscalar x = = y'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const malformed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MALFORMED_OPERATOR
+            );
+            expect(malformed).toHaveLength(0);
+        });
+
+        it('respects @lsp-ignore on the trailing line of a /// pair', () => {
+            // The first `=` sits on line 0 and the second on line 1; the
+            // ignore comment is on line 1 only. The diagnostic spans both
+            // lines, so it must be suppressed (#268).
+            const doc = create_document_state(
+                'scalar x = ///\n    = y // @lsp-ignore'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const malformed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MALFORMED_OPERATOR
+            );
+            expect(malformed).toHaveLength(0);
+        });
+
+        it('still reports a /// pair with no ignore directive', () => {
+            const doc = create_document_state('scalar x = ///\n    = y');
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const malformed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MALFORMED_OPERATOR
+            );
+            expect(malformed).toHaveLength(1);
+        });
+
+        it('does not pair operators across a ; after a /// (semicolon mode)', () => {
+            // The newline after `///` is WHITESPACE under `#delimit ;`,
+            // so the `;` on the next line is a real terminator that
+            // breaks operator adjacency: the trailing `=` of the first
+            // statement and the leading `=` of the next are not a pair.
+            const doc = create_document_state(
+                '#delimit ;\nscalar x = ///\n;\n= y ;'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const malformed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MALFORMED_OPERATOR
+            );
+            expect(malformed).toHaveLength(0);
+        });
+    });
+
     describe('Compound Operators Without Spaces (Requirement 4.2)', () => {
         it('<= produces a single OPERATOR token', () => {
             const result = lexer.tokenize('display x <= y');

--- a/tests/unit/st-local-mata.test.ts
+++ b/tests/unit/st-local-mata.test.ts
@@ -140,6 +140,17 @@ describe('st_local / st_global declarations in Mata', () => {
         expect(undefined_macros(src)).toEqual([]);
     });
 
+    it('a ; on the line after a /// ends the inline setter (semicolon mode)', () => {
+        // The newline after `///` lexes as WHITESPACE under `#delimit ;`,
+        // so the `;` on the next line is a REAL terminator: the inline
+        // `mata:` statement ends before the setter receives its name
+        // argument, and no local must be registered.
+        const src =
+            '#delimit ;\nmata: st_local( ///\n;\n"foo", "1") ;\ndisplay `foo\' ;';
+        expect(analyze(src).symbols.localMacros.has('foo')).toBe(false);
+        expect(undefined_macros(src)).toContain('foo');
+    });
+
     it('a reference within the same inline mata unit is not yet defined', () => {
         // `;` is a Mata operator here (one inline statement). Stata expands
         // the line before the Mata code runs, so `foo` is undefined at the

--- a/tests/unit/statement-span.test.ts
+++ b/tests/unit/statement-span.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for next_statement_line_span (issue #268 item 2).
+ *
+ * The span walk drives @lsp-ignore-next suppression: it must cover every
+ * physical line of the next logical statement (including `///`-continued
+ * lines and a `{` block-header line) without ever entering a block body.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { StataLexer } from '../../src/lexer';
+import { next_statement_line_span } from '../../src/utils/statement-span';
+
+const lexer = new StataLexer();
+
+/**
+ * Tokenize `source` and return the span of the statement following the
+ * first COMMENT_LINE containing `@lsp-ignore-next`.
+ */
+function span_after_directive(source: string) {
+    const { tokens } = lexer.tokenize(source);
+    const my_directive_index = tokens.findIndex(
+        (my_token) =>
+            my_token.type === 'COMMENT_LINE' &&
+            my_token.value.includes('@lsp-ignore-next')
+    );
+    expect(my_directive_index).toBeGreaterThanOrEqual(0);
+    return next_statement_line_span(tokens, my_directive_index);
+}
+
+describe('next_statement_line_span', () => {
+    it('spans a single-line statement', () => {
+        const my_span = span_after_directive(
+            '// @lsp-ignore-next\nlocal x = 1\nlocal y = 2'
+        );
+        expect(my_span).toEqual({ start_line: 1, end_line: 1 });
+    });
+
+    it('spans every line of a ///-continued statement', () => {
+        const my_span = span_after_directive(
+            '// @lsp-ignore-next\nlocal x = 1 + ///\n    2 + ///\n    3\nlocal y = 4'
+        );
+        expect(my_span).toEqual({ start_line: 1, end_line: 3 });
+    });
+
+    it('ends at a comment-only continued line (its newline is a real terminator)', () => {
+        // `///` joins only the immediately following line. A line that is
+        // all comment ends the statement at its own newline — the same
+        // rule collect_significant_tokens applies — so the span covers
+        // the joined comment line but not the code after it.
+        const my_span = span_after_directive(
+            '// @lsp-ignore-next\nlocal x = 1 + ///\n    // interior comment\n    2\nlocal y = 4'
+        );
+        expect(my_span).toEqual({ start_line: 1, end_line: 2 });
+    });
+
+    it('skips blank lines between the directive and the statement', () => {
+        const my_span = span_after_directive(
+            '// @lsp-ignore-next\n\n\nlocal x = 1'
+        );
+        expect(my_span).toEqual({ start_line: 3, end_line: 3 });
+    });
+
+    it('skips other comments between the directive and the statement', () => {
+        const my_span = span_after_directive(
+            '// @lsp-ignore-next\n// unrelated comment\nlocal x = 1'
+        );
+        expect(my_span).toEqual({ start_line: 2, end_line: 2 });
+    });
+
+    it('stops at a { block header and never enters the body', () => {
+        const my_span = span_after_directive(
+            '// @lsp-ignore-next\nif a == 1 {\n    display b\n}'
+        );
+        expect(my_span).toEqual({ start_line: 1, end_line: 1 });
+    });
+
+    it('covers a ///-continued block header up to the {', () => {
+        const my_span = span_after_directive(
+            '// @lsp-ignore-next\nif a == 1 & ///\n    b == 2 {\n    display c\n}'
+        );
+        expect(my_span).toEqual({ start_line: 1, end_line: 2 });
+    });
+
+    it('spans a multi-line statement under #delimit ;', () => {
+        const my_span = span_after_directive(
+            '#delimit ;\n// @lsp-ignore-next\nlocal x = 1 +\n    2 +\n    3 ;\nlocal y = 4 ;'
+        );
+        expect(my_span).toEqual({ start_line: 2, end_line: 4 });
+    });
+
+    it('ends at a real ; terminator on the line after a /// (semicolon mode)', () => {
+        // In `#delimit ;` mode the newline after `///` lexes as
+        // WHITESPACE, so a `;` on the following line is a REAL
+        // terminator — it must end the statement, not be swallowed as
+        // the continuation's newline (which only ever lexes as '\n').
+        const my_span = span_after_directive(
+            '#delimit ;\n// @lsp-ignore-next\nlocal x = 1 ///\n;\ndisplay $undef ;'
+        );
+        expect(my_span).toEqual({ start_line: 2, end_line: 3 });
+    });
+
+    it('skips a #delimit mode switch between directive and statement', () => {
+        const my_span = span_after_directive(
+            '// @lsp-ignore-next\n#delimit ;\nlocal x = 1 ;'
+        );
+        expect(my_span).toEqual({ start_line: 2, end_line: 2 });
+    });
+
+    it('returns undefined when only EOF follows', () => {
+        const my_span = span_after_directive('// @lsp-ignore-next\n');
+        expect(my_span).toBeUndefined();
+    });
+
+    it('spans a lone } as a single-line statement', () => {
+        const my_span = span_after_directive(
+            'if a == 1 {\n    display b\n// @lsp-ignore-next\n}'
+        );
+        expect(my_span).toEqual({ start_line: 3, end_line: 3 });
+    });
+
+    it('stops at a mata block header and never enters the body', () => {
+        const my_span = span_after_directive(
+            '// @lsp-ignore-next\nmata:\n    x = 1 < 2 < 3\nend'
+        );
+        expect(my_span).toEqual({ start_line: 1, end_line: 1 });
+    });
+});


### PR DESCRIPTION
Addresses items **2** and **3** of #268 (item 1 is left as-is per the maintainer comment on the issue; the full command-context infrastructure remains deferred, with its seam documented in `src/providers/command-position.ts`).

## What changed

### Item 2 — `@lsp-ignore-next` covers the whole statement (all diagnostic families)
`ignore_next_non_trivia_line` previously recorded only the **first** physical line of the next statement, so a diagnostic anchored to a later line of a `///`-continued statement escaped suppression. It now records every line the next logical statement spans, via the new `next_statement_line_span` walk (`src/utils/statement-span.ts`):
- `///`-continued and multi-line `#delimit ;` statements are fully covered
- a `{` / `mata` / `python` block header is covered through the opener; the block body never is
- the AST-trivia fallback stays single-line by design (documented in `parse_directive` — every production caller passes tokens, so the token path is authoritative)

### Suppression consistency
All four token-stream analyzers (chained-comparison, mixed-logical, operator-sequence, literal-macro-adjacency) now share `is_diagnostic_range_ignored`, so a trailing `@lsp-ignore` on **any** line a multi-line diagnostic spans suppresses it — previously only `CHAINED_COMPARISON` did this.

### Item 3 — `assert` as a bare-expression command
`LITERAL_MACRO_ADJACENCY` now flags a leading literal-macro pair after `assert` in **command position** (statement start, optionally after `capture`/`quietly`/`noisily` prefixes and colons), via the new `src/providers/command-position.ts`. Both `assert 1`b'` and the adjacent-paren form `assert(1`b') == 10` are flagged like `if 1`b'`, while non-command uses (`display assert(1`b')`, `gen y = assert[1`b']`) stay clean. Kept deliberately separate from the `if`/`while` keyword set used by call-opener detection (folding them together would misclassify those non-command uses — caught in adversarial design review).

### Review-driven correctness fix (swept codebase-wide)
Only a `'\n'` terminator is swallowed by a `///` continuation; under `#delimit ;` the newline after `///` lexes as WHITESPACE, so a `;` on the next line is a **real** statement end. The rule now lives in one shared predicate (`src/utils/continuation.ts`) used by six sites: statement spans, `collect_significant_tokens`, operator adjacency, mixed-logical grouping (×2), and the Mata `st_local`/`st_global` setter scan — the last of which previously registered a local from a setter call the statement never completed, masking a real undefined-macro warning.

## Review process
Three architecture/quality reviewers, an 8-angle `/code-review` fan-out (subagents), and three Codex adversarial rounds. Codex found two real bugs (the `#delimit ;` `;`-after-`///` over-suppression, then the same pattern in the Mata setter scan); both fixed in-branch with regression tests. Final round: Codex "no findings" + independent Opus verification "fix batch is clean". `bun run test` (typecheck + 7056 tests) and `bun run lint` both clean.

## Accepted trade-offs (reviewed, intentionally not changed)
- `next_statement_line_span` is O(statement length) per directive; on an unterminated `#delimit ;` statement mid-edit that is the file tail. Same order as the rest of the per-keystroke pipeline; a cap would reintroduce the correctness gap.
- Colon prefixes outside `SINGLE_LINE_PREFIX_COMMANDS` (`by:`, `svy:`, `xi:`) do not put `assert` in command position — a conservative miss, never a false positive; the deferred command-context resolver is the seam for broadening.
- The tokenless raw-line fallback in `should_suppress_undefined_symbol` keeps single-line semantics (no token stream to walk).
- Two pre-existing, out-of-scope observations from the final sweep (a practically-unreachable value-agnostic check in `parser/index.ts` `find_code_before_on_same_line`; hover's boundary handling tracks no continuation state) were reviewed and left untouched.

https://claude.ai/code/session_0197q1wsx2RtSsnJmZtCSdgk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `@lsp-ignore-next` now applies to the full next statement, including multi-line continuations and `#delimit ;` formatting.
  * `assert` is now recognized correctly in command position for relevant diagnostics.

* **Bug Fixes**
  * Diagnostic suppression now works across multi-line diagnostics instead of only on a single line.
  * Block headers and block bodies are handled more precisely, avoiding over-suppression inside blocks.
  * Operator and logical-comparison warnings now respect continuation lines and semicolon-delimited statements more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #268
