### PR TITLE
Route all swallowed-terminator decisions through the shared predicate; fix hover across /// continuations

### DIFF
--- a/docs/declaration-directives.md
+++ b/docs/declaration-directives.md
@@ -18,8 +18,9 @@ remain permanent aliases, so `// @lsp-ignore` still works.
 
 "The next statement" means every physical line that statement spans:
 a statement continued with `///` (or spanning lines under `#delimit ;`)
-is covered on all of its lines. A statement that opens a `{` block is
-covered through the header line only, never the block body.
+is covered on all of its lines. A statement that opens a block (`{`,
+`mata`, or `python`) is covered through the header line only, never the
+block body.
 
 ```stata
 // Suppress warning on the next line

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -288,7 +288,7 @@ When the next statement spans several physical lines — via `///`
 continuations, or under `#delimit ;` — a standalone `sight: ignore` /
 `sight: ignore-next` covers every line the statement spans, wherever in
 the statement the flagged construct sits. A statement that opens a block
-is covered through its header line (up to and including the `{`), but
+(`{`, `mata`, or `python`) is covered through its header line only, but
 never the block body: to suppress a diagnostic inside a block, put the
 directive on the offending statement inside the block. A trailing
 `// sight: ignore` on any physical line an operator-style diagnostic

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1817,7 +1817,12 @@ export class StataParser {
       }
       
       this.advance(); // consume continuation
-      if (!this.isAtEnd() && this.check('STATEMENT_TERMINATOR')) {
+      // Only the swallowed newline is trivia; a literal terminator on
+      // the next line is a real statement end
+      if (
+        !this.isAtEnd() &&
+        is_swallowed_continuation_terminator(this.peek(), true)
+      ) {
         this.advance(); // skip newline after continuation
       }
       return true;
@@ -2072,9 +2077,16 @@ export class StataParser {
 
       // Collect specification until {
       while (!this.check('LBRACE') && !this.isAtEnd()) {
-        // Stop at statement terminator unless preceded by continuation
+        // Stop at a real statement terminator; only the swallowed '\n'
+        // of a /// continuation is skipped
         if (this.check('STATEMENT_TERMINATOR')) {
-          if (this.current > 0 && this.tokens[this.current - 1].type === 'CONTINUATION') {
+          if (
+            is_swallowed_continuation_terminator(
+              this.tokens[this.current],
+              this.current > 0 &&
+                this.tokens[this.current - 1].type === 'CONTINUATION'
+            )
+          ) {
             this.advance(); // skip newline after continuation
             continue;
           }
@@ -2587,7 +2599,10 @@ export class StataParser {
       if (token.type === 'CONTINUATION') {
         offset++;
         if (this.current + offset < this.tokens.length &&
-            this.tokens[this.current + offset].type === 'STATEMENT_TERMINATOR') {
+            is_swallowed_continuation_terminator(
+              this.tokens[this.current + offset],
+              true
+            )) {
           offset++;
         }
         continue;

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -24,6 +24,7 @@ import {
 } from '../types';
 import { ContextTracker } from '../context-tracker';
 import { isFileCommand } from '../utils/file-path-utils';
+import { is_swallowed_continuation_terminator } from '../utils/continuation';
 
 const PREFIX_COMMANDS = new Set(['by', 'bysort', 'quietly', 'qui', 'capture', 'cap', 'noisily', 'noi']);
 
@@ -3205,8 +3206,14 @@ export class StataParser {
       if (my_token.range.start.line !== current_line) {
         // STATEMENT_TERMINATOR after continuation - skip it and check for continuation
         if (my_token.type === 'STATEMENT_TERMINATOR') {
-          // Look back for a continuation on the previous line
-          if (i > 0 && this.tokens[i - 1].type === 'CONTINUATION') {
+          // Only a swallowed '\n' right after a /// continuation is
+          // trivia; any other terminator is a real statement end.
+          if (
+            is_swallowed_continuation_terminator(
+              my_token,
+              i > 0 && this.tokens[i - 1].type === 'CONTINUATION'
+            )
+          ) {
             current_line = this.tokens[i - 1].range.start.line;
             i--; // skip the continuation too
             continue;

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1804,7 +1804,8 @@ export class StataParser {
   }
 
   /**
-   * Skip continuation token and its following statement terminator.
+   * Skip a continuation token and, if present, the swallowed newline
+   * terminator that follows it.
    * Returns true if a continuation was skipped, false otherwise.
    */
   private skipContinuation(): boolean {
@@ -2563,7 +2564,8 @@ export class StataParser {
 
   // Skip trivia within a macro definition statement, bridging `///`
   // continuations onto the next physical line (skipContinuation consumes
-  // the continuation token AND the following statement terminator).
+  // the continuation token AND its swallowed newline terminator, if
+  // present).
   //
   // Stata 18 MP audit: `local x = ///` followed by `1 / 2` succeeds with
   // `_rc == 0` and x == .5, while bare `local x =` errors with invalid
@@ -2590,8 +2592,9 @@ export class StataParser {
   /**
    * Advance a lookahead offset past trivia, bridging `///` continuations the
    * same way skipMacroDefinitionTrivia does for the live cursor (a continuation
-   * also consumes the following statement terminator). Returns the offset of
-   * the next significant token (or the end-of-token offset).
+   * also consumes its swallowed newline terminator, if present).
+   * Returns the offset of the next significant token (or the
+   * end-of-token offset).
    */
   private nextSignificantOffsetForMacroDef(offset: number): number {
     while (this.current + offset < this.tokens.length) {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -3164,6 +3164,8 @@ export class StataParser {
    * Check if there are non-trivia tokens after the given position on the same line.
    * Returns the first non-trivia token if found, null otherwise.
    * Skips WHITESPACE, COMMENT_LINE, COMMENT_BLOCK, CONTINUATION tokens.
+   * A `///` continuation joins the next physical line, so "same
+   * line" means the same logical line.
    */
   find_code_after_on_same_line(start_pos: number, line: number): Token | null {
     const trivia_types: TokenType[] = [
@@ -3173,12 +3175,30 @@ export class StataParser {
       'CONTINUATION',
     ];
 
+    let current_line = line;
+
     for (let i = start_pos; i < this.tokens.length; i++) {
       const my_token = this.tokens[i];
 
       // Stop if we've moved to a different line
-      if (my_token.range.start.line !== line) {
+      if (my_token.range.start.line !== current_line) {
         return null;
+      }
+
+      // The swallowed '\n' of a /// continuation joins the next
+      // physical line into this logical line
+      if (
+        is_swallowed_continuation_terminator(
+          my_token,
+          i > 0 && this.tokens[i - 1].type === 'CONTINUATION'
+        )
+      ) {
+        const next_token = this.tokens[i + 1];
+        if (!next_token) {
+          return null;
+        }
+        current_line = next_token.range.start.line;
+        continue;
       }
 
       // Stop at statement terminator or EOF
@@ -3202,6 +3222,8 @@ export class StataParser {
    * Check if there are non-trivia tokens before the given position on the same line.
    * Returns the last non-trivia token if found, null otherwise.
    * Skips WHITESPACE, COMMENT_LINE, COMMENT_BLOCK, CONTINUATION tokens.
+   * A `///` continuation joins the next physical line, so "same
+   * line" means the same logical line.
    */
   find_code_before_on_same_line(end_pos: number, line: number): Token | null {
     const trivia_types: TokenType[] = [

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -3171,6 +3171,20 @@ export class StataParser {
    * line" means the same logical line.
    */
   find_code_after_on_same_line(start_pos: number, line: number): Token | null {
+    return this.scan_code_on_same_line(start_pos, line)?.first_token ?? null;
+  }
+
+  /**
+   * Walk the logical line starting at `start_pos` in a single pass
+   * and return its first and last non-trivia tokens, or null when the
+   * line has no code before a real terminator or EOF. A `///`
+   * continuation joins the next physical line into the same logical
+   * line. Skips WHITESPACE, COMMENT_LINE, COMMENT_BLOCK, CONTINUATION.
+   */
+  scan_code_on_same_line(
+    start_pos: number,
+    line: number
+  ): { first_token: Token; last_token: Token } | null {
     const trivia_types: TokenType[] = [
       'WHITESPACE',
       'COMMENT_LINE',
@@ -3178,6 +3192,8 @@ export class StataParser {
       'CONTINUATION',
     ];
 
+    let first_token: Token | null = null;
+    let last_token: Token | null = null;
     let current_line = line;
 
     for (let i = start_pos; i < this.tokens.length; i++) {
@@ -3185,7 +3201,7 @@ export class StataParser {
 
       // Stop if we've moved to a different line
       if (my_token.range.start.line !== current_line) {
-        return null;
+        break;
       }
 
       // The swallowed '\n' of a /// continuation joins the next
@@ -3198,7 +3214,7 @@ export class StataParser {
       ) {
         const next_token = this.tokens[i + 1];
         if (!next_token) {
-          return null;
+          break;
         }
         current_line = next_token.range.start.line;
         continue;
@@ -3206,7 +3222,7 @@ export class StataParser {
 
       // Stop at statement terminator or EOF
       if (my_token.type === 'STATEMENT_TERMINATOR' || my_token.type === 'EOF') {
-        return null;
+        break;
       }
 
       // Skip trivia tokens
@@ -3214,11 +3230,16 @@ export class StataParser {
         continue;
       }
 
-      // Found a non-trivia token on the same line
-      return my_token;
+      if (first_token === null) {
+        first_token = my_token;
+      }
+      last_token = my_token;
     }
 
-    return null;
+    if (first_token === null || last_token === null) {
+      return null;
+    }
+    return { first_token, last_token };
   }
 
   /**
@@ -3364,48 +3385,14 @@ export class StataParser {
 
     // Check for code AFTER the open brace on the same line
     // This is a warning because Stata runs but silently ignores the code
-    const code_after = this.find_code_after_on_same_line(brace_index + 1, brace_line);
+    const code_after = this.scan_code_on_same_line(brace_index + 1, brace_line);
     if (code_after) {
-      // Find the last token on the same logical line to get the full
-      // range, following /// joins like find_code_after_on_same_line
-      let last_token = code_after;
-      let my_current_line = brace_line;
-      for (let i = brace_index + 2; i < this.tokens.length; i++) {
-        const my_token = this.tokens[i];
-        if (my_token.range.start.line !== my_current_line) {
-          break;
-        }
-        if (
-          is_swallowed_continuation_terminator(
-            my_token,
-            i > 0 && this.tokens[i - 1].type === 'CONTINUATION'
-          )
-        ) {
-          const next_token = this.tokens[i + 1];
-          if (!next_token) {
-            break;
-          }
-          my_current_line = next_token.range.start.line;
-          continue;
-        }
-        if (my_token.type === 'STATEMENT_TERMINATOR' || my_token.type === 'EOF') {
-          break;
-        }
-        // Skip trivia when determining the last code token
-        const trivia_types: TokenType[] = [
-          'WHITESPACE',
-          'COMMENT_LINE',
-          'COMMENT_BLOCK',
-          'CONTINUATION',
-        ];
-        if (!trivia_types.includes(my_token.type)) {
-          last_token = my_token;
-        }
-      }
-
       this.errors.push({
         message: 'code after open brace may be silently ignored',
-        range: this.makeRange(brace_token.range.start, last_token.range.end),
+        range: this.makeRange(
+          brace_token.range.start,
+          code_after.last_token.range.end
+        ),
         code: ParseErrorCode.CODE_AFTER_OPEN_BRACE,
       });
     }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -3363,12 +3363,27 @@ export class StataParser {
     // This is a warning because Stata runs but silently ignores the code
     const code_after = this.find_code_after_on_same_line(brace_index + 1, brace_line);
     if (code_after) {
-      // Find the last token on the same line to get the full range
+      // Find the last token on the same logical line to get the full
+      // range, following /// joins like find_code_after_on_same_line
       let last_token = code_after;
+      let my_current_line = brace_line;
       for (let i = brace_index + 2; i < this.tokens.length; i++) {
         const my_token = this.tokens[i];
-        if (my_token.range.start.line !== brace_line) {
+        if (my_token.range.start.line !== my_current_line) {
           break;
+        }
+        if (
+          is_swallowed_continuation_terminator(
+            my_token,
+            i > 0 && this.tokens[i - 1].type === 'CONTINUATION'
+          )
+        ) {
+          const next_token = this.tokens[i + 1];
+          if (!next_token) {
+            break;
+          }
+          my_current_line = next_token.range.start.line;
+          continue;
         }
         if (my_token.type === 'STATEMENT_TERMINATOR' || my_token.type === 'EOF') {
           break;

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -433,6 +433,17 @@ export class HoverProvider {
         let statement_start_index = 0;
         for (let i = end_index; i >= 0; i--) {
             if (tokens[i].type === 'STATEMENT_TERMINATOR') {
+                // A '\n' terminator right after a `///` continuation is
+                // trivia, not a statement boundary — scan past both.
+                if (
+                    is_swallowed_continuation_terminator(
+                        tokens[i],
+                        i > 0 && tokens[i - 1].type === 'CONTINUATION'
+                    )
+                ) {
+                    i--; // skip the continuation too
+                    continue;
+                }
                 statement_start_index = i + 1;
                 break;
             }
@@ -1443,14 +1454,16 @@ export class HoverProvider {
             return { is_subcommand: false, prefix_command: null };
         }
 
-        // Verify the hovered word is a valid subcommand
+        // Verify the hovered word is a valid subcommand. Subcommands
+        // are case-sensitive and stored canonical-lowercase, so compare
+        // exactly: `frame Create` is not valid Stata.
         const subcommands = this.command_db.get_subcommands(potential_prefix);
         if (!subcommands) {
             return { is_subcommand: false, prefix_command: null };
         }
 
         const is_valid_subcommand = subcommands.some(
-            sub => sub.name.toLowerCase() === hovered_word.toLowerCase()
+            sub => sub.name === hovered_word
         );
 
         if (!is_valid_subcommand) {
@@ -1561,8 +1574,9 @@ export class HoverProvider {
                     && words_after_colon.length === 1
                 ) {
                     const subcommands = this.command_db.get_subcommands(potential_prefix);
+                    // Exact match: subcommands are case-sensitive.
                     const is_valid = subcommands?.some(
-                        sub => sub.name.toLowerCase() === hovered_word.toLowerCase()
+                        sub => sub.name === hovered_word
                     );
                     if (is_valid) {
                         return { is_subcommand: true, prefix_command: potential_prefix };
@@ -1590,14 +1604,15 @@ export class HoverProvider {
             return { is_subcommand: false, prefix_command: null };
         }
 
-        // Verify the hovered word is a valid subcommand
+        // Verify the hovered word is a valid subcommand. Exact match:
+        // subcommands are case-sensitive and stored canonical-lowercase.
         const subcommands = this.command_db.get_subcommands(potential_prefix);
         if (!subcommands) {
             return { is_subcommand: false, prefix_command: null };
         }
 
         const is_valid_subcommand = subcommands.some(
-            sub => sub.name.toLowerCase() === hovered_word.toLowerCase()
+            sub => sub.name === hovered_word
         );
 
         if (!is_valid_subcommand) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -430,24 +430,8 @@ export class HoverProvider {
         // Walk backwards to find the start of the current statement. If
         // no STATEMENT_TERMINATOR is found, the statement starts at the
         // beginning of the file.
-        let statement_start_index = 0;
-        for (let i = end_index; i >= 0; i--) {
-            if (tokens[i].type === 'STATEMENT_TERMINATOR') {
-                // A '\n' terminator right after a `///` continuation is
-                // trivia, not a statement boundary — scan past both.
-                if (
-                    is_swallowed_continuation_terminator(
-                        tokens[i],
-                        i > 0 && tokens[i - 1].type === 'CONTINUATION'
-                    )
-                ) {
-                    i--; // skip the continuation too
-                    continue;
-                }
-                statement_start_index = i + 1;
-                break;
-            }
-        }
+        const statement_start_index =
+            this.find_statement_start_index(tokens, end_index);
 
         // Forward scan the statement window, matching the original
         // depth-tracking semantics. A comma counts as top-level whenever
@@ -475,6 +459,34 @@ export class HoverProvider {
         }
 
         return false;
+    }
+
+    /**
+     * Index of the first token of the statement containing
+     * `end_index`, scanning backward to the previous real statement
+     * boundary. A '\n' terminator right after a `///` continuation is
+     * trivia, not a boundary — the scan crosses it (and the
+     * continuation). Returns 0 when no boundary exists.
+     */
+    private find_statement_start_index(
+        tokens: Token[],
+        end_index: number
+    ): number {
+        for (let i = end_index; i >= 0; i--) {
+            if (tokens[i].type === 'STATEMENT_TERMINATOR') {
+                if (
+                    is_swallowed_continuation_terminator(
+                        tokens[i],
+                        i > 0 && tokens[i - 1].type === 'CONTINUATION'
+                    )
+                ) {
+                    i--; // skip the continuation too
+                    continue;
+                }
+                return i + 1;
+            }
+        }
+        return 0;
     }
 
     /**
@@ -1368,24 +1380,8 @@ export class HoverProvider {
         }
 
         // Find the start of the current statement (after last STATEMENT_TERMINATOR or start of file)
-        let statement_start_index = 0;
-        for (let i = hovered_token_index - 1; i >= 0; i--) {
-            if (tokens[i].type === 'STATEMENT_TERMINATOR') {
-                // A '\n' terminator right after a `///` continuation is
-                // trivia, not a statement boundary — scan past both.
-                if (
-                    is_swallowed_continuation_terminator(
-                        tokens[i],
-                        i > 0 && tokens[i - 1].type === 'CONTINUATION'
-                    )
-                ) {
-                    i--; // skip the continuation too
-                    continue;
-                }
-                statement_start_index = i + 1;
-                break;
-            }
-        }
+        const statement_start_index =
+            this.find_statement_start_index(tokens, hovered_token_index - 1);
 
         // Collect non-trivia WORD tokens from statement start to hovered token.
         // Preserve raw source case; Stata commands/prefixes are case-sensitive.

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1636,13 +1636,15 @@ export class HoverProvider {
             return null;
         }
 
-        const prefix = context.prefix_command.toLowerCase();
-        const subcommand = word.toLowerCase();
+        // The context gate already validated prefix and subcommand with
+        // exact case, so both are canonical-lowercase here — compare
+        // exactly like the validation sites.
+        const prefix = context.prefix_command;
 
         // Get subcommand from command database
         const subcommands = this.command_db.get_subcommands(prefix);
         if (subcommands) {
-            const sub = subcommands.find(s => s.name.toLowerCase() === subcommand);
+            const sub = subcommands.find(s => s.name === word);
             if (sub) {
                 // Capitalize prefix name for display
                 const prefix_display = prefix.charAt(0).toUpperCase() + prefix.slice(1);

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -42,6 +42,7 @@ import { IContextTracker } from '../context-tracker/types';
 import { LanguageContext } from '../context-tracker/types';
 import { ScopeResolver } from '../scope-resolver';
 import { format_help_link } from '../utils/help-link';
+import { is_swallowed_continuation_terminator } from '../utils/continuation';
 import type { WorkspaceIndexer } from '../indexer';
 import { build_scope_resolver_config } from '../scope-resolver';
 import { get_visible_symbols_at } from '../scope-resolver';
@@ -1359,6 +1360,17 @@ export class HoverProvider {
         let statement_start_index = 0;
         for (let i = hovered_token_index - 1; i >= 0; i--) {
             if (tokens[i].type === 'STATEMENT_TERMINATOR') {
+                // A '\n' terminator right after a `///` continuation is
+                // trivia, not a statement boundary — scan past both.
+                if (
+                    is_swallowed_continuation_terminator(
+                        tokens[i],
+                        i > 0 && tokens[i - 1].type === 'CONTINUATION'
+                    )
+                ) {
+                    i--; // skip the continuation too
+                    continue;
+                }
                 statement_start_index = i + 1;
                 break;
             }

--- a/src/providers/mixed-logical-diagnostics.ts
+++ b/src/providers/mixed-logical-diagnostics.ts
@@ -132,8 +132,8 @@ export class MixedLogicalOperatorAnalyzer {
             }
 
             if (my_token.type === 'COMMA') {
+                my_in_continuation = false;
                 if (my_state.paren_depth === 0) {
-                    my_in_continuation = false;
                     this.flush(my_state, my_diagnostics, my_severity, my_ignored_lines);
                     my_state = this.fresh_state();
                 } else {

--- a/src/utils/continuation.ts
+++ b/src/utils/continuation.ts
@@ -11,11 +11,13 @@ import { Token } from '../types';
  * is a literal `;` — always a real statement end.
  *
  * Shared by every token scan that applies this rule, so it cannot
- * drift between them: forward scans pass an in-continuation flag they
- * track across trivia; backward scans (brace placement, hover
- * statement-start) pass "the immediately preceding token is a
- * CONTINUATION", which is equivalent because the lexer emits the
- * swallowed '\n' terminator directly after its continuation token.
+ * drift between them. Callers either track an in-continuation flag
+ * across trivia (statement spans, the diagnostics token scans) or
+ * pass "the token adjacent to this terminator is a CONTINUATION"
+ * when they only ever look one token away from a continuation
+ * (brace placement, hover statement-start, the parser's trivia
+ * skips). Both are equivalent because the lexer emits the swallowed
+ * '\n' terminator directly after its continuation token.
  */
 export function is_swallowed_continuation_terminator(
     my_token: Token,

--- a/src/utils/continuation.ts
+++ b/src/utils/continuation.ts
@@ -12,12 +12,14 @@ import { Token } from '../types';
  *
  * Shared by every token scan that applies this rule, so it cannot
  * drift between them. Callers either track an in-continuation flag
- * across trivia (statement spans, the diagnostics token scans) or
- * pass "the token adjacent to this terminator is a CONTINUATION"
- * when they only ever look one token away from a continuation
- * (brace placement, hover statement-start, the parser's trivia
- * skips). Both are equivalent because the lexer emits the swallowed
- * '\n' terminator directly after its continuation token.
+ * across trivia (e.g. statement spans, the diagnostics token scans,
+ * the analyzer's Mata-setter forward scan) or pass "the token
+ * adjacent to this terminator is a CONTINUATION" when they only
+ * ever look one token away from a continuation (e.g. brace
+ * placement, hover statement-start, the parser's trivia skips, the
+ * analyzer's Mata-setter backward scan). Both are equivalent
+ * because the lexer emits the swallowed '\n' terminator directly
+ * after its continuation token.
  */
 export function is_swallowed_continuation_terminator(
     my_token: Token,

--- a/src/utils/continuation.ts
+++ b/src/utils/continuation.ts
@@ -10,10 +10,12 @@ import { Token } from '../types';
  * WHITESPACE, so any STATEMENT_TERMINATOR seen mid-continuation there
  * is a literal `;` — always a real statement end.
  *
- * Shared by every token scan that tracks an in-continuation flag
- * (statement spans, significant-token collection, operator adjacency,
- * mixed-logical grouping, Mata setter scanning) so the rule cannot
- * drift between them.
+ * Shared by every token scan that applies this rule, so it cannot
+ * drift between them: forward scans pass an in-continuation flag they
+ * track across trivia; backward scans (brace placement, hover
+ * statement-start) pass "the immediately preceding token is a
+ * CONTINUATION", which is equivalent because the lexer emits the
+ * swallowed '\n' terminator directly after its continuation token.
  */
 export function is_swallowed_continuation_terminator(
     my_token: Token,

--- a/tests/property/close-brace-validation.prop.test.ts
+++ b/tests/property/close-brace-validation.prop.test.ts
@@ -743,6 +743,30 @@ describe('Close Brace Validation Property Tests', () => {
             );
         });
 
+        it('extends the CODE_AFTER_OPEN_BRACE range across a /// join to the last code token', () => {
+            // The single-line form ranges through all the offending
+            // code; the ///-joined form must do the same, not stop at
+            // the first token of the continued line.
+            fc.assert(
+                fc.property(arbitrary_command, arbitrary_command, (cmd1, cmd2) => {
+                    const document = `if 1 > 0 { ///\n ${cmd1} ${cmd2}\n}`;
+                    const { errors } = parse_document(document);
+
+                    const my_error = errors.find(
+                        e => e.code === ParseErrorCode.CODE_AFTER_OPEN_BRACE
+                    ) as { range?: { end: { line: number; character: number } } } | undefined;
+                    if (!my_error || !my_error.range) {
+                        return false;
+                    }
+
+                    const expected_end_character = ` ${cmd1} ${cmd2}`.length;
+                    return my_error.range.end.line === 1 &&
+                        my_error.range.end.character === expected_end_character;
+                }),
+                { numRuns: 100 }
+            );
+        });
+
         it('flags BRACE_ELSE_SAME_LINE for `else` joined to a close brace via ///', () => {
             fc.assert(
                 fc.property(arbitrary_command, (cmd1) => {

--- a/tests/property/close-brace-validation.prop.test.ts
+++ b/tests/property/close-brace-validation.prop.test.ts
@@ -689,4 +689,36 @@ describe('Close Brace Validation Property Tests', () => {
             );
         });
     });
+
+    /**
+     * Continuation handling: `find_code_before_on_same_line` follows a
+     * `///` continuation across the swallowed '\n' terminator (see
+     * is_swallowed_continuation_terminator), joining the physical lines
+     * into one logical line for brace placement checks.
+     */
+    describe('Brace placement across /// continuations', () => {
+        it('does not flag OPEN_BRACE_ALONE when the condition continues via ///', () => {
+            fc.assert(
+                fc.property(arbitrary_command, (cmd1) => {
+                    const document = `if 1 > 0 ///\n{\n    ${cmd1}\n}`;
+                    const { errors } = parse_document(document);
+
+                    return !has_error_code(errors, ParseErrorCode.OPEN_BRACE_ALONE);
+                }),
+                { numRuns: 20 }
+            );
+        });
+
+        it('flags BRACE_NOT_ALONE for a close brace joined to code via ///', () => {
+            fc.assert(
+                fc.property(arbitrary_command, (cmd1) => {
+                    const document = `if 1 > 0 {\n    ${cmd1} ///\n}`;
+                    const { errors } = parse_document(document);
+
+                    return has_error_code(errors, ParseErrorCode.BRACE_NOT_ALONE);
+                }),
+                { numRuns: 20 }
+            );
+        });
+    });
 });

--- a/tests/property/close-brace-validation.prop.test.ts
+++ b/tests/property/close-brace-validation.prop.test.ts
@@ -727,5 +727,32 @@ describe('Close Brace Validation Property Tests', () => {
                 { numRuns: 100 }
             );
         });
+
+        it('flags CODE_AFTER_OPEN_BRACE for code joined to an open brace via ///', () => {
+            // `{ ///` joins the next physical line, so the code there is
+            // logically on the brace line and Stata silently ignores it —
+            // the same warning as the single-line `if 1 > 0 { display`.
+            fc.assert(
+                fc.property(arbitrary_command, (cmd1) => {
+                    const document = `if 1 > 0 { ///\n ${cmd1}\n}`;
+                    const { errors } = parse_document(document);
+
+                    return has_error_code(errors, ParseErrorCode.CODE_AFTER_OPEN_BRACE);
+                }),
+                { numRuns: 100 }
+            );
+        });
+
+        it('flags BRACE_ELSE_SAME_LINE for `else` joined to a close brace via ///', () => {
+            fc.assert(
+                fc.property(arbitrary_command, (cmd1) => {
+                    const document = `if 1 > 0 {\n    ${cmd1}\n} ///\nelse {\n    ${cmd1}\n}`;
+                    const { errors } = parse_document(document);
+
+                    return has_error_code(errors, ParseErrorCode.BRACE_ELSE_SAME_LINE);
+                }),
+                { numRuns: 100 }
+            );
+        });
     });
 });

--- a/tests/property/close-brace-validation.prop.test.ts
+++ b/tests/property/close-brace-validation.prop.test.ts
@@ -705,7 +705,7 @@ describe('Close Brace Validation Property Tests', () => {
 
                     return !has_error_code(errors, ParseErrorCode.OPEN_BRACE_ALONE);
                 }),
-                { numRuns: 20 }
+                { numRuns: 100 }
             );
         });
 
@@ -717,7 +717,7 @@ describe('Close Brace Validation Property Tests', () => {
 
                     return has_error_code(errors, ParseErrorCode.BRACE_NOT_ALONE);
                 }),
-                { numRuns: 20 }
+                { numRuns: 100 }
             );
         });
     });

--- a/tests/property/close-brace-validation.prop.test.ts
+++ b/tests/property/close-brace-validation.prop.test.ts
@@ -695,6 +695,13 @@ describe('Close Brace Validation Property Tests', () => {
      * `///` continuation across the swallowed '\n' terminator (see
      * is_swallowed_continuation_terminator), joining the physical lines
      * into one logical line for brace placement checks.
+     *
+     * These lock the continuation-crossing contract the stricter
+     * value-checked predicate must preserve. They cannot differentiate
+     * the predicate from a value-agnostic check: the divergent state (a
+     * non-'\n' terminator directly after a CONTINUATION) is unreachable
+     * from the lexer, which is why the predicate swap is behavior-
+     * preserving (issue #281).
      */
     describe('Brace placement across /// continuations', () => {
         it('does not flag OPEN_BRACE_ALONE when the condition continues via ///', () => {

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -341,6 +341,23 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             }
         });
 
+        it('should return subcommand hover across a `///` continuation', async () => {
+            command_db = create_frame_command_db();
+            hover_provider = new HoverProvider(command_db, context_tracker);
+
+            const my_content = 'frame ///\ncreate myframe';
+            const my_doc = create_test_document(my_content);
+            init_tracker_from_source(context_tracker, my_content);
+
+            // cursor is on "create" at line 1, column 2
+            const my_hover = await hover_provider.get_hover(my_doc, { line: 1, character: 2 });
+
+            expect(my_hover).not.toBeNull();
+            if (typeof my_hover?.contents === 'object' && 'value' in my_hover.contents) {
+                expect(my_hover.contents.value).toContain('Frame Subcommand');
+            }
+        });
+
         it('should not return subcommand hover for uppercase `BY` prefix (Stata is case-sensitive)', async () => {
             command_db = create_frame_command_db();
             hover_provider = new HoverProvider(command_db, context_tracker);

--- a/tests/unit/hover.test.ts
+++ b/tests/unit/hover.test.ts
@@ -358,6 +358,46 @@ describe('HoverProvider - Context-Aware Behavior', () => {
             }
         });
 
+        it('should not return command hover after a top-level comma split by ///', async () => {
+            const my_content = 'regress y x, ///\n generate';
+            const my_doc = create_test_document(my_content);
+            init_tracker_from_source(context_tracker, my_content);
+
+            // cursor is on "generate" at line 1, column 2 — option
+            // position, same as the single-line `regress y x, generate`
+            const my_hover = await hover_provider.get_hover(my_doc, { line: 1, character: 2 });
+
+            expect(my_hover).toBeNull();
+        });
+
+        it('should not return subcommand hover for mis-cased `Create` across a /// continuation', async () => {
+            command_db = create_frame_command_db();
+            hover_provider = new HoverProvider(command_db, context_tracker);
+
+            const my_content = 'frame ///\nCreate myframe';
+            const my_doc = create_test_document(my_content);
+            init_tracker_from_source(context_tracker, my_content);
+
+            // cursor is on "Create" at line 1, column 2
+            const my_hover = await hover_provider.get_hover(my_doc, { line: 1, character: 2 });
+
+            expect(my_hover).toBeNull();
+        });
+
+        it('should not return subcommand hover for mis-cased `Create` subcommand (Stata is case-sensitive)', async () => {
+            command_db = create_frame_command_db();
+            hover_provider = new HoverProvider(command_db, context_tracker);
+
+            const my_content = 'frame Create myframe';
+            const my_doc = create_test_document(my_content);
+            init_tracker_from_source(context_tracker, my_content);
+
+            // cursor is on "Create" at column 8
+            const my_hover = await hover_provider.get_hover(my_doc, { line: 0, character: 8 });
+
+            expect(my_hover).toBeNull();
+        });
+
         it('should not return subcommand hover for uppercase `BY` prefix (Stata is case-sensitive)', async () => {
             command_db = create_frame_command_db();
             hover_provider = new HoverProvider(command_db, context_tracker);
@@ -426,6 +466,33 @@ describe('HoverProvider - Context-Aware Behavior', () => {
                     my_doc,
                     { line: 0, character: 8 } as Position,
                     'create'
+                );
+
+                expect(my_result).toEqual({
+                    is_subcommand: false,
+                    prefix_command: null,
+                });
+            }
+        );
+
+        it(
+            'should not detect line-fallback subcommand context for mis-cased `Create` subcommand',
+            () => {
+                command_db = create_frame_command_db();
+                hover_provider = new HoverProvider(command_db, context_tracker);
+
+                const my_content = 'frame Create mygood';
+                const my_doc = {
+                    uri: 'file:///test.do',
+                    version: 1,
+                    content: my_content,
+                    tokens: [],
+                } as unknown as DocumentState;
+
+                const my_result = (hover_provider as any).get_subcommand_context_from_line(
+                    my_doc,
+                    { line: 0, character: 8 } as Position,
+                    'Create'
                 );
 
                 expect(my_result).toEqual({

--- a/tests/unit/mixed-logical-diagnostics.test.ts
+++ b/tests/unit/mixed-logical-diagnostics.test.ts
@@ -470,6 +470,21 @@ describe('MixedLogicalOperatorAnalyzer Unit Tests', () => {
             expect(mixed).toHaveLength(0);
         });
 
+        it('resets continuation state at a comma inside parens (semicolon mode)', () => {
+            // `foo(x ///\n, y)` reaches the comma-inside-parens branch
+            // right after a continuation. The flag must reset there so
+            // the later real `;` terminator ends the statement and the
+            // `&` and `|` are never reported as a cross-statement mix.
+            const doc = create_document_state(
+                '#delimit ;\ngen z = foo(x ///\n, y) & w ;\ngen q = a | b ;'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const mixed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+            expect(mixed).toHaveLength(0);
+        });
+
         it('does not warn for same operator across /// continuation', () => {
             const doc = create_document_state('keep if x & /// \n y & z');
             const diagnostics = analyzer.analyze(doc, default_config);

--- a/tests/unit/mixed-logical-diagnostics.test.ts
+++ b/tests/unit/mixed-logical-diagnostics.test.ts
@@ -470,11 +470,13 @@ describe('MixedLogicalOperatorAnalyzer Unit Tests', () => {
             expect(mixed).toHaveLength(0);
         });
 
-        it('resets continuation state at a comma inside parens (semicolon mode)', () => {
+        it('keeps statements separate when a comma inside parens follows a /// (semicolon mode)', () => {
             // `foo(x ///\n, y)` reaches the comma-inside-parens branch
-            // right after a continuation. The flag must reset there so
-            // the later real `;` terminator ends the statement and the
-            // `&` and `|` are never reported as a cross-statement mix.
+            // right after a continuation. The reset there is hygiene —
+            // a `;` terminator's value is never '\n', so the stale flag
+            // cannot change output today. This locks the statement
+            // separation in case the swallowed-terminator value guard
+            // is ever weakened.
             const doc = create_document_state(
                 '#delimit ;\ngen z = foo(x ///\n, y) & w ;\ngen q = a | b ;'
             );


### PR DESCRIPTION
Closes #281.

## What this does

Issue #281 listed four small residuals from the PR #279 review sweep. Implementing them — and holding the branch to a two-consecutive-clean-rounds review gate — surfaced several more members of the same pattern family, all fixed here:

**Swallowed-terminator hygiene.** Every decision of the form "is this `STATEMENT_TERMINATOR` the trivia newline swallowed by a `///` continuation, or a real statement end?" now routes through the shared `is_swallowed_continuation_terminator` predicate (requires value `'\n'`; under `#delimit ;` a literal `;` is always a real boundary):
- `find_code_before_on_same_line` (parser) — the instance named in the issue
- `get_subcommand_context_from_tokens` (hover) — **user-visible fix**: subcommand hover now works across `///` continuations (`frame ///` + `create x` previously lost its prefix)
- `is_after_top_level_comma` (hover) — **user-visible fix**: a word in option position split across a `///` (`regress y x, ///` + `generate`) no longer gets spurious command hover
- `skipContinuation`, the forvalues/foreach loop-spec collector, and `nextSignificantOffsetForMacroDef` (parser forward trivia skips)
- `find_code_after_on_same_line` (parser) — **user-visible fix**: `if 1 > 0 { ///` + code now fires `CODE_AFTER_OPEN_BRACE`, and `} ///` + `else` fires `BRACE_ELSE_SAME_LINE`, matching the single-line forms
- `validate_open_brace`'s range-extension loop — the diagnostic range spans the full `///`-joined code instead of truncating at the first token

**Exact-case subcommand validation** (hover): all four subcommand-name comparison sites now compare exactly (`sub.name === word`). `frame Create` no longer gets subcommand hover — Stata is case-sensitive and rejects it — matching the pre-existing exact-case prefix guard.

**Mixed-logical diagnostics**: the comma-inside-parens branch now resets `my_in_continuation` like every sibling branch (hygiene; provably no behavior change today, and the test says so honestly).

**Docs**: block coverage wording in `docs/declaration-directives.md` and `docs/diagnostics.md` now names all three opener forms (`{`, `mata`, `python`), per CodeRabbit's suggestions on PR #279; the predicate's doc comment describes both caller mechanisms accurately.

**Tests**: 9 new tests (hover continuation/option-position/case-sensitivity; mixed-logical semicolon-mode comma; brace placement and diagnostic ranges across `///` joins), each verified to fail on the pre-fix code where the behavior is observable.

## Reviewed deferrals (not addressed here, by decision)

1. **Subcommand abbreviations never match hover validation** (`mi est: …` shows the standalone `estimates` command hover instead of `Mi Subcommand: estimate`). Verified pre-existing by probing an identical build of `main`: behavior is byte-identical before and after this branch. Abbreviation-aware subcommand hover is a separable enhancement.
2. **Mis-cased subcommand-slot words fall through to generic command hover** (`mi Estimate: …` now shows the `estimates` command hover). This is the intended consequence of rejecting invalid subcommand hover: the fall-through is the same position-agnostic, case-normalized command-DB lookup any word gets, a convenience CLAUDE.md explicitly sanctions. On `main` this input falsely validated as subcommand hover. Suppressing the fall-through entirely is a separate design question.
3. **`git diff --check` reports whitespace on added lines in `src/parser/index.ts`** — inherent to that file being committed with CRLF line endings; every added line intentionally matches the file's existing CRLF convention (verified byte-level: no mixed endings introduced).
4. **`skipToStatementEnd`** (program-define error recovery) treats any terminator as a boundary; byte-identical to `main`, only reachable in an error-recovery path, left untouched.

## Review gate

Per the agreed gate, the final diff passed **two consecutive fully-clean rounds** (rounds 11 and 12) of four independent reviewers each: Codex plus three cold Claude reviewers (correctness / conventions-and-docs / un-primed sweep). Earlier rounds' findings — including two user-visible hover bugs, the brace-diagnostic misses, a diagnostic-range truncation, and several comment-accuracy issues — were each fixed in-branch with regression tests where observable (commits are one-per-review-round).

`bun run test` (typecheck + 7072 tests) and `bun run lint` (not in CI) are clean.

https://claude.ai/code/session_01SF2TJXvsBx5cjmi2LRvpBn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified multi-line directive coverage semantics for continued blocks, including embedded language blocks.
  - Updated suppression guidance for continued `///` blocks and opening/terminator coverage.

- **Bug Fixes**
  - Improved statement-boundary handling across `///` continuations to ensure hover and diagnostics are computed correctly.
  - Made subcommand-hover resolution case-sensitive for more accurate matching.
  - Refined brace-placement diagnostics for logically joined lines and expanded relevant diagnostic ranges.
  - Fixed mixed logical operator detection around commas in continued lines.

- **Tests**
  - Added/expanded property and unit tests for brace placement, hover behavior, and continued-line mixed-operator scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->