### PR TITLE
Make hover/definition/references/completion scope-aware for local macros

### DIFF
--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -985,23 +985,25 @@ export class SemanticAnalyzer {
         // These all mutate program_symbol.* and must follow first-def-wins
         // semantics to match location / additional_definitions behaviour.
         //
-        // NOTE: `extract_and_attach_signature` does NOT register implicit
-        // locals into `program_scope` — it only merges/attaches
-        // `ProgramSignature` metadata onto `program_symbol.signature` (and
-        // the node). The implicit locals from `syntax` arguments/options
-        // are registered by `analyze_syntax_node` ->
-        // `register_implicit_locals`, which runs during the UNCONDITIONAL
-        // `build_symbols_in_body` traversal above for every redeclared
-        // body, not just the first — so each body's own implicit locals
-        // (e.g. `` `b' `` from that body's own `syntax varlist, B(string)`)
-        // resolve correctly regardless of this gate.
+        // NOTE: `extract_and_attach_signature` does NOT register
+        // implicit locals into `program_scope` — it only merges and
+        // attaches `ProgramSignature` metadata onto
+        // `program_symbol.signature` (and the node). Implicit locals
+        // from `syntax` arguments/options are registered by
+        // `analyze_syntax_node` -> `register_implicit_locals`, which
+        // runs during the UNCONDITIONAL `build_symbols_in_body`
+        // traversal above for every redeclared body, not just the
+        // first — so each body's own implicit locals (e.g. `` `b' ``
+        // from that body's own `syntax varlist, B(string)`) resolve
+        // correctly regardless of this gate.
         //
-        // What first-def-wins DOES limit: for a redeclared program whose
-        // body #2 declares a DIFFERENT signature, `program_symbol.signature`
-        // keeps body #1's signature. Consumers reading `.signature`
-        // (program-argument completion, hover parameter display) show
-        // body #1's parameters even inside body #2 — a narrow, pre-existing
-        // signature-metadata limitation, not a diagnostics false positive.
+        // What first-def-wins DOES limit: for a redeclared program
+        // whose body #2 declares a DIFFERENT signature,
+        // `program_symbol.signature` keeps body #1's signature.
+        // Consumers reading `.signature` (program-argument completion,
+        // hover parameter display) show body #1's parameters even
+        // inside body #2 — a narrow, pre-existing signature-metadata
+        // limitation, not a diagnostics false positive.
         if (is_first_definition) {
             // Extract c_local macro names from program body
             const c_locals = this.extract_c_locals(node.body);
@@ -1009,9 +1011,9 @@ export class SemanticAnalyzer {
                 program_symbol.c_locals = c_locals;
             }
 
-            // Extract and attach signature metadata from program body FIRST
-            // (implicit locals are registered per body by analyze_syntax_node
-            // during the unconditional traversal above, not here)
+            // Extract and attach signature metadata from the body
+            // FIRST (implicit locals are registered per body by
+            // analyze_syntax_node in the traversal above, not here)
             this.extract_and_attach_signature(node, program_symbol, program_scope, symbols);
 
             // Extract macro-creating option patterns from program body

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -3615,6 +3615,13 @@ export class SemanticAnalyzer {
      * turn a genuine forward reference into a resolved one — see the
      * "Consumers read the PRIMARY definition markers" invariant in
      * `inject_expanded_macro`.
+     *
+     * LOCKSTEP: `macro_resolves_at_position` in utils/scoped-locals.ts
+     * is the providers' position-only mirror of this method (minus the
+     * preorder-index check, which has no position equivalent). Any
+     * change to the visibility_start / line / same-line rules here
+     * must be applied there too, or navigation and diagnostics will
+     * disagree about whether a reference resolves.
      */
     private macro_resolves_at_reference(
         macro: MacroSymbol,

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -3,6 +3,7 @@ import {
     find_enclosing_scope,
     program_body_start_line,
 } from '../utils/scope-position';
+import { assemble_visible_scopes } from '../utils/scoped-locals';
 import {
     format_undefined_macro_message,
     format_undefined_variable_message,
@@ -3452,12 +3453,10 @@ export class SemanticAnalyzer {
         }
 
         const dofile_scope = this.current_scopes[0];
-        const the_visible_scopes =
-            reference_scope.type !== 'dofile' &&
-            dofile_scope !== undefined &&
-            dofile_scope !== reference_scope
-                ? [reference_scope, dofile_scope]
-                : [reference_scope];
+        const the_visible_scopes = assemble_visible_scopes(
+            reference_scope,
+            dofile_scope
+        );
 
         let same_name_in_visible_scope = false;
         for (const my_scope of the_visible_scopes) {

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -984,20 +984,23 @@ export class SemanticAnalyzer {
         // These all mutate program_symbol.* and must follow first-def-wins
         // semantics to match location / additional_definitions behaviour.
         //
-        // Known limitation (outside issue #135 scope): the first-def-wins
-        // gate below also gates `extract_and_attach_signature`, which is
-        // the only code path that registers implicit locals from `syntax`
-        // into `program_scope`. For redeclared programs with *different*
-        // signatures, body #2's implicit locals are therefore not
-        // registered, and a reference to `` `B' `` in body #2 where the
-        // second body declared `syntax varlist, B(string)` will emit a
-        // false-positive "undefined local macro" diagnostic. The pattern
-        // (two `program define NAME` blocks in one file with divergent
-        // signatures) is rare in practice — dropping and redefining a
-        // program usually uses `program drop NAME` first. If this bites,
-        // the fix is to split signature extraction into "register implicit
-        // locals" (per body) and "attach signature to program_symbol"
-        // (first-def-wins only).
+        // NOTE: `extract_and_attach_signature` does NOT register implicit
+        // locals into `program_scope` — it only merges/attaches
+        // `ProgramSignature` metadata onto `program_symbol.signature` (and
+        // the node). The implicit locals from `syntax` arguments/options
+        // are registered by `analyze_syntax_node` ->
+        // `register_implicit_locals`, which runs during the UNCONDITIONAL
+        // `build_symbols_in_body` traversal above for every redeclared
+        // body, not just the first — so each body's own implicit locals
+        // (e.g. `` `b' `` from that body's own `syntax varlist, B(string)`)
+        // resolve correctly regardless of this gate.
+        //
+        // What first-def-wins DOES limit: for a redeclared program whose
+        // body #2 declares a DIFFERENT signature, `program_symbol.signature`
+        // keeps body #1's signature. Consumers reading `.signature`
+        // (program-argument completion, hover parameter display) show
+        // body #1's parameters even inside body #2 — a narrow, pre-existing
+        // signature-metadata limitation, not a diagnostics false positive.
         if (is_first_definition) {
             // Extract c_local macro names from program body
             const c_locals = this.extract_c_locals(node.body);
@@ -1005,8 +1008,9 @@ export class SemanticAnalyzer {
                 program_symbol.c_locals = c_locals;
             }
 
-            // Extract and attach signature from program body FIRST
-            // This also registers implicit locals from all syntax commands
+            // Extract and attach signature metadata from program body FIRST
+            // (implicit locals are registered per body by analyze_syntax_node
+            // during the unconditional traversal above, not here)
             this.extract_and_attach_signature(node, program_symbol, program_scope, symbols);
 
             // Extract macro-creating option patterns from program body

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -36,7 +36,7 @@ import {
     ScopeInfo,
 } from '../types';
 import { program_body_start_line } from '../utils/scope-position';
-import { lookup_scoped_local_macro } from '../utils/scoped-locals';
+import { collect_visible_local_macros } from '../utils/scoped-locals';
 import { IContextTracker, LanguageContext } from '../context-tracker/types';
 import { CompletionPrefixCache } from '../utils/lru-cache';
 import { SymbolIndexCache } from '../utils/symbol-index-cache';
@@ -1734,6 +1734,11 @@ export class CompletionProvider {
                 the_scoped_names.add(my_name);
             }
         }
+        // Position-invariant across the loop below: resolve the
+        // enclosing scope once, not per candidate name.
+        const the_visible_macros = collect_visible_local_macros(
+            the_scopes, position
+        );
 
         const the_macros = new Map<string, MacroSymbol>();
         for (const [my_name, my_macro] of flat) {
@@ -1745,16 +1750,16 @@ export class CompletionProvider {
                 the_macros.set(my_name, my_macro);
                 continue;
             }
-            const scoped = lookup_scoped_local_macro(
-                the_scopes, position, my_name
-            );
-            if (scoped.out_of_scope) {
+            const scoped_symbol = the_visible_macros.get(my_name);
+            if (scoped_symbol === undefined) {
+                // Tracked in this file but in no visible scope: out of
+                // scope at the cursor — drop.
                 continue;
             }
             the_macros.set(
                 my_name,
-                scoped.symbol?.containingScope === 'program'
-                    ? scoped.symbol
+                scoped_symbol.containingScope === 'program'
+                    ? scoped_symbol
                     : my_macro
             );
         }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -36,7 +36,11 @@ import {
     ScopeInfo,
 } from '../types';
 import { program_body_start_line } from '../utils/scope-position';
-import { collect_visible_local_macros } from '../utils/scoped-locals';
+import {
+    collect_visible_local_macros,
+    enumerate_scoped_local_macros,
+} from '../utils/scoped-locals';
+import { find_inherited_dofile_local } from '../utils/dofile-locals';
 import { IContextTracker, LanguageContext } from '../context-tracker/types';
 import { CompletionPrefixCache } from '../utils/lru-cache';
 import { SymbolIndexCache } from '../utils/symbol-index-cache';
@@ -1026,6 +1030,12 @@ export class CompletionProvider {
 
             // === ASYNC PHASE: Scope resolution (only if needed) ===
             let resolved_scope: ResolvedScope | undefined;
+            // The resolved scope whenever the resolver ran at all —
+            // unlike `resolved_scope` (scope-resolved mode only), this
+            // also carries forward-include data in global mode, needed
+            // for the inherited-local lookup in
+            // build_local_macro_completion_map (#270 round-2 gate).
+            let inherited_lookup_scope: ResolvedScope | undefined;
             let symbols_for_completion: SymbolTable = document.symbols;
 
             if (scope_resolver) {
@@ -1036,6 +1046,7 @@ export class CompletionProvider {
                     resolve_config,
                     cancellation_token
                 );
+                inherited_lookup_scope = temp_scope;
                 const has_directives = temp_scope.has_directives;
                 const has_auto_parents = temp_scope.has_auto_parents;
                 const visible_forward_overlay =
@@ -1124,7 +1135,8 @@ export class CompletionProvider {
                         position,
                         symbols_for_completion,
                         out_of_scope_symbols,
-                        resolved_scope
+                        resolved_scope,
+                        inherited_lookup_scope
                     );
                     the_completions.push(...macro_completions);
                     return the_completions;
@@ -1154,7 +1166,7 @@ export class CompletionProvider {
 
                 case 'macro':
                     // Always provide macro completions (macros work in all contexts)
-                    return this.get_macro_completions(context, document, position, symbols_for_completion, out_of_scope_symbols, resolved_scope);
+                    return this.get_macro_completions(context, document, position, symbols_for_completion, out_of_scope_symbols, resolved_scope, inherited_lookup_scope);
 
                 case 'variable':
                     // Suppress variable completions in embedded language contexts
@@ -1725,13 +1737,16 @@ export class CompletionProvider {
      * view already reflects cross-file execution-order shadowing
      * (e.g. a later `include` redefinition) that document.scopes — a
      * same-file-only structure — cannot see. A name registered only
-     * in scopes not visible from the cursor is dropped entirely,
-     * matching hover/definition/references.
+     * in scopes not visible from the cursor resolves to a cross-file
+     * INHERITED do-file local when one exists (matching the
+     * analyzer's cross-file suppression), else is dropped — matching
+     * hover/definition/references.
      */
     private build_local_macro_completion_map(
         document: DocumentState,
         symbols: SymbolTable,
-        position: Position
+        position: Position,
+        resolved_scope?: ResolvedScope
     ): Map<string, MacroSymbol> {
         const flat = coerce_macro_map(symbols.localMacros);
 
@@ -1740,12 +1755,15 @@ export class CompletionProvider {
             return flat;
         }
 
-        const the_scoped_names = new Set<string>();
-        for (const my_scope of the_scopes) {
-            for (const my_name of my_scope.localMacros.keys()) {
-                the_scoped_names.add(my_name);
-            }
-        }
+        // Names tracked ANYWHERE in this file (visible or not) — what
+        // disambiguates "untracked, keep the merged entry" from
+        // "tracked but out of scope at the cursor" below. Derived from
+        // the shared enumerator so the membership rule cannot drift
+        // from the outline/workspace-search enumeration.
+        const the_scoped_names = new Set(
+            enumerate_scoped_local_macros(the_scopes, flat)
+                .map(([my_name]) => my_name)
+        );
         // Position-invariant across the loop below: resolve the
         // enclosing scope once, not per candidate name.
         const the_visible_macros = collect_visible_local_macros(
@@ -1774,7 +1792,16 @@ export class CompletionProvider {
             }
             if (scoped_symbol === undefined) {
                 // Tracked in this file but in no visible scope: out of
-                // scope at the cursor — drop.
+                // scope at the cursor. A cross-file INHERITED do-file
+                // local of the same name is still genuinely defined
+                // here (the analyzer's cross-file suppression treats
+                // it as defined) — offer it; otherwise drop.
+                const inherited = find_inherited_dofile_local(
+                    resolved_scope, my_name, position.line, document.uri
+                );
+                if (inherited) {
+                    the_macros.set(my_name, inherited);
+                }
                 continue;
             }
             // Do-file-scoped: keep the flat/merged entry, which already
@@ -1790,7 +1817,8 @@ export class CompletionProvider {
         position: Position,
         symbols: SymbolTable,
         out_of_scope: SymbolTable,
-        resolved_scope?: ResolvedScope
+        resolved_scope?: ResolvedScope,
+        inherited_lookup_scope?: ResolvedScope
     ): CompletionItem[] {
         // Use context.form to determine scope and delimiter behavior
         const scope = context.scope;
@@ -1820,7 +1848,8 @@ export class CompletionProvider {
         // Ensure we are accessing the Maps correctly and handling plain objects if necessary.
         const the_macros: Map<string, MacroSymbol> = scope === 'local'
             ? this.build_local_macro_completion_map(
-                document, symbols, position
+                document, symbols, position,
+                inherited_lookup_scope ?? resolved_scope
             )
             : coerce_macro_map(symbols.globalMacros);
         

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -1780,15 +1780,23 @@ export class CompletionProvider {
 
         const the_macros = new Map<string, MacroSymbol>();
         let the_inherited_locals: Map<string, MacroSymbol> | undefined;
+        const get_inherited = (my_name: string): MacroSymbol | undefined => {
+            // Position-invariant: build the map once, lazily, instead
+            // of re-walking the chain per name.
+            the_inherited_locals ??= collect_inherited_dofile_locals(
+                resolved_scope, position.line, document.uri
+            );
+            return the_inherited_locals.get(my_name);
+        };
         for (const [my_name, my_macro] of flat) {
-            const scoped_symbol = the_visible_macros.get(my_name);
-            if (scoped_symbol?.containingScope === 'program') {
-                // A visible program-scoped local wins outright — even
-                // over a cross-file merged representative (#271: the
-                // program's own local shadows everything at the
-                // cursor, and a same-named local elsewhere is a
-                // different macro).
-                the_macros.set(my_name, scoped_symbol);
+            const resolved_symbol = the_visible_macros.resolved.get(my_name);
+            if (resolved_symbol?.containingScope === 'program') {
+                // A positionally resolved program-scoped local wins
+                // outright — even over a cross-file merged
+                // representative (#271: the program's own local
+                // shadows everything at the cursor, and a same-named
+                // local elsewhere is a different macro).
+                the_macros.set(my_name, resolved_symbol);
                 continue;
             }
             if (
@@ -1799,20 +1807,28 @@ export class CompletionProvider {
                 the_macros.set(my_name, my_macro);
                 continue;
             }
-            if (scoped_symbol === undefined) {
-                // Tracked in this file but in no visible scope: out of
-                // scope at the cursor. A cross-file INHERITED do-file
-                // local of the same name is still genuinely defined
-                // here (the analyzer's cross-file suppression treats
-                // it as defined) — offer it; otherwise drop. The
-                // inherited map is position-invariant: build it once,
-                // lazily, instead of re-walking the chain per name.
-                the_inherited_locals ??= collect_inherited_dofile_locals(
-                    resolved_scope, position.line, document.uri
-                );
-                const inherited = the_inherited_locals.get(my_name);
+            if (resolved_symbol === undefined) {
+                // No positionally resolved same-file winner (out of
+                // scope, or a not-yet-defined forward local). A
+                // cross-file INHERITED do-file local is genuinely
+                // defined here (the analyzer's cross-file suppression
+                // treats it as defined) and outranks the forward
+                // identity target (round-9 gate) — offer it;
+                // otherwise the forward symbol (which the downstream
+                // definition-line filter drops as future-defined) or,
+                // for a forward DO-FILE local, the flat/merged entry;
+                // else drop.
+                const inherited = get_inherited(my_name);
+                const forward_symbol =
+                    the_visible_macros.forward.get(my_name);
                 if (inherited) {
                     the_macros.set(my_name, inherited);
+                } else if (
+                    forward_symbol?.containingScope === 'program'
+                ) {
+                    the_macros.set(my_name, forward_symbol);
+                } else if (forward_symbol) {
+                    the_macros.set(my_name, my_macro);
                 }
                 continue;
             }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -36,6 +36,7 @@ import {
     ScopeInfo,
 } from '../types';
 import { program_body_start_line } from '../utils/scope-position';
+import { lookup_scoped_local_macro } from '../utils/scoped-locals';
 import { IContextTracker, LanguageContext } from '../context-tracker/types';
 import { CompletionPrefixCache } from '../utils/lru-cache';
 import { SymbolIndexCache } from '../utils/symbol-index-cache';
@@ -1697,6 +1698,69 @@ export class CompletionProvider {
      * @param resolved_scope - Optional resolved scope for cross-file symbols
      * @returns Array of completion items filtered by prefix and sorted alphabetically
      */
+    /**
+     * Local-macro completion source (issue #270). A PROGRAM-scoped
+     * local visible at the cursor comes from its OWNING scope's own
+     * map — the flat one-per-name view otherwise drops it whenever a
+     * same-named local in a different scope holds the slot. A
+     * do-file-scoped name keeps the flat/merged entry UNCHANGED: that
+     * view already reflects cross-file execution-order shadowing
+     * (e.g. a later `include` redefinition) that document.scopes — a
+     * same-file-only structure — cannot see. A name registered only
+     * in scopes not visible from the cursor is dropped entirely,
+     * matching hover/definition/references.
+     */
+    private build_local_macro_completion_map(
+        document: DocumentState,
+        symbols: SymbolTable,
+        position: Position
+    ): Map<string, MacroSymbol> {
+        const localMacros = symbols.localMacros;
+        const flat: Map<string, MacroSymbol> =
+            localMacros instanceof Map
+                ? localMacros
+                : (localMacros && typeof localMacros === 'object'
+                    ? new Map(Object.entries(localMacros))
+                    : new Map());
+
+        const the_scopes = document.scopes;
+        if (!the_scopes || the_scopes.length === 0) {
+            return flat;
+        }
+
+        const the_scoped_names = new Set<string>();
+        for (const my_scope of the_scopes) {
+            for (const my_name of my_scope.localMacros.keys()) {
+                the_scoped_names.add(my_name);
+            }
+        }
+
+        const the_macros = new Map<string, MacroSymbol>();
+        for (const [my_name, my_macro] of flat) {
+            if (
+                my_macro.sourceUri !== document.uri ||
+                !the_scoped_names.has(my_name)
+            ) {
+                // Cross-file / workspace or untracked entry: unchanged.
+                the_macros.set(my_name, my_macro);
+                continue;
+            }
+            const scoped = lookup_scoped_local_macro(
+                the_scopes, position, my_name
+            );
+            if (scoped.out_of_scope) {
+                continue;
+            }
+            the_macros.set(
+                my_name,
+                scoped.symbol?.containingScope === 'program'
+                    ? scoped.symbol
+                    : my_macro
+            );
+        }
+        return the_macros;
+    }
+
     private get_macro_completions(
         context: MacroCompletionContext,
         document: DocumentState,
@@ -1733,14 +1797,9 @@ export class CompletionProvider {
         // Ensure we are accessing the Maps correctly and handling plain objects if necessary.
         let the_macros: Map<string, MacroSymbol>;
         if (scope === 'local') {
-            const localMacros = symbols.localMacros;
-            if (localMacros instanceof Map) {
-                the_macros = localMacros;
-            } else if (localMacros && typeof localMacros === 'object') {
-                the_macros = new Map(Object.entries(localMacros));
-            } else {
-                the_macros = new Map();
-            }
+            the_macros = this.build_local_macro_completion_map(
+                document, symbols, position
+            );
         } else {
             const globalMacros = symbols.globalMacros;
             if (globalMacros instanceof Map) {

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -76,6 +76,24 @@ const DIRECTIVE_PATH_CONTEXT_PATTERN = new RegExp(
 );
 
 /**
+ * Defensive SymbolTable-map coercion: production always passes Maps,
+ * but unit tests may pass plain objects (or partial stubs with the
+ * field missing). Shared by the local- and global-macro completion
+ * sources so the coercion contract lives in one place.
+ */
+function coerce_macro_map(
+    value: Map<string, MacroSymbol> | Record<string, MacroSymbol> | undefined
+): Map<string, MacroSymbol> {
+    if (value instanceof Map) {
+        return value;
+    }
+    if (value && typeof value === 'object') {
+        return new Map(Object.entries(value));
+    }
+    return new Map();
+}
+
+/**
  * Map ForwardCallSite.effective_type to directive_type for ranking.
  * 'include' -> 'included-by', else 'done-by'
  */
@@ -1715,13 +1733,7 @@ export class CompletionProvider {
         symbols: SymbolTable,
         position: Position
     ): Map<string, MacroSymbol> {
-        const localMacros = symbols.localMacros;
-        const flat: Map<string, MacroSymbol> =
-            localMacros instanceof Map
-                ? localMacros
-                : (localMacros && typeof localMacros === 'object'
-                    ? new Map(Object.entries(localMacros))
-                    : new Map());
+        const flat = coerce_macro_map(symbols.localMacros);
 
         const the_scopes = document.scopes;
         if (!the_scopes || the_scopes.length === 0) {
@@ -1742,6 +1754,16 @@ export class CompletionProvider {
 
         const the_macros = new Map<string, MacroSymbol>();
         for (const [my_name, my_macro] of flat) {
+            const scoped_symbol = the_visible_macros.get(my_name);
+            if (scoped_symbol?.containingScope === 'program') {
+                // A visible program-scoped local wins outright — even
+                // over a cross-file merged representative (#271: the
+                // program's own local shadows everything at the
+                // cursor, and a same-named local elsewhere is a
+                // different macro).
+                the_macros.set(my_name, scoped_symbol);
+                continue;
+            }
             if (
                 my_macro.sourceUri !== document.uri ||
                 !the_scoped_names.has(my_name)
@@ -1750,18 +1772,14 @@ export class CompletionProvider {
                 the_macros.set(my_name, my_macro);
                 continue;
             }
-            const scoped_symbol = the_visible_macros.get(my_name);
             if (scoped_symbol === undefined) {
                 // Tracked in this file but in no visible scope: out of
                 // scope at the cursor — drop.
                 continue;
             }
-            the_macros.set(
-                my_name,
-                scoped_symbol.containingScope === 'program'
-                    ? scoped_symbol
-                    : my_macro
-            );
+            // Do-file-scoped: keep the flat/merged entry, which already
+            // reflects cross-file execution-order shadowing.
+            the_macros.set(my_name, my_macro);
         }
         return the_macros;
     }
@@ -1800,21 +1818,11 @@ export class CompletionProvider {
         // CRITICAL FIX: Ensure 'symbols' actually has content and is a valid SymbolTable.
         // In unit tests, partial or mock objects might be passed.
         // Ensure we are accessing the Maps correctly and handling plain objects if necessary.
-        let the_macros: Map<string, MacroSymbol>;
-        if (scope === 'local') {
-            the_macros = this.build_local_macro_completion_map(
+        const the_macros: Map<string, MacroSymbol> = scope === 'local'
+            ? this.build_local_macro_completion_map(
                 document, symbols, position
-            );
-        } else {
-            const globalMacros = symbols.globalMacros;
-            if (globalMacros instanceof Map) {
-                the_macros = globalMacros;
-            } else if (globalMacros && typeof globalMacros === 'object') {
-                the_macros = new Map(Object.entries(globalMacros));
-            } else {
-                the_macros = new Map();
-            }
-        }
+            )
+            : coerce_macro_map(symbols.globalMacros);
         
         // Build lowercase index for faster prefix matching
         // This avoids calling toLowerCase() for each symbol in the loop
@@ -1891,7 +1899,18 @@ export class CompletionProvider {
             // For local macro completions, respect program scoping.
             // - If cursor is inside a program: include locals defined in that program + locals defined at file scope.
             // - If cursor is outside any program: exclude locals defined inside programs.
-            if (scope === 'local' && document.ast) {
+            // Degenerate-state fallback ONLY (#270): with scopes
+            // present, build_local_macro_completion_map already applied
+            // the authoritative ScopeInfo-based visibility; re-running
+            // this AST walk would just risk boundary disagreements
+            // (///-continued headers) and spurious matches for
+            // cross-file entries whose positions belong to other files.
+            if (
+                scope === 'local' &&
+                document.ast &&
+                (document.scopes === undefined ||
+                    document.scopes.length === 0)
+            ) {
                 const macro_pos = macro.location?.range?.start;
                 if (macro_pos) {
                     const containing_program = this.find_program_containing_position(

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -40,7 +40,7 @@ import {
     collect_visible_local_macros,
     enumerate_scoped_local_macros,
 } from '../utils/scoped-locals';
-import { find_inherited_dofile_local } from '../utils/dofile-locals';
+import { collect_inherited_dofile_locals } from '../utils/dofile-locals';
 import { IContextTracker, LanguageContext } from '../context-tracker/types';
 import { CompletionPrefixCache } from '../utils/lru-cache';
 import { SymbolIndexCache } from '../utils/symbol-index-cache';
@@ -1166,7 +1166,15 @@ export class CompletionProvider {
 
                 case 'macro':
                     // Always provide macro completions (macros work in all contexts)
-                    return this.get_macro_completions(context, document, position, symbols_for_completion, out_of_scope_symbols, resolved_scope, inherited_lookup_scope);
+                    return this.get_macro_completions(
+                        context,
+                        document,
+                        position,
+                        symbols_for_completion,
+                        out_of_scope_symbols,
+                        resolved_scope,
+                        inherited_lookup_scope
+                    );
 
                 case 'variable':
                     // Suppress variable completions in embedded language contexts
@@ -1771,6 +1779,7 @@ export class CompletionProvider {
         );
 
         const the_macros = new Map<string, MacroSymbol>();
+        let the_inherited_locals: Map<string, MacroSymbol> | undefined;
         for (const [my_name, my_macro] of flat) {
             const scoped_symbol = the_visible_macros.get(my_name);
             if (scoped_symbol?.containingScope === 'program') {
@@ -1795,10 +1804,13 @@ export class CompletionProvider {
                 // scope at the cursor. A cross-file INHERITED do-file
                 // local of the same name is still genuinely defined
                 // here (the analyzer's cross-file suppression treats
-                // it as defined) — offer it; otherwise drop.
-                const inherited = find_inherited_dofile_local(
-                    resolved_scope, my_name, position.line, document.uri
+                // it as defined) — offer it; otherwise drop. The
+                // inherited map is position-invariant: build it once,
+                // lazily, instead of re-walking the chain per name.
+                the_inherited_locals ??= collect_inherited_dofile_locals(
+                    resolved_scope, position.line, document.uri
                 );
+                const inherited = the_inherited_locals.get(my_name);
                 if (inherited) {
                     the_macros.set(my_name, inherited);
                 }
@@ -1848,8 +1860,7 @@ export class CompletionProvider {
         // Ensure we are accessing the Maps correctly and handling plain objects if necessary.
         const the_macros: Map<string, MacroSymbol> = scope === 'local'
             ? this.build_local_macro_completion_map(
-                document, symbols, position,
-                inherited_lookup_scope ?? resolved_scope
+                document, symbols, position, inherited_lookup_scope
             )
             : coerce_macro_map(symbols.globalMacros);
         

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -1290,14 +1290,28 @@ export class DefinitionProvider {
 
         const { word } = word_info;
 
+        // Preserve the reference's delimiter intent (#270 round-13
+        // gate): `` `x' `` is an explicit LOCAL reference and $x/${x}
+        // an explicit GLOBAL one — a rejected lookup in one namespace
+        // must not fall through to the other. Bare words keep the
+        // pre-existing local-then-global order.
+        const looks_like_local = this.reference_looks_like_macro(
+            document, position, word_info.range.start.character, 'local'
+        );
+        const looks_like_global = this.reference_looks_like_macro(
+            document, position, word_info.range.start.character, 'global'
+        );
+        const allow_local = !looks_like_global;
+        const allow_global = !looks_like_local;
+
         // Scope-aware same-file resolution first (#270): a
         // positionally RESOLVED program-scoped local is authoritative
         // (never crosses files, #271); an out-of-scope or
         // forward-only name must not fall back to the flat slot
         // below.
-        const scoped = lookup_scoped_local_macro(
-            document.scopes, position, word
-        );
+        const scoped = allow_local
+            ? lookup_scoped_local_macro(document.scopes, position, word)
+            : { symbol: undefined, forward_only: false, out_of_scope: false };
         const fast_path_locations = this.resolved_program_locations(scoped);
         if (fast_path_locations) {
             return this.locations_to_definition(fast_path_locations);
@@ -1320,8 +1334,7 @@ export class DefinitionProvider {
                 // inherited winner outranks a forward identity target
                 // of EITHER scope kind (round-9/10 gates); an
                 // out-of-scope name with no winner yields nothing for
-                // the LOCAL branch (globals below are a separate
-                // namespace and stay unaffected).
+                // the LOCAL branch.
                 const effective = classify_effective_local(
                     document.scopes, position, word, resolved_scope,
                     document.uri
@@ -1335,7 +1348,7 @@ export class DefinitionProvider {
                         )
                     );
                 }
-            } else {
+            } else if (allow_local) {
                 const local_locs = this.collect_local_macro_scope_locations(
                     resolved_scope,
                     word,
@@ -1347,8 +1360,12 @@ export class DefinitionProvider {
                 }
             }
 
-            // Check global macros — do/run/include all propagate globals
-            const global_macro = resolved_scope.symbols.globalMacros.get(word);
+            // Check global macros — do/run/include all propagate
+            // globals. Skipped for explicit local references: a
+            // rejected local must not surface the global namespace.
+            const global_macro = allow_global
+                ? resolved_scope.symbols.globalMacros.get(word)
+                : undefined;
             if (global_macro) {
                 const out: Location[] =
                     this.macro_symbol_to_locations(global_macro);
@@ -1400,7 +1417,7 @@ export class DefinitionProvider {
         // 1. Check local macros (skipped when the name is tracked in
         //    this file but out of scope or forward-only at the cursor
         //    — the flat slot may point at that very symbol, #270)
-        const local_macro = local_needs_effective
+        const local_macro = local_needs_effective || !allow_local
             ? undefined
             : document.symbols.localMacros.get(word);
 
@@ -1411,7 +1428,7 @@ export class DefinitionProvider {
         // winner handled above; the indexer pooling has no
         // execution-order gate and would surface not-yet-inherited
         // declarations (round-4 gate).
-        const cross_local_locs = local_needs_effective
+        const cross_local_locs = local_needs_effective || !allow_local
             ? []
             : this.collect_workspace_definition_locations(
                 document.uri,
@@ -1420,12 +1437,14 @@ export class DefinitionProvider {
                 workspace_indexer,
                 { include_only: true }
             );
-        const cross_global_locs = this.collect_workspace_definition_locations(
-            document.uri,
-            word,
-            'global',
-            workspace_indexer
-        );
+        const cross_global_locs = allow_global
+            ? this.collect_workspace_definition_locations(
+                document.uri,
+                word,
+                'global',
+                workspace_indexer
+            )
+            : [];
 
         if (local_macro) {
             const out: Location[] =
@@ -1440,14 +1459,16 @@ export class DefinitionProvider {
             );
         }
 
-        // 2. Check global macros
-        const global_macro =
-            document.symbols.globalMacros.get(word) ||
-            (
-                (!workspace_indexer || cross_global_locs.length > 0)
-                    ? workspace_symbols?.globalMacros.get(word)
-                    : undefined
-            );
+        // 2. Check global macros (skipped for explicit local
+        //    references — see the delimiter-intent gate above)
+        const global_macro = allow_global
+            ? (document.symbols.globalMacros.get(word) ||
+                (
+                    (!workspace_indexer || cross_global_locs.length > 0)
+                        ? workspace_symbols?.globalMacros.get(word)
+                        : undefined
+                ))
+            : undefined;
         if (global_macro) {
             const out: Location[] =
                 this.macro_symbol_to_locations(global_macro);

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -55,6 +55,7 @@ import {
 import {
     lookup_scoped_local_macro,
     resolve_scoped_or_flat,
+    ScopedLocalLookupResult,
 } from '../utils/scoped-locals';
 import { is_cursor_in_comment, is_cursor_in_block_comment } from '../utils/comment-utils';
 import {
@@ -263,6 +264,27 @@ export class DefinitionProvider {
     }
 
     /**
+     * The resolver-free authoritative fast path (#271): a positionally
+     * RESOLVED program-scoped local's own locations (primary +
+     * same-scope additional_definitions), or null when the lookup is
+     * anything else. Shared by both definition entry points so the
+     * fast-path rule cannot drift between them.
+     */
+    private resolved_program_locations(
+        scoped: ScopedLocalLookupResult
+    ): Location[] | null {
+        if (
+            scoped.symbol?.containingScope === 'program' &&
+            !scoped.forward_only
+        ) {
+            return this.dedupe_locations(
+                this.macro_symbol_to_locations(scoped.symbol)
+            );
+        }
+        return null;
+    }
+
+    /**
      * Resolve local macro only (for MACRO_REF_LOCAL tokens and extended macro context).
      */
     private async resolve_local_macro_only(
@@ -280,13 +302,9 @@ export class DefinitionProvider {
         const scoped = position
             ? lookup_scoped_local_macro(document.scopes, position, word)
             : { symbol: undefined, forward_only: false, out_of_scope: false };
-        if (
-            scoped.symbol?.containingScope === 'program' &&
-            !scoped.forward_only
-        ) {
-            return this.locations_to_definition(this.dedupe_locations(
-                this.macro_symbol_to_locations(scoped.symbol)
-            ));
+        const fast_path_locations = this.resolved_program_locations(scoped);
+        if (fast_path_locations) {
+            return this.locations_to_definition(fast_path_locations);
         }
 
         const resolved_scope = scope_resolver
@@ -1280,13 +1298,9 @@ export class DefinitionProvider {
         const scoped = lookup_scoped_local_macro(
             document.scopes, position, word
         );
-        if (
-            scoped.symbol?.containingScope === 'program' &&
-            !scoped.forward_only
-        ) {
-            return this.locations_to_definition(this.dedupe_locations(
-                this.macro_symbol_to_locations(scoped.symbol)
-            ));
+        const fast_path_locations = this.resolved_program_locations(scoped);
+        if (fast_path_locations) {
+            return this.locations_to_definition(fast_path_locations);
         }
         const local_needs_effective =
             scoped.out_of_scope || scoped.forward_only;

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -318,11 +318,16 @@ export class DefinitionProvider {
         const scoped = position
             ? this.resolve_scoped_local_definition(document, word, position)
             : null;
-        if (scoped !== null) {
-            return scoped.blocked
-                ? null
-                : this.locations_to_definition(scoped.locations);
+        if (scoped !== null && !scoped.blocked) {
+            return this.locations_to_definition(scoped.locations);
         }
+        // Out-of-scope same-file (#270): the flat slot and same-file
+        // chain contributions are forbidden (they may be the very
+        // out-of-scope sibling symbol), but cross-file INHERITED
+        // definitions remain legitimate — the analyzer's cross-file
+        // suppression treats them as defined, so filter same-file
+        // hits rather than bail out entirely (round-2 gate).
+        const local_out_of_scope = scoped?.blocked === true;
 
         // Try scope resolver first
         if (scope_resolver) {
@@ -334,19 +339,26 @@ export class DefinitionProvider {
                 cancellation_token
             );
 
-            const local_locs = this.collect_local_macro_scope_locations(
+            let local_locs = this.collect_local_macro_scope_locations(
                 resolved_scope,
                 word,
                 position,
                 document.uri
             );
+            if (local_out_of_scope) {
+                local_locs = local_locs.filter(
+                    my_loc => my_loc.uri !== document.uri
+                );
+            }
             if (local_locs.length > 0) {
                 return this.locations_to_definition(local_locs);
             }
         }
 
         // Check document symbols
-        const local_macro = document.symbols.localMacros.get(word);
+        const local_macro = local_out_of_scope
+            ? undefined
+            : document.symbols.localMacros.get(word);
 
         // Collect workspace-indexer cross-file definitions for the same
         // name regardless of whether the current file defines it too, so
@@ -1308,16 +1320,22 @@ export class DefinitionProvider {
                 cancellation_token
             );
 
-            if (!local_out_of_scope) {
-                const local_locs = this.collect_local_macro_scope_locations(
-                    resolved_scope,
-                    word,
-                    position,
-                    document.uri
+            // Out-of-scope same-file names still resolve to cross-file
+            // INHERITED definitions — only same-file hits are
+            // forbidden (round-2 gate; see resolve_local_macro_only).
+            let local_locs = this.collect_local_macro_scope_locations(
+                resolved_scope,
+                word,
+                position,
+                document.uri
+            );
+            if (local_out_of_scope) {
+                local_locs = local_locs.filter(
+                    my_loc => my_loc.uri !== document.uri
                 );
-                if (local_locs.length > 0) {
-                    return this.locations_to_definition(local_locs);
-                }
+            }
+            if (local_locs.length > 0) {
+                return this.locations_to_definition(local_locs);
             }
 
             // Check global macros — do/run/include all propagate globals
@@ -1367,18 +1385,17 @@ export class DefinitionProvider {
             : document.symbols.localMacros.get(word);
 
         // Collect cross-file workspace-indexer definitions (both kinds).
-        // An out-of-scope local reference resolves to nothing at all —
-        // consistent with diagnostics, which flag it as "defined only
-        // inside program X" — so cross-file pooling is skipped too.
-        const cross_local_locs = local_out_of_scope
-            ? []
-            : this.collect_workspace_definition_locations(
-                document.uri,
-                word,
-                'local',
-                workspace_indexer,
-                { include_only: true }
-            );
+        // Cross-file pooling stays on for out-of-scope names: only
+        // same-file candidates are forbidden there (round-2 gate); the
+        // include-chain hits are already gated by
+        // is_cross_file_hidden_local inside the collector.
+        const cross_local_locs = this.collect_workspace_definition_locations(
+            document.uri,
+            word,
+            'local',
+            workspace_indexer,
+            { include_only: true }
+        );
         const cross_global_locs = this.collect_workspace_definition_locations(
             document.uri,
             word,

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -49,7 +49,10 @@ import { URI } from 'vscode-uri';
 import { resolve_path_rich, resolve_forward_call_rich } from '../utils/file-path-utils';
 import { get_line_text } from '../utils/line-utils';
 import { is_cross_file_hidden_local } from '../utils/dofile-locals';
-import { lookup_scoped_local_macro } from '../utils/scoped-locals';
+import {
+    lookup_scoped_local_macro,
+    resolve_scoped_or_flat,
+} from '../utils/scoped-locals';
 import { is_cursor_in_comment, is_cursor_in_block_comment } from '../utils/comment-utils';
 import {
     BACKWARD_DIRECTIVE_KEYWORDS,
@@ -266,11 +269,11 @@ export class DefinitionProvider {
      *   resolved-scope/flat code also handles cross-file
      *   execution-order shadowing that document.scopes cannot see).
      *   Callers must run the pre-existing code unchanged.
-     * - `[]`: the name IS tracked in this file but not visible from
-     *   `position` (a sibling scope's local) — exclusive shadowing,
-     *   no result; the flat slot must not substitute.
-     * - non-empty: the visible symbol is program-scoped — its own
-     *   primary + same-scope additional_definitions only. Program
+     * - `blocked: true`: the name IS tracked in this file but not
+     *   visible from `position` (a sibling scope's local) — exclusive
+     *   shadowing, no result; the flat slot must not substitute.
+     * - `blocked: false`: the visible symbol is program-scoped — its
+     *   own primary + same-scope additional_definitions only. Program
      *   locals never cross file boundaries (#271), so cross-file
      *   same-name hits are NOT merged in (a same-named local in an
      *   included file is a different macro) — consistent with
@@ -281,19 +284,22 @@ export class DefinitionProvider {
         document: DocumentState,
         word: string,
         position: Position
-    ): Location[] | null {
+    ): { blocked: boolean; locations: Location[] } | null {
         const scoped = lookup_scoped_local_macro(
             document.scopes, position, word
         );
         if (scoped.out_of_scope) {
-            return [];
+            return { blocked: true, locations: [] };
         }
         if (!scoped.symbol || scoped.symbol.containingScope !== 'program') {
             return null;
         }
-        return this.dedupe_locations(
-            this.macro_symbol_to_locations(scoped.symbol)
-        );
+        return {
+            blocked: false,
+            locations: this.dedupe_locations(
+                this.macro_symbol_to_locations(scoped.symbol)
+            ),
+        };
     }
 
     /**
@@ -309,13 +315,13 @@ export class DefinitionProvider {
         position?: Position
     ): Promise<Definition | null> {
         // Scope-aware same-file resolution first (#270).
-        const scoped_locs = position
+        const scoped = position
             ? this.resolve_scoped_local_definition(document, word, position)
             : null;
-        if (scoped_locs !== null) {
-            return scoped_locs.length > 0
-                ? this.locations_to_definition(scoped_locs)
-                : null;
+        if (scoped !== null) {
+            return scoped.blocked
+                ? null
+                : this.locations_to_definition(scoped.locations);
         }
 
         // Try scope resolver first
@@ -902,13 +908,9 @@ export class DefinitionProvider {
         // do-file-scoped symbols too — a declaration-range hit is a pure
         // text question, and the do-file symbol here is object-identical
         // to the flat entry.
-        const scoped_local = lookup_scoped_local_macro(
-            document.scopes, position, word
+        const local_macro = resolve_scoped_or_flat(
+            document.scopes, position, word, document.symbols.localMacros
         );
-        const local_macro = scoped_local.symbol
-            ?? (scoped_local.out_of_scope
-                ? undefined
-                : document.symbols.localMacros.get(word));
         if (
             local_macro
             && this.position_hits_symbol_definition(position, local_macro)
@@ -1288,13 +1290,13 @@ export class DefinitionProvider {
         // Scope-aware same-file resolution first (#270): a program-scoped
         // visible local is authoritative (never crosses files, #271); an
         // out-of-scope name must not fall back to the flat slot below.
-        const scoped_locs = this.resolve_scoped_local_definition(
+        const scoped = this.resolve_scoped_local_definition(
             document, word, position
         );
-        if (scoped_locs !== null && scoped_locs.length > 0) {
-            return this.locations_to_definition(scoped_locs);
+        if (scoped !== null && !scoped.blocked) {
+            return this.locations_to_definition(scoped.locations);
         }
-        const local_out_of_scope = scoped_locs !== null;
+        const local_out_of_scope = scoped?.blocked === true;
 
         // Try scope resolver first if available
         if (scope_resolver) {

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -926,9 +926,9 @@ export class DefinitionProvider {
         // Scope-aware (#270): resolve the declaration against the scope
         // that textually contains it, so a losing-flat-slot program
         // local still matches its own declaration range. Safe for
-        // do-file-scoped symbols too — a declaration-range hit is a pure
-        // text question, and the do-file symbol here is object-identical
-        // to the flat entry.
+        // do-file-scoped symbols too — a declaration-range hit is a
+        // pure text question, and the do-file symbol here is
+        // object-identical to the flat entry.
         const local_macro = resolve_scoped_or_flat(
             document.scopes, position, word, document.symbols.localMacros
         );
@@ -1308,9 +1308,10 @@ export class DefinitionProvider {
 
         const { word } = word_info;
 
-        // Scope-aware same-file resolution first (#270): a program-scoped
-        // visible local is authoritative (never crosses files, #271); an
-        // out-of-scope name must not fall back to the flat slot below.
+        // Scope-aware same-file resolution first (#270): a
+        // program-scoped visible local is authoritative (never
+        // crosses files, #271); an out-of-scope name must not fall
+        // back to the flat slot below.
         const scoped = this.resolve_scoped_local_definition(
             document, word, position
         );
@@ -1404,7 +1405,8 @@ export class DefinitionProvider {
             ? undefined
             : document.symbols.localMacros.get(word);
 
-        // Collect cross-file workspace-indexer definitions (both kinds).
+        // Collect cross-file workspace-indexer definitions (both
+        // kinds).
         // Barred for out-of-scope names: their only legitimate local
         // identity is the call-line-gated inherited winner handled
         // above; the indexer pooling has no execution-order gate and

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -49,6 +49,7 @@ import { URI } from 'vscode-uri';
 import { resolve_path_rich, resolve_forward_call_rich } from '../utils/file-path-utils';
 import { get_line_text } from '../utils/line-utils';
 import { is_cross_file_hidden_local } from '../utils/dofile-locals';
+import { lookup_scoped_local_macro } from '../utils/scoped-locals';
 import { is_cursor_in_comment, is_cursor_in_block_comment } from '../utils/comment-utils';
 import {
     BACKWARD_DIRECTIVE_KEYWORDS,
@@ -256,6 +257,50 @@ export class DefinitionProvider {
     }
 
     /**
+     * Scope-aware override for local-macro definition lookups (#270).
+     * Return values:
+     * - `null`: the scoped model has no opinion (scopes empty, name
+     *   untracked in this file, or the visible symbol is do-file
+     *   scoped — publish_flat_local guarantees a do-file definition
+     *   always owns the flat slot when one exists, and the existing
+     *   resolved-scope/flat code also handles cross-file
+     *   execution-order shadowing that document.scopes cannot see).
+     *   Callers must run the pre-existing code unchanged.
+     * - `[]`: the name IS tracked in this file but not visible from
+     *   `position` (a sibling scope's local) — exclusive shadowing,
+     *   no result; the flat slot must not substitute.
+     * - non-empty: the visible symbol is program-scoped — its own
+     *   primary + same-scope additional_definitions (#271: program
+     *   locals never cross files), merged with the workspace-indexer
+     *   include-chain hits (already gated by is_cross_file_hidden_local).
+     */
+    private resolve_scoped_local_definition(
+        document: DocumentState,
+        word: string,
+        position: Position,
+        workspace_indexer?: WorkspaceIndexer
+    ): Location[] | null {
+        const scoped = lookup_scoped_local_macro(
+            document.scopes, position, word
+        );
+        if (scoped.out_of_scope) {
+            return [];
+        }
+        if (!scoped.symbol || scoped.symbol.containingScope !== 'program') {
+            return null;
+        }
+        const out = this.macro_symbol_to_locations(scoped.symbol);
+        out.push(...this.collect_workspace_definition_locations(
+            document.uri,
+            word,
+            'local',
+            workspace_indexer,
+            { include_only: true }
+        ));
+        return this.dedupe_locations(out);
+    }
+
+    /**
      * Resolve local macro only (for MACRO_REF_LOCAL tokens and extended macro context).
      */
     private async resolve_local_macro_only(
@@ -267,6 +312,18 @@ export class DefinitionProvider {
         cancellation_token?: CancellationToken,
         position?: Position
     ): Promise<Definition | null> {
+        // Scope-aware same-file resolution first (#270).
+        const scoped_locs = position
+            ? this.resolve_scoped_local_definition(
+                document, word, position, workspace_indexer
+            )
+            : null;
+        if (scoped_locs !== null) {
+            return scoped_locs.length > 0
+                ? this.locations_to_definition(scoped_locs)
+                : null;
+        }
+
         // Try scope resolver first
         if (scope_resolver) {
             const resolve_config = build_scope_resolver_config(cross_file_config);
@@ -845,7 +902,19 @@ export class DefinitionProvider {
                 this.macro_symbol_to_locations(global_macro)
             );
         }
-        const local_macro = document.symbols.localMacros.get(word);
+        // Scope-aware (#270): resolve the declaration against the scope
+        // that textually contains it, so a losing-flat-slot program
+        // local still matches its own declaration range. Safe for
+        // do-file-scoped symbols too — a declaration-range hit is a pure
+        // text question, and the do-file symbol here is object-identical
+        // to the flat entry.
+        const scoped_local = lookup_scoped_local_macro(
+            document.scopes, position, word
+        );
+        const local_macro = scoped_local.symbol
+            ?? (scoped_local.out_of_scope
+                ? undefined
+                : document.symbols.localMacros.get(word));
         if (
             local_macro
             && this.position_hits_symbol_definition(position, local_macro)
@@ -1222,6 +1291,17 @@ export class DefinitionProvider {
 
         const { word } = word_info;
 
+        // Scope-aware same-file resolution first (#270): a program-scoped
+        // visible local is authoritative (never crosses files, #271); an
+        // out-of-scope name must not fall back to the flat slot below.
+        const scoped_locs = this.resolve_scoped_local_definition(
+            document, word, position, workspace_indexer
+        );
+        if (scoped_locs !== null && scoped_locs.length > 0) {
+            return this.locations_to_definition(scoped_locs);
+        }
+        const local_out_of_scope = scoped_locs !== null;
+
         // Try scope resolver first if available
         if (scope_resolver) {
             const resolve_config = build_scope_resolver_config(cross_file_config);
@@ -1232,14 +1312,16 @@ export class DefinitionProvider {
                 cancellation_token
             );
 
-            const local_locs = this.collect_local_macro_scope_locations(
-                resolved_scope,
-                word,
-                position,
-                document.uri
-            );
-            if (local_locs.length > 0) {
-                return this.locations_to_definition(local_locs);
+            if (!local_out_of_scope) {
+                const local_locs = this.collect_local_macro_scope_locations(
+                    resolved_scope,
+                    word,
+                    position,
+                    document.uri
+                );
+                if (local_locs.length > 0) {
+                    return this.locations_to_definition(local_locs);
+                }
             }
 
             // Check global macros — do/run/include all propagate globals
@@ -1281,17 +1363,26 @@ export class DefinitionProvider {
         }
 
         // Only check macros, not programs or other Stata symbols
-        // 1. Check local macros
-        const local_macro = document.symbols.localMacros.get(word);
+        // 1. Check local macros (skipped when the name is tracked in
+        //    this file but out of scope at the cursor — the flat slot
+        //    may point at that very out-of-scope symbol, #270)
+        const local_macro = local_out_of_scope
+            ? undefined
+            : document.symbols.localMacros.get(word);
 
-        // Collect cross-file workspace-indexer definitions (both kinds)
-        const cross_local_locs = this.collect_workspace_definition_locations(
-            document.uri,
-            word,
-            'local',
-            workspace_indexer,
-            { include_only: true }
-        );
+        // Collect cross-file workspace-indexer definitions (both kinds).
+        // An out-of-scope local reference resolves to nothing at all —
+        // consistent with diagnostics, which flag it as "defined only
+        // inside program X" — so cross-file pooling is skipped too.
+        const cross_local_locs = local_out_of_scope
+            ? []
+            : this.collect_workspace_definition_locations(
+                document.uri,
+                word,
+                'local',
+                workspace_indexer,
+                { include_only: true }
+            );
         const cross_global_locs = this.collect_workspace_definition_locations(
             document.uri,
             word,

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -263,8 +263,8 @@ export class DefinitionProvider {
     }
 
     /**
-     * Scope-aware override for local-macro definition lookups (#270).
-     * Return values:
+     * Scope-aware classification for local-macro definition lookups
+     * (#270). Return values:
      * - `null`: the scoped model has no opinion (scopes empty, name
      *   untracked in this file, or the visible symbol is do-file
      *   scoped — publish_flat_local guarantees a do-file definition
@@ -272,37 +272,43 @@ export class DefinitionProvider {
      *   resolved-scope/flat code also handles cross-file
      *   execution-order shadowing that document.scopes cannot see).
      *   Callers must run the pre-existing code unchanged.
-     * - `blocked: true`: the name IS tracked in this file but not
-     *   visible from `position` (a sibling scope's local) — exclusive
-     *   shadowing, no result; the flat slot must not substitute.
-     * - `blocked: false`: the visible symbol is program-scoped — its
-     *   own primary + same-scope additional_definitions only. Program
-     *   locals never cross file boundaries (#271), so cross-file
-     *   same-name hits are NOT merged in (a same-named local in an
-     *   included file is a different macro) — consistent with
-     *   find-references skipping the cross-file scan for
-     *   program-scoped targets.
+     * - `kind: 'authoritative'`: a positionally RESOLVED
+     *   program-scoped local — its own primary + same-scope
+     *   additional_definitions only. Program locals never cross file
+     *   boundaries (#271), so cross-file same-name hits are NOT
+     *   merged in — consistent with find-references skipping the
+     *   cross-file scan for program-scoped targets.
+     * - `kind: 'needs_inherited'`: the same-file answer defers to the
+     *   cross-file INHERITED do-file local when one exists (the
+     *   analyzer's cross-file suppression treats the reference as
+     *   defined via it, round-9 gate). `fallback_locations` carries a
+     *   same-scope FORWARD identity target's locations (used only
+     *   when no inherited winner exists); null for an out-of-scope
+     *   name, whose only candidate is the inherited winner.
      */
     private resolve_scoped_local_definition(
         document: DocumentState,
         word: string,
         position: Position
-    ): { blocked: boolean; locations: Location[] } | null {
+    ):
+        | { kind: 'authoritative'; locations: Location[] }
+        | { kind: 'needs_inherited'; fallback_locations: Location[] | null }
+        | null {
         const scoped = lookup_scoped_local_macro(
             document.scopes, position, word
         );
         if (scoped.out_of_scope) {
-            return { blocked: true, locations: [] };
+            return { kind: 'needs_inherited', fallback_locations: null };
         }
         if (!scoped.symbol || scoped.symbol.containingScope !== 'program') {
             return null;
         }
-        return {
-            blocked: false,
-            locations: this.dedupe_locations(
-                this.macro_symbol_to_locations(scoped.symbol)
-            ),
-        };
+        const the_locations = this.dedupe_locations(
+            this.macro_symbol_to_locations(scoped.symbol)
+        );
+        return scoped.forward_only
+            ? { kind: 'needs_inherited', fallback_locations: the_locations }
+            : { kind: 'authoritative', locations: the_locations };
     }
 
     /**
@@ -321,7 +327,7 @@ export class DefinitionProvider {
         const scoped = position
             ? this.resolve_scoped_local_definition(document, word, position)
             : null;
-        if (scoped !== null && !scoped.blocked) {
+        if (scoped?.kind === 'authoritative') {
             return this.locations_to_definition(scoped.locations);
         }
 
@@ -334,22 +340,25 @@ export class DefinitionProvider {
             )
             : undefined;
 
-        if (scoped?.blocked === true) {
-            // Out-of-scope same-file (#270): the identity is the
-            // cross-file INHERITED do-file local — the exact winner
-            // hover/completion/references resolve — or nothing.
-            // Ungated chain walks and workspace pooling would
+        if (scoped?.kind === 'needs_inherited') {
+            // The cross-file INHERITED do-file local outranks a
+            // same-scope forward identity target (round-9 gate) and
+            // is the only candidate for an out-of-scope name (round-4
+            // gate): ungated chain walks and workspace pooling would
             // navigate to superseded or not-yet-executed include
-            // declarations (round-4 gate).
+            // declarations.
             const inherited = position
                 ? find_inherited_dofile_local(
                     resolved_scope, word, position.line, document.uri
                 )
                 : undefined;
-            return inherited
-                ? this.locations_to_definition(
+            if (inherited) {
+                return this.locations_to_definition(
                     this.macro_symbol_to_locations(inherited)
-                )
+                );
+            }
+            return scoped.fallback_locations
+                ? this.locations_to_definition(scoped.fallback_locations)
                 : null;
         }
 
@@ -1309,16 +1318,17 @@ export class DefinitionProvider {
         const { word } = word_info;
 
         // Scope-aware same-file resolution first (#270): a
-        // program-scoped visible local is authoritative (never
-        // crosses files, #271); an out-of-scope name must not fall
-        // back to the flat slot below.
+        // positionally resolved program-scoped local is authoritative
+        // (never crosses files, #271); an out-of-scope or
+        // forward-only name must not fall back to the flat slot
+        // below.
         const scoped = this.resolve_scoped_local_definition(
             document, word, position
         );
-        if (scoped !== null && !scoped.blocked) {
+        if (scoped?.kind === 'authoritative') {
             return this.locations_to_definition(scoped.locations);
         }
-        const local_out_of_scope = scoped?.blocked === true;
+        const local_needs_inherited = scoped?.kind === 'needs_inherited';
 
         // Try scope resolver first if available
         if (scope_resolver) {
@@ -1330,21 +1340,25 @@ export class DefinitionProvider {
                 cancellation_token
             );
 
-            if (local_out_of_scope) {
-                // Out-of-scope same-file (#270): the identity is the
-                // cross-file INHERITED do-file local — the exact
-                // winner hover/completion/references resolve — or
-                // nothing for the LOCAL branch (globals below are a
-                // separate namespace and stay unaffected). Ungated
-                // chain walks would navigate to superseded or
-                // not-yet-executed include declarations (round-4
-                // gate; see resolve_local_macro_only).
+            if (scoped?.kind === 'needs_inherited') {
+                // The cross-file INHERITED do-file local outranks a
+                // same-scope forward identity target (round-9 gate)
+                // and is the only candidate for an out-of-scope name
+                // (round-4 gate) — or nothing for the LOCAL branch
+                // (globals below are a separate namespace and stay
+                // unaffected). Ungated chain walks would navigate to
+                // superseded or not-yet-executed include declarations.
                 const inherited = find_inherited_dofile_local(
                     resolved_scope, word, position.line, document.uri
                 );
                 if (inherited) {
                     return this.locations_to_definition(
                         this.macro_symbol_to_locations(inherited)
+                    );
+                }
+                if (scoped.fallback_locations) {
+                    return this.locations_to_definition(
+                        scoped.fallback_locations
                     );
                 }
             } else {
@@ -1397,21 +1411,31 @@ export class DefinitionProvider {
             }
         }
 
+        // Without a scope resolver an inherited winner is
+        // unknowable: a forward identity target still navigates
+        // (pre-round-9 parity for resolver-less setups); an
+        // out-of-scope name yields nothing for the local namespace.
+        if (local_needs_inherited && !scope_resolver &&
+            scoped.fallback_locations) {
+            return this.locations_to_definition(scoped.fallback_locations);
+        }
+
         // Only check macros, not programs or other Stata symbols
         // 1. Check local macros (skipped when the name is tracked in
-        //    this file but out of scope at the cursor — the flat slot
-        //    may point at that very out-of-scope symbol, #270)
-        const local_macro = local_out_of_scope
+        //    this file but out of scope or forward-only at the cursor
+        //    — the flat slot may point at that very symbol, #270)
+        const local_macro = local_needs_inherited
             ? undefined
             : document.symbols.localMacros.get(word);
 
         // Collect cross-file workspace-indexer definitions (both
         // kinds).
-        // Barred for out-of-scope names: their only legitimate local
-        // identity is the call-line-gated inherited winner handled
-        // above; the indexer pooling has no execution-order gate and
-        // would surface not-yet-inherited declarations (round-4 gate).
-        const cross_local_locs = local_out_of_scope
+        // Barred for out-of-scope/forward-only names: their only
+        // legitimate local identity is the call-line-gated inherited
+        // winner handled above; the indexer pooling has no
+        // execution-order gate and would surface not-yet-inherited
+        // declarations (round-4 gate).
+        const cross_local_locs = local_needs_inherited
             ? []
             : this.collect_workspace_definition_locations(
                 document.uri,

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -270,15 +270,17 @@ export class DefinitionProvider {
      *   `position` (a sibling scope's local) — exclusive shadowing,
      *   no result; the flat slot must not substitute.
      * - non-empty: the visible symbol is program-scoped — its own
-     *   primary + same-scope additional_definitions (#271: program
-     *   locals never cross files), merged with the workspace-indexer
-     *   include-chain hits (already gated by is_cross_file_hidden_local).
+     *   primary + same-scope additional_definitions only. Program
+     *   locals never cross file boundaries (#271), so cross-file
+     *   same-name hits are NOT merged in (a same-named local in an
+     *   included file is a different macro) — consistent with
+     *   find-references skipping the cross-file scan for
+     *   program-scoped targets.
      */
     private resolve_scoped_local_definition(
         document: DocumentState,
         word: string,
-        position: Position,
-        workspace_indexer?: WorkspaceIndexer
+        position: Position
     ): Location[] | null {
         const scoped = lookup_scoped_local_macro(
             document.scopes, position, word
@@ -289,15 +291,9 @@ export class DefinitionProvider {
         if (!scoped.symbol || scoped.symbol.containingScope !== 'program') {
             return null;
         }
-        const out = this.macro_symbol_to_locations(scoped.symbol);
-        out.push(...this.collect_workspace_definition_locations(
-            document.uri,
-            word,
-            'local',
-            workspace_indexer,
-            { include_only: true }
-        ));
-        return this.dedupe_locations(out);
+        return this.dedupe_locations(
+            this.macro_symbol_to_locations(scoped.symbol)
+        );
     }
 
     /**
@@ -314,9 +310,7 @@ export class DefinitionProvider {
     ): Promise<Definition | null> {
         // Scope-aware same-file resolution first (#270).
         const scoped_locs = position
-            ? this.resolve_scoped_local_definition(
-                document, word, position, workspace_indexer
-            )
+            ? this.resolve_scoped_local_definition(document, word, position)
             : null;
         if (scoped_locs !== null) {
             return scoped_locs.length > 0
@@ -1295,7 +1289,7 @@ export class DefinitionProvider {
         // visible local is authoritative (never crosses files, #271); an
         // out-of-scope name must not fall back to the flat slot below.
         const scoped_locs = this.resolve_scoped_local_definition(
-            document, word, position, workspace_indexer
+            document, word, position
         );
         if (scoped_locs !== null && scoped_locs.length > 0) {
             return this.locations_to_definition(scoped_locs);

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -48,7 +48,10 @@ import * as path from 'path';
 import { URI } from 'vscode-uri';
 import { resolve_path_rich, resolve_forward_call_rich } from '../utils/file-path-utils';
 import { get_line_text } from '../utils/line-utils';
-import { is_cross_file_hidden_local } from '../utils/dofile-locals';
+import {
+    find_inherited_dofile_local,
+    is_cross_file_hidden_local,
+} from '../utils/dofile-locals';
 import {
     lookup_scoped_local_macro,
     resolve_scoped_or_flat,
@@ -321,44 +324,50 @@ export class DefinitionProvider {
         if (scoped !== null && !scoped.blocked) {
             return this.locations_to_definition(scoped.locations);
         }
-        // Out-of-scope same-file (#270): the flat slot and same-file
-        // chain contributions are forbidden (they may be the very
-        // out-of-scope sibling symbol), but cross-file INHERITED
-        // definitions remain legitimate — the analyzer's cross-file
-        // suppression treats them as defined, so filter same-file
-        // hits rather than bail out entirely (round-2 gate).
-        const local_out_of_scope = scoped?.blocked === true;
 
-        // Try scope resolver first
-        if (scope_resolver) {
-            const resolve_config = build_scope_resolver_config(cross_file_config);
-            const resolved_scope = await scope_resolver.resolve(
+        const resolved_scope = scope_resolver
+            ? await scope_resolver.resolve(
                 document.uri,
                 document.content,
-                resolve_config,
+                build_scope_resolver_config(cross_file_config),
                 cancellation_token
-            );
+            )
+            : undefined;
 
-            let local_locs = this.collect_local_macro_scope_locations(
+        if (scoped?.blocked === true) {
+            // Out-of-scope same-file (#270): the identity is the
+            // cross-file INHERITED do-file local — the exact winner
+            // hover/completion/references resolve — or nothing.
+            // Ungated chain walks and workspace pooling would
+            // navigate to superseded or not-yet-executed include
+            // declarations (round-4 gate).
+            const inherited = position
+                ? find_inherited_dofile_local(
+                    resolved_scope, word, position.line, document.uri
+                )
+                : undefined;
+            return inherited
+                ? this.locations_to_definition(
+                    this.macro_symbol_to_locations(inherited)
+                )
+                : null;
+        }
+
+        // Try scope resolver first
+        if (resolved_scope) {
+            const local_locs = this.collect_local_macro_scope_locations(
                 resolved_scope,
                 word,
                 position,
                 document.uri
             );
-            if (local_out_of_scope) {
-                local_locs = local_locs.filter(
-                    my_loc => my_loc.uri !== document.uri
-                );
-            }
             if (local_locs.length > 0) {
                 return this.locations_to_definition(local_locs);
             }
         }
 
         // Check document symbols
-        const local_macro = local_out_of_scope
-            ? undefined
-            : document.symbols.localMacros.get(word);
+        const local_macro = document.symbols.localMacros.get(word);
 
         // Collect workspace-indexer cross-file definitions for the same
         // name regardless of whether the current file defines it too, so
@@ -1320,22 +1329,33 @@ export class DefinitionProvider {
                 cancellation_token
             );
 
-            // Out-of-scope same-file names still resolve to cross-file
-            // INHERITED definitions — only same-file hits are
-            // forbidden (round-2 gate; see resolve_local_macro_only).
-            let local_locs = this.collect_local_macro_scope_locations(
-                resolved_scope,
-                word,
-                position,
-                document.uri
-            );
             if (local_out_of_scope) {
-                local_locs = local_locs.filter(
-                    my_loc => my_loc.uri !== document.uri
+                // Out-of-scope same-file (#270): the identity is the
+                // cross-file INHERITED do-file local — the exact
+                // winner hover/completion/references resolve — or
+                // nothing for the LOCAL branch (globals below are a
+                // separate namespace and stay unaffected). Ungated
+                // chain walks would navigate to superseded or
+                // not-yet-executed include declarations (round-4
+                // gate; see resolve_local_macro_only).
+                const inherited = find_inherited_dofile_local(
+                    resolved_scope, word, position.line, document.uri
                 );
-            }
-            if (local_locs.length > 0) {
-                return this.locations_to_definition(local_locs);
+                if (inherited) {
+                    return this.locations_to_definition(
+                        this.macro_symbol_to_locations(inherited)
+                    );
+                }
+            } else {
+                const local_locs = this.collect_local_macro_scope_locations(
+                    resolved_scope,
+                    word,
+                    position,
+                    document.uri
+                );
+                if (local_locs.length > 0) {
+                    return this.locations_to_definition(local_locs);
+                }
             }
 
             // Check global macros — do/run/include all propagate globals
@@ -1385,17 +1405,19 @@ export class DefinitionProvider {
             : document.symbols.localMacros.get(word);
 
         // Collect cross-file workspace-indexer definitions (both kinds).
-        // Cross-file pooling stays on for out-of-scope names: only
-        // same-file candidates are forbidden there (round-2 gate); the
-        // include-chain hits are already gated by
-        // is_cross_file_hidden_local inside the collector.
-        const cross_local_locs = this.collect_workspace_definition_locations(
-            document.uri,
-            word,
-            'local',
-            workspace_indexer,
-            { include_only: true }
-        );
+        // Barred for out-of-scope names: their only legitimate local
+        // identity is the call-line-gated inherited winner handled
+        // above; the indexer pooling has no execution-order gate and
+        // would surface not-yet-inherited declarations (round-4 gate).
+        const cross_local_locs = local_out_of_scope
+            ? []
+            : this.collect_workspace_definition_locations(
+                document.uri,
+                word,
+                'local',
+                workspace_indexer,
+                { include_only: true }
+            );
         const cross_global_locs = this.collect_workspace_definition_locations(
             document.uri,
             word,

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -49,7 +49,7 @@ import { URI } from 'vscode-uri';
 import { resolve_path_rich, resolve_forward_call_rich } from '../utils/file-path-utils';
 import { get_line_text } from '../utils/line-utils';
 import {
-    find_inherited_dofile_local,
+    classify_effective_local,
     is_cross_file_hidden_local,
 } from '../utils/dofile-locals';
 import {
@@ -263,55 +263,6 @@ export class DefinitionProvider {
     }
 
     /**
-     * Scope-aware classification for local-macro definition lookups
-     * (#270). Return values:
-     * - `null`: the scoped model has no opinion (scopes empty, name
-     *   untracked in this file, or the visible symbol is do-file
-     *   scoped — publish_flat_local guarantees a do-file definition
-     *   always owns the flat slot when one exists, and the existing
-     *   resolved-scope/flat code also handles cross-file
-     *   execution-order shadowing that document.scopes cannot see).
-     *   Callers must run the pre-existing code unchanged.
-     * - `kind: 'authoritative'`: a positionally RESOLVED
-     *   program-scoped local — its own primary + same-scope
-     *   additional_definitions only. Program locals never cross file
-     *   boundaries (#271), so cross-file same-name hits are NOT
-     *   merged in — consistent with find-references skipping the
-     *   cross-file scan for program-scoped targets.
-     * - `kind: 'needs_inherited'`: the same-file answer defers to the
-     *   cross-file INHERITED do-file local when one exists (the
-     *   analyzer's cross-file suppression treats the reference as
-     *   defined via it, round-9 gate). `fallback_locations` carries a
-     *   same-scope FORWARD identity target's locations (used only
-     *   when no inherited winner exists); null for an out-of-scope
-     *   name, whose only candidate is the inherited winner.
-     */
-    private resolve_scoped_local_definition(
-        document: DocumentState,
-        word: string,
-        position: Position
-    ):
-        | { kind: 'authoritative'; locations: Location[] }
-        | { kind: 'needs_inherited'; fallback_locations: Location[] | null }
-        | null {
-        const scoped = lookup_scoped_local_macro(
-            document.scopes, position, word
-        );
-        if (scoped.out_of_scope) {
-            return { kind: 'needs_inherited', fallback_locations: null };
-        }
-        if (!scoped.symbol || scoped.symbol.containingScope !== 'program') {
-            return null;
-        }
-        const the_locations = this.dedupe_locations(
-            this.macro_symbol_to_locations(scoped.symbol)
-        );
-        return scoped.forward_only
-            ? { kind: 'needs_inherited', fallback_locations: the_locations }
-            : { kind: 'authoritative', locations: the_locations };
-    }
-
-    /**
      * Resolve local macro only (for MACRO_REF_LOCAL tokens and extended macro context).
      */
     private async resolve_local_macro_only(
@@ -323,12 +274,19 @@ export class DefinitionProvider {
         cancellation_token?: CancellationToken,
         position?: Position
     ): Promise<Definition | null> {
-        // Scope-aware same-file resolution first (#270).
+        // Scope-aware same-file resolution first (#270): a
+        // positionally RESOLVED program-scoped local is authoritative
+        // without touching the resolver (#271 fast path).
         const scoped = position
-            ? this.resolve_scoped_local_definition(document, word, position)
-            : null;
-        if (scoped?.kind === 'authoritative') {
-            return this.locations_to_definition(scoped.locations);
+            ? lookup_scoped_local_macro(document.scopes, position, word)
+            : { symbol: undefined, forward_only: false, out_of_scope: false };
+        if (
+            scoped.symbol?.containingScope === 'program' &&
+            !scoped.forward_only
+        ) {
+            return this.locations_to_definition(this.dedupe_locations(
+                this.macro_symbol_to_locations(scoped.symbol)
+            ));
         }
 
         const resolved_scope = scope_resolver
@@ -340,25 +298,22 @@ export class DefinitionProvider {
             )
             : undefined;
 
-        if (scoped?.kind === 'needs_inherited') {
-            // The cross-file INHERITED do-file local outranks a
-            // same-scope forward identity target (round-9 gate) and
-            // is the only candidate for an out-of-scope name (round-4
-            // gate): ungated chain walks and workspace pooling would
-            // navigate to superseded or not-yet-executed include
-            // declarations.
-            const inherited = position
-                ? find_inherited_dofile_local(
-                    resolved_scope, word, position.line, document.uri
-                )
-                : undefined;
-            if (inherited) {
-                return this.locations_to_definition(
-                    this.macro_symbol_to_locations(inherited)
-                );
-            }
-            return scoped.fallback_locations
-                ? this.locations_to_definition(scoped.fallback_locations)
+        if (position && (scoped.out_of_scope || scoped.forward_only)) {
+            // THE effective order (classify_effective_local): the
+            // inherited winner outranks a forward identity target of
+            // EITHER scope kind (round-9/10 gates); an out-of-scope
+            // name with no winner resolves to nothing — ungated chain
+            // walks and workspace pooling would navigate to
+            // superseded or not-yet-executed include declarations
+            // (round-4 gate).
+            const effective = classify_effective_local(
+                document.scopes, position, word, resolved_scope,
+                document.uri
+            );
+            return effective.symbol
+                ? this.locations_to_definition(this.dedupe_locations(
+                    this.macro_symbol_to_locations(effective.symbol)
+                ))
                 : null;
         }
 
@@ -1318,17 +1273,23 @@ export class DefinitionProvider {
         const { word } = word_info;
 
         // Scope-aware same-file resolution first (#270): a
-        // positionally resolved program-scoped local is authoritative
+        // positionally RESOLVED program-scoped local is authoritative
         // (never crosses files, #271); an out-of-scope or
         // forward-only name must not fall back to the flat slot
         // below.
-        const scoped = this.resolve_scoped_local_definition(
-            document, word, position
+        const scoped = lookup_scoped_local_macro(
+            document.scopes, position, word
         );
-        if (scoped?.kind === 'authoritative') {
-            return this.locations_to_definition(scoped.locations);
+        if (
+            scoped.symbol?.containingScope === 'program' &&
+            !scoped.forward_only
+        ) {
+            return this.locations_to_definition(this.dedupe_locations(
+                this.macro_symbol_to_locations(scoped.symbol)
+            ));
         }
-        const local_needs_inherited = scoped?.kind === 'needs_inherited';
+        const local_needs_effective =
+            scoped.out_of_scope || scoped.forward_only;
 
         // Try scope resolver first if available
         if (scope_resolver) {
@@ -1340,25 +1301,24 @@ export class DefinitionProvider {
                 cancellation_token
             );
 
-            if (scoped?.kind === 'needs_inherited') {
-                // The cross-file INHERITED do-file local outranks a
-                // same-scope forward identity target (round-9 gate)
-                // and is the only candidate for an out-of-scope name
-                // (round-4 gate) — or nothing for the LOCAL branch
-                // (globals below are a separate namespace and stay
-                // unaffected). Ungated chain walks would navigate to
-                // superseded or not-yet-executed include declarations.
-                const inherited = find_inherited_dofile_local(
-                    resolved_scope, word, position.line, document.uri
+            if (local_needs_effective) {
+                // THE effective order (classify_effective_local): the
+                // inherited winner outranks a forward identity target
+                // of EITHER scope kind (round-9/10 gates); an
+                // out-of-scope name with no winner yields nothing for
+                // the LOCAL branch (globals below are a separate
+                // namespace and stay unaffected).
+                const effective = classify_effective_local(
+                    document.scopes, position, word, resolved_scope,
+                    document.uri
                 );
-                if (inherited) {
+                if (effective.symbol) {
                     return this.locations_to_definition(
-                        this.macro_symbol_to_locations(inherited)
-                    );
-                }
-                if (scoped.fallback_locations) {
-                    return this.locations_to_definition(
-                        scoped.fallback_locations
+                        this.dedupe_locations(
+                            this.macro_symbol_to_locations(
+                                effective.symbol
+                            )
+                        )
                     );
                 }
             } else {
@@ -1415,16 +1375,18 @@ export class DefinitionProvider {
         // unknowable: a forward identity target still navigates
         // (pre-round-9 parity for resolver-less setups); an
         // out-of-scope name yields nothing for the local namespace.
-        if (local_needs_inherited && !scope_resolver &&
-            scoped.fallback_locations) {
-            return this.locations_to_definition(scoped.fallback_locations);
+        if (local_needs_effective && !scope_resolver &&
+            scoped.forward_only && scoped.symbol) {
+            return this.locations_to_definition(this.dedupe_locations(
+                this.macro_symbol_to_locations(scoped.symbol)
+            ));
         }
 
         // Only check macros, not programs or other Stata symbols
         // 1. Check local macros (skipped when the name is tracked in
         //    this file but out of scope or forward-only at the cursor
         //    — the flat slot may point at that very symbol, #270)
-        const local_macro = local_needs_inherited
+        const local_macro = local_needs_effective
             ? undefined
             : document.symbols.localMacros.get(word);
 
@@ -1435,7 +1397,7 @@ export class DefinitionProvider {
         // winner handled above; the indexer pooling has no
         // execution-order gate and would surface not-yet-inherited
         // declarations (round-4 gate).
-        const cross_local_locs = local_needs_inherited
+        const cross_local_locs = local_needs_effective
             ? []
             : this.collect_workspace_definition_locations(
                 document.uri,

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -18,6 +18,7 @@ import {
 import {
     find_enclosing_scope,
 } from '../utils/scope-position';
+import { get_visible_local_scopes } from '../utils/scoped-locals';
 import {
     ScopeResolver,
     get_visible_forward_call_sites,
@@ -1061,25 +1062,14 @@ export class DiagnosticsProvider {
         // Locals resolve the forward hint scope-aware: the flat view's
         // slot prefers a do-file definition, which may be an unrelated
         // later redefinition rather than the same-scope definition the
-        // user should be pointed at. Mirror lookup_local_macro's
-        // visibility (own scope + do-file scope) and pick the nearest
-        // definition after the reference across both. Falls back to the
-        // flat read when no scopes were provided (partial states).
+        // user should be pointed at. get_visible_local_scopes mirrors
+        // lookup_local_macro's visibility (own scope + do-file scope,
+        // body_only per #273); pick the nearest definition after the
+        // reference across both. Falls back to the flat read when no
+        // scopes were provided (partial states).
         if (reference_kind === 'local' && scopes.length > 0) {
-            // body_only: a reference on a program's header/end line
-            // expands in the enclosing frame, so the hint must never
-            // name a body local (issue #273).
-            const enclosing_scope = find_enclosing_scope(
-                scopes,
-                reference_position,
-                { body_only: true }
-            );
             const the_visible_scopes =
-                enclosing_scope.type !== 'dofile' &&
-                scopes[0] !== undefined &&
-                scopes[0] !== enclosing_scope
-                    ? [enclosing_scope, scopes[0]]
-                    : [enclosing_scope];
+                get_visible_local_scopes(scopes, reference_position);
             let nearest_forward_line: number | null = null;
             for (const my_scope of the_visible_scopes) {
                 const my_symbol = my_scope.localMacros.get(symbol_name);

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -334,14 +334,25 @@ export class HoverProvider {
 
         // In embedded language context, only check for macros (suppress other Stata-specific hover)
         if (my_context !== LanguageContext.STATA) {
-            // Macros work in all contexts - check local and global macros only
-            const local_macro_content = this.get_local_macro_hover(document, word, resolved_scope, workspace_root, position, workspace_indexer);
-            if (local_macro_content) {
-                return { contents: local_macro_content, range };
+            // Macros work in all contexts — but preserve the
+            // reference's delimiter intent (#270 round-13 gate):
+            // `` `x' `` is an explicit LOCAL reference and $x an
+            // explicit GLOBAL one, so a rejected lookup in one
+            // namespace must not fall through to the other. Bare
+            // words keep the local-then-global order.
+            const embedded_reference_type =
+                this.get_reference_type_from_context(document, position, word);
+            if (embedded_reference_type !== 'global_macro') {
+                const local_macro_content = this.get_local_macro_hover(document, word, resolved_scope, workspace_root, position, workspace_indexer);
+                if (local_macro_content) {
+                    return { contents: local_macro_content, range };
+                }
             }
-            const global_macro_content = this.get_global_macro_hover(document, word, workspace_symbols, resolved_scope, workspace_root, position, workspace_indexer);
-            if (global_macro_content) {
-                return { contents: global_macro_content, range };
+            if (embedded_reference_type !== 'local_macro') {
+                const global_macro_content = this.get_global_macro_hover(document, word, workspace_symbols, resolved_scope, workspace_root, position, workspace_indexer);
+                if (global_macro_content) {
+                    return { contents: global_macro_content, range };
+                }
             }
             return null;
         }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1009,8 +1009,11 @@ export class HoverProvider {
         // Scope-aware same-file resolution first (#270).
         const scoped = position
             ? lookup_scoped_local_macro(document.scopes, position, word)
-            : { symbol: undefined, out_of_scope: false };
-        if (scoped.symbol?.containingScope === 'program') {
+            : { symbol: undefined, forward_only: false, out_of_scope: false };
+        if (
+            scoped.symbol?.containingScope === 'program' &&
+            !scoped.forward_only
+        ) {
             // Program locals never cross files (#271) — the visible
             // program-scoped symbol is unconditionally the answer, and
             // it fixes the case where an unrelated same-named local
@@ -1024,33 +1027,50 @@ export class HoverProvider {
                 undefined,
             );
         }
-        if (scoped.out_of_scope) {
-            // The name exists same-file only in scopes not visible
-            // from here, so the flat slot is forbidden — but a
-            // cross-file INHERITED do-file local is genuinely defined
-            // at this position (the analyzer's cross-file suppression
-            // treats it as defined), so consult include-inherited
-            // sources before giving up (#270 round-2 gate).
+        if (scoped.out_of_scope || scoped.forward_only) {
+            // No positionally resolved same-file winner. A cross-file
+            // INHERITED do-file local is genuinely defined at this
+            // position (the analyzer's cross-file suppression treats
+            // it as defined), so it outranks a not-yet-defined
+            // same-scope forward local (round-9 gate) and is the only
+            // candidate for an out-of-scope name (round-2 gate). The
+            // workspace indexer is withheld: its footer keeps
+            // same-file hits, so the very sibling or forward
+            // program-local would be presented as a "redefinition" of
+            // the inherited macro (round-5 gate).
             const inherited = position
                 ? find_inherited_dofile_local(
                     resolved_scope, word, position.line, document.uri
                 )
                 : undefined;
-            // The workspace indexer is withheld: its footer keeps
-            // same-file hits, so the very sibling program-local that
-            // made the name out-of-scope would be presented as a
-            // "redefinition" of the inherited macro (round-5 gate).
-            return inherited
-                ? this.render_local_macro_hover(
+            if (inherited) {
+                return this.render_local_macro_hover(
                     document, inherited, word, workspace_root,
                     undefined,
-                )
-                : null;
+                );
+            }
+            if (
+                scoped.forward_only &&
+                scoped.symbol?.containingScope === 'program'
+            ) {
+                // Forward identity target: navigation-friendly hover
+                // for a same-scope reference before its definition.
+                return this.render_local_macro_hover(
+                    document, scoped.symbol, word, workspace_root,
+                    undefined,
+                );
+            }
+            if (scoped.out_of_scope) {
+                return null;
+            }
+            // Do-file forward: fall through to the resolved-scope /
+            // flat paths, which own do-file-level precedence.
         }
 
         // Do-file-scoped or no scoped opinion: unchanged — the
-        // resolved scope / flat fallback also apply execution-order
-        // precedence that document.scopes cannot see.
+        // resolved scope / flat fallback also apply CROSS-FILE
+        // execution-order precedence that document.scopes (a
+        // same-file-only structure) cannot see.
         const local_macro_symbols = this.safe_visible_symbols(resolved_scope, position);
         if (local_macro_symbols) {
             const local_macro = local_macro_symbols.localMacros.get(word);

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1048,8 +1048,8 @@ export class HoverProvider {
                 : null;
         }
 
-        // Do-file-scoped or no scoped opinion: unchanged — the resolved
-        // scope / flat fallback also apply cross-file execution-order
+        // Do-file-scoped or no scoped opinion: unchanged — the
+        // resolved scope / flat fallback also apply execution-order
         // precedence that document.scopes cannot see.
         const local_macro_symbols = this.safe_visible_symbols(resolved_scope, position);
         if (local_macro_symbols) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -1036,10 +1036,14 @@ export class HoverProvider {
                     resolved_scope, word, position.line, document.uri
                 )
                 : undefined;
+            // The workspace indexer is withheld: its footer keeps
+            // same-file hits, so the very sibling program-local that
+            // made the name out-of-scope would be presented as a
+            // "redefinition" of the inherited macro (round-5 gate).
             return inherited
                 ? this.render_local_macro_hover(
                     document, inherited, word, workspace_root,
-                    workspace_indexer,
+                    undefined,
                 )
                 : null;
         }

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -53,7 +53,10 @@ import {
 } from '../utils/token-utils';
 import { is_cursor_in_comment } from '../utils/comment-utils';
 import { is_cursor_in_string_literal } from '../utils/string-literal-utils';
-import { is_cross_file_hidden_local } from '../utils/dofile-locals';
+import {
+    find_inherited_dofile_local,
+    is_cross_file_hidden_local,
+} from '../utils/dofile-locals';
 import { lookup_scoped_local_macro } from '../utils/scoped-locals';
 
 const MARKDOWN_TEXT_ESCAPE_PATTERN =
@@ -679,11 +682,22 @@ export class HoverProvider {
         workspace_root?: string,
         workspace_indexer?: WorkspaceIndexer,
     ): SymbolMatch[] {
-        // Check for out-of-scope symbol matching the reference type
+        // Check for out-of-scope symbol matching the reference type.
+        // A visible PROGRAM-scoped local pre-empts the out-of-scope
+        // display (#270 round-2 gate): the program's own local is the
+        // authoritative answer at this cursor, so a same-named
+        // cross-file out-of-scope entry must not hijack the hover.
         const reference_type = this.get_reference_type_from_context(document, position, word);
-        const out_of_scope_match = this.get_out_of_scope_hover(
-            word, reference_type, resolved_scope, document.uri, workspace_root
-        );
+        const scoped_preempts_out_of_scope =
+            reference_type === 'local_macro' &&
+            lookup_scoped_local_macro(document.scopes, position, word)
+                .symbol?.containingScope === 'program';
+        const out_of_scope_match = scoped_preempts_out_of_scope
+            ? null
+            : this.get_out_of_scope_hover(
+                word, reference_type, resolved_scope, document.uri,
+                workspace_root
+            );
         if (out_of_scope_match) {
             return [out_of_scope_match];
         }
@@ -998,10 +1012,23 @@ export class HoverProvider {
             );
         }
         if (scoped.out_of_scope) {
-            // Exclusive shadowing: the name exists only in scopes not
-            // visible from here — matches the analyzer's out-of-scope
-            // diagnostic for this reference.
-            return null;
+            // The name exists same-file only in scopes not visible
+            // from here, so the flat slot is forbidden — but a
+            // cross-file INHERITED do-file local is genuinely defined
+            // at this position (the analyzer's cross-file suppression
+            // treats it as defined), so consult include-inherited
+            // sources before giving up (#270 round-2 gate).
+            const inherited = position
+                ? find_inherited_dofile_local(
+                    resolved_scope, word, position.line, document.uri
+                )
+                : undefined;
+            return inherited
+                ? this.render_local_macro_hover(
+                    document, inherited, word, workspace_root,
+                    workspace_indexer,
+                )
+                : null;
         }
 
         // Do-file-scoped or no scoped opinion: unchanged — the resolved

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -987,10 +987,14 @@ export class HoverProvider {
             // Program locals never cross files (#271) — the visible
             // program-scoped symbol is unconditionally the answer, and
             // it fixes the case where an unrelated same-named local
-            // elsewhere in the file holds the flat slot.
+            // elsewhere in the file holds the flat slot. The workspace
+            // indexer is deliberately withheld: the redefinition
+            // footer must not pool cross-file same-name locals for a
+            // symbol whose identity never crosses files (matching
+            // definition/references skipping their cross-file scans).
             return this.render_local_macro_hover(
                 document, scoped.symbol, word, workspace_root,
-                workspace_indexer,
+                undefined,
             );
         }
         if (scoped.out_of_scope) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -54,6 +54,7 @@ import {
 import { is_cursor_in_comment } from '../utils/comment-utils';
 import { is_cursor_in_string_literal } from '../utils/string-literal-utils';
 import { is_cross_file_hidden_local } from '../utils/dofile-locals';
+import { lookup_scoped_local_macro } from '../utils/scoped-locals';
 
 const MARKDOWN_TEXT_ESCAPE_PATTERN =
     /([\\`*_{}\[\]()#+\-.!|])/g;
@@ -978,64 +979,86 @@ export class HoverProvider {
         position?: Position,
         workspace_indexer?: WorkspaceIndexer,
     ): MarkupContent | null {
-        // Check resolved scope first if available
+        // Scope-aware same-file resolution first (#270).
+        const scoped = position
+            ? lookup_scoped_local_macro(document.scopes, position, word)
+            : { symbol: undefined, out_of_scope: false };
+        if (scoped.symbol?.containingScope === 'program') {
+            // Program locals never cross files (#271) — the visible
+            // program-scoped symbol is unconditionally the answer, and
+            // it fixes the case where an unrelated same-named local
+            // elsewhere in the file holds the flat slot.
+            return this.render_local_macro_hover(
+                document, scoped.symbol, word, workspace_root,
+                workspace_indexer,
+            );
+        }
+        if (scoped.out_of_scope) {
+            // Exclusive shadowing: the name exists only in scopes not
+            // visible from here — matches the analyzer's out-of-scope
+            // diagnostic for this reference.
+            return null;
+        }
+
+        // Do-file-scoped or no scoped opinion: unchanged — the resolved
+        // scope / flat fallback also apply cross-file execution-order
+        // precedence that document.scopes cannot see.
         const local_macro_symbols = this.safe_visible_symbols(resolved_scope, position);
         if (local_macro_symbols) {
             const local_macro = local_macro_symbols.localMacros.get(word);
             if (local_macro) {
-                const source_link = this.format_source_link(local_macro.sourceUri, document.uri, workspace_root);
-                const line_info = this.macro_definition_line_info(local_macro);
-                const source_info = source_link
-                    ? `\n\nSource: ${source_link}${line_info}`
-                    : `\n\nDefined at: this file${line_info}`;
-                // Use inline code for short values, code block for multi-line
-                const expansion_text = local_macro.value
-                    ? (local_macro.value.includes('\n')
-                        ? `\n\nExpansion:\n\`\`\`\n${local_macro.value}\n\`\`\``
-                        : `\n\nExpansion: \`${local_macro.value}\``)
-                    : '';
-                const the_combined_extras = this.collect_workspace_additional_definitions(
-                    word, 'local', local_macro, workspace_indexer, document.uri,
+                return this.render_local_macro_hover(
+                    document, local_macro, word, workspace_root,
+                    workspace_indexer,
                 );
-                const footer = this.format_redefinition_footer(
-                    local_macro.location?.uri ?? local_macro.sourceUri,
-                    the_combined_extras,
-                );
-                return {
-                    kind: MarkupKind.Markdown,
-                    value: `**Local Macro:** \`${word}\`${source_info}${expansion_text}${footer}`,
-                };
             }
         }
 
         // Fallback to document symbols
         const local_macro = document.symbols.localMacros.get(word);
         if (local_macro) {
-            const source_link = this.format_source_link(local_macro.sourceUri, document.uri, workspace_root);
-            const line_info = this.macro_definition_line_info(local_macro);
-            const source_info = source_link
-                ? `\n\nSource: ${source_link}${line_info}`
-                : `\n\nDefined at: this file${line_info}`;
-            // Use inline code for short values, code block for multi-line
-            const expansion_text = local_macro.value
-                ? (local_macro.value.includes('\n')
-                    ? `\n\nExpansion:\n\`\`\`\n${local_macro.value}\n\`\`\``
-                    : `\n\nExpansion: \`${local_macro.value}\``)
-                : '';
-            const the_combined_extras = this.collect_workspace_additional_definitions(
-                word, 'local', local_macro, workspace_indexer, document.uri,
+            return this.render_local_macro_hover(
+                document, local_macro, word, workspace_root,
+                workspace_indexer,
             );
-            const footer = this.format_redefinition_footer(
-                local_macro.location?.uri ?? local_macro.sourceUri,
-                the_combined_extras,
-            );
-            return {
-                kind: MarkupKind.Markdown,
-                value: `**Local Macro:** \`${word}\`${source_info}${expansion_text}${footer}`,
-            };
         }
 
         return null;
+    }
+
+    /**
+     * Render the hover markdown for a resolved local-macro symbol
+     * (shared by the scoped, resolved-scope, and flat lookups above).
+     */
+    private render_local_macro_hover(
+        document: DocumentState,
+        local_macro: MacroSymbol,
+        word: string,
+        workspace_root?: string,
+        workspace_indexer?: WorkspaceIndexer,
+    ): MarkupContent {
+        const source_link = this.format_source_link(local_macro.sourceUri, document.uri, workspace_root);
+        const line_info = this.macro_definition_line_info(local_macro);
+        const source_info = source_link
+            ? `\n\nSource: ${source_link}${line_info}`
+            : `\n\nDefined at: this file${line_info}`;
+        // Use inline code for short values, code block for multi-line
+        const expansion_text = local_macro.value
+            ? (local_macro.value.includes('\n')
+                ? `\n\nExpansion:\n\`\`\`\n${local_macro.value}\n\`\`\``
+                : `\n\nExpansion: \`${local_macro.value}\``)
+            : '';
+        const the_combined_extras = this.collect_workspace_additional_definitions(
+            word, 'local', local_macro, workspace_indexer, document.uri,
+        );
+        const footer = this.format_redefinition_footer(
+            local_macro.location?.uri ?? local_macro.sourceUri,
+            the_combined_extras,
+        );
+        return {
+            kind: MarkupKind.Markdown,
+            value: `**Local Macro:** \`${word}\`${source_info}${expansion_text}${footer}`,
+        };
     }
 
     /**

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -692,7 +692,10 @@ export class HoverProvider {
         // out-of-scope display renders only when that resolution has
         // no answer, so it can never hijack a resolvable reference.
         if (reference_type === 'local_macro') {
-            const local_macro_content = this.get_local_macro_hover(document, word, resolved_scope, workspace_root, position, workspace_indexer);
+            const local_macro_content = this.get_local_macro_hover(
+                document, word, resolved_scope, workspace_root,
+                position, workspace_indexer
+            );
             if (local_macro_content) {
                 return [{ type: 'local_macro', content: local_macro_content }];
             }
@@ -713,7 +716,7 @@ export class HoverProvider {
 
         const the_matches: SymbolMatch[] = [];
 
-        // When reference type is explicit (global macro syntax), only check that type
+        // Explicit global-macro syntax checks only that type;
         // When reference type is 'other' (bare identifier), check all symbol types
 
         // 1. Check local macros - only for bare identifiers (explicit

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -683,32 +683,42 @@ export class HoverProvider {
         workspace_indexer?: WorkspaceIndexer,
     ): SymbolMatch[] {
         // Check for out-of-scope symbol matching the reference type.
-        // A visible PROGRAM-scoped local pre-empts the out-of-scope
-        // display (#270 round-2 gate): the program's own local is the
-        // authoritative answer at this cursor, so a same-named
-        // cross-file out-of-scope entry must not hijack the hover.
         const reference_type = this.get_reference_type_from_context(document, position, word);
-        const scoped_preempts_out_of_scope =
-            reference_type === 'local_macro' &&
-            lookup_scoped_local_macro(document.scopes, position, word)
-                .symbol?.containingScope === 'program';
-        const out_of_scope_match = scoped_preempts_out_of_scope
-            ? null
-            : this.get_out_of_scope_hover(
+
+        // Local-macro references resolve through the scoped/inherited
+        // precedence FIRST (#270: a visible program-scoped local wins,
+        // an out-of-scope name falls through to the inherited do-file
+        // local — all inside get_local_macro_hover); the cross-file
+        // out-of-scope display renders only when that resolution has
+        // no answer, so it can never hijack a resolvable reference.
+        if (reference_type === 'local_macro') {
+            const local_macro_content = this.get_local_macro_hover(document, word, resolved_scope, workspace_root, position, workspace_indexer);
+            if (local_macro_content) {
+                return [{ type: 'local_macro', content: local_macro_content }];
+            }
+            const out_of_scope_only = this.get_out_of_scope_hover(
                 word, reference_type, resolved_scope, document.uri,
                 workspace_root
             );
+            return out_of_scope_only ? [out_of_scope_only] : [];
+        }
+
+        // Check for out-of-scope symbol matching the reference type
+        const out_of_scope_match = this.get_out_of_scope_hover(
+            word, reference_type, resolved_scope, document.uri, workspace_root
+        );
         if (out_of_scope_match) {
             return [out_of_scope_match];
         }
 
         const the_matches: SymbolMatch[] = [];
 
-        // When reference type is explicit (local or global macro syntax), only check that type
+        // When reference type is explicit (global macro syntax), only check that type
         // When reference type is 'other' (bare identifier), check all symbol types
 
-        // 1. Check local macros - only if reference is local macro or bare identifier
-        if (reference_type === 'local_macro' || reference_type === 'other') {
+        // 1. Check local macros - only for bare identifiers (explicit
+        //    local-macro references returned above)
+        if (reference_type === 'other') {
             const local_macro_content = this.get_local_macro_hover(document, word, resolved_scope, workspace_root, position, workspace_indexer);
             if (local_macro_content) {
                 the_matches.push({ type: 'local_macro', content: local_macro_content });

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -218,7 +218,7 @@ export class ReferencesProvider {
                 // cursor-visible scope's own MacroSymbol) supersedes the
                 // flat slot, which may belong to a different scope. For
                 // an out-of-scope reference the flat slot is forbidden
-                // entirely — the identity is exactly the call-line-gated
+                // entirely — the identity is the call-line-gated
                 // inherited winner (its primary + same-scope
                 // additional_definitions) or nothing; the broad
                 // workspace pool below stays off for this mode, or a

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -199,7 +199,7 @@ export class ReferencesProvider {
         cursor_line?: number,
         target_local_macro?: MacroSymbol,
         exclude_same_file_local?: boolean,
-        has_inherited_target?: boolean,
+        inherited_target?: MacroSymbol,
     ): Location[] {
         const locations: Location[] = [];
         const seen = new Set<string>();
@@ -299,7 +299,7 @@ export class ReferencesProvider {
         const undefined_out_of_scope_target =
             symbol_type === 'local_macro' &&
             exclude_same_file_local === true &&
-            has_inherited_target !== true;
+            inherited_target === undefined;
         if (
             workspace_indexer &&
             !is_program_scoped_target &&
@@ -491,7 +491,7 @@ export class ReferencesProvider {
             position.line,
             target.symbol,
             target.exclude_same_file_local,
-            this.has_inherited_target(
+            this.inherited_target_symbol(
                 target, resolved_scope, identified_symbol.name,
                 position.line, document.uri
             ),
@@ -507,19 +507,19 @@ export class ReferencesProvider {
      * is_cross_file_hidden_local hides its declaration would be
      * incoherent (round-3 gate).
      */
-    private has_inherited_target(
+    private inherited_target_symbol(
         target: { symbol?: MacroSymbol; exclude_same_file_local: boolean },
         resolved_scope: ResolvedScope | undefined,
         symbol_name: string,
         reference_line: number,
         current_uri: string
-    ): boolean {
+    ): MacroSymbol | undefined {
         if (!target.exclude_same_file_local) {
-            return false;
+            return undefined;
         }
         return find_inherited_dofile_local(
             resolved_scope, symbol_name, reference_line, current_uri
-        ) !== undefined;
+        );
     }
 
     /**
@@ -991,7 +991,7 @@ export class ReferencesProvider {
             position.line,
             target.symbol,
             target.exclude_same_file_local,
-            this.has_inherited_target(
+            this.inherited_target_symbol(
                 target, resolved_scope, identified_symbol.name,
                 position.line, document.uri
             ),
@@ -1013,7 +1013,7 @@ export class ReferencesProvider {
         cursor_line?: number,
         target_local_macro?: MacroSymbol,
         exclude_same_file_local?: boolean,
-        has_inherited_target?: boolean,
+        inherited_target?: MacroSymbol,
     ): Promise<Location[]> {
         const search_context: ReferenceSearchContext = {
             symbol_name,
@@ -1031,7 +1031,7 @@ export class ReferencesProvider {
             cursor_line,
             target_local_macro,
             exclude_same_file_local,
-            has_inherited_target,
+            inherited_target,
         );
 
         // Search workspace-indexed files (Req 13.3).
@@ -1069,7 +1069,7 @@ export class ReferencesProvider {
         const undefined_out_of_scope_target =
             symbol_type === 'local_macro' &&
             exclude_same_file_local === true &&
-            has_inherited_target !== true;
+            inherited_target === undefined;
         let the_related: Map<string, ReferenceScanRange>;
         if (
             is_program_scoped_target ||
@@ -1142,11 +1142,12 @@ export class ReferencesProvider {
                 // lexically belong to a DIFFERENT same-named local
                 // (shadowing) — keep only occurrences whose own
                 // position resolves to the exact target symbol. For an
-                // out-of-scope reference (exclude_same_file_local) the
-                // shared identity is "resolves to no same-file symbol"
-                // (the cross-file inherited local, or plain undefined),
-                // so occurrences that resolve to some same-file local
-                // are excluded instead. resolve_visible_local skips
+                // out-of-scope reference (exclude_same_file_local) an
+                // occurrence must resolve to no same-file symbol AND
+                // its own line's inherited winner must be the cursor's
+                // (identity-equal; undefined for plain-undefined): an
+                // occurrence before an include is a different
+                // resolution class than one after it (round-5 gate). resolve_visible_local skips
                 // lookup_scoped_local_macro's out-of-scope bookkeeping
                 // scan, which these comparisons never read.
                 if (symbol_type === 'local_macro') {
@@ -1163,11 +1164,17 @@ export class ReferencesProvider {
                     if (
                         target_local_macro === undefined &&
                         exclude_same_file_local === true &&
-                        resolve_visible_local(
+                        (resolve_visible_local(
                             document.scopes,
                             my_match.range.start,
                             symbol_name
-                        ) !== undefined
+                        ) !== undefined ||
+                            find_inherited_dofile_local(
+                                resolved_scope,
+                                symbol_name,
+                                my_match.range.start.line,
+                                document.uri
+                            ) !== inherited_target)
                     ) {
                         continue;
                     }

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -16,7 +16,11 @@ import { DocumentState } from '../document-store';
 import { LanguageContext, MacroSymbol, Token, ContextRange } from '../types';
 import { get_line_text } from '../utils/line-utils';
 import { is_cross_file_hidden_local } from '../utils/dofile-locals';
-import { lookup_scoped_local_macro } from '../utils/scoped-locals';
+import {
+    lookup_scoped_local_macro,
+    resolve_scoped_or_flat,
+    resolve_visible_local,
+} from '../utils/scoped-locals';
 import type { WorkspaceIndexer } from '../indexer';
 import type { IContextTracker } from '../context-tracker/types';
 import type { ScopeResolver } from '../scope-resolver';
@@ -732,13 +736,10 @@ export class ReferencesProvider {
         // Scope-aware (#270): resolve against the scope that textually
         // contains the cursor, so a losing-flat-slot program local
         // still matches its own declaration range.
-        const scoped_decl = lookup_scoped_local_macro(
-            document.scopes, range.start, word
+        const local_macro = resolve_scoped_or_flat(
+            document.scopes, range.start, word,
+            document.symbols.localMacros
         );
-        const local_macro = scoped_decl.symbol
-            ?? (scoped_decl.out_of_scope
-                ? undefined
-                : document.symbols.localMacros.get(word));
         if (
             local_macro
             && this.position_hits_symbol_definition(range.start, local_macro)
@@ -1075,14 +1076,17 @@ export class ReferencesProvider {
                 // lexically belong to a DIFFERENT same-named local
                 // (shadowing) — keep only occurrences whose own
                 // position resolves to the exact target symbol.
+                // resolve_visible_local skips lookup_scoped_local_macro's
+                // out-of-scope bookkeeping scan, which this identity
+                // comparison never reads.
                 if (
                     symbol_type === 'local_macro' &&
                     target_local_macro !== undefined &&
-                    lookup_scoped_local_macro(
+                    resolve_visible_local(
                         document.scopes,
                         my_match.range.start,
                         symbol_name
-                    ).symbol !== target_local_macro
+                    ) !== target_local_macro
                 ) {
                     continue;
                 }

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -215,7 +215,8 @@ export class ReferencesProvider {
         switch (symbol_type) {
             case 'local_macro': {
                 // Scope-aware (#270): the resolved target symbol (the
-                // cursor-visible scope's own MacroSymbol) supersedes the
+                // cursor-visible scope's own MacroSymbol) supersedes
+                // the
                 // flat slot, which may belong to a different scope. For
                 // an out-of-scope reference the flat slot is forbidden
                 // entirely — the identity is the call-line-gated
@@ -1062,7 +1063,8 @@ export class ReferencesProvider {
         // See docs/find-references.md for the rationale behind this three-tier model.
         const restrict_to_related = symbol_type !== 'variable';
         // A program-scoped local target never crosses file boundaries
-        // (#271) — restrict the scan to the current file, skipping the
+        // (#271) — restrict the scan to the current file, skipping
+        // the
         // cross-file token scan entirely (#270). Same for an
         // out-of-scope cursor with NO inherited target: the reference
         // is plain undefined, and a same-named local in an

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -15,12 +15,12 @@ import {
 import { DocumentState } from '../document-store';
 import { LanguageContext, MacroSymbol, Token, ContextRange } from '../types';
 import { get_line_text } from '../utils/line-utils';
-import { is_cross_file_hidden_local } from '../utils/dofile-locals';
-import { resolve_scoped_or_flat } from '../utils/scoped-locals';
 import {
     classify_effective_local,
+    is_cross_file_hidden_local,
     resolve_effective_local,
 } from '../utils/dofile-locals';
+import { resolve_scoped_or_flat } from '../utils/scoped-locals';
 import type { WorkspaceIndexer } from '../indexer';
 import type { IContextTracker } from '../context-tracker/types';
 import type { ScopeResolver } from '../scope-resolver';

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -218,11 +218,15 @@ export class ReferencesProvider {
                 // cursor-visible scope's own MacroSymbol) supersedes the
                 // flat slot, which may belong to a different scope. For
                 // an out-of-scope reference the flat slot is forbidden
-                // entirely — the identity is the cross-file inherited
-                // local (pooled from the indexer below) or nothing.
+                // entirely — the identity is exactly the call-line-gated
+                // inherited winner (its primary + same-scope
+                // additional_definitions) or nothing; the broad
+                // workspace pool below stays off for this mode, or a
+                // superseded include's same-name declaration would
+                // surface next to the winner (round-6 gate).
                 const local_macro = target_local_macro
                     ?? (exclude_same_file_local
-                        ? undefined
+                        ? inherited_target
                         : symbols.localMacros.get(symbol_name));
                 if (local_macro) {
                     // Loop-expanded definitions anchor at the template statement
@@ -291,19 +295,20 @@ export class ReferencesProvider {
 
         // A program-scoped local target never crosses file boundaries
         // (#271), so cross-file declaration pooling is skipped (#270).
-        // An out-of-scope cursor with NO inherited target is plain
-        // undefined — nothing legitimate to pool cross-file either.
+        // Out-of-scope cursors skip it too: their declaration set is
+        // exactly the inherited winner handled above (or nothing when
+        // plain undefined) — the ungated same-name pool would surface
+        // superseded includes' declarations (round-6 gate).
         const is_program_scoped_target = this.is_program_scoped_local_target(
             symbol_type, target_local_macro
         );
-        const undefined_out_of_scope_target =
+        const out_of_scope_local_target =
             symbol_type === 'local_macro' &&
-            exclude_same_file_local === true &&
-            inherited_target === undefined;
+            exclude_same_file_local === true;
         if (
             workspace_indexer &&
             !is_program_scoped_target &&
-            !undefined_out_of_scope_target
+            !out_of_scope_local_target
         ) {
             const ws_type: 'program' | 'local' | 'global' | 'variable' | 'scalar' | 'matrix' =
                 symbol_type === 'local_macro' ? 'local' :
@@ -1147,7 +1152,8 @@ export class ReferencesProvider {
                 // its own line's inherited winner must be the cursor's
                 // (identity-equal; undefined for plain-undefined): an
                 // occurrence before an include is a different
-                // resolution class than one after it (round-5 gate). resolve_visible_local skips
+                // resolution class than one after it (round-5 gate).
+                // resolve_visible_local skips
                 // lookup_scoped_local_macro's out-of-scope bookkeeping
                 // scan, which these comparisons never read.
                 if (symbol_type === 'local_macro') {

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -19,9 +19,11 @@ import { is_cross_file_hidden_local } from '../utils/dofile-locals';
 import {
     lookup_scoped_local_macro,
     resolve_scoped_or_flat,
-    resolve_visible_local,
 } from '../utils/scoped-locals';
-import { find_inherited_dofile_local } from '../utils/dofile-locals';
+import {
+    find_inherited_dofile_local,
+    resolve_effective_local,
+} from '../utils/dofile-locals';
 import type { WorkspaceIndexer } from '../indexer';
 import type { IContextTracker } from '../context-tracker/types';
 import type { ScopeResolver } from '../scope-resolver';
@@ -467,11 +469,6 @@ export class ReferencesProvider {
             return [];
         }
 
-        // Scope-aware local-macro target resolution (#270).
-        const target = this.resolve_local_reference_target(
-            document, position, identified_symbol
-        );
-
         // Resolve the scope once here (cached by ScopeResolver) so
         // find_definitions can apply the call-site filter to declarations
         // pooled from the workspace indexer. See issue #129.
@@ -485,6 +482,11 @@ export class ReferencesProvider {
             )
             : undefined;
 
+        // Scope-aware local-macro target resolution (#270).
+        const target = this.resolve_local_reference_target(
+            document, position, identified_symbol, resolved_scope
+        );
+
         return this.collect_references(
             document,
             identified_symbol.name,
@@ -495,67 +497,74 @@ export class ReferencesProvider {
             cancellation_token,
             resolved_scope,
             position.line,
-            target.symbol,
+            target.target_local_macro,
             target.exclude_same_file_local,
-            this.inherited_target_symbol(
-                target, resolved_scope, identified_symbol.name,
-                position.line, document.uri
-            ),
-        );
-    }
-
-    /**
-     * In exclude-same-file mode, does a cross-file INHERITED do-file
-     * local actually exist for this cursor? When it does not, the
-     * reference is plain undefined and the cross-file scan must not
-     * run — a same-named local in an include-related file's program
-     * body is a different macro, and surfacing its usages while
-     * is_cross_file_hidden_local hides its declaration would be
-     * incoherent (round-3 gate).
-     */
-    private inherited_target_symbol(
-        target: { symbol?: MacroSymbol; exclude_same_file_local: boolean },
-        resolved_scope: ResolvedScope | undefined,
-        symbol_name: string,
-        reference_line: number,
-        current_uri: string
-    ): MacroSymbol | undefined {
-        if (!target.exclude_same_file_local) {
-            return undefined;
-        }
-        return find_inherited_dofile_local(
-            resolved_scope, symbol_name, reference_line, current_uri
+            target.inherited_target,
         );
     }
 
     /**
      * Scope-aware target resolution for local-macro find-references
-     * (#270). `exclude_same_file_local: true` = the name exists
-     * same-file only in scopes not visible from the cursor (a sibling
-     * program's local): the flat slot must not be pooled and same-file
-     * occurrences count only when they resolve to no same-file symbol
-     * themselves — the reference's identity is then the cross-file
-     * INHERITED do-file local (or plain undefined), matching the
-     * analyzer's cross-file suppression (round-2 gate).
-     * `symbol: undefined, exclude_same_file_local: false` = the scoped
-     * model has no opinion (empty scopes, cross-file inherited name,
-     * positional arg); existing name-based scanning proceeds unchanged.
+     * (#270), applying the effective order (see
+     * resolve_effective_local): a positionally RESOLVED same-file
+     * symbol is the target; else the cross-file INHERITED do-file
+     * local is the winner (`exclude_same_file_local` + 
+     * `inherited_target`: the flat slot must not be pooled,
+     * declarations come from the winner, and same-file occurrences
+     * count only when their own effective resolution is the winner);
+     * else a same-scope FORWARD identity target behaves like a
+     * resolved one (round-9 gate); else, for an out-of-scope name
+     * with no inherited winner, the reference is plain undefined
+     * (`exclude_same_file_local` alone: current-file-only,
+     * same-resolution-class occurrences). All fields undefined/false
+     * = the scoped model has no opinion (empty scopes, cross-file
+     * name, positional arg); existing name-based scanning proceeds
+     * unchanged.
      */
     private resolve_local_reference_target(
         document: DocumentState,
         position: Position,
-        identified_symbol: IdentifiedSymbol
-    ): { symbol?: MacroSymbol; exclude_same_file_local: boolean } {
+        identified_symbol: IdentifiedSymbol,
+        resolved_scope: ResolvedScope | undefined
+    ): {
+        target_local_macro?: MacroSymbol;
+        exclude_same_file_local: boolean;
+        inherited_target?: MacroSymbol;
+    } {
         if (identified_symbol.type !== 'local_macro') {
             return { exclude_same_file_local: false };
         }
         const scoped = lookup_scoped_local_macro(
             document.scopes, position, identified_symbol.name
         );
-        return {
-            symbol: scoped.symbol,
-            exclude_same_file_local: scoped.out_of_scope,
-        };
+        if (scoped.symbol && !scoped.forward_only) {
+            return {
+                target_local_macro: scoped.symbol,
+                exclude_same_file_local: false,
+            };
+        }
+        if (scoped.out_of_scope || scoped.forward_only) {
+            const inherited = find_inherited_dofile_local(
+                resolved_scope,
+                identified_symbol.name,
+                position.line,
+                document.uri
+            );
+            if (inherited) {
+                return {
+                    exclude_same_file_local: true,
+                    inherited_target: inherited,
+                };
+            }
+            if (scoped.forward_only) {
+                return {
+                    target_local_macro: scoped.symbol,
+                    exclude_same_file_local: false,
+                };
+            }
+            return { exclude_same_file_local: true };
+        }
+        return { exclude_same_file_local: false };
     }
 
     /**
@@ -967,11 +976,6 @@ export class ReferencesProvider {
             return [];
         }
 
-        // Scope-aware local-macro target resolution (#270).
-        const target = this.resolve_local_reference_target(
-            document, position, identified_symbol
-        );
-
         // Resolve the scope once so find_definitions can apply the
         // call-site filter to non-variable declarations pooled from the
         // workspace indexer. See issue #129.
@@ -985,6 +989,11 @@ export class ReferencesProvider {
             )
             : undefined;
 
+        // Scope-aware local-macro target resolution (#270).
+        const target = this.resolve_local_reference_target(
+            document, position, identified_symbol, resolved_scope
+        );
+
         return this.collect_references(
             document,
             identified_symbol.name,
@@ -995,12 +1004,9 @@ export class ReferencesProvider {
             cancellation_token,
             resolved_scope,
             position.line,
-            target.symbol,
+            target.target_local_macro,
             target.exclude_same_file_local,
-            this.inherited_target_symbol(
-                target, resolved_scope, identified_symbol.name,
-                position.line, document.uri
-            ),
+            target.inherited_target,
         );
     }
 
@@ -1147,45 +1153,26 @@ export class ReferencesProvider {
                 }
                 // Scope-filter (#270): a same-file name match may
                 // lexically belong to a DIFFERENT same-named local
-                // (shadowing) — keep only occurrences whose own
-                // position resolves to the exact target symbol. For an
-                // out-of-scope reference (exclude_same_file_local) an
-                // occurrence must resolve to no same-file symbol AND
-                // its own line's inherited winner must be the cursor's
-                // (identity-equal; undefined for plain-undefined): an
-                // occurrence before an include is a different
-                // resolution class than one after it (round-5 gate).
-                // resolve_visible_local skips
-                // lookup_scoped_local_macro's out-of-scope bookkeeping
-                // scan, which these comparisons never read.
-                if (symbol_type === 'local_macro') {
-                    if (
-                        target_local_macro !== undefined &&
-                        resolve_visible_local(
-                            document.scopes,
-                            my_match.range.start,
-                            symbol_name
-                        ) !== target_local_macro
-                    ) {
-                        continue;
-                    }
-                    if (
-                        target_local_macro === undefined &&
-                        exclude_same_file_local === true &&
-                        (resolve_visible_local(
-                            document.scopes,
-                            my_match.range.start,
-                            symbol_name
-                        ) !== undefined ||
-                            find_inherited_dofile_local(
-                                resolved_scope,
-                                symbol_name,
-                                my_match.range.start.line,
-                                document.uri
-                            ) !== inherited_target)
-                    ) {
-                        continue;
-                    }
+                // (shadowing, inheritance, or forward order) — keep
+                // only occurrences whose own EFFECTIVE resolution
+                // (resolved -> inherited -> forward, the same order
+                // every provider uses; round-9 gate) is
+                // identity-equal to the cursor's effective target
+                // (undefined matching undefined for the
+                // plain-undefined class; round-5 gate).
+                if (
+                    symbol_type === 'local_macro' &&
+                    (target_local_macro !== undefined ||
+                        exclude_same_file_local === true) &&
+                    resolve_effective_local(
+                        document.scopes,
+                        my_match.range.start,
+                        symbol_name,
+                        resolved_scope,
+                        document.uri
+                    ) !== (target_local_macro ?? inherited_target)
+                ) {
+                    continue;
                 }
                 locations.push({ uri: my_match.uri, range: my_match.range });
             }

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -554,6 +554,12 @@ export class ReferencesProvider {
                 return { exclude_same_file_local: true };
             case 'none':
                 return { exclude_same_file_local: false };
+            default: {
+                // Compiler-enforced exhaustiveness: a new
+                // classification tier must be mapped here explicitly.
+                const unhandled: never = effective.kind;
+                throw new Error(`unhandled effective kind: ${unhandled}`);
+            }
         }
     }
 

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -16,12 +16,9 @@ import { DocumentState } from '../document-store';
 import { LanguageContext, MacroSymbol, Token, ContextRange } from '../types';
 import { get_line_text } from '../utils/line-utils';
 import { is_cross_file_hidden_local } from '../utils/dofile-locals';
+import { resolve_scoped_or_flat } from '../utils/scoped-locals';
 import {
-    lookup_scoped_local_macro,
-    resolve_scoped_or_flat,
-} from '../utils/scoped-locals';
-import {
-    find_inherited_dofile_local,
+    classify_effective_local,
     resolve_effective_local,
 } from '../utils/dofile-locals';
 import type { WorkspaceIndexer } from '../indexer';
@@ -534,37 +531,30 @@ export class ReferencesProvider {
         if (identified_symbol.type !== 'local_macro') {
             return { exclude_same_file_local: false };
         }
-        const scoped = lookup_scoped_local_macro(
-            document.scopes, position, identified_symbol.name
+        const effective = classify_effective_local(
+            document.scopes,
+            position,
+            identified_symbol.name,
+            resolved_scope,
+            document.uri
         );
-        if (scoped.symbol && !scoped.forward_only) {
-            return {
-                target_local_macro: scoped.symbol,
-                exclude_same_file_local: false,
-            };
-        }
-        if (scoped.out_of_scope || scoped.forward_only) {
-            const inherited = find_inherited_dofile_local(
-                resolved_scope,
-                identified_symbol.name,
-                position.line,
-                document.uri
-            );
-            if (inherited) {
+        switch (effective.kind) {
+            case 'resolved':
+            case 'forward':
                 return {
-                    exclude_same_file_local: true,
-                    inherited_target: inherited,
-                };
-            }
-            if (scoped.forward_only) {
-                return {
-                    target_local_macro: scoped.symbol,
+                    target_local_macro: effective.symbol,
                     exclude_same_file_local: false,
                 };
-            }
-            return { exclude_same_file_local: true };
+            case 'inherited':
+                return {
+                    exclude_same_file_local: true,
+                    inherited_target: effective.symbol,
+                };
+            case 'out_of_scope':
+                return { exclude_same_file_local: true };
+            case 'none':
+                return { exclude_same_file_local: false };
         }
-        return { exclude_same_file_local: false };
     }
 
     /**

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -197,6 +197,7 @@ export class ReferencesProvider {
         resolved_scope?: ResolvedScope,
         cursor_line?: number,
         target_local_macro?: MacroSymbol,
+        exclude_same_file_local?: boolean,
     ): Location[] {
         const locations: Location[] = [];
         const seen = new Set<string>();
@@ -213,9 +214,14 @@ export class ReferencesProvider {
             case 'local_macro': {
                 // Scope-aware (#270): the resolved target symbol (the
                 // cursor-visible scope's own MacroSymbol) supersedes the
-                // flat slot, which may belong to a different scope.
-                const local_macro =
-                    target_local_macro ?? symbols.localMacros.get(symbol_name);
+                // flat slot, which may belong to a different scope. For
+                // an out-of-scope reference the flat slot is forbidden
+                // entirely — the identity is the cross-file inherited
+                // local (pooled from the indexer below) or nothing.
+                const local_macro = target_local_macro
+                    ?? (exclude_same_file_local
+                        ? undefined
+                        : symbols.localMacros.get(symbol_name));
                 if (local_macro) {
                     // Loop-expanded definitions anchor at the template statement
                     // (`local x_`i'`), whose text does not contain the concrete
@@ -447,9 +453,6 @@ export class ReferencesProvider {
         const target = this.resolve_local_reference_target(
             document, position, identified_symbol
         );
-        if (target.blocked) {
-            return [];
-        }
 
         // Resolve the scope once here (cached by ScopeResolver) so
         // find_definitions can apply the call-site filter to declarations
@@ -475,33 +478,38 @@ export class ReferencesProvider {
             resolved_scope,
             position.line,
             target.symbol,
+            target.exclude_same_file_local,
         );
     }
 
     /**
      * Scope-aware target resolution for local-macro find-references
-     * (#270). `blocked: true` = the name exists only in scopes not
-     * visible from the cursor (a sibling program's local) — no
-     * legitimate target, matching hover/definition's empty result.
-     * `symbol: undefined, blocked: false` = the scoped model has no
-     * opinion (empty scopes, cross-file inherited name, positional
-     * arg); existing name-based scanning proceeds unchanged.
+     * (#270). `exclude_same_file_local: true` = the name exists
+     * same-file only in scopes not visible from the cursor (a sibling
+     * program's local): the flat slot must not be pooled and same-file
+     * occurrences count only when they resolve to no same-file symbol
+     * themselves — the reference's identity is then the cross-file
+     * INHERITED do-file local (or plain undefined), matching the
+     * analyzer's cross-file suppression (round-2 gate).
+     * `symbol: undefined, exclude_same_file_local: false` = the scoped
+     * model has no opinion (empty scopes, cross-file inherited name,
+     * positional arg); existing name-based scanning proceeds unchanged.
      */
     private resolve_local_reference_target(
         document: DocumentState,
         position: Position,
         identified_symbol: IdentifiedSymbol
-    ): { symbol?: MacroSymbol; blocked: boolean } {
+    ): { symbol?: MacroSymbol; exclude_same_file_local: boolean } {
         if (identified_symbol.type !== 'local_macro') {
-            return { blocked: false };
+            return { exclude_same_file_local: false };
         }
         const scoped = lookup_scoped_local_macro(
             document.scopes, position, identified_symbol.name
         );
-        if (scoped.out_of_scope) {
-            return { blocked: true };
-        }
-        return { symbol: scoped.symbol, blocked: false };
+        return {
+            symbol: scoped.symbol,
+            exclude_same_file_local: scoped.out_of_scope,
+        };
     }
 
     /**
@@ -917,9 +925,6 @@ export class ReferencesProvider {
         const target = this.resolve_local_reference_target(
             document, position, identified_symbol
         );
-        if (target.blocked) {
-            return [];
-        }
 
         // Resolve the scope once so find_definitions can apply the
         // call-site filter to non-variable declarations pooled from the
@@ -945,6 +950,7 @@ export class ReferencesProvider {
             resolved_scope,
             position.line,
             target.symbol,
+            target.exclude_same_file_local,
         );
     }
 
@@ -962,6 +968,7 @@ export class ReferencesProvider {
         resolved_scope?: ResolvedScope,
         cursor_line?: number,
         target_local_macro?: MacroSymbol,
+        exclude_same_file_local?: boolean,
     ): Promise<Location[]> {
         const search_context: ReferenceSearchContext = {
             symbol_name,
@@ -978,6 +985,7 @@ export class ReferencesProvider {
             resolved_scope,
             cursor_line,
             target_local_macro,
+            exclude_same_file_local,
         );
 
         // Search workspace-indexed files (Req 13.3).
@@ -1075,20 +1083,36 @@ export class ReferencesProvider {
                 // Scope-filter (#270): a same-file name match may
                 // lexically belong to a DIFFERENT same-named local
                 // (shadowing) — keep only occurrences whose own
-                // position resolves to the exact target symbol.
-                // resolve_visible_local skips lookup_scoped_local_macro's
-                // out-of-scope bookkeeping scan, which this identity
-                // comparison never reads.
-                if (
-                    symbol_type === 'local_macro' &&
-                    target_local_macro !== undefined &&
-                    resolve_visible_local(
-                        document.scopes,
-                        my_match.range.start,
-                        symbol_name
-                    ) !== target_local_macro
-                ) {
-                    continue;
+                // position resolves to the exact target symbol. For an
+                // out-of-scope reference (exclude_same_file_local) the
+                // shared identity is "resolves to no same-file symbol"
+                // (the cross-file inherited local, or plain undefined),
+                // so occurrences that resolve to some same-file local
+                // are excluded instead. resolve_visible_local skips
+                // lookup_scoped_local_macro's out-of-scope bookkeeping
+                // scan, which these comparisons never read.
+                if (symbol_type === 'local_macro') {
+                    if (
+                        target_local_macro !== undefined &&
+                        resolve_visible_local(
+                            document.scopes,
+                            my_match.range.start,
+                            symbol_name
+                        ) !== target_local_macro
+                    ) {
+                        continue;
+                    }
+                    if (
+                        target_local_macro === undefined &&
+                        exclude_same_file_local === true &&
+                        resolve_visible_local(
+                            document.scopes,
+                            my_match.range.start,
+                            symbol_name
+                        ) !== undefined
+                    ) {
+                        continue;
+                    }
                 }
                 locations.push({ uri: my_match.uri, range: my_match.range });
             }

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -13,9 +13,10 @@ import {
     CancellationToken,
 } from 'vscode-languageserver';
 import { DocumentState } from '../document-store';
-import { LanguageContext, Token, ContextRange } from '../types';
+import { LanguageContext, MacroSymbol, Token, ContextRange } from '../types';
 import { get_line_text } from '../utils/line-utils';
 import { is_cross_file_hidden_local } from '../utils/dofile-locals';
+import { lookup_scoped_local_macro } from '../utils/scoped-locals';
 import type { WorkspaceIndexer } from '../indexer';
 import type { IContextTracker } from '../context-tracker/types';
 import type { ScopeResolver } from '../scope-resolver';
@@ -191,6 +192,7 @@ export class ReferencesProvider {
         workspace_indexer?: WorkspaceIndexer,
         resolved_scope?: ResolvedScope,
         cursor_line?: number,
+        target_local_macro?: MacroSymbol,
     ): Location[] {
         const locations: Location[] = [];
         const seen = new Set<string>();
@@ -205,7 +207,11 @@ export class ReferencesProvider {
         const symbols = document.symbols;
         switch (symbol_type) {
             case 'local_macro': {
-                const local_macro = symbols.localMacros.get(symbol_name);
+                // Scope-aware (#270): the resolved target symbol (the
+                // cursor-visible scope's own MacroSymbol) supersedes the
+                // flat slot, which may belong to a different scope.
+                const local_macro =
+                    target_local_macro ?? symbols.localMacros.get(symbol_name);
                 if (local_macro) {
                     // Loop-expanded definitions anchor at the template statement
                     // (`local x_`i'`), whose text does not contain the concrete
@@ -271,7 +277,12 @@ export class ReferencesProvider {
             }
         }
 
-        if (workspace_indexer) {
+        // A program-scoped local target never crosses file boundaries
+        // (#271), so cross-file declaration pooling is skipped (#270).
+        const is_program_scoped_target =
+            symbol_type === 'local_macro' &&
+            target_local_macro?.containingScope === 'program';
+        if (workspace_indexer && !is_program_scoped_target) {
             const ws_type: 'program' | 'local' | 'global' | 'variable' | 'scalar' | 'matrix' =
                 symbol_type === 'local_macro' ? 'local' :
                 symbol_type === 'global_macro' ? 'global' :
@@ -428,6 +439,14 @@ export class ReferencesProvider {
             return [];
         }
 
+        // Scope-aware local-macro target resolution (#270).
+        const target = this.resolve_local_reference_target(
+            document, position, identified_symbol
+        );
+        if (target.blocked) {
+            return [];
+        }
+
         // Resolve the scope once here (cached by ScopeResolver) so
         // find_definitions can apply the call-site filter to declarations
         // pooled from the workspace indexer. See issue #129.
@@ -451,7 +470,34 @@ export class ReferencesProvider {
             cancellation_token,
             resolved_scope,
             position.line,
+            target.symbol,
         );
+    }
+
+    /**
+     * Scope-aware target resolution for local-macro find-references
+     * (#270). `blocked: true` = the name exists only in scopes not
+     * visible from the cursor (a sibling program's local) — no
+     * legitimate target, matching hover/definition's empty result.
+     * `symbol: undefined, blocked: false` = the scoped model has no
+     * opinion (empty scopes, cross-file inherited name, positional
+     * arg); existing name-based scanning proceeds unchanged.
+     */
+    private resolve_local_reference_target(
+        document: DocumentState,
+        position: Position,
+        identified_symbol: IdentifiedSymbol
+    ): { symbol?: MacroSymbol; blocked: boolean } {
+        if (identified_symbol.type !== 'local_macro') {
+            return { blocked: false };
+        }
+        const scoped = lookup_scoped_local_macro(
+            document.scopes, position, identified_symbol.name
+        );
+        if (scoped.out_of_scope) {
+            return { blocked: true };
+        }
+        return { symbol: scoped.symbol, blocked: false };
     }
 
     /**
@@ -668,7 +714,16 @@ export class ReferencesProvider {
         ) {
             return { name: word, type: 'global_macro', range };
         }
-        const local_macro = document.symbols.localMacros.get(word);
+        // Scope-aware (#270): resolve against the scope that textually
+        // contains the cursor, so a losing-flat-slot program local
+        // still matches its own declaration range.
+        const scoped_decl = lookup_scoped_local_macro(
+            document.scopes, range.start, word
+        );
+        const local_macro = scoped_decl.symbol
+            ?? (scoped_decl.out_of_scope
+                ? undefined
+                : document.symbols.localMacros.get(word));
         if (
             local_macro
             && this.position_hits_symbol_definition(range.start, local_macro)
@@ -842,6 +897,14 @@ export class ReferencesProvider {
             return [];
         }
 
+        // Scope-aware local-macro target resolution (#270).
+        const target = this.resolve_local_reference_target(
+            document, position, identified_symbol
+        );
+        if (target.blocked) {
+            return [];
+        }
+
         // Resolve the scope once so find_definitions can apply the
         // call-site filter to non-variable declarations pooled from the
         // workspace indexer. See issue #129.
@@ -865,6 +928,7 @@ export class ReferencesProvider {
             cancellation_token,
             resolved_scope,
             position.line,
+            target.symbol,
         );
     }
 
@@ -881,6 +945,7 @@ export class ReferencesProvider {
         cancellation_token?: CancellationToken,
         resolved_scope?: ResolvedScope,
         cursor_line?: number,
+        target_local_macro?: MacroSymbol,
     ): Promise<Location[]> {
         const search_context: ReferenceSearchContext = {
             symbol_name,
@@ -896,6 +961,7 @@ export class ReferencesProvider {
             workspace_indexer,
             resolved_scope,
             cursor_line,
+            target_local_macro,
         );
 
         // Search workspace-indexed files (Req 13.3).
@@ -920,8 +986,14 @@ export class ReferencesProvider {
         // understands `include_only`.
         // See docs/find-references.md for the rationale behind this three-tier model.
         const restrict_to_related = symbol_type !== 'variable';
+        // A program-scoped local target never crosses file boundaries
+        // (#271) — restrict the scan to the current file, skipping the
+        // cross-file token scan entirely (#270).
+        const is_program_scoped_target =
+            symbol_type === 'local_macro' &&
+            target_local_macro?.containingScope === 'program';
         let the_related: Map<string, ReferenceScanRange>;
-        if (!workspace_indexer) {
+        if (is_program_scoped_target || !workspace_indexer) {
             the_related = new Map([[document.uri, {}]]);
         } else if (
             restrict_to_related &&
@@ -982,6 +1054,21 @@ export class ReferencesProvider {
             const doc_range = the_related.get(document.uri);
             for (const my_match of matches) {
                 if (doc_range && !line_within_scan_range(my_match.range.start.line, doc_range)) {
+                    continue;
+                }
+                // Scope-filter (#270): a same-file name match may
+                // lexically belong to a DIFFERENT same-named local
+                // (shadowing) — keep only occurrences whose own
+                // position resolves to the exact target symbol.
+                if (
+                    symbol_type === 'local_macro' &&
+                    target_local_macro !== undefined &&
+                    lookup_scoped_local_macro(
+                        document.scopes,
+                        my_match.range.start,
+                        symbol_name
+                    ).symbol !== target_local_macro
+                ) {
                     continue;
                 }
                 locations.push({ uri: my_match.uri, range: my_match.range });

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -279,9 +279,9 @@ export class ReferencesProvider {
 
         // A program-scoped local target never crosses file boundaries
         // (#271), so cross-file declaration pooling is skipped (#270).
-        const is_program_scoped_target =
-            symbol_type === 'local_macro' &&
-            target_local_macro?.containingScope === 'program';
+        const is_program_scoped_target = this.is_program_scoped_local_target(
+            symbol_type, target_local_macro
+        );
         if (workspace_indexer && !is_program_scoped_target) {
             const ws_type: 'program' | 'local' | 'global' | 'variable' | 'scalar' | 'matrix' =
                 symbol_type === 'local_macro' ? 'local' :
@@ -498,6 +498,21 @@ export class ReferencesProvider {
             return { blocked: true };
         }
         return { symbol: scoped.symbol, blocked: false };
+    }
+
+    /**
+     * True when the resolved find-references target is a program-scoped
+     * local. Such a target never crosses file boundaries (#271), so
+     * both declaration pooling and the token scan stay current-file
+     * only. Shared by find_definitions and collect_references so the
+     * two gates cannot drift (#270).
+     */
+    private is_program_scoped_local_target(
+        symbol_type: string,
+        target_local_macro?: MacroSymbol
+    ): boolean {
+        return symbol_type === 'local_macro' &&
+            target_local_macro?.containingScope === 'program';
     }
 
     /**
@@ -989,9 +1004,9 @@ export class ReferencesProvider {
         // A program-scoped local target never crosses file boundaries
         // (#271) — restrict the scan to the current file, skipping the
         // cross-file token scan entirely (#270).
-        const is_program_scoped_target =
-            symbol_type === 'local_macro' &&
-            target_local_macro?.containingScope === 'program';
+        const is_program_scoped_target = this.is_program_scoped_local_target(
+            symbol_type, target_local_macro
+        );
         let the_related: Map<string, ReferenceScanRange>;
         if (is_program_scoped_target || !workspace_indexer) {
             the_related = new Map([[document.uri, {}]]);

--- a/src/providers/references.ts
+++ b/src/providers/references.ts
@@ -21,6 +21,7 @@ import {
     resolve_scoped_or_flat,
     resolve_visible_local,
 } from '../utils/scoped-locals';
+import { find_inherited_dofile_local } from '../utils/dofile-locals';
 import type { WorkspaceIndexer } from '../indexer';
 import type { IContextTracker } from '../context-tracker/types';
 import type { ScopeResolver } from '../scope-resolver';
@@ -198,6 +199,7 @@ export class ReferencesProvider {
         cursor_line?: number,
         target_local_macro?: MacroSymbol,
         exclude_same_file_local?: boolean,
+        has_inherited_target?: boolean,
     ): Location[] {
         const locations: Location[] = [];
         const seen = new Set<string>();
@@ -289,10 +291,20 @@ export class ReferencesProvider {
 
         // A program-scoped local target never crosses file boundaries
         // (#271), so cross-file declaration pooling is skipped (#270).
+        // An out-of-scope cursor with NO inherited target is plain
+        // undefined — nothing legitimate to pool cross-file either.
         const is_program_scoped_target = this.is_program_scoped_local_target(
             symbol_type, target_local_macro
         );
-        if (workspace_indexer && !is_program_scoped_target) {
+        const undefined_out_of_scope_target =
+            symbol_type === 'local_macro' &&
+            exclude_same_file_local === true &&
+            has_inherited_target !== true;
+        if (
+            workspace_indexer &&
+            !is_program_scoped_target &&
+            !undefined_out_of_scope_target
+        ) {
             const ws_type: 'program' | 'local' | 'global' | 'variable' | 'scalar' | 'matrix' =
                 symbol_type === 'local_macro' ? 'local' :
                 symbol_type === 'global_macro' ? 'global' :
@@ -479,7 +491,35 @@ export class ReferencesProvider {
             position.line,
             target.symbol,
             target.exclude_same_file_local,
+            this.has_inherited_target(
+                target, resolved_scope, identified_symbol.name,
+                position.line, document.uri
+            ),
         );
+    }
+
+    /**
+     * In exclude-same-file mode, does a cross-file INHERITED do-file
+     * local actually exist for this cursor? When it does not, the
+     * reference is plain undefined and the cross-file scan must not
+     * run — a same-named local in an include-related file's program
+     * body is a different macro, and surfacing its usages while
+     * is_cross_file_hidden_local hides its declaration would be
+     * incoherent (round-3 gate).
+     */
+    private has_inherited_target(
+        target: { symbol?: MacroSymbol; exclude_same_file_local: boolean },
+        resolved_scope: ResolvedScope | undefined,
+        symbol_name: string,
+        reference_line: number,
+        current_uri: string
+    ): boolean {
+        if (!target.exclude_same_file_local) {
+            return false;
+        }
+        return find_inherited_dofile_local(
+            resolved_scope, symbol_name, reference_line, current_uri
+        ) !== undefined;
     }
 
     /**
@@ -951,6 +991,10 @@ export class ReferencesProvider {
             position.line,
             target.symbol,
             target.exclude_same_file_local,
+            this.has_inherited_target(
+                target, resolved_scope, identified_symbol.name,
+                position.line, document.uri
+            ),
         );
     }
 
@@ -969,6 +1013,7 @@ export class ReferencesProvider {
         cursor_line?: number,
         target_local_macro?: MacroSymbol,
         exclude_same_file_local?: boolean,
+        has_inherited_target?: boolean,
     ): Promise<Location[]> {
         const search_context: ReferenceSearchContext = {
             symbol_name,
@@ -986,6 +1031,7 @@ export class ReferencesProvider {
             cursor_line,
             target_local_macro,
             exclude_same_file_local,
+            has_inherited_target,
         );
 
         // Search workspace-indexed files (Req 13.3).
@@ -1012,12 +1058,24 @@ export class ReferencesProvider {
         const restrict_to_related = symbol_type !== 'variable';
         // A program-scoped local target never crosses file boundaries
         // (#271) — restrict the scan to the current file, skipping the
-        // cross-file token scan entirely (#270).
+        // cross-file token scan entirely (#270). Same for an
+        // out-of-scope cursor with NO inherited target: the reference
+        // is plain undefined, and a same-named local in an
+        // include-related file's program body is a different macro
+        // (round-3 gate).
         const is_program_scoped_target = this.is_program_scoped_local_target(
             symbol_type, target_local_macro
         );
+        const undefined_out_of_scope_target =
+            symbol_type === 'local_macro' &&
+            exclude_same_file_local === true &&
+            has_inherited_target !== true;
         let the_related: Map<string, ReferenceScanRange>;
-        if (is_program_scoped_target || !workspace_indexer) {
+        if (
+            is_program_scoped_target ||
+            undefined_out_of_scope_target ||
+            !workspace_indexer
+        ) {
             the_related = new Map([[document.uri, {}]]);
         } else if (
             restrict_to_related &&

--- a/src/providers/symbols.ts
+++ b/src/providers/symbols.ts
@@ -459,20 +459,26 @@ export class SymbolProvider {
                     if (my_macro.sourceUri !== document.uri) {
                         continue;
                     }
-                    const my_local_symbol =
-                        make_local_symbol(my_name, my_macro);
-                    if (my_scope.type === 'program') {
-                        // Geometric fallback only for degenerate
-                        // program scopes with no registered container.
-                        nest_local_symbol(
-                            my_local_symbol,
-                            my_container,
-                            my_macro.location.range.start
-                        );
-                    } else {
-                        // Do-file-owned: top-level by ownership.
-                        symbols.push(my_local_symbol);
-                    }
+                    // ENUMERATION is by owning scope (one entry per
+                    // scope — nothing lost to the flat slot), but
+                    // PLACEMENT is a range-containment question: the
+                    // DocumentSymbol tree is an LSP text-structure
+                    // view, and a top-level entry whose range sits
+                    // inside a program container would overlap a
+                    // sibling on the wire. Program-owned locals use
+                    // their owning body's container (exact for
+                    // redeclared bodies; geometric fallback only for
+                    // degenerate container-less scopes); do-file-owned
+                    // locals nest geometrically (e.g. a directive-
+                    // declared do-file local written inside a program
+                    // body renders under that program).
+                    nest_local_symbol(
+                        make_local_symbol(my_name, my_macro),
+                        my_scope.type === 'program'
+                            ? my_container
+                            : undefined,
+                        my_macro.location.range.start
+                    );
                 }
             }
         } else {

--- a/src/providers/symbols.ts
+++ b/src/providers/symbols.ts
@@ -18,6 +18,7 @@ import {
     WorkspaceSymbolSource,
 } from '../types';
 import { get_line_text, get_line_count } from '../utils/line-utils';
+import { enumerate_scoped_local_macros } from '../utils/scoped-locals';
 import { extract_sections, RawSection } from './section-detector';
 import * as path from 'path';
 
@@ -378,8 +379,13 @@ export class SymbolProvider {
             }
         }
 
-        // 3. Add local macros - nest under containing program or add as top-level
-        for (const [name, macro] of document.symbols.localMacros) {
+        // 3. Add local macros - nest under containing program or add as
+        //    top-level. Enumerate per scope (#270): the flat view keeps
+        //    one representative per name, dropping same-named locals
+        //    declared in other program scopes from the outline.
+        for (const [name, macro] of enumerate_scoped_local_macros(
+            document.scopes, document.symbols.localMacros
+        )) {
             if (macro.sourceUri === document.uri) {
                 const my_local_symbol: DocumentSymbol = {
                     name: `\`${name}'`,
@@ -726,8 +732,11 @@ export class SymbolProvider {
                 }
             }
 
-            // Local macros
-            for (const [my_name, my_macro] of document.symbols.localMacros) {
+            // Local macros — per scope (#270), same rationale as the
+            // document outline above.
+            for (const [my_name, my_macro] of enumerate_scoped_local_macros(
+                document.scopes, document.symbols.localMacros
+            )) {
                 if (my_name.toLowerCase().includes(lower_query)) {
                     symbols.push({
                         name: `\`${my_name}'`,

--- a/src/providers/symbols.ts
+++ b/src/providers/symbols.ts
@@ -334,36 +334,65 @@ export class SymbolProvider {
         // Store program info for containment checking
         const program_infos = new Map<string, ProgramInfo>();
 
-        for (const [_name, program] of document.symbols.programs) {
-            // Defensive: only include programs defined in this document.
-            // (Prevents accidental cross-file contamination if symbols are ever merged.)
-            if (program.sourceUri !== document.uri) {
-                continue;
-            }
-
-            // Prefer AST ranges if available for accuracy
-            const my_program_range = this.get_program_range(document, program.name)
-                || program.location.range;
-
-            // Prefer selecting just the identifier for better UX in outline views.
-            const my_program_selection_range =
-                this.get_program_name_range(document, program.name, my_program_range)
-                || my_program_range;
-
+        const register_program_container = (
+            container_key: string,
+            program_name: string,
+            program_range: Range
+        ): void => {
+            // Prefer selecting just the identifier for better UX in
+            // outline views.
+            const my_selection_range =
+                this.get_program_name_range(
+                    document, program_name, program_range
+                ) || program_range;
             const my_program_symbol: DocumentSymbol = {
-                name: program.name,
+                name: program_name,
                 kind: SymbolKind.Function,
-                range: my_program_range,
-                selectionRange: my_program_selection_range,
+                range: program_range,
+                selectionRange: my_selection_range,
                 detail: 'Program',
                 children: [],
             };
-
             symbols.push(my_program_symbol);
-            program_infos.set(program.name, {
+            program_infos.set(container_key, {
                 symbol: my_program_symbol,
-                range: my_program_range,
+                range: program_range,
             });
+        };
+
+        // One container per program BODY (#270): the flat programs map
+        // holds one entry per name, so a redeclared program's second
+        // body would have no container and its locals would float to
+        // the top level. Program ScopeInfos carry each body's exact
+        // range; fall back to the flat map for degenerate states
+        // without scopes.
+        const the_program_scopes = (document.scopes ?? []).filter(
+            my_scope => my_scope.type === 'program' && my_scope.program_name
+        );
+        if (the_program_scopes.length > 0) {
+            for (const my_scope of the_program_scopes) {
+                register_program_container(
+                    `${my_scope.program_name}#${my_scope.id}`,
+                    my_scope.program_name!,
+                    my_scope.range
+                );
+            }
+        } else {
+            for (const [_name, program] of document.symbols.programs) {
+                // Defensive: only include programs defined in this document.
+                // (Prevents accidental cross-file contamination if symbols are ever merged.)
+                if (program.sourceUri !== document.uri) {
+                    continue;
+                }
+
+                // Prefer AST ranges if available for accuracy
+                const my_program_range =
+                    this.get_program_range(document, program.name)
+                    || program.location.range;
+                register_program_container(
+                    program.name, program.name, my_program_range
+                );
+            }
         }
 
         // 2. Add global macros (defined in this file) - always top-level

--- a/src/providers/symbols.ts
+++ b/src/providers/symbols.ts
@@ -12,6 +12,7 @@ import {
 import { Position, Range } from 'vscode-languageserver-textdocument';
 import { DocumentState } from '../document-store';
 import {
+    MacroSymbol,
     StataNode,
     EmbeddedLanguageBlockNode,
     WorkspaceSymbolMatch,
@@ -411,35 +412,81 @@ export class SymbolProvider {
         // 3. Add local macros - nest under containing program or add as
         //    top-level. Enumerate per scope (#270): the flat view keeps
         //    one representative per name, dropping same-named locals
-        //    declared in other program scopes from the outline.
-        for (const [name, macro] of enumerate_scoped_local_macros(
-            document.scopes, document.symbols.localMacros
-        )) {
-            if (macro.sourceUri === document.uri) {
-                const my_local_symbol: DocumentSymbol = {
-                    name: `\`${name}'`,
-                    kind: SymbolKind.Variable,
-                    range: macro.location.range,
-                    selectionRange: macro.location.range,
-                    detail: 'Local Macro',
-                };
-
-                // Check if this local macro is inside any program
-                const my_containing_program = find_containing_program(
-                    macro.location.range.start,
-                    program_infos
+        //    declared in other program scopes from the outline. Each
+        //    local nests under its OWNING scope's container — the
+        //    authoritative ownership already in hand — rather than
+        //    re-deriving containment geometrically (a location anchored
+        //    outside its scope's body, e.g. a directive-declared
+        //    do-file local on a line inside a program range, must not
+        //    change owners).
+        const nest_local_symbol = (
+            my_local_symbol: DocumentSymbol,
+            container: ProgramInfo | undefined,
+            declaration_position: Position
+        ): void => {
+            const my_containing_program = container?.symbol
+                ?? find_containing_program(
+                    declaration_position, program_infos
                 );
-
-                if (my_containing_program) {
-                    // Add as child of the containing program
-                    if (!my_containing_program.children) {
-                        my_containing_program.children = [];
-                    }
-                    my_containing_program.children.push(my_local_symbol);
-                } else {
-                    // Add as top-level symbol
-                    symbols.push(my_local_symbol);
+            if (my_containing_program) {
+                if (!my_containing_program.children) {
+                    my_containing_program.children = [];
                 }
+                my_containing_program.children.push(my_local_symbol);
+            } else {
+                symbols.push(my_local_symbol);
+            }
+        };
+        const make_local_symbol = (
+            name: string,
+            macro: MacroSymbol
+        ): DocumentSymbol => ({
+            name: `\`${name}'`,
+            kind: SymbolKind.Variable,
+            range: macro.location.range,
+            selectionRange: macro.location.range,
+            detail: 'Local Macro',
+        });
+        if ((document.scopes ?? []).length > 0) {
+            for (const my_scope of document.scopes!) {
+                const my_container = my_scope.type === 'program' &&
+                    my_scope.program_name
+                    ? program_infos.get(
+                        `${my_scope.program_name}#${my_scope.id}`
+                    )
+                    : undefined;
+                for (const [my_name, my_macro] of my_scope.localMacros) {
+                    if (my_macro.sourceUri !== document.uri) {
+                        continue;
+                    }
+                    const my_local_symbol =
+                        make_local_symbol(my_name, my_macro);
+                    if (my_scope.type === 'program') {
+                        // Geometric fallback only for degenerate
+                        // program scopes with no registered container.
+                        nest_local_symbol(
+                            my_local_symbol,
+                            my_container,
+                            my_macro.location.range.start
+                        );
+                    } else {
+                        // Do-file-owned: top-level by ownership.
+                        symbols.push(my_local_symbol);
+                    }
+                }
+            }
+        } else {
+            // Degenerate no-scopes fallback: flat view + geometric
+            // containment, matching the pre-#270 behavior.
+            for (const [name, macro] of document.symbols.localMacros) {
+                if (macro.sourceUri !== document.uri) {
+                    continue;
+                }
+                nest_local_symbol(
+                    make_local_symbol(name, macro),
+                    undefined,
+                    macro.location.range.start
+                );
             }
         }
 

--- a/src/providers/symbols.ts
+++ b/src/providers/symbols.ts
@@ -409,16 +409,16 @@ export class SymbolProvider {
             }
         }
 
-        // 3. Add local macros - nest under containing program or add as
-        //    top-level. Enumerate per scope (#270): the flat view keeps
-        //    one representative per name, dropping same-named locals
-        //    declared in other program scopes from the outline. Each
-        //    local nests under its OWNING scope's container — the
-        //    authoritative ownership already in hand — rather than
-        //    re-deriving containment geometrically (a location anchored
-        //    outside its scope's body, e.g. a directive-declared
-        //    do-file local on a line inside a program range, must not
-        //    change owners).
+        // 3. Add local macros - nest under containing program or add
+        //    as top-level. ENUMERATE per scope (#270): the flat view
+        //    keeps one representative per name, dropping same-named
+        //    locals declared in other program scopes from the
+        //    outline. PLACE by range containment (round-8): the
+        //    DocumentSymbol tree is an LSP text-structure view, so
+        //    program-owned locals use their owning body's container
+        //    (exact for redeclared bodies) and do-file-owned locals
+        //    nest geometrically — a top-level entry ranged inside a
+        //    program container would overlap a sibling on the wire.
         const nest_local_symbol = (
             my_local_symbol: DocumentSymbol,
             container: ProgramInfo | undefined,

--- a/src/utils/dofile-locals.ts
+++ b/src/utils/dofile-locals.ts
@@ -134,8 +134,9 @@ export function find_inherited_dofile_local(
 }
 
 /**
- * THE effective local-macro resolution order at a position — the one
- * rule every provider consumes (issue #270, round-9 gate):
+ * THE effective local-macro resolution order at a position, for names
+ * TRACKED in the current file's scope tree — the one rule every
+ * provider consumes (issue #270, round-9 gate):
  *   1. the positionally RESOLVED winner in [enclosing, dofile]
  *      (same-file scoped identity);
  *   2. else the cross-file INHERITED do-file local (the analyzer's
@@ -144,8 +145,12 @@ export function find_inherited_dofile_local(
  *   3. else the nearest visible scope's FORWARD identity target (a
  *      same-scope forward reference keeps navigation working; the
  *      analyzer treats it as plain undefined);
- *   4. else nothing (untracked, positional args, or out-of-scope —
- *      distinguish via lookup_scoped_local_macro where needed).
+ *   4. else nothing: tracked-but-invisible names are out-of-scope,
+ *      while UNTRACKED names (positional args, purely cross-file
+ *      names) belong to the pre-existing resolved-scope/flat
+ *      machinery — an inherited-only name is ONE frame-local whose
+ *      include-chain definitions pool like same-file redefinitions,
+ *      so the winner-only rules deliberately do not apply there.
  */
 export function resolve_effective_local(
     scopes: ScopeInfo[] | undefined,

--- a/src/utils/dofile-locals.ts
+++ b/src/utils/dofile-locals.ts
@@ -85,14 +85,20 @@ export function collect_inherited_dofile_locals(
             }
         }
     };
+    // No directive_type filter: inheritance is applied by EFFECTIVE
+    // call type (apply_inheritance_rules in the resolver), which can
+    // differ from the written directive type stored on the entry —
+    // e.g. `@lsp-done-by` where the parent actually uses `include`.
+    // The entry's localMacros are already inheritance-filtered, so a
+    // done-by-effective entry carries no locals and contributes
+    // nothing here; only the current file's own raw entry (chain[0])
+    // must be excluded by uri.
     const the_parents = (resolved_scope.chain ?? [])
-        .filter(
-            my_entry => my_entry.directive_type === 'included-by' &&
-                my_entry.uri !== current_uri
-        )
+        .filter(my_entry => my_entry.uri !== current_uri)
         .sort(
             (a, b) => b.depth - a.depth ||
-                a.directive_order - b.directive_order
+                a.directive_order - b.directive_order ||
+                a.sort_key.localeCompare(b.sort_key)
         );
     for (const my_entry of the_parents) {
         put_qualifying(my_entry.symbols.localMacros);

--- a/src/utils/dofile-locals.ts
+++ b/src/utils/dofile-locals.ts
@@ -41,13 +41,22 @@ export function filter_dofile_locals(
 }
 
 /**
- * The cross-file INHERITED do-file local for `name` visible at a
- * position in the current file, or undefined. Locals cross file
- * boundaries only through `include` semantics: backward via an
- * `included-by` chain entry (already call-site filtered by the
- * resolver), forward via an `include`-effective call site executed
- * before the reference line. Only do-file-scoped symbols qualify
+ * Every cross-file INHERITED do-file local visible at a position in
+ * the current file, keyed by name, with effective-scope precedence.
+ * Locals cross file boundaries only through `include` semantics:
+ * backward via `included-by` chain entries (already call-site
+ * filtered and inheritance-filtered by the resolver), forward via
+ * `include`-effective call sites executed before the reference line.
+ * Only do-file-scoped symbols from OTHER files qualify
  * (`is_dofile_local`, #271).
+ *
+ * Precedence mirrors the resolver's merge exactly: chain entries are
+ * applied far-to-near (depth descending, same-depth lattermost
+ * directive last) so nearer parents overwrite; executed forward
+ * include sites are then applied in array (source) order so later
+ * includes overwrite — and override the chain, matching
+ * get_visible_symbols_at's last-wins overlay and Stata's execution
+ * order.
  *
  * Used by providers when a name is OUT OF SCOPE same-file (tracked
  * only in non-visible sibling scopes, #270): the same-file flat slot
@@ -55,27 +64,38 @@ export function filter_dofile_locals(
  * defined at the reference — the analyzer's cross-file suppression
  * treats it as defined, so hover/definition/completion must too.
  */
-export function find_inherited_dofile_local(
+export function collect_inherited_dofile_locals(
     resolved_scope: ResolvedScope | undefined,
-    name: string,
     reference_line: number,
     current_uri: string
-): MacroSymbol | undefined {
+): Map<string, MacroSymbol> {
+    const out = new Map<string, MacroSymbol>();
     if (!resolved_scope) {
-        return undefined;
+        return out;
     }
-    for (const my_entry of resolved_scope.chain ?? []) {
-        if (my_entry.directive_type !== 'included-by') {
-            continue;
+    const put_qualifying = (
+        locals: Map<string, MacroSymbol>
+    ): void => {
+        for (const [my_name, my_symbol] of locals) {
+            if (
+                my_symbol.sourceUri !== current_uri &&
+                is_dofile_local(my_symbol)
+            ) {
+                out.set(my_name, my_symbol);
+            }
         }
-        const my_symbol = my_entry.symbols.localMacros.get(name);
-        if (
-            my_symbol &&
-            my_symbol.sourceUri !== current_uri &&
-            is_dofile_local(my_symbol)
-        ) {
-            return my_symbol;
-        }
+    };
+    const the_parents = (resolved_scope.chain ?? [])
+        .filter(
+            my_entry => my_entry.directive_type === 'included-by' &&
+                my_entry.uri !== current_uri
+        )
+        .sort(
+            (a, b) => b.depth - a.depth ||
+                a.directive_order - b.directive_order
+        );
+    for (const my_entry of the_parents) {
+        put_qualifying(my_entry.symbols.localMacros);
     }
     for (const my_site of resolved_scope.forward_call_symbols ?? []) {
         if (my_site.effective_type !== 'include') {
@@ -84,16 +104,24 @@ export function find_inherited_dofile_local(
         if (reference_line <= my_site.call_line) {
             continue;
         }
-        const my_symbol = my_site.symbols.localMacros.get(name);
-        if (
-            my_symbol &&
-            my_symbol.sourceUri !== current_uri &&
-            is_dofile_local(my_symbol)
-        ) {
-            return my_symbol;
-        }
+        put_qualifying(my_site.symbols.localMacros);
     }
-    return undefined;
+    return out;
+}
+
+/**
+ * Single-name convenience over `collect_inherited_dofile_locals` —
+ * same precedence by construction.
+ */
+export function find_inherited_dofile_local(
+    resolved_scope: ResolvedScope | undefined,
+    name: string,
+    reference_line: number,
+    current_uri: string
+): MacroSymbol | undefined {
+    return collect_inherited_dofile_locals(
+        resolved_scope, reference_line, current_uri
+    ).get(name);
 }
 
 /**

--- a/src/utils/dofile-locals.ts
+++ b/src/utils/dofile-locals.ts
@@ -17,6 +17,7 @@ import {
     MacroSymbol,
     MatrixSymbol,
     ProgramSymbol,
+    ResolvedScope,
     ScalarSymbol,
     VariableSymbol,
 } from '../types';
@@ -37,6 +38,62 @@ export function filter_dofile_locals(
         }
     }
     return filtered;
+}
+
+/**
+ * The cross-file INHERITED do-file local for `name` visible at a
+ * position in the current file, or undefined. Locals cross file
+ * boundaries only through `include` semantics: backward via an
+ * `included-by` chain entry (already call-site filtered by the
+ * resolver), forward via an `include`-effective call site executed
+ * before the reference line. Only do-file-scoped symbols qualify
+ * (`is_dofile_local`, #271).
+ *
+ * Used by providers when a name is OUT OF SCOPE same-file (tracked
+ * only in non-visible sibling scopes, #270): the same-file flat slot
+ * is forbidden there, but an inherited do-file local is genuinely
+ * defined at the reference — the analyzer's cross-file suppression
+ * treats it as defined, so hover/definition/completion must too.
+ */
+export function find_inherited_dofile_local(
+    resolved_scope: ResolvedScope | undefined,
+    name: string,
+    reference_line: number,
+    current_uri: string
+): MacroSymbol | undefined {
+    if (!resolved_scope) {
+        return undefined;
+    }
+    for (const my_entry of resolved_scope.chain ?? []) {
+        if (my_entry.directive_type !== 'included-by') {
+            continue;
+        }
+        const my_symbol = my_entry.symbols.localMacros.get(name);
+        if (
+            my_symbol &&
+            my_symbol.sourceUri !== current_uri &&
+            is_dofile_local(my_symbol)
+        ) {
+            return my_symbol;
+        }
+    }
+    for (const my_site of resolved_scope.forward_call_symbols ?? []) {
+        if (my_site.effective_type !== 'include') {
+            continue;
+        }
+        if (reference_line <= my_site.call_line) {
+            continue;
+        }
+        const my_symbol = my_site.symbols.localMacros.get(name);
+        if (
+            my_symbol &&
+            my_symbol.sourceUri !== current_uri &&
+            is_dofile_local(my_symbol)
+        ) {
+            return my_symbol;
+        }
+    }
+    return undefined;
 }
 
 /**

--- a/src/utils/dofile-locals.ts
+++ b/src/utils/dofile-locals.ts
@@ -23,7 +23,7 @@ import {
     VariableSymbol,
 } from '../types';
 import { Position } from './scope-position';
-import { resolve_visible_local } from './scoped-locals';
+import { lookup_scoped_local_macro } from './scoped-locals';
 
 export function is_dofile_local(
     symbol: Pick<MacroSymbol, 'containingScope'>
@@ -154,13 +154,51 @@ export function resolve_effective_local(
     resolved_scope: ResolvedScope | undefined,
     current_uri: string
 ): MacroSymbol | undefined {
-    const visible = resolve_visible_local(scopes, position, name);
-    if (visible.resolved) {
-        return visible.resolved;
+    return classify_effective_local(
+        scopes, position, name, resolved_scope, current_uri
+    ).symbol;
+}
+
+export interface EffectiveLocalClassification {
+    /** Which tier of the effective order won (see
+     * resolve_effective_local): 'out_of_scope' = tracked same-file
+     * but invisible with no inherited winner; 'none' = untracked
+     * (positional args, names foreign to this file). */
+    kind: 'resolved' | 'inherited' | 'forward' | 'out_of_scope' | 'none';
+    symbol?: MacroSymbol;
+}
+
+/**
+ * The effective order with its winning tier exposed, for providers
+ * whose handling differs per tier (references' target modes,
+ * definition's fast path / fallbacks). THE single arm mapping —
+ * bespoke per-provider re-derivations of this order are how the
+ * round-9/10 gate bugs happened.
+ */
+export function classify_effective_local(
+    scopes: ScopeInfo[] | undefined,
+    position: Position,
+    name: string,
+    resolved_scope: ResolvedScope | undefined,
+    current_uri: string
+): EffectiveLocalClassification {
+    const scoped = lookup_scoped_local_macro(scopes, position, name);
+    if (scoped.symbol && !scoped.forward_only) {
+        return { kind: 'resolved', symbol: scoped.symbol };
     }
-    return find_inherited_dofile_local(
-        resolved_scope, name, position.line, current_uri
-    ) ?? visible.forward;
+    if (scoped.out_of_scope || scoped.forward_only) {
+        const inherited = find_inherited_dofile_local(
+            resolved_scope, name, position.line, current_uri
+        );
+        if (inherited) {
+            return { kind: 'inherited', symbol: inherited };
+        }
+        if (scoped.forward_only) {
+            return { kind: 'forward', symbol: scoped.symbol };
+        }
+        return { kind: 'out_of_scope' };
+    }
+    return { kind: 'none' };
 }
 
 /**

--- a/src/utils/dofile-locals.ts
+++ b/src/utils/dofile-locals.ts
@@ -19,8 +19,11 @@ import {
     ProgramSymbol,
     ResolvedScope,
     ScalarSymbol,
+    ScopeInfo,
     VariableSymbol,
 } from '../types';
+import { Position } from './scope-position';
+import { resolve_visible_local } from './scoped-locals';
 
 export function is_dofile_local(
     symbol: Pick<MacroSymbol, 'containingScope'>
@@ -128,6 +131,36 @@ export function find_inherited_dofile_local(
     return collect_inherited_dofile_locals(
         resolved_scope, reference_line, current_uri
     ).get(name);
+}
+
+/**
+ * THE effective local-macro resolution order at a position — the one
+ * rule every provider consumes (issue #270, round-9 gate):
+ *   1. the positionally RESOLVED winner in [enclosing, dofile]
+ *      (same-file scoped identity);
+ *   2. else the cross-file INHERITED do-file local (the analyzer's
+ *      cross-file suppression treats the reference as defined via it,
+ *      so it outranks a not-yet-defined same-scope local);
+ *   3. else the nearest visible scope's FORWARD identity target (a
+ *      same-scope forward reference keeps navigation working; the
+ *      analyzer treats it as plain undefined);
+ *   4. else nothing (untracked, positional args, or out-of-scope —
+ *      distinguish via lookup_scoped_local_macro where needed).
+ */
+export function resolve_effective_local(
+    scopes: ScopeInfo[] | undefined,
+    position: Position,
+    name: string,
+    resolved_scope: ResolvedScope | undefined,
+    current_uri: string
+): MacroSymbol | undefined {
+    const visible = resolve_visible_local(scopes, position, name);
+    if (visible.resolved) {
+        return visible.resolved;
+    }
+    return find_inherited_dofile_local(
+        resolved_scope, name, position.line, current_uri
+    ) ?? visible.forward;
 }
 
 /**

--- a/src/utils/scope-position.ts
+++ b/src/utils/scope-position.ts
@@ -11,12 +11,13 @@
 import { Range } from 'vscode-languageserver-textdocument';
 import { ScopeInfo } from '../types';
 
-interface Position {
+export interface Position {
     line: number;
     character: number;
 }
 
-function compare_positions(a: Position, b: Position): number {
+/** Line-then-character comparator shared with scoped-locals.ts. */
+export function compare_positions(a: Position, b: Position): number {
     if (a.line !== b.line) {
         return a.line - b.line;
     }

--- a/src/utils/scoped-locals.ts
+++ b/src/utils/scoped-locals.ts
@@ -1,14 +1,19 @@
 /**
  * Scope-aware local-macro lookup shared by hover, go-to-definition,
- * find-references, and completion (issue #270).
+ * find-references, completion, and document/workspace symbols
+ * (issue #270).
  *
- * Mirrors the analyzer's `lookup_local_macro` (src/analyzer/index.ts)
- * and the diagnostics provider's `find_same_file_out_of_scope_match`
+ * Mirrors the analyzer's `lookup_local_macro` +
+ * `macro_resolves_at_reference` (src/analyzer/index.ts) and the
+ * diagnostics provider's `find_same_file_out_of_scope_match`
  * (src/providers/diagnostics.ts): a local macro is visible from a
  * position only in its enclosing scope and the do-file scope, in that
- * order, first-match-wins (shadowing). Position-to-scope resolution
- * goes through `find_enclosing_scope` (src/utils/scope-position.ts) —
- * THE single mechanism for that question; this module does not
+ * order — and among visible scopes, the first whose symbol has
+ * already been DEFINED at the position wins, so a reference before a
+ * program-local's definition resolves to a same-named do-file local
+ * exactly like the analyzer does. Position-to-scope resolution goes
+ * through `find_enclosing_scope` (src/utils/scope-position.ts) — THE
+ * single mechanism for that question; this module does not
  * reimplement it. `body_only` applies throughout: a reference on a
  * program's header or `end` line expands in the enclosing frame
  * (issue #273).
@@ -34,6 +39,74 @@ interface Position {
     character: number;
 }
 
+function compare_positions(a: Position, b: Position): number {
+    if (a.line !== b.line) {
+        return a.line - b.line;
+    }
+    return a.character - b.character;
+}
+
+/**
+ * The ordered visibility list for a reference whose enclosing scope
+ * is already resolved: [enclosing, dofile], collapsed to one entry
+ * when the enclosing scope IS the do-file scope. THE single encoding
+ * of the list-assembly rule — shared with the analyzer's
+ * `lookup_local_macro`, which resolves its reference scope through
+ * live-analysis state rather than a position.
+ */
+export function assemble_visible_scopes(
+    enclosing_scope: ScopeInfo,
+    dofile_scope: ScopeInfo | undefined
+): ScopeInfo[] {
+    return enclosing_scope.type !== 'dofile' &&
+        dofile_scope !== undefined &&
+        dofile_scope !== enclosing_scope
+        ? [enclosing_scope, dofile_scope]
+        : [enclosing_scope];
+}
+
+/**
+ * Has `symbol` already been defined at `position`? Line/position
+ * mirror of the analyzer's `macro_resolves_at_reference` (which also
+ * has a preorder-index check unavailable here): a Mata setter's
+ * `visibility_start` is authoritative when present; otherwise the
+ * primary definition line must be at-or-before the position, with a
+ * same-line reference-before-definition check. Only the PRIMARY
+ * definition is consulted — the analyzer keeps the primary as the
+ * earliest definition, so `additional_definitions` can never turn a
+ * forward reference into a resolved one. Permissive when the symbol
+ * carries no position markers.
+ */
+export function macro_resolves_at_position(
+    symbol: MacroSymbol,
+    position: Position
+): boolean {
+    if (symbol.visibility_start !== undefined) {
+        return compare_positions(position, symbol.visibility_start) >= 0;
+    }
+    if (
+        symbol.definition_line !== undefined &&
+        symbol.definition_line > position.line
+    ) {
+        return false;
+    }
+    // Same-line forward reference: only when the definition's
+    // execution-order line matches its source location (mirrors
+    // is_reference_before_macro_definition; sentinel lines like the
+    // `args` 0-line mean "in scope from the start").
+    const definition_line =
+        symbol.definition_line ?? symbol.location?.range?.start?.line;
+    if (
+        definition_line !== undefined &&
+        definition_line === symbol.location?.range?.start?.line &&
+        position.line === symbol.location.range.start.line &&
+        compare_positions(position, symbol.location.range.start) < 0
+    ) {
+        return false;
+    }
+    return true;
+}
+
 /**
  * Ordered visibility list for `position`: the innermost enclosing
  * program scope (body-only, #273) first, then the do-file scope —
@@ -51,29 +124,68 @@ export function get_visible_local_scopes(
     const enclosing_scope = find_enclosing_scope(scopes, position, {
         body_only: true,
     });
-    const dofile_scope = scopes[0];
-    return enclosing_scope.type !== 'dofile' &&
-        dofile_scope !== undefined &&
-        dofile_scope !== enclosing_scope
-        ? [enclosing_scope, dofile_scope]
-        : [enclosing_scope];
+    return assemble_visible_scopes(enclosing_scope, scopes[0]);
 }
 
 /**
- * All local macros visible at `position`, first-match-wins across the
- * visibility list — a name shadowed by the enclosing program scope
- * never surfaces the do-file scope's symbol.
+ * The visible symbol for `name` at `position`, or undefined. Two
+ * passes over the visibility list: first the scopes whose symbol has
+ * already been defined at `position` (matching the analyzer's
+ * resolution — a not-yet-defined program local does not shadow an
+ * already-defined do-file local); then, when nothing resolves
+ * positionally, the nearest visible scope that defines the name at
+ * all (a same-scope FORWARD reference keeps its identity target so
+ * navigation still works — the analyzer treats it as plain
+ * undefined, not out-of-scope). No out-of-scope bookkeeping — use
+ * `lookup_scoped_local_macro` when that distinction matters.
+ */
+export function resolve_visible_local(
+    scopes: ScopeInfo[] | undefined,
+    position: Position,
+    name: string
+): MacroSymbol | undefined {
+    const the_visible_scopes = get_visible_local_scopes(scopes, position);
+    let forward_fallback: MacroSymbol | undefined;
+    for (const my_scope of the_visible_scopes) {
+        const my_symbol = my_scope.localMacros.get(name);
+        if (!my_symbol) {
+            continue;
+        }
+        if (macro_resolves_at_position(my_symbol, position)) {
+            return my_symbol;
+        }
+        forward_fallback = forward_fallback ?? my_symbol;
+    }
+    return forward_fallback;
+}
+
+/**
+ * All local macros visible at `position`. Per name, the first
+ * visible scope whose symbol has already been defined at `position`
+ * wins; a name defined only later (forward) still appears via its
+ * nearest visible scope — same rule as `resolve_visible_local`.
  */
 export function collect_visible_local_macros(
     scopes: ScopeInfo[] | undefined,
     position: Position
 ): Map<string, MacroSymbol> {
     const out = new Map<string, MacroSymbol>();
+    const the_fallbacks = new Map<string, MacroSymbol>();
     for (const my_scope of get_visible_local_scopes(scopes, position)) {
         for (const [my_name, my_symbol] of my_scope.localMacros) {
-            if (!out.has(my_name)) {
-                out.set(my_name, my_symbol);
+            if (out.has(my_name)) {
+                continue;
             }
+            if (macro_resolves_at_position(my_symbol, position)) {
+                out.set(my_name, my_symbol);
+            } else if (!the_fallbacks.has(my_name)) {
+                the_fallbacks.set(my_name, my_symbol);
+            }
+        }
+    }
+    for (const [my_name, my_symbol] of the_fallbacks) {
+        if (!out.has(my_name)) {
+            out.set(my_name, my_symbol);
         }
     }
     return out;
@@ -106,7 +218,8 @@ export function enumerate_scoped_local_macros(
 
 export interface ScopedLocalLookupResult {
     /** THE symbol when a visible scope defines the name (exclusive
-     * shadowing: the nearest visible scope's symbol, issue #270). */
+     * shadowing among resolved definitions; see
+     * `resolve_visible_local` for the forward-reference fallback). */
     symbol: MacroSymbol | undefined;
     /** True when `name` is registered ONLY in scopes not visible from
      * `position` (e.g. a sibling program's body). Callers must not
@@ -131,11 +244,9 @@ export function lookup_scoped_local_macro(
     if (scopes === undefined || scopes.length === 0) {
         return { symbol: undefined, out_of_scope: false };
     }
-    for (const my_scope of get_visible_local_scopes(scopes, position)) {
-        const my_symbol = my_scope.localMacros.get(name);
-        if (my_symbol) {
-            return { symbol: my_symbol, out_of_scope: false };
-        }
+    const visible_symbol = resolve_visible_local(scopes, position, name);
+    if (visible_symbol) {
+        return { symbol: visible_symbol, out_of_scope: false };
     }
     for (const my_scope of scopes) {
         if (my_scope.localMacros.has(name)) {
@@ -143,4 +254,27 @@ export function lookup_scoped_local_macro(
         }
     }
     return { symbol: undefined, out_of_scope: false };
+}
+
+/**
+ * The scoped-or-flat declaration-lookup idiom shared by the
+ * cursor-on-declaration classifiers in definition.ts and
+ * references.ts: the visible scoped symbol wins; an out-of-scope
+ * name yields undefined (the flat slot may be that very out-of-scope
+ * symbol); otherwise fall back to the flat compatibility view
+ * (degenerate states, names untracked in this file).
+ */
+export function resolve_scoped_or_flat(
+    scopes: ScopeInfo[] | undefined,
+    position: Position,
+    name: string,
+    flat_local_macros: Map<string, MacroSymbol>
+): MacroSymbol | undefined {
+    const scoped = lookup_scoped_local_macro(scopes, position, name);
+    if (scoped.symbol) {
+        return scoped.symbol;
+    }
+    return scoped.out_of_scope
+        ? undefined
+        : flat_local_macros.get(name);
 }

--- a/src/utils/scoped-locals.ts
+++ b/src/utils/scoped-locals.ts
@@ -79,6 +79,31 @@ export function collect_visible_local_macros(
     return out;
 }
 
+/**
+ * Every local-macro declaration in the file, one entry per owning
+ * scope — the flat view holds a single representative per name, which
+ * silently drops same-named locals in other scopes (issue #270).
+ * Every analyzer write path registers into a scope before publishing
+ * to the flat view, so enumerating scopes loses nothing. Falls back
+ * to the flat map when `scopes` is empty (degenerate states). Order:
+ * do-file scope first, then program scopes in registration order.
+ */
+export function enumerate_scoped_local_macros(
+    scopes: ScopeInfo[] | undefined,
+    flat_local_macros: Map<string, MacroSymbol>
+): Array<[string, MacroSymbol]> {
+    if (scopes === undefined || scopes.length === 0) {
+        return [...flat_local_macros];
+    }
+    const out: Array<[string, MacroSymbol]> = [];
+    for (const my_scope of scopes) {
+        for (const my_entry of my_scope.localMacros) {
+            out.push(my_entry);
+        }
+    }
+    return out;
+}
+
 export interface ScopedLocalLookupResult {
     /** THE symbol when a visible scope defines the name (exclusive
      * shadowing: the nearest visible scope's symbol, issue #270). */

--- a/src/utils/scoped-locals.ts
+++ b/src/utils/scoped-locals.ts
@@ -32,19 +32,11 @@
  */
 
 import { MacroSymbol, ScopeInfo } from '../types';
-import { find_enclosing_scope } from './scope-position';
-
-interface Position {
-    line: number;
-    character: number;
-}
-
-function compare_positions(a: Position, b: Position): number {
-    if (a.line !== b.line) {
-        return a.line - b.line;
-    }
-    return a.character - b.character;
-}
+import {
+    compare_positions,
+    find_enclosing_scope,
+    Position,
+} from './scope-position';
 
 /**
  * The ordered visibility list for a reference whose enclosing scope
@@ -76,6 +68,9 @@ export function assemble_visible_scopes(
  * earliest definition, so `additional_definitions` can never turn a
  * forward reference into a resolved one. Permissive when the symbol
  * carries no position markers.
+ *
+ * LOCKSTEP: any change to these rules must also be applied to the
+ * analyzer's `macro_resolves_at_reference`, and vice versa.
  */
 export function macro_resolves_at_position(
     symbol: MacroSymbol,
@@ -163,7 +158,9 @@ export function resolve_visible_local(
  * All local macros visible at `position`. Per name, the first
  * visible scope whose symbol has already been defined at `position`
  * wins; a name defined only later (forward) still appears via its
- * nearest visible scope — same rule as `resolve_visible_local`.
+ * nearest visible scope — the SAME resolved-first-then-forward-
+ * fallback policy as `resolve_visible_local`, encoded map-wise here
+ * for enumeration. Keep the two in lockstep.
  */
 export function collect_visible_local_macros(
     scopes: ScopeInfo[] | undefined,

--- a/src/utils/scoped-locals.ts
+++ b/src/utils/scoped-locals.ts
@@ -122,70 +122,83 @@ export function get_visible_local_scopes(
     return assemble_visible_scopes(enclosing_scope, scopes[0]);
 }
 
+export interface VisibleLocalResolution {
+    /** Positionally RESOLVED winner in the visibility list — already
+     * defined at `position` in the nearest visible scope. */
+    resolved?: MacroSymbol;
+    /** The nearest visible scope's not-yet-defined symbol (a
+     * same-scope FORWARD reference's identity target). Consumers must
+     * rank this BELOW a cross-file inherited do-file local (see
+     * find_inherited_dofile_local): the analyzer's cross-file
+     * suppression treats such references as defined via the inherited
+     * symbol, so the forward identity applies only when nothing else
+     * resolves. */
+    forward?: MacroSymbol;
+}
+
 /**
- * The visible symbol for `name` at `position`, or undefined. Two
- * passes over the visibility list: first the scopes whose symbol has
- * already been defined at `position` (matching the analyzer's
+ * The visible symbols for `name` at `position`. One pass over the
+ * visibility list: the first scope whose symbol has already been
+ * defined at `position` yields `resolved` (matching the analyzer's
  * resolution — a not-yet-defined program local does not shadow an
- * already-defined do-file local); then, when nothing resolves
- * positionally, the nearest visible scope that defines the name at
- * all (a same-scope FORWARD reference keeps its identity target so
- * navigation still works — the analyzer treats it as plain
- * undefined, not out-of-scope). No out-of-scope bookkeeping — use
- * `lookup_scoped_local_macro` when that distinction matters.
+ * already-defined do-file local); the nearest visible scope defining
+ * the name only later yields `forward`. No out-of-scope bookkeeping —
+ * use `lookup_scoped_local_macro` when that distinction matters.
  */
 export function resolve_visible_local(
     scopes: ScopeInfo[] | undefined,
     position: Position,
     name: string
-): MacroSymbol | undefined {
-    const the_visible_scopes = get_visible_local_scopes(scopes, position);
-    let forward_fallback: MacroSymbol | undefined;
-    for (const my_scope of the_visible_scopes) {
+): VisibleLocalResolution {
+    const out: VisibleLocalResolution = {};
+    for (const my_scope of get_visible_local_scopes(scopes, position)) {
         const my_symbol = my_scope.localMacros.get(name);
         if (!my_symbol) {
             continue;
         }
         if (macro_resolves_at_position(my_symbol, position)) {
-            return my_symbol;
+            out.resolved = my_symbol;
+            return out;
         }
-        forward_fallback = forward_fallback ?? my_symbol;
+        out.forward = out.forward ?? my_symbol;
     }
-    return forward_fallback;
+    return out;
+}
+
+export interface VisibleLocalMacroMaps {
+    /** Per name: the positionally resolved winner. */
+    resolved: Map<string, MacroSymbol>;
+    /** Per name with NO resolved winner: the nearest visible scope's
+     * forward symbol — same below-inherited ranking caveat as
+     * `VisibleLocalResolution.forward`. */
+    forward: Map<string, MacroSymbol>;
 }
 
 /**
- * All local macros visible at `position`. Per name, the first
- * visible scope whose symbol has already been defined at `position`
- * wins; a name defined only later (forward) still appears via its
- * nearest visible scope — the SAME resolved-first-then-forward-
- * fallback policy as `resolve_visible_local`, encoded map-wise here
- * for enumeration. Keep the two in lockstep.
+ * All local macros visible at `position`, split into resolved and
+ * forward-only maps — the SAME policy as `resolve_visible_local`,
+ * encoded map-wise for enumeration. Keep the two in lockstep.
  */
 export function collect_visible_local_macros(
     scopes: ScopeInfo[] | undefined,
     position: Position
-): Map<string, MacroSymbol> {
-    const out = new Map<string, MacroSymbol>();
-    const the_fallbacks = new Map<string, MacroSymbol>();
+): VisibleLocalMacroMaps {
+    const resolved = new Map<string, MacroSymbol>();
+    const forward = new Map<string, MacroSymbol>();
     for (const my_scope of get_visible_local_scopes(scopes, position)) {
         for (const [my_name, my_symbol] of my_scope.localMacros) {
-            if (out.has(my_name)) {
+            if (resolved.has(my_name)) {
                 continue;
             }
             if (macro_resolves_at_position(my_symbol, position)) {
-                out.set(my_name, my_symbol);
-            } else if (!the_fallbacks.has(my_name)) {
-                the_fallbacks.set(my_name, my_symbol);
+                resolved.set(my_name, my_symbol);
+                forward.delete(my_name);
+            } else if (!forward.has(my_name)) {
+                forward.set(my_name, my_symbol);
             }
         }
     }
-    for (const [my_name, my_symbol] of the_fallbacks) {
-        if (!out.has(my_name)) {
-            out.set(my_name, my_symbol);
-        }
-    }
-    return out;
+    return { resolved, forward };
 }
 
 /**
@@ -215,9 +228,16 @@ export function enumerate_scoped_local_macros(
 
 export interface ScopedLocalLookupResult {
     /** THE symbol when a visible scope defines the name (exclusive
-     * shadowing among resolved definitions; see
-     * `resolve_visible_local` for the forward-reference fallback). */
+     * shadowing among resolved definitions; the forward identity
+     * target when nothing resolves positionally — see
+     * `forward_only`). */
     symbol: MacroSymbol | undefined;
+    /** True when `symbol` is a not-yet-defined forward identity
+     * target rather than a positionally resolved winner. Consumers
+     * must rank such a symbol BELOW a cross-file inherited do-file
+     * local (the analyzer's cross-file suppression treats the
+     * reference as defined via the inherited symbol). */
+    forward_only: boolean;
     /** True when `name` is registered ONLY in scopes not visible from
      * `position` (e.g. a sibling program's body). Callers must not
      * substitute the flat view's representative — it may be that very
@@ -239,18 +259,33 @@ export function lookup_scoped_local_macro(
     name: string
 ): ScopedLocalLookupResult {
     if (scopes === undefined || scopes.length === 0) {
-        return { symbol: undefined, out_of_scope: false };
+        return { symbol: undefined, forward_only: false, out_of_scope: false };
     }
-    const visible_symbol = resolve_visible_local(scopes, position, name);
-    if (visible_symbol) {
-        return { symbol: visible_symbol, out_of_scope: false };
+    const visible = resolve_visible_local(scopes, position, name);
+    if (visible.resolved) {
+        return {
+            symbol: visible.resolved,
+            forward_only: false,
+            out_of_scope: false,
+        };
+    }
+    if (visible.forward) {
+        return {
+            symbol: visible.forward,
+            forward_only: true,
+            out_of_scope: false,
+        };
     }
     for (const my_scope of scopes) {
         if (my_scope.localMacros.has(name)) {
-            return { symbol: undefined, out_of_scope: true };
+            return {
+                symbol: undefined,
+                forward_only: false,
+                out_of_scope: true,
+            };
         }
     }
-    return { symbol: undefined, out_of_scope: false };
+    return { symbol: undefined, forward_only: false, out_of_scope: false };
 }
 
 /**

--- a/src/utils/scoped-locals.ts
+++ b/src/utils/scoped-locals.ts
@@ -42,10 +42,10 @@ interface Position {
  * analyzer states); callers fall back to the flat compatibility view.
  */
 export function get_visible_local_scopes(
-    scopes: ScopeInfo[],
+    scopes: ScopeInfo[] | undefined,
     position: Position
 ): ScopeInfo[] {
-    if (scopes.length === 0) {
+    if (scopes === undefined || scopes.length === 0) {
         return [];
     }
     const enclosing_scope = find_enclosing_scope(scopes, position, {
@@ -65,7 +65,7 @@ export function get_visible_local_scopes(
  * never surfaces the do-file scope's symbol.
  */
 export function collect_visible_local_macros(
-    scopes: ScopeInfo[],
+    scopes: ScopeInfo[] | undefined,
     position: Position
 ): Map<string, MacroSymbol> {
     const out = new Map<string, MacroSymbol>();
@@ -99,11 +99,11 @@ export interface ScopedLocalLookupResult {
  * unchanged.
  */
 export function lookup_scoped_local_macro(
-    scopes: ScopeInfo[],
+    scopes: ScopeInfo[] | undefined,
     position: Position,
     name: string
 ): ScopedLocalLookupResult {
-    if (scopes.length === 0) {
+    if (scopes === undefined || scopes.length === 0) {
         return { symbol: undefined, out_of_scope: false };
     }
     for (const my_scope of get_visible_local_scopes(scopes, position)) {

--- a/src/utils/scoped-locals.ts
+++ b/src/utils/scoped-locals.ts
@@ -1,0 +1,121 @@
+/**
+ * Scope-aware local-macro lookup shared by hover, go-to-definition,
+ * find-references, and completion (issue #270).
+ *
+ * Mirrors the analyzer's `lookup_local_macro` (src/analyzer/index.ts)
+ * and the diagnostics provider's `find_same_file_out_of_scope_match`
+ * (src/providers/diagnostics.ts): a local macro is visible from a
+ * position only in its enclosing scope and the do-file scope, in that
+ * order, first-match-wins (shadowing). Position-to-scope resolution
+ * goes through `find_enclosing_scope` (src/utils/scope-position.ts) —
+ * THE single mechanism for that question; this module does not
+ * reimplement it. `body_only` applies throughout: a reference on a
+ * program's header or `end` line expands in the enclosing frame
+ * (issue #273).
+ *
+ * IMPORTANT: `document.scopes` describes only THIS file's own text. A
+ * do-file-scoped result here does NOT account for cross-file
+ * execution-order shadowing (e.g. an `include` that redefined the name
+ * after this file's own definition — see the forward-call overlay in
+ * src/scope-resolver/visible-symbols.ts). Callers must treat a
+ * do-file-scoped `symbol` as informational only for same-file
+ * structural questions (declaration-range hits, same-file occurrence
+ * identity) and must NOT use it to bypass the resolved-scope / flat
+ * value-resolution code. Only a PROGRAM-scoped `symbol` is
+ * unconditionally authoritative: issue #271 guarantees program-body
+ * locals never cross file boundaries (src/utils/dofile-locals.ts).
+ */
+
+import { MacroSymbol, ScopeInfo } from '../types';
+import { find_enclosing_scope } from './scope-position';
+
+interface Position {
+    line: number;
+    character: number;
+}
+
+/**
+ * Ordered visibility list for `position`: the innermost enclosing
+ * program scope (body-only, #273) first, then the do-file scope —
+ * collapsed to one entry when the enclosing scope IS the do-file
+ * scope. Returns [] when `scopes` is empty (degenerate/partial
+ * analyzer states); callers fall back to the flat compatibility view.
+ */
+export function get_visible_local_scopes(
+    scopes: ScopeInfo[],
+    position: Position
+): ScopeInfo[] {
+    if (scopes.length === 0) {
+        return [];
+    }
+    const enclosing_scope = find_enclosing_scope(scopes, position, {
+        body_only: true,
+    });
+    const dofile_scope = scopes[0];
+    return enclosing_scope.type !== 'dofile' &&
+        dofile_scope !== undefined &&
+        dofile_scope !== enclosing_scope
+        ? [enclosing_scope, dofile_scope]
+        : [enclosing_scope];
+}
+
+/**
+ * All local macros visible at `position`, first-match-wins across the
+ * visibility list — a name shadowed by the enclosing program scope
+ * never surfaces the do-file scope's symbol.
+ */
+export function collect_visible_local_macros(
+    scopes: ScopeInfo[],
+    position: Position
+): Map<string, MacroSymbol> {
+    const out = new Map<string, MacroSymbol>();
+    for (const my_scope of get_visible_local_scopes(scopes, position)) {
+        for (const [my_name, my_symbol] of my_scope.localMacros) {
+            if (!out.has(my_name)) {
+                out.set(my_name, my_symbol);
+            }
+        }
+    }
+    return out;
+}
+
+export interface ScopedLocalLookupResult {
+    /** THE symbol when a visible scope defines the name (exclusive
+     * shadowing: the nearest visible scope's symbol, issue #270). */
+    symbol: MacroSymbol | undefined;
+    /** True when `name` is registered ONLY in scopes not visible from
+     * `position` (e.g. a sibling program's body). Callers must not
+     * substitute the flat view's representative — it may be that very
+     * out-of-scope symbol. */
+    out_of_scope: boolean;
+}
+
+/**
+ * Resolve local macro `name` at `position` against this file's own
+ * scope tree. `{symbol: undefined, out_of_scope: false}` means the
+ * scoped model has no opinion (empty `scopes`, or the name is not
+ * registered anywhere in this file — e.g. positional args and
+ * cross-file inherited locals) and existing fallback code should run
+ * unchanged.
+ */
+export function lookup_scoped_local_macro(
+    scopes: ScopeInfo[],
+    position: Position,
+    name: string
+): ScopedLocalLookupResult {
+    if (scopes.length === 0) {
+        return { symbol: undefined, out_of_scope: false };
+    }
+    for (const my_scope of get_visible_local_scopes(scopes, position)) {
+        const my_symbol = my_scope.localMacros.get(name);
+        if (my_symbol) {
+            return { symbol: my_symbol, out_of_scope: false };
+        }
+    }
+    for (const my_scope of scopes) {
+        if (my_scope.localMacros.has(name)) {
+            return { symbol: undefined, out_of_scope: true };
+        }
+    }
+    return { symbol: undefined, out_of_scope: false };
+}

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -1374,7 +1374,7 @@ describe('scoped local macros: round-6 gate regression', () => {
         }
     });
 
-    it('references: only the last include\'s declaration is pooled for an out-of-scope name', async () => {
+    it('references: only the winner declaration is pooled', async () => {
         const references_provider = new ReferencesProvider(scope_resolver);
         const a_path = join(test_temp_dir, 'a.do');
         const b_path = join(test_temp_dir, 'b.do');

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -1341,3 +1341,71 @@ describe('scoped local macros: round-5 gate regressions', () => {
         expect(value).not.toContain('Redefined');
     });
 });
+
+// Round-6 gate regression (#270): in exclude-mode with an inherited
+// winner, includeDeclaration must surface exactly the winner's
+// declaration — never a superseded earlier include's.
+describe('scoped local macros: round-6 gate regression', () => {
+    let test_temp_dir: string;
+    let indexer: WorkspaceIndexer;
+    let scope_resolver: ScopeResolver;
+    let forward_scope_resolver: ForwardScopeResolver;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate6-'));
+        indexer = new WorkspaceIndexer();
+        const the_dep_graph = new DependencyGraph();
+        indexer.set_dependency_graph(the_dep_graph);
+        scope_resolver = new ScopeResolver();
+        scope_resolver.set_dependency_graph(the_dep_graph);
+        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        try { scope_resolver?.dispose(); } catch {}
+        try { forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('references: only the last include\'s declaration is pooled for an out-of-scope name', async () => {
+        const references_provider = new ReferencesProvider(scope_resolver);
+        const a_path = join(test_temp_dir, 'a.do');
+        const b_path = join(test_temp_dir, 'b.do');
+        writeFileSync(a_path, 'local flag A\n');
+        writeFileSync(b_path, 'local flag B\n');
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = [
+            'include "a.do"',          // 0
+            'include "b.do"',          // 1
+            'program define p',        // 2
+            '    local flag prog',     // 3
+            'end',                     // 4
+            'di "`flag\'"',            // 5
+        ].join('\n');
+        writeFileSync(main_path, main_content);
+        await indexer.initialize([test_temp_dir]);
+        const uri = URI.file(main_path).toString();
+        await document_store.open(uri, main_content, 1);
+        const character = main_content.split('\n')[5].indexOf('flag');
+        const the_locations = await references_provider.get_references(
+            document_store.get(uri)!,
+            { line: 5, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const the_uris = the_locations.map(my_loc => my_loc.uri);
+        expect(the_uris).toContain(URI.file(b_path).toString());
+        expect(the_uris).not.toContain(URI.file(a_path).toString());
+        const main_lines = the_locations
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line);
+        expect(main_lines).toEqual([5]);
+    });
+});

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -1219,3 +1219,125 @@ describe('scoped local macros: round-4 gate regressions', () => {
         expect(value).toContain('Expansion: `P`');
     });
 });
+
+// Round-5 gate regressions (#270): exclude-mode occurrences must share
+// the cursor's per-line inherited identity (pre-include occurrences are
+// a different resolution class), and the inherited hover footer must
+// not present the out-of-scope sibling program-local as a redefinition.
+describe('scoped local macros: round-5 gate regressions', () => {
+    let test_temp_dir: string;
+    let indexer: WorkspaceIndexer;
+    let scope_resolver: ScopeResolver;
+    let forward_scope_resolver: ForwardScopeResolver;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate5-'));
+        indexer = new WorkspaceIndexer();
+        const the_dep_graph = new DependencyGraph();
+        indexer.set_dependency_graph(the_dep_graph);
+        scope_resolver = new ScopeResolver();
+        scope_resolver.set_dependency_graph(the_dep_graph);
+        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        try { scope_resolver?.dispose(); } catch {}
+        try { forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_file(name: string, lines: string[]) {
+        const file_path = join(test_temp_dir, name);
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    const PRE_POST_INCLUDE_LINES = [
+        'program define a',     // 0
+        '    local x own',      // 1
+        'end',                  // 2
+        'di "`x\'"',            // 3 — before the include: plain undefined
+        'include "lib.do"',     // 4
+        'di "`x\'"',            // 5 — after the include: lib's x
+    ];
+
+    it('references: a pre-include occurrence is not grouped with post-include references', async () => {
+        const references_provider = new ReferencesProvider(scope_resolver);
+        writeFileSync(join(test_temp_dir, 'lib.do'), 'local x lib\n');
+        const { uri, content, document_state } =
+            await open_file('main.do', PRE_POST_INCLUDE_LINES);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[5].indexOf('x\'');
+        const the_locations = await references_provider.get_references(
+            document_state,
+            { line: 5, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const the_lines = the_locations
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line);
+        expect(the_lines).toContain(5);
+        expect(the_lines).not.toContain(3);
+        expect(the_lines).not.toContain(1);
+    });
+
+    it('references: a plain-undefined cursor excludes post-include occurrences', async () => {
+        const references_provider = new ReferencesProvider(scope_resolver);
+        writeFileSync(join(test_temp_dir, 'lib.do'), 'local x lib\n');
+        const { uri, content, document_state } =
+            await open_file('main.do', PRE_POST_INCLUDE_LINES);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[3].indexOf('x\'');
+        const the_locations = await references_provider.get_references(
+            document_state,
+            { line: 3, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const the_lines = the_locations
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line);
+        expect(the_lines).toContain(3);
+        expect(the_lines).not.toContain(5);
+    });
+
+    it('hover: inherited footer never cites the out-of-scope sibling program-local', async () => {
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        writeFileSync(join(test_temp_dir, 'parent.do'), [
+            'local flag P',
+            'include "child.do"',
+        ].join('\n'));
+        const { content, document_state } = await open_file('child.do', [
+            'program define foo',   // 0
+            '    local flag 9',     // 1
+            'end',                  // 2
+            'di "`flag\'"',         // 3
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[3].indexOf('flag');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 3, character },
+            undefined,
+            scope_resolver,
+            undefined,
+            undefined,
+            test_temp_dir,
+            indexer,
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).toContain('Expansion: `P`');
+        expect(value).not.toContain('Redefined');
+    });
+});

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -1096,3 +1096,126 @@ describe('scoped local macros: round-3 gate regressions', () => {
         ).toEqual([4]);
     });
 });
+
+// Round-4 gate regressions (#270): definition's out-of-scope path must
+// return exactly the call-line-gated inherited winner (no multi-include
+// pooling, no not-yet-executed includes), and backward inheritance must
+// follow the EFFECTIVE call type, not the written directive type.
+describe('scoped local macros: round-4 gate regressions', () => {
+    let test_temp_dir: string;
+    let indexer: WorkspaceIndexer;
+    let scope_resolver: ScopeResolver;
+    let forward_scope_resolver: ForwardScopeResolver;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate4-'));
+        indexer = new WorkspaceIndexer();
+        const the_dep_graph = new DependencyGraph();
+        indexer.set_dependency_graph(the_dep_graph);
+        scope_resolver = new ScopeResolver();
+        scope_resolver.set_dependency_graph(the_dep_graph);
+        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        try { scope_resolver?.dispose(); } catch {}
+        try { forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_file(name: string, lines: string[]) {
+        const file_path = join(test_temp_dir, name);
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    it('definition: out-of-scope name resolves to the single last-include winner', async () => {
+        const definition_provider = new DefinitionProvider();
+        const a_path = join(test_temp_dir, 'a.do');
+        const b_path = join(test_temp_dir, 'b.do');
+        writeFileSync(a_path, 'local flag A\n');
+        writeFileSync(b_path, 'local flag B\n');
+        const { content, document_state } = await open_file('main.do', [
+            'include "a.do"',          // 0
+            'include "b.do"',          // 1
+            'program define p',        // 2
+            '    local flag prog',     // 3
+            'end',                     // 4
+            'di "`flag\'"',            // 5
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[5].indexOf('flag');
+        const result = await definition_provider.get_definition(
+            document_state,
+            { line: 5, character },
+            undefined,
+            undefined,
+            scope_resolver,
+            indexer,
+            undefined,
+        );
+        const the_locations = as_locations(result);
+        expect(new Set(the_locations.map(my_loc => my_loc.uri)))
+            .toEqual(new Set([URI.file(b_path).toString()]));
+    });
+
+    it('definition: an include AFTER the reference is not yet inherited', async () => {
+        const definition_provider = new DefinitionProvider();
+        writeFileSync(join(test_temp_dir, 'has_x.do'), 'local x lib\n');
+        const { content, document_state } = await open_file('main.do', [
+            'program define p',    // 0
+            '    di "`x\'"',       // 1 — before the include executes
+            '    local x own',     // 2 (makes p shadow later; keep simple)
+            'end',                 // 3
+            'di "`x\'"',           // 4 — still before the include
+            'include "has_x.do"',  // 5
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[4].indexOf('x\'');
+        const result = await definition_provider.get_definition(
+            document_state,
+            { line: 4, character },
+            undefined,
+            undefined,
+            scope_resolver,
+            indexer,
+            undefined,
+        );
+        expect(as_locations(result)).toEqual([]);
+    });
+
+    it('hover: a done-by directive whose parent actually includes inherits locals (effective type)', async () => {
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        writeFileSync(join(test_temp_dir, 'parent.do'), [
+            'local flag P',
+            'include "child.do"',
+        ].join('\n'));
+        const { content, document_state } = await open_file('child.do', [
+            '// @lsp-done-by: "parent.do"',  // 0
+            'program define foo',            // 1
+            '    local flag 9',              // 2
+            'end',                           // 3
+            'di "`flag\'"',                  // 4
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[4].indexOf('flag');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 4, character },
+            undefined,
+            scope_resolver,
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).toContain('Expansion: `P`');
+    });
+});

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -344,23 +344,32 @@ describe('scoped local macros: find-references (#270)', () => {
         expect(the_lines).toEqual([0, 1, 7]);
     });
 
-    it('top-level reference to a program-only local returns nothing', async () => {
+    it('top-level reference to a program-only local never pools the program\'s sites', async () => {
+        // The out-of-scope reference's identity class is "resolves to
+        // no same-file symbol" (a cross-file inherited local, or plain
+        // undefined) — its own occurrence is included, the sibling
+        // program's declaration and occurrences never are.
         const { uri, content } = await open_file('a.do', [
             'program define prog_a',   // 0
             '    local hidden 1',      // 1
-            'end',                     // 2
-            'di "`hidden\'"',          // 3
+            '    di "`hidden\'"',      // 2
+            'end',                     // 3
+            'di "`hidden\'"',          // 4
         ]);
         await indexer.initialize([test_temp_dir]);
         await document_store.open(uri, content, 1);
-        const character = content.split('\n')[3].indexOf('hidden');
+        const character = content.split('\n')[4].indexOf('hidden');
         const the_locations = await references_provider.get_references(
             document_store.get(uri)!,
-            { line: 3, character },
+            { line: 4, character },
             { includeDeclaration: true },
             indexer,
         );
-        expect(the_locations).toEqual([]);
+        const the_lines = the_locations
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line)
+            .sort((a, b) => a - b);
+        expect(the_lines).toEqual([4]);
     });
 
     it('program-scoped target skips the cross-file scan entirely', async () => {
@@ -776,5 +785,186 @@ describe('scoped local macros: round-1 gate regressions', () => {
         );
         expect(the_item).toBeDefined();
         expect(the_item!.documentation).toBe('Value: 1');
+    });
+});
+
+// Round-2 gate regressions (#270): an out-of-scope same-file name must
+// still resolve to a cross-file INHERITED do-file local (the analyzer's
+// cross-file suppression treats it as defined), and a visible
+// program-scoped local must pre-empt the out-of-scope hover display.
+describe('scoped local macros: round-2 gate regressions', () => {
+    let test_temp_dir: string;
+    let indexer: WorkspaceIndexer;
+    let scope_resolver: ScopeResolver;
+    let forward_scope_resolver: ForwardScopeResolver;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate2-'));
+        indexer = new WorkspaceIndexer();
+        const the_dep_graph = new DependencyGraph();
+        indexer.set_dependency_graph(the_dep_graph);
+        scope_resolver = new ScopeResolver();
+        scope_resolver.set_dependency_graph(the_dep_graph);
+        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        try { scope_resolver?.dispose(); } catch {}
+        try { forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_file(name: string, lines: string[]) {
+        const file_path = join(test_temp_dir, name);
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    const PARENT_LINES = [
+        'local flag 1',        // 0
+        'include "child.do"',  // 1
+    ];
+    const CHILD_LINES = [
+        'program define foo',  // 0
+        '    local flag 9',    // 1
+        'end',                 // 2
+        'display `flag\'',     // 3
+    ];
+
+    it('hover: sibling program name does not suppress an inherited do-file local', async () => {
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        const parent_path = join(test_temp_dir, 'parent.do');
+        writeFileSync(parent_path, PARENT_LINES.join('\n'));
+        const { content, document_state } =
+            await open_file('child.do', CHILD_LINES);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[3].indexOf('flag');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 3, character },
+            undefined,
+            scope_resolver,
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).toContain('Expansion: `1`');
+        expect(value).not.toContain('Expansion: `9`');
+    });
+
+    it('definition: inherited do-file local resolves cross-file, never to the sibling program', async () => {
+        const definition_provider = new DefinitionProvider();
+        const parent_path = join(test_temp_dir, 'parent.do');
+        writeFileSync(parent_path, PARENT_LINES.join('\n'));
+        const { uri, content, document_state } =
+            await open_file('child.do', CHILD_LINES);
+        await indexer.initialize([test_temp_dir]);
+        const parent_uri = URI.file(parent_path).toString();
+        const character = content.split('\n')[3].indexOf('flag');
+        const result = await definition_provider.get_definition(
+            document_state,
+            { line: 3, character },
+            undefined,
+            undefined,
+            scope_resolver,
+            indexer,
+            undefined,
+        );
+        const the_locations = as_locations(result);
+        expect(
+            the_locations.some(
+                my_loc => my_loc.uri === parent_uri &&
+                    my_loc.range.start.line === 0
+            )
+        ).toBe(true);
+        expect(
+            the_locations.some(my_loc => my_loc.uri === uri)
+        ).toBe(false);
+    });
+
+    it('references: inherited do-file local pools cross-file sites, never the sibling program\'s', async () => {
+        const references_provider = new ReferencesProvider(scope_resolver);
+        const parent_path = join(test_temp_dir, 'parent.do');
+        writeFileSync(parent_path, PARENT_LINES.join('\n'));
+        const { uri, content, document_state } =
+            await open_file('child.do', CHILD_LINES);
+        await indexer.initialize([test_temp_dir]);
+        const parent_uri = URI.file(parent_path).toString();
+        const character = content.split('\n')[3].indexOf('flag');
+        const the_locations = await references_provider.get_references(
+            document_state,
+            { line: 3, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const child_lines = the_locations
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line);
+        const parent_lines = the_locations
+            .filter(my_loc => my_loc.uri === parent_uri)
+            .map(my_loc => my_loc.range.start.line);
+        expect(child_lines).toEqual([3]);
+        expect(parent_lines).toContain(0);
+        expect(child_lines).not.toContain(1);
+    });
+
+    it('completion: forward-included do-file local offered despite a sibling program reusing the name', async () => {
+        const completion_provider =
+            new CompletionProvider(new CommandDatabase());
+        writeFileSync(join(test_temp_dir, 'lib.do'), 'local hidden lib\n');
+        const { document_state } = await open_file('main.do', [
+            'include "lib.do"',        // 0
+            'program define p',        // 1
+            '    local hidden prog',   // 2
+            'end',                     // 3
+            'di "`h',                  // 4
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const the_completions = await completion_provider.get_completions(
+            document_state,
+            { line: 4, character: 6 },
+            '`',
+            scope_resolver,
+            indexer.get_all_symbols(),
+        );
+        const the_item = the_completions.find(
+            my_item => my_item.label === 'hidden'
+        );
+        expect(the_item).toBeDefined();
+        expect(the_item!.documentation).toBe('Value: lib');
+    });
+
+    it('hover: visible program local pre-empts the out-of-scope display', async () => {
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        const parent_path = join(test_temp_dir, 'parent.do');
+        writeFileSync(parent_path, [
+            'local x 5',          // 0
+            'do "child.do"',      // 1
+        ].join('\n'));
+        const { content, document_state } = await open_file('child.do', [
+            'program define p',    // 0
+            '    local x 1',       // 1
+            '    di "`x\'"',       // 2
+            'end',                 // 3
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[2].indexOf('x\'');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 2, character },
+            undefined,
+            scope_resolver,
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).toContain('Expansion: `1`');
+        expect(value).not.toContain('(out of scope)');
     });
 });

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -1631,3 +1631,96 @@ describe('scoped local macros: round-9 gate regressions', () => {
         expect(the_item!.documentation).toBe('Value: lib');
     });
 });
+
+// Round-10 gate regression (#270): a FORWARD do-file local (defined
+// after the cursor) also defers to the inherited winner — definition
+// must return only the last include's declaration, not pool every
+// prior include.
+describe('scoped local macros: round-10 gate regression', () => {
+    let test_temp_dir: string;
+    let indexer: WorkspaceIndexer;
+    let scope_resolver: ScopeResolver;
+    let forward_scope_resolver: ForwardScopeResolver;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate10-'));
+        indexer = new WorkspaceIndexer();
+        const the_dep_graph = new DependencyGraph();
+        indexer.set_dependency_graph(the_dep_graph);
+        scope_resolver = new ScopeResolver();
+        scope_resolver.set_dependency_graph(the_dep_graph);
+        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        try { scope_resolver?.dispose(); } catch {}
+        try { forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('definition: forward do-file local defers to the single inherited winner', async () => {
+        const definition_provider = new DefinitionProvider();
+        const a_path = join(test_temp_dir, 'a.do');
+        const b_path = join(test_temp_dir, 'b.do');
+        writeFileSync(a_path, 'local x A\n');
+        writeFileSync(b_path, 'local x B\n');
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = [
+            'include "a.do"',   // 0
+            'include "b.do"',   // 1
+            'di "`x\'"',        // 2 — before the same-file def
+            'local x own',      // 3
+        ].join('\n');
+        writeFileSync(main_path, main_content);
+        await indexer.initialize([test_temp_dir]);
+        const uri = URI.file(main_path).toString();
+        await document_store.open(uri, main_content, 1);
+        const character = main_content.split('\n')[2].indexOf('x\'');
+        const result = await definition_provider.get_definition(
+            document_store.get(uri)!,
+            { line: 2, character },
+            undefined,
+            undefined,
+            scope_resolver,
+            indexer,
+            undefined,
+        );
+        const the_locations = as_locations(result);
+        expect(new Set(the_locations.map(my_loc => my_loc.uri)))
+            .toEqual(new Set([URI.file(b_path).toString()]));
+    });
+
+    it('definition: forward do-file local with no includes keeps identity navigation', async () => {
+        const definition_provider = new DefinitionProvider();
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = [
+            'di "`x\'"',        // 0 — before the def
+            'local x own',      // 1
+        ].join('\n');
+        writeFileSync(main_path, main_content);
+        await indexer.initialize([test_temp_dir]);
+        const uri = URI.file(main_path).toString();
+        await document_store.open(uri, main_content, 1);
+        const character = main_content.split('\n')[0].indexOf('x\'');
+        const result = await definition_provider.get_definition(
+            document_store.get(uri)!,
+            { line: 0, character },
+            undefined,
+            undefined,
+            scope_resolver,
+            indexer,
+            undefined,
+        );
+        const the_lines = as_locations(result)
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line);
+        expect(the_lines).toEqual([1]);
+    });
+});

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -1,0 +1,146 @@
+// Issue #270: hover / go-to-definition / find-references / completion
+// must resolve local macros through the scoped environment model
+// (DocumentState.scopes), not the flat one-representative-per-name
+// compatibility view. Mirrors the analyzer-level scenarios in
+// tests/unit/scoped-local-macro-identity.test.ts at the provider level.
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { join } from 'path';
+import { writeFileSync, mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { URI } from 'vscode-uri';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { DocumentStore } from '../../src/document-store';
+import { DefinitionProvider } from '../../src/providers/definition';
+import { Location } from 'vscode-languageserver';
+
+const SIBLING_LINES = [
+    'program define prog_a',   // 0
+    '    local shared 1',      // 1
+    'end',                     // 2
+    'program define prog_b',   // 3
+    '    local shared 2',      // 4
+    '    di "`shared\'"',      // 5
+    'end',                     // 6
+];
+
+function as_locations(
+    result: Location | Location[] | null
+): Location[] {
+    if (!result) return [];
+    return Array.isArray(result) ? result : [result];
+}
+
+describe('scoped local macros: go-to-definition (#270)', () => {
+    let test_temp_dir: string;
+    let indexer: WorkspaceIndexer;
+    let provider: DefinitionProvider;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-def-'));
+        indexer = new WorkspaceIndexer();
+        indexer.set_dependency_graph(new DependencyGraph());
+        provider = new DefinitionProvider();
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_document(lines: string[]) {
+        const file_path = join(test_temp_dir, 'a.do');
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        await indexer.initialize([test_temp_dir]);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    it('reference inside prog_b resolves only to prog_b\'s definition', async () => {
+        const { uri, content, document_state } =
+            await open_document(SIBLING_LINES);
+        const character = content.split('\n')[5].indexOf('shared');
+        const result = await provider.get_definition(
+            document_state,
+            { line: 5, character },
+            undefined,
+            undefined,
+            undefined,
+            indexer,
+            undefined,
+        );
+        const the_lines = as_locations(result)
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line);
+        expect(the_lines).toEqual([4]);
+    });
+
+    it('cursor on a losing-flat-slot declaration resolves to itself', async () => {
+        const { uri, content, document_state } =
+            await open_document(SIBLING_LINES);
+        // prog_a's `shared` (earliest) owns the flat slot; prog_b's
+        // declaration must still match its own range.
+        const character = content.split('\n')[4].indexOf('shared');
+        const result = await provider.get_definition(
+            document_state,
+            { line: 4, character },
+            undefined,
+            undefined,
+            undefined,
+            indexer,
+            undefined,
+        );
+        const the_lines = as_locations(result)
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line);
+        expect(the_lines).toEqual([4]);
+    });
+
+    it('top-level reference to a program-only local resolves to nothing', async () => {
+        const { document_state, content } = await open_document([
+            'program define prog_a',   // 0
+            '    local hidden 1',      // 1
+            'end',                     // 2
+            'di "`hidden\'"',          // 3
+        ]);
+        const character = content.split('\n')[3].indexOf('hidden');
+        const result = await provider.get_definition(
+            document_state,
+            { line: 3, character },
+            undefined,
+            undefined,
+            undefined,
+            indexer,
+            undefined,
+        );
+        expect(as_locations(result)).toEqual([]);
+    });
+
+    it('program reference still sees do-file locals (permissive)', async () => {
+        const { uri, content, document_state } = await open_document([
+            'local top_x 5',       // 0
+            'program define p',    // 1
+            '    di "`top_x\'"',   // 2
+            'end',                 // 3
+        ]);
+        const character = content.split('\n')[2].indexOf('top_x');
+        const result = await provider.get_definition(
+            document_state,
+            { line: 2, character },
+            undefined,
+            undefined,
+            undefined,
+            indexer,
+            undefined,
+        );
+        const the_lines = as_locations(result)
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line);
+        expect(the_lines).toContain(0);
+    });
+});

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -13,6 +13,9 @@ import { DependencyGraph } from '../../src/dependency-graph';
 import { DocumentStore } from '../../src/document-store';
 import { DefinitionProvider } from '../../src/providers/definition';
 import { HoverProvider } from '../../src/providers/hover';
+import { ReferencesProvider } from '../../src/providers/references';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
 import { CommandDatabase } from '../../src/command-database';
 import { Location } from 'vscode-languageserver';
 
@@ -242,5 +245,172 @@ describe('scoped local macros: hover (#270)', () => {
             { line: 2, character },
         );
         expect(hover_value(hover)).toContain('Expansion: `5`');
+    });
+});
+
+describe('scoped local macros: find-references (#270)', () => {
+    let test_temp_dir: string;
+    let indexer: WorkspaceIndexer;
+    let scope_resolver: ScopeResolver;
+    let forward_scope_resolver: ForwardScopeResolver;
+    let references_provider: ReferencesProvider;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-refs-'));
+        indexer = new WorkspaceIndexer();
+        const the_dep_graph = new DependencyGraph();
+        indexer.set_dependency_graph(the_dep_graph);
+        scope_resolver = new ScopeResolver();
+        scope_resolver.set_dependency_graph(the_dep_graph);
+        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+        references_provider = new ReferencesProvider(scope_resolver);
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        try { scope_resolver?.dispose(); } catch {}
+        try { forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_file(name: string, lines: string[]) {
+        const file_path = join(test_temp_dir, name);
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        return { uri, content, file_path };
+    }
+
+    it('references inside prog_b exclude prog_a\'s same-named local (issue repro)', async () => {
+        const { uri, content } = await open_file('a.do', [
+            'program define a',        // 0
+            '    local shared 1',      // 1
+            '    di "`shared\'"',      // 2
+            'end',                     // 3
+            'program define b',        // 4
+            '    local shared 2',      // 5
+            '    display `shared\'',   // 6
+            'end',                     // 7
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        await document_store.open(uri, content, 1);
+        const character = content.split('\n')[6].indexOf('shared');
+        const the_locations = await references_provider.get_references(
+            document_store.get(uri)!,
+            { line: 6, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const the_lines = the_locations
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line)
+            .sort((a, b) => a - b);
+        expect(the_lines).toEqual([5, 6]);
+    });
+
+    it('do-file target excludes occurrences inside a shadowing program', async () => {
+        const { uri, content } = await open_file('a.do', [
+            'local x top',             // 0
+            'di "`x\'"',               // 1
+            'program define shadow',   // 2
+            '    local x body',        // 3
+            '    di "`x\'"',           // 4
+            'end',                     // 5
+            'program define open_p',   // 6
+            '    di "`x\'"',           // 7 (permissive: sees do-file x)
+            'end',                     // 8
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        await document_store.open(uri, content, 1);
+        const character = content.split('\n')[1].indexOf('x');
+        const the_locations = await references_provider.get_references(
+            document_store.get(uri)!,
+            { line: 1, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const the_lines = the_locations
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line)
+            .sort((a, b) => a - b);
+        expect(the_lines).toEqual([0, 1, 7]);
+    });
+
+    it('top-level reference to a program-only local returns nothing', async () => {
+        const { uri, content } = await open_file('a.do', [
+            'program define prog_a',   // 0
+            '    local hidden 1',      // 1
+            'end',                     // 2
+            'di "`hidden\'"',          // 3
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        await document_store.open(uri, content, 1);
+        const character = content.split('\n')[3].indexOf('hidden');
+        const the_locations = await references_provider.get_references(
+            document_store.get(uri)!,
+            { line: 3, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        expect(the_locations).toEqual([]);
+    });
+
+    it('program-scoped target skips the cross-file scan entirely', async () => {
+        await open_file('lib.do', [
+            'local helper lib',    // 0
+            'di "`helper\'"',      // 1
+        ]);
+        const { uri, content } = await open_file('main.do', [
+            'include "lib.do"',        // 0
+            'program define p',        // 1
+            '    local helper 1',      // 2
+            '    di "`helper\'"',      // 3
+            'end',                     // 4
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        await document_store.open(uri, content, 1);
+        const character = content.split('\n')[3].indexOf('helper');
+        const the_locations = await references_provider.get_references(
+            document_store.get(uri)!,
+            { line: 3, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const the_uris = new Set(the_locations.map(my_loc => my_loc.uri));
+        expect(the_uris).toEqual(new Set([uri]));
+        const the_lines = the_locations
+            .map(my_loc => my_loc.range.start.line)
+            .sort((a, b) => a - b);
+        expect(the_lines).toEqual([2, 3]);
+    });
+
+    it('do-file target keeps the include-chain scan (regression guard)', async () => {
+        const lib = await open_file('lib.do', [
+            'local helper lib',    // 0
+            'di "`helper\'"',      // 1
+        ]);
+        const { uri, content } = await open_file('main.do', [
+            'include "lib.do"',        // 0
+            'local helper main',       // 1
+            'di "`helper\'"',          // 2
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        await document_store.open(uri, content, 1);
+        const character = content.split('\n')[2].indexOf('helper');
+        const the_locations = await references_provider.get_references(
+            document_store.get(uri)!,
+            { line: 2, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const the_uris = new Set(the_locations.map(my_loc => my_loc.uri));
+        expect(the_uris.has(uri)).toBe(true);
+        expect(the_uris.has(lib.uri)).toBe(true);
     });
 });

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -12,6 +12,8 @@ import { WorkspaceIndexer } from '../../src/indexer';
 import { DependencyGraph } from '../../src/dependency-graph';
 import { DocumentStore } from '../../src/document-store';
 import { DefinitionProvider } from '../../src/providers/definition';
+import { HoverProvider } from '../../src/providers/hover';
+import { CommandDatabase } from '../../src/command-database';
 import { Location } from 'vscode-languageserver';
 
 const SIBLING_LINES = [
@@ -142,5 +144,103 @@ describe('scoped local macros: go-to-definition (#270)', () => {
             .filter(my_loc => my_loc.uri === uri)
             .map(my_loc => my_loc.range.start.line);
         expect(the_lines).toContain(0);
+    });
+});
+
+describe('scoped local macros: hover (#270)', () => {
+    let test_temp_dir: string;
+    let hover_provider: HoverProvider;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-hover-'));
+        hover_provider = new HoverProvider(new CommandDatabase());
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_document(lines: string[]) {
+        const file_path = join(test_temp_dir, 'a.do');
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    function hover_value(hover: Awaited<
+        ReturnType<HoverProvider['get_hover']>
+    >): string {
+        const contents = hover?.contents as
+            | { kind: string; value: string }
+            | undefined;
+        return contents?.value ?? '';
+    }
+
+    it('hover inside prog_b shows prog_b\'s value, not prog_a\'s', async () => {
+        const { content, document_state } =
+            await open_document(SIBLING_LINES);
+        const character = content.split('\n')[5].indexOf('shared');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 5, character },
+        );
+        const value = hover_value(hover);
+        expect(value).toContain('Local Macro');
+        expect(value).toContain('Expansion: `2`');
+        expect(value).not.toContain('Expansion: `1`');
+    });
+
+    it('hover inside a program shows its value over a same-named do-file local (issue repro)', async () => {
+        const { content, document_state } = await open_document([
+            'program define myprog',   // 0
+            '    local x 1',           // 1
+            '    display "`x\'"',      // 2
+            'end',                     // 3
+            'local x 2',               // 4
+        ]);
+        const character = content.split('\n')[2].indexOf('x\'');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 2, character },
+        );
+        const value = hover_value(hover);
+        expect(value).toContain('Expansion: `1`');
+        expect(value).not.toContain('Expansion: `2`');
+    });
+
+    it('top-level hover on a program-only local shows nothing', async () => {
+        const { content, document_state } = await open_document([
+            'program define prog_a',   // 0
+            '    local hidden 1',      // 1
+            'end',                     // 2
+            'di "`hidden\'"',          // 3
+        ]);
+        const character = content.split('\n')[3].indexOf('hidden');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 3, character },
+        );
+        expect(hover_value(hover)).not.toContain('Expansion: `1`');
+    });
+
+    it('program hover still sees do-file locals (permissive)', async () => {
+        const { content, document_state } = await open_document([
+            'local top_x 5',       // 0
+            'program define p',    // 1
+            '    di "`top_x\'"',   // 2
+            'end',                 // 3
+        ]);
+        const character = content.split('\n')[2].indexOf('top_x');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 2, character },
+        );
+        expect(hover_value(hover)).toContain('Expansion: `5`');
     });
 });

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -18,6 +18,7 @@ import { ScopeResolver } from '../../src/scope-resolver';
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
 import { CommandDatabase } from '../../src/command-database';
 import { CompletionProvider } from '../../src/providers/completion';
+import { SymbolProvider } from '../../src/providers/symbols';
 import { Location } from 'vscode-languageserver';
 
 const SIBLING_LINES = [
@@ -516,5 +517,112 @@ describe('scoped local macros: completion (#270)', () => {
         expect(
             the_completions.map(my_item => my_item.label)
         ).not.toContain('hidden');
+    });
+});
+
+describe('scoped local macros: document symbols / workspace search (#270)', () => {
+    let test_temp_dir: string;
+    let symbol_provider: SymbolProvider;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-syms-'));
+        symbol_provider = new SymbolProvider();
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_document(lines: string[]) {
+        const file_path = join(test_temp_dir, 'a.do');
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    it('outline lists every scope\'s same-named local, nested correctly', async () => {
+        const { document_state } = await open_document(SIBLING_LINES);
+        const the_symbols =
+            symbol_provider.get_document_symbols(document_state);
+        const prog_a = the_symbols.find(my_sym => my_sym.name === 'prog_a');
+        const prog_b = the_symbols.find(my_sym => my_sym.name === 'prog_b');
+        expect(prog_a?.children?.map(my_child => my_child.name))
+            .toContain("`shared'");
+        expect(prog_b?.children?.map(my_child => my_child.name))
+            .toContain("`shared'");
+    });
+
+    it('workspace symbol search surfaces both same-named locals', async () => {
+        const { document_state } = await open_document(SIBLING_LINES);
+        const the_symbols = symbol_provider.get_workspace_symbols(
+            'shared',
+            [document_state],
+        );
+        const the_local_lines = the_symbols
+            .filter(my_sym => my_sym.name === "`shared'")
+            .map(my_sym => my_sym.location.range.start.line)
+            .sort((a, b) => a - b);
+        expect(the_local_lines).toEqual([1, 4]);
+    });
+});
+
+describe('scoped local macros: definition ignores cross-file hits for program locals (#270)', () => {
+    let test_temp_dir: string;
+    let indexer: WorkspaceIndexer;
+    let provider: DefinitionProvider;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-def-xfile-'));
+        indexer = new WorkspaceIndexer();
+        indexer.set_dependency_graph(new DependencyGraph());
+        provider = new DefinitionProvider();
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('program-scoped target returns only its own declaration', async () => {
+        writeFileSync(
+            join(test_temp_dir, 'lib.do'),
+            'local helper lib\n'
+        );
+        const main_path = join(test_temp_dir, 'main.do');
+        const main_content = [
+            'include "lib.do"',        // 0
+            'program define p',        // 1
+            '    local helper 1',      // 2
+            '    di "`helper\'"',      // 3
+            'end',                     // 4
+        ].join('\n');
+        writeFileSync(main_path, main_content);
+        await indexer.initialize([test_temp_dir]);
+        const uri = URI.file(main_path).toString();
+        await document_store.open(uri, main_content, 1);
+        const character = main_content.split('\n')[3].indexOf('helper');
+        const result = await provider.get_definition(
+            document_store.get(uri)!,
+            { line: 3, character },
+            undefined,
+            undefined,
+            undefined,
+            indexer,
+            undefined,
+        );
+        const the_locations = as_locations(result);
+        expect(new Set(the_locations.map(my_loc => my_loc.uri)))
+            .toEqual(new Set([uri]));
+        expect(the_locations.map(my_loc => my_loc.range.start.line))
+            .toEqual([2]);
     });
 });

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -17,6 +17,7 @@ import { ReferencesProvider } from '../../src/providers/references';
 import { ScopeResolver } from '../../src/scope-resolver';
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
 import { CommandDatabase } from '../../src/command-database';
+import { CompletionProvider } from '../../src/providers/completion';
 import { Location } from 'vscode-languageserver';
 
 const SIBLING_LINES = [
@@ -412,5 +413,108 @@ describe('scoped local macros: find-references (#270)', () => {
         const the_uris = new Set(the_locations.map(my_loc => my_loc.uri));
         expect(the_uris.has(uri)).toBe(true);
         expect(the_uris.has(lib.uri)).toBe(true);
+    });
+});
+
+describe('scoped local macros: completion (#270)', () => {
+    let test_temp_dir: string;
+    let completion_provider: CompletionProvider;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-comp-'));
+        completion_provider = new CompletionProvider(new CommandDatabase());
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_document(lines: string[]) {
+        const file_path = join(test_temp_dir, 'a.do');
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        await document_store.wait_for_update(uri);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    it('offers prog_b\'s local even when prog_a\'s owns the flat slot (lost-completion regression)', async () => {
+        const { document_state } = await open_document([
+            'program define prog_a',   // 0
+            '    local shared 1',      // 1
+            'end',                     // 2
+            'program define prog_b',   // 3
+            '    local shared 2',      // 4
+            '    di "`s',              // 5 — cursor after the prefix
+            'end',                     // 6
+        ]);
+        const the_completions = await completion_provider.get_completions(
+            document_state,
+            { line: 5, character: 10 },
+            '`',
+        );
+        const the_shared = the_completions.find(
+            my_item => my_item.label === 'shared'
+        );
+        expect(the_shared).toBeDefined();
+        expect(the_shared!.documentation).toBe('Value: 2');
+    });
+
+    it('does not offer a sibling program\'s local', async () => {
+        const { document_state } = await open_document([
+            'program define prog_a',   // 0
+            '    local only_a 1',      // 1
+            'end',                     // 2
+            'program define prog_b',   // 3
+            '    di "`o',              // 4
+            'end',                     // 5
+        ]);
+        const the_completions = await completion_provider.get_completions(
+            document_state,
+            { line: 4, character: 10 },
+            '`',
+        );
+        expect(
+            the_completions.map(my_item => my_item.label)
+        ).not.toContain('only_a');
+    });
+
+    it('offers do-file locals inside a program (permissive)', async () => {
+        const { document_state } = await open_document([
+            'local top_x 5',       // 0
+            'program define p',    // 1
+            '    di "`t',          // 2
+            'end',                 // 3
+        ]);
+        const the_completions = await completion_provider.get_completions(
+            document_state,
+            { line: 2, character: 10 },
+            '`',
+        );
+        expect(
+            the_completions.map(my_item => my_item.label)
+        ).toContain('top_x');
+    });
+
+    it('does not offer program-only locals at top level', async () => {
+        const { document_state } = await open_document([
+            'program define prog_a',   // 0
+            '    local hidden 1',      // 1
+            'end',                     // 2
+            'di "`h',                  // 3
+        ]);
+        const the_completions = await completion_provider.get_completions(
+            document_state,
+            { line: 3, character: 6 },
+            '`',
+        );
+        expect(
+            the_completions.map(my_item => my_item.label)
+        ).not.toContain('hidden');
     });
 });

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -626,3 +626,155 @@ describe('scoped local macros: definition ignores cross-file hits for program lo
             .toEqual([2]);
     });
 });
+
+// Round-1 gate regressions (#270 review findings).
+describe('scoped local macros: round-1 gate regressions', () => {
+    let test_temp_dir: string;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate-'));
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_file(name: string, lines: string[]) {
+        const file_path = join(test_temp_dir, name);
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    it('hover before a program-local definition shows the do-file value (forward order)', async () => {
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        const { content, document_state } = await open_file('a.do', [
+            'local x top',         // 0
+            'program define p',    // 1
+            '    di "`x\'"',       // 2 — before the program definition
+            '    local x body',    // 3
+            'end',                 // 4
+        ]);
+        const character = content.split('\n')[2].indexOf('x\'');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 2, character },
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).toContain('Expansion: `top`');
+        expect(value).not.toContain('Expansion: `body`');
+    });
+
+    it('completion before a program-local definition offers the do-file symbol', async () => {
+        const completion_provider =
+            new CompletionProvider(new CommandDatabase());
+        const { document_state } = await open_file('a.do', [
+            'local x top',         // 0
+            'program define p',    // 1
+            '    di "`',           // 2 — cursor after the backtick
+            '    local x body',    // 3
+            'end',                 // 4
+        ]);
+        const the_completions = await completion_provider.get_completions(
+            document_state,
+            { line: 2, character: 9 },
+            '`',
+        );
+        const the_item = the_completions.find(
+            my_item => my_item.label === 'x'
+        );
+        expect(the_item).toBeDefined();
+        expect(the_item!.documentation).toBe('Value: top');
+    });
+
+    it('program-scoped hover footer never cites cross-file same-name locals', async () => {
+        const indexer = new WorkspaceIndexer();
+        indexer.set_dependency_graph(new DependencyGraph());
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        writeFileSync(join(test_temp_dir, 'lib.do'), 'local helper lib\n');
+        const { content, document_state } = await open_file('main.do', [
+            'include "lib.do"',        // 0
+            'program define p',        // 1
+            '    local helper 1',      // 2
+            '    di "`helper\'"',      // 3
+            'end',                     // 4
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[3].indexOf('helper');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 3, character },
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            test_temp_dir,
+            indexer,
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).toContain('Expansion: `1`');
+        expect(value).not.toContain('Redefined');
+        expect(value).not.toContain('other file');
+    });
+
+    it('redeclared program bodies each nest their own locals in the outline', async () => {
+        const symbol_provider = new SymbolProvider();
+        const { document_state } = await open_file('a.do', [
+            'program define p',    // 0
+            '    local a 1',       // 1
+            'end',                 // 2
+            'program define p',    // 3
+            '    local b 2',       // 4
+            'end',                 // 5
+        ]);
+        const the_symbols =
+            symbol_provider.get_document_symbols(document_state);
+        const the_program_nodes = the_symbols.filter(
+            my_sym => my_sym.name === 'p' && my_sym.detail === 'Program'
+        );
+        expect(the_program_nodes).toHaveLength(2);
+        const the_nested_names = the_program_nodes.flatMap(
+            my_node => (my_node.children ?? []).map(my_child => my_child.name)
+        );
+        expect(the_nested_names).toContain("`a'");
+        expect(the_nested_names).toContain("`b'");
+        // Neither local floats to the top level.
+        const the_top_level_names = the_symbols.map(my_sym => my_sym.name);
+        expect(the_top_level_names).not.toContain("`a'");
+        expect(the_top_level_names).not.toContain("`b'");
+    });
+
+    it('a program\'s own local wins completion over a cross-file merged slot', async () => {
+        const indexer = new WorkspaceIndexer();
+        indexer.set_dependency_graph(new DependencyGraph());
+        const completion_provider =
+            new CompletionProvider(new CommandDatabase());
+        writeFileSync(join(test_temp_dir, 'lib.do'), 'local helper lib\n');
+        const { document_state } = await open_file('main.do', [
+            'include "lib.do"',        // 0
+            'program define p',        // 1
+            '    local helper 1',      // 2
+            '    di "`h',              // 3
+            'end',                     // 4
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const the_completions = await completion_provider.get_completions(
+            document_state,
+            { line: 3, character: 10 },
+            '`',
+            undefined,
+            indexer.get_all_symbols(),
+        );
+        const the_item = the_completions.find(
+            my_item => my_item.label === 'helper'
+        );
+        expect(the_item).toBeDefined();
+        expect(the_item!.documentation).toBe('Value: 1');
+    });
+});

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -19,7 +19,7 @@ import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
 import { CommandDatabase } from '../../src/command-database';
 import { CompletionProvider } from '../../src/providers/completion';
 import { SymbolProvider } from '../../src/providers/symbols';
-import { Location } from 'vscode-languageserver';
+import { as_locations } from '../property/helpers/document-utils';
 
 const SIBLING_LINES = [
     'program define prog_a',   // 0
@@ -31,31 +31,65 @@ const SIBLING_LINES = [
     'end',                     // 6
 ];
 
-function as_locations(
-    result: Location | Location[] | null
-): Location[] {
-    if (!result) return [];
-    return Array.isArray(result) ? result : [result];
+
+interface ScopedTestHarness {
+    test_temp_dir: string;
+    indexer: WorkspaceIndexer;
+    scope_resolver: ScopeResolver;
+    forward_scope_resolver: ForwardScopeResolver;
+    document_store: DocumentStore;
+    dispose(): void;
+}
+
+/**
+ * One fully-wired pipeline per test: temp workspace, indexer +
+ * dependency graph, scope/forward resolvers, document store, and a
+ * single dispose. Shared by every describe block so the wiring and
+ * teardown cannot drift between the per-round regression suites
+ * (blocks that don't need the resolver simply don't use it).
+ */
+function create_scoped_test_harness(prefix: string): ScopedTestHarness {
+    const test_temp_dir = mkdtempSync(join(tmpdir(), prefix));
+    const indexer = new WorkspaceIndexer();
+    const the_dep_graph = new DependencyGraph();
+    indexer.set_dependency_graph(the_dep_graph);
+    const scope_resolver = new ScopeResolver();
+    scope_resolver.set_dependency_graph(the_dep_graph);
+    const forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+        max_forward_depth: 10,
+    });
+    scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+    return {
+        test_temp_dir,
+        indexer,
+        scope_resolver,
+        forward_scope_resolver,
+        document_store: new DocumentStore(),
+        dispose(): void {
+            try { scope_resolver.dispose(); } catch { /* disposed */ }
+            try { forward_scope_resolver.dispose(); } catch { /* disposed */ }
+            if (existsSync(test_temp_dir)) {
+                rmSync(test_temp_dir, { recursive: true, force: true });
+            }
+        },
+    };
 }
 
 describe('scoped local macros: go-to-definition (#270)', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let indexer: WorkspaceIndexer;
     let provider: DefinitionProvider;
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-def-'));
-        indexer = new WorkspaceIndexer();
-        indexer.set_dependency_graph(new DependencyGraph());
+        harness = create_scoped_test_harness('scoped-def-');
+        ({ test_temp_dir, indexer, document_store } = harness);
         provider = new DefinitionProvider();
-        document_store = new DocumentStore();
     });
 
     afterEach(() => {
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_document(lines: string[]) {
@@ -153,20 +187,19 @@ describe('scoped local macros: go-to-definition (#270)', () => {
 });
 
 describe('scoped local macros: hover (#270)', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let hover_provider: HoverProvider;
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-hover-'));
+        harness = create_scoped_test_harness('scoped-hover-');
+        ({ test_temp_dir, document_store } = harness);
         hover_provider = new HoverProvider(new CommandDatabase());
-        document_store = new DocumentStore();
     });
 
     afterEach(() => {
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_document(lines: string[]) {
@@ -251,6 +284,7 @@ describe('scoped local macros: hover (#270)', () => {
 });
 
 describe('scoped local macros: find-references (#270)', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let indexer: WorkspaceIndexer;
     let scope_resolver: ScopeResolver;
@@ -259,26 +293,16 @@ describe('scoped local macros: find-references (#270)', () => {
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-refs-'));
-        indexer = new WorkspaceIndexer();
-        const the_dep_graph = new DependencyGraph();
-        indexer.set_dependency_graph(the_dep_graph);
-        scope_resolver = new ScopeResolver();
-        scope_resolver.set_dependency_graph(the_dep_graph);
-        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
-            max_forward_depth: 10,
-        });
-        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+        harness = create_scoped_test_harness('scoped-refs-');
+        ({
+            test_temp_dir, indexer, scope_resolver,
+            forward_scope_resolver, document_store,
+        } = harness);
         references_provider = new ReferencesProvider(scope_resolver);
-        document_store = new DocumentStore();
     });
 
     afterEach(() => {
-        try { scope_resolver?.dispose(); } catch {}
-        try { forward_scope_resolver?.dispose(); } catch {}
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_file(name: string, lines: string[]) {
@@ -427,20 +451,19 @@ describe('scoped local macros: find-references (#270)', () => {
 });
 
 describe('scoped local macros: completion (#270)', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let completion_provider: CompletionProvider;
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-comp-'));
+        harness = create_scoped_test_harness('scoped-comp-');
+        ({ test_temp_dir, document_store } = harness);
         completion_provider = new CompletionProvider(new CommandDatabase());
-        document_store = new DocumentStore();
     });
 
     afterEach(() => {
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_document(lines: string[]) {
@@ -534,20 +557,19 @@ describe('scoped local macros: completion (#270)', () => {
 });
 
 describe('scoped local macros: document symbols / workspace search (#270)', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let symbol_provider: SymbolProvider;
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-syms-'));
+        harness = create_scoped_test_harness('scoped-syms-');
+        ({ test_temp_dir, document_store } = harness);
         symbol_provider = new SymbolProvider();
-        document_store = new DocumentStore();
     });
 
     afterEach(() => {
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_document(lines: string[]) {
@@ -586,23 +608,20 @@ describe('scoped local macros: document symbols / workspace search (#270)', () =
 });
 
 describe('scoped local macros: definition ignores cross-file hits for program locals (#270)', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let indexer: WorkspaceIndexer;
     let provider: DefinitionProvider;
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-def-xfile-'));
-        indexer = new WorkspaceIndexer();
-        indexer.set_dependency_graph(new DependencyGraph());
+        harness = create_scoped_test_harness('scoped-def-xfile-');
+        ({ test_temp_dir, indexer, document_store } = harness);
         provider = new DefinitionProvider();
-        document_store = new DocumentStore();
     });
 
     afterEach(() => {
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     it('program-scoped target returns only its own declaration', async () => {
@@ -642,18 +661,17 @@ describe('scoped local macros: definition ignores cross-file hits for program lo
 
 // Round-1 gate regressions (#270 review findings).
 describe('scoped local macros: round-1 gate regressions', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate-'));
-        document_store = new DocumentStore();
+        harness = create_scoped_test_harness('scoped-gate-');
+        ({ test_temp_dir, document_store } = harness);
     });
 
     afterEach(() => {
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_file(name: string, lines: string[]) {
@@ -797,6 +815,7 @@ describe('scoped local macros: round-1 gate regressions', () => {
 // cross-file suppression treats it as defined), and a visible
 // program-scoped local must pre-empt the out-of-scope hover display.
 describe('scoped local macros: round-2 gate regressions', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let indexer: WorkspaceIndexer;
     let scope_resolver: ScopeResolver;
@@ -804,25 +823,15 @@ describe('scoped local macros: round-2 gate regressions', () => {
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate2-'));
-        indexer = new WorkspaceIndexer();
-        const the_dep_graph = new DependencyGraph();
-        indexer.set_dependency_graph(the_dep_graph);
-        scope_resolver = new ScopeResolver();
-        scope_resolver.set_dependency_graph(the_dep_graph);
-        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
-            max_forward_depth: 10,
-        });
-        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
-        document_store = new DocumentStore();
+        harness = create_scoped_test_harness('scoped-gate2-');
+        ({
+            test_temp_dir, indexer, scope_resolver,
+            forward_scope_resolver, document_store,
+        } = harness);
     });
 
     afterEach(() => {
-        try { scope_resolver?.dispose(); } catch {}
-        try { forward_scope_resolver?.dispose(); } catch {}
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_file(name: string, lines: string[]) {
@@ -979,6 +988,7 @@ describe('scoped local macros: round-2 gate regressions', () => {
 // out-of-scope cursor with NO inherited target must not surface
 // same-named program-body usages from include-related files.
 describe('scoped local macros: round-3 gate regressions', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let indexer: WorkspaceIndexer;
     let scope_resolver: ScopeResolver;
@@ -986,25 +996,15 @@ describe('scoped local macros: round-3 gate regressions', () => {
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate3-'));
-        indexer = new WorkspaceIndexer();
-        const the_dep_graph = new DependencyGraph();
-        indexer.set_dependency_graph(the_dep_graph);
-        scope_resolver = new ScopeResolver();
-        scope_resolver.set_dependency_graph(the_dep_graph);
-        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
-            max_forward_depth: 10,
-        });
-        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
-        document_store = new DocumentStore();
+        harness = create_scoped_test_harness('scoped-gate3-');
+        ({
+            test_temp_dir, indexer, scope_resolver,
+            forward_scope_resolver, document_store,
+        } = harness);
     });
 
     afterEach(() => {
-        try { scope_resolver?.dispose(); } catch {}
-        try { forward_scope_resolver?.dispose(); } catch {}
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_file(name: string, lines: string[]) {
@@ -1106,6 +1106,7 @@ describe('scoped local macros: round-3 gate regressions', () => {
 // pooling, no not-yet-executed includes), and backward inheritance must
 // follow the EFFECTIVE call type, not the written directive type.
 describe('scoped local macros: round-4 gate regressions', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let indexer: WorkspaceIndexer;
     let scope_resolver: ScopeResolver;
@@ -1113,25 +1114,15 @@ describe('scoped local macros: round-4 gate regressions', () => {
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate4-'));
-        indexer = new WorkspaceIndexer();
-        const the_dep_graph = new DependencyGraph();
-        indexer.set_dependency_graph(the_dep_graph);
-        scope_resolver = new ScopeResolver();
-        scope_resolver.set_dependency_graph(the_dep_graph);
-        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
-            max_forward_depth: 10,
-        });
-        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
-        document_store = new DocumentStore();
+        harness = create_scoped_test_harness('scoped-gate4-');
+        ({
+            test_temp_dir, indexer, scope_resolver,
+            forward_scope_resolver, document_store,
+        } = harness);
     });
 
     afterEach(() => {
-        try { scope_resolver?.dispose(); } catch {}
-        try { forward_scope_resolver?.dispose(); } catch {}
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_file(name: string, lines: string[]) {
@@ -1229,6 +1220,7 @@ describe('scoped local macros: round-4 gate regressions', () => {
 // a different resolution class), and the inherited hover footer must
 // not present the out-of-scope sibling program-local as a redefinition.
 describe('scoped local macros: round-5 gate regressions', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let indexer: WorkspaceIndexer;
     let scope_resolver: ScopeResolver;
@@ -1236,25 +1228,15 @@ describe('scoped local macros: round-5 gate regressions', () => {
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate5-'));
-        indexer = new WorkspaceIndexer();
-        const the_dep_graph = new DependencyGraph();
-        indexer.set_dependency_graph(the_dep_graph);
-        scope_resolver = new ScopeResolver();
-        scope_resolver.set_dependency_graph(the_dep_graph);
-        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
-            max_forward_depth: 10,
-        });
-        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
-        document_store = new DocumentStore();
+        harness = create_scoped_test_harness('scoped-gate5-');
+        ({
+            test_temp_dir, indexer, scope_resolver,
+            forward_scope_resolver, document_store,
+        } = harness);
     });
 
     afterEach(() => {
-        try { scope_resolver?.dispose(); } catch {}
-        try { forward_scope_resolver?.dispose(); } catch {}
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_file(name: string, lines: string[]) {
@@ -1350,6 +1332,7 @@ describe('scoped local macros: round-5 gate regressions', () => {
 // winner, includeDeclaration must surface exactly the winner's
 // declaration — never a superseded earlier include's.
 describe('scoped local macros: round-6 gate regression', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let indexer: WorkspaceIndexer;
     let scope_resolver: ScopeResolver;
@@ -1357,25 +1340,15 @@ describe('scoped local macros: round-6 gate regression', () => {
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate6-'));
-        indexer = new WorkspaceIndexer();
-        const the_dep_graph = new DependencyGraph();
-        indexer.set_dependency_graph(the_dep_graph);
-        scope_resolver = new ScopeResolver();
-        scope_resolver.set_dependency_graph(the_dep_graph);
-        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
-            max_forward_depth: 10,
-        });
-        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
-        document_store = new DocumentStore();
+        harness = create_scoped_test_harness('scoped-gate6-');
+        ({
+            test_temp_dir, indexer, scope_resolver,
+            forward_scope_resolver, document_store,
+        } = harness);
     });
 
     afterEach(() => {
-        try { scope_resolver?.dispose(); } catch {}
-        try { forward_scope_resolver?.dispose(); } catch {}
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     it('references: out-of-scope pooling is winner-only', async () => {
@@ -1419,18 +1392,17 @@ describe('scoped local macros: round-6 gate regression', () => {
 // ranged inside a program container would overlap a sibling on the
 // wire), while ENUMERATION stays ownership-based.
 describe('scoped local macros: round-8 gate regression', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate8-'));
-        document_store = new DocumentStore();
+        harness = create_scoped_test_harness('scoped-gate8-');
+        ({ test_temp_dir, document_store } = harness);
     });
 
     afterEach(() => {
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     it('a directive-declared do-file local inside a program body nests geometrically', async () => {
@@ -1470,6 +1442,7 @@ describe('scoped local macros: round-8 gate regression', () => {
 // cross-file suppression treats the pre-definition reference as
 // defined via the inherited symbol.
 describe('scoped local macros: round-9 gate regressions', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let indexer: WorkspaceIndexer;
     let scope_resolver: ScopeResolver;
@@ -1477,25 +1450,15 @@ describe('scoped local macros: round-9 gate regressions', () => {
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate9-'));
-        indexer = new WorkspaceIndexer();
-        const the_dep_graph = new DependencyGraph();
-        indexer.set_dependency_graph(the_dep_graph);
-        scope_resolver = new ScopeResolver();
-        scope_resolver.set_dependency_graph(the_dep_graph);
-        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
-            max_forward_depth: 10,
-        });
-        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
-        document_store = new DocumentStore();
+        harness = create_scoped_test_harness('scoped-gate9-');
+        ({
+            test_temp_dir, indexer, scope_resolver,
+            forward_scope_resolver, document_store,
+        } = harness);
     });
 
     afterEach(() => {
-        try { scope_resolver?.dispose(); } catch {}
-        try { forward_scope_resolver?.dispose(); } catch {}
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     async function open_file(name: string, lines: string[]) {
@@ -1637,6 +1600,7 @@ describe('scoped local macros: round-9 gate regressions', () => {
 // must return only the last include's declaration, not pool every
 // prior include.
 describe('scoped local macros: round-10 gate regression', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let indexer: WorkspaceIndexer;
     let scope_resolver: ScopeResolver;
@@ -1644,25 +1608,15 @@ describe('scoped local macros: round-10 gate regression', () => {
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate10-'));
-        indexer = new WorkspaceIndexer();
-        const the_dep_graph = new DependencyGraph();
-        indexer.set_dependency_graph(the_dep_graph);
-        scope_resolver = new ScopeResolver();
-        scope_resolver.set_dependency_graph(the_dep_graph);
-        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
-            max_forward_depth: 10,
-        });
-        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
-        document_store = new DocumentStore();
+        harness = create_scoped_test_harness('scoped-gate10-');
+        ({
+            test_temp_dir, indexer, scope_resolver,
+            forward_scope_resolver, document_store,
+        } = harness);
     });
 
     afterEach(() => {
-        try { scope_resolver?.dispose(); } catch {}
-        try { forward_scope_resolver?.dispose(); } catch {}
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     it('definition: forward do-file local defers to the single inherited winner', async () => {
@@ -1729,18 +1683,17 @@ describe('scoped local macros: round-10 gate regression', () => {
 // preserve delimiter intent — an explicit local reference whose local
 // resolution is rejected must not fall through to the GLOBAL namespace.
 describe('scoped local macros: round-13 gate regression', () => {
+    let harness: ScopedTestHarness;
     let test_temp_dir: string;
     let document_store: DocumentStore;
 
     beforeEach(() => {
-        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate13-'));
-        document_store = new DocumentStore();
+        harness = create_scoped_test_harness('scoped-gate13-');
+        ({ test_temp_dir, document_store } = harness);
     });
 
     afterEach(() => {
-        if (existsSync(test_temp_dir)) {
-            rmSync(test_temp_dir, { recursive: true, force: true });
-        }
+        harness.dispose();
     });
 
     const MATA_LINES = [

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -968,3 +968,131 @@ describe('scoped local macros: round-2 gate regressions', () => {
         expect(value).not.toContain('(out of scope)');
     });
 });
+
+// Round-3 gate regressions (#270): inherited-local lookups must apply
+// effective-scope precedence (last executed include wins and overrides
+// the backward chain; nearer parents beat farther ancestors), and an
+// out-of-scope cursor with NO inherited target must not surface
+// same-named program-body usages from include-related files.
+describe('scoped local macros: round-3 gate regressions', () => {
+    let test_temp_dir: string;
+    let indexer: WorkspaceIndexer;
+    let scope_resolver: ScopeResolver;
+    let forward_scope_resolver: ForwardScopeResolver;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate3-'));
+        indexer = new WorkspaceIndexer();
+        const the_dep_graph = new DependencyGraph();
+        indexer.set_dependency_graph(the_dep_graph);
+        scope_resolver = new ScopeResolver();
+        scope_resolver.set_dependency_graph(the_dep_graph);
+        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        try { scope_resolver?.dispose(); } catch {}
+        try { forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_file(name: string, lines: string[]) {
+        const file_path = join(test_temp_dir, name);
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    it('hover: the LAST executed include wins for an out-of-scope name', async () => {
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        writeFileSync(join(test_temp_dir, 'a.do'), 'local flag A\n');
+        writeFileSync(join(test_temp_dir, 'b.do'), 'local flag B\n');
+        const { content, document_state } = await open_file('main.do', [
+            'include "a.do"',          // 0
+            'include "b.do"',          // 1
+            'program define p',        // 2
+            '    local flag prog',     // 3
+            'end',                     // 4
+            'di "`flag\'"',            // 5
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[5].indexOf('flag');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 5, character },
+            undefined,
+            scope_resolver,
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).toContain('Expansion: `B`');
+        expect(value).not.toContain('Expansion: `A`');
+    });
+
+    it('hover: the nearer included-by parent wins over the grandparent', async () => {
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        writeFileSync(join(test_temp_dir, 'grandparent.do'), [
+            'local flag G',
+            'include "parent.do"',
+        ].join('\n'));
+        writeFileSync(join(test_temp_dir, 'parent.do'), [
+            'local flag P',
+            'include "child.do"',
+        ].join('\n'));
+        const { content, document_state } = await open_file('child.do', [
+            'program define foo',   // 0
+            '    local flag 9',     // 1
+            'end',                  // 2
+            'di "`flag\'"',         // 3
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[3].indexOf('flag');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 3, character },
+            undefined,
+            scope_resolver,
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).toContain('Expansion: `P`');
+        expect(value).not.toContain('Expansion: `G`');
+    });
+
+    it('references: no inherited target means no cross-file usages of a different macro', async () => {
+        const references_provider = new ReferencesProvider(scope_resolver);
+        writeFileSync(join(test_temp_dir, 'child.do'), [
+            'program define b',     // 0
+            '    local foo 1',      // 1
+            '    di "`foo\'"',      // 2
+            'end',                  // 3
+        ].join('\n'));
+        const { uri, content, document_state } = await open_file('main.do', [
+            'include "child.do"',   // 0
+            'program define a',     // 1
+            '    local foo 2',      // 2
+            'end',                  // 3
+            'di "`foo\'"',          // 4
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[4].indexOf('foo');
+        const the_locations = await references_provider.get_references(
+            document_state,
+            { line: 4, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const the_uris = new Set(the_locations.map(my_loc => my_loc.uri));
+        expect(the_uris).toEqual(new Set([uri]));
+        expect(
+            the_locations.map(my_loc => my_loc.range.start.line)
+        ).toEqual([4]);
+    });
+});

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -1374,7 +1374,7 @@ describe('scoped local macros: round-6 gate regression', () => {
         }
     });
 
-    it('references: only the winner declaration is pooled', async () => {
+    it('references: out-of-scope pooling is winner-only', async () => {
         const references_provider = new ReferencesProvider(scope_resolver);
         const a_path = join(test_temp_dir, 'a.do');
         const b_path = join(test_temp_dir, 'b.do');
@@ -1407,5 +1407,56 @@ describe('scoped local macros: round-6 gate regression', () => {
             .filter(my_loc => my_loc.uri === uri)
             .map(my_loc => my_loc.range.start.line);
         expect(main_lines).toEqual([5]);
+    });
+});
+
+// Round-8 gate regression (#270): outline PLACEMENT is geometric (the
+// DocumentSymbol tree is a range-containment view — a top-level entry
+// ranged inside a program container would overlap a sibling on the
+// wire), while ENUMERATION stays ownership-based.
+describe('scoped local macros: round-8 gate regression', () => {
+    let test_temp_dir: string;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate8-'));
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('a directive-declared do-file local inside a program body nests geometrically', async () => {
+        const symbol_provider = new SymbolProvider();
+        const file_path = join(test_temp_dir, 'a.do');
+        const content = [
+            'program define p',        // 0
+            '    // @lsp-local ghost', // 1 — do-file-owned, ranged in p
+            '    local x 1',           // 2
+            'end',                     // 3
+        ].join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        const the_symbols = symbol_provider.get_document_symbols(
+            document_store.get(uri)!
+        );
+        const program_node = the_symbols.find(
+            my_sym => my_sym.name === 'p' && my_sym.detail === 'Program'
+        );
+        const the_children = (program_node?.children ?? []).map(
+            my_child => my_child.name
+        );
+        expect(the_children).toContain("`ghost'");
+        expect(the_children).toContain("`x'");
+        // Wire-shape invariant: no top-level local sits inside the
+        // program container's range.
+        const the_top_level_locals = the_symbols.filter(
+            my_sym => my_sym.detail === 'Local Macro'
+        );
+        expect(the_top_level_locals).toEqual([]);
     });
 });

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -513,19 +513,23 @@ describe('scoped local macros: completion (#270)', () => {
 
     it('does not offer program-only locals at top level', async () => {
         const { document_state } = await open_document([
-            'program define prog_a',   // 0
-            '    local hidden 1',      // 1
-            'end',                     // 2
-            'di "`h',                  // 3
+            'local top_ok 1',          // 0
+            'program define prog_a',   // 1
+            '    local hidden 1',      // 2
+            'end',                     // 3
+            'di "`',                   // 4
         ]);
         const the_completions = await completion_provider.get_completions(
             document_state,
-            { line: 3, character: 6 },
+            { line: 4, character: 5 },
             '`',
         );
-        expect(
-            the_completions.map(my_item => my_item.label)
-        ).not.toContain('hidden');
+        const the_labels = the_completions.map(my_item => my_item.label);
+        // Positive baseline: the bare-signature top-level surface is
+        // alive (a broken empty list would make the exclusion below
+        // pass vacuously).
+        expect(the_labels).toContain('top_ok');
+        expect(the_labels).not.toContain('hidden');
     });
 });
 
@@ -1458,5 +1462,172 @@ describe('scoped local macros: round-8 gate regression', () => {
             my_sym => my_sym.detail === 'Local Macro'
         );
         expect(the_top_level_locals).toEqual([]);
+    });
+});
+
+// Round-9 gate regressions (#270): a cross-file INHERITED do-file
+// local outranks a same-scope FORWARD identity target — the analyzer's
+// cross-file suppression treats the pre-definition reference as
+// defined via the inherited symbol.
+describe('scoped local macros: round-9 gate regressions', () => {
+    let test_temp_dir: string;
+    let indexer: WorkspaceIndexer;
+    let scope_resolver: ScopeResolver;
+    let forward_scope_resolver: ForwardScopeResolver;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate9-'));
+        indexer = new WorkspaceIndexer();
+        const the_dep_graph = new DependencyGraph();
+        indexer.set_dependency_graph(the_dep_graph);
+        scope_resolver = new ScopeResolver();
+        scope_resolver.set_dependency_graph(the_dep_graph);
+        forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
+            max_forward_depth: 10,
+        });
+        scope_resolver.set_forward_scope_resolver(forward_scope_resolver);
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        try { scope_resolver?.dispose(); } catch {}
+        try { forward_scope_resolver?.dispose(); } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    async function open_file(name: string, lines: string[]) {
+        const file_path = join(test_temp_dir, name);
+        const content = lines.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    const FORWARD_VS_INHERITED = [
+        'include "lib.do"',     // 0
+        'program define p',     // 1
+        '    display "`x\'"',   // 2 — before the program-local def
+        '    local x body',     // 3
+        '    display "`x\'"',   // 4 — after: the program local
+        'end',                  // 5
+    ];
+
+    it('hover: inherited do-file local outranks the not-yet-defined program local', async () => {
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        writeFileSync(join(test_temp_dir, 'lib.do'), 'local x lib\n');
+        const { content, document_state } =
+            await open_file('main.do', FORWARD_VS_INHERITED);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[2].indexOf('x\'');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 2, character },
+            undefined,
+            scope_resolver,
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).toContain('Expansion: `lib`');
+        expect(value).not.toContain('Expansion: `body`');
+    });
+
+    it('definition: pre-definition reference resolves to the inherited declaration', async () => {
+        const definition_provider = new DefinitionProvider();
+        const lib_path = join(test_temp_dir, 'lib.do');
+        writeFileSync(lib_path, 'local x lib\n');
+        const { uri, content, document_state } =
+            await open_file('main.do', FORWARD_VS_INHERITED);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[2].indexOf('x\'');
+        const result = await definition_provider.get_definition(
+            document_state,
+            { line: 2, character },
+            undefined,
+            undefined,
+            scope_resolver,
+            indexer,
+            undefined,
+        );
+        const the_locations = as_locations(result);
+        expect(new Set(the_locations.map(my_loc => my_loc.uri)))
+            .toEqual(new Set([URI.file(lib_path).toString()]));
+        expect(
+            the_locations.some(my_loc => my_loc.uri === uri)
+        ).toBe(false);
+    });
+
+    it('references: pre-definition reference groups with the inherited local, not the program\'s', async () => {
+        const references_provider = new ReferencesProvider(scope_resolver);
+        const lib_path = join(test_temp_dir, 'lib.do');
+        writeFileSync(lib_path, 'local x lib\n');
+        const { uri, content, document_state } =
+            await open_file('main.do', FORWARD_VS_INHERITED);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[2].indexOf('x\'');
+        const the_locations = await references_provider.get_references(
+            document_state,
+            { line: 2, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const main_lines = the_locations
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line);
+        expect(main_lines).toEqual([2]);
+        expect(
+            the_locations.some(
+                my_loc => my_loc.uri === URI.file(lib_path).toString()
+            )
+        ).toBe(true);
+    });
+
+    it('references: post-definition reference stays with the program local', async () => {
+        const references_provider = new ReferencesProvider(scope_resolver);
+        writeFileSync(join(test_temp_dir, 'lib.do'), 'local x lib\n');
+        const { uri, content, document_state } =
+            await open_file('main.do', FORWARD_VS_INHERITED);
+        await indexer.initialize([test_temp_dir]);
+        const character = content.split('\n')[4].indexOf('x\'');
+        const the_locations = await references_provider.get_references(
+            document_state,
+            { line: 4, character },
+            { includeDeclaration: true },
+            indexer,
+        );
+        const the_uris = new Set(the_locations.map(my_loc => my_loc.uri));
+        expect(the_uris).toEqual(new Set([uri]));
+        const main_lines = the_locations
+            .filter(my_loc => my_loc.uri === uri)
+            .map(my_loc => my_loc.range.start.line)
+            .sort((a, b) => a - b);
+        expect(main_lines).toEqual([3, 4]);
+    });
+
+    it('completion: inherited do-file local offered before the program-local definition', async () => {
+        const completion_provider =
+            new CompletionProvider(new CommandDatabase());
+        writeFileSync(join(test_temp_dir, 'lib.do'), 'local x lib\n');
+        const { document_state } = await open_file('main.do', [
+            'include "lib.do"',     // 0
+            'program define p',     // 1
+            '    di "`',            // 2 — before the program-local def
+            '    local x body',     // 3
+            'end',                  // 4
+        ]);
+        await indexer.initialize([test_temp_dir]);
+        const the_completions = await completion_provider.get_completions(
+            document_state,
+            { line: 2, character: 9 },
+            '`',
+            scope_resolver,
+        );
+        const the_item = the_completions.find(
+            my_item => my_item.label === 'x'
+        );
+        expect(the_item).toBeDefined();
+        expect(the_item!.documentation).toBe('Value: lib');
     });
 });

--- a/tests/integration/scoped-local-macro-providers.test.ts
+++ b/tests/integration/scoped-local-macro-providers.test.ts
@@ -1724,3 +1724,86 @@ describe('scoped local macros: round-10 gate regression', () => {
         expect(the_lines).toEqual([1]);
     });
 });
+
+// Round-13 gate regression (#270): embedded-language macro paths must
+// preserve delimiter intent — an explicit local reference whose local
+// resolution is rejected must not fall through to the GLOBAL namespace.
+describe('scoped local macros: round-13 gate regression', () => {
+    let test_temp_dir: string;
+    let document_store: DocumentStore;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'scoped-gate13-'));
+        document_store = new DocumentStore();
+    });
+
+    afterEach(() => {
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    const MATA_LINES = [
+        'global x 42',           // 0
+        'program define sibling',// 1
+        '    local x 7',         // 2
+        'end',                   // 3
+        'mata:',                 // 4
+        'y = `x\'',              // 5 — explicit LOCAL ref, out of scope
+        'end',                   // 6
+    ];
+
+    async function open_document() {
+        const file_path = join(test_temp_dir, 'a.do');
+        const content = MATA_LINES.join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        return { uri, content, document_state: document_store.get(uri)! };
+    }
+
+    it('hover: an out-of-scope local ref in Mata never shows the global', async () => {
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        const { content, document_state } = await open_document();
+        const character = content.split('\n')[5].indexOf('x\'');
+        const hover = await hover_provider.get_hover(
+            document_state,
+            { line: 5, character },
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).not.toContain('Global Macro');
+        expect(value).not.toContain('42');
+    });
+
+    it('definition: an out-of-scope local ref in Mata never jumps to the global', async () => {
+        const definition_provider = new DefinitionProvider();
+        const { content, document_state } = await open_document();
+        const character = content.split('\n')[5].indexOf('x\'');
+        const result = await definition_provider.get_definition(
+            document_state,
+            { line: 5, character },
+        );
+        expect(as_locations(result)).toEqual([]);
+    });
+
+    it('hover: an explicit GLOBAL ref in Mata still resolves', async () => {
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        const file_path = join(test_temp_dir, 'b.do');
+        const content = [
+            'global x 42',   // 0
+            'mata:',         // 1
+            'y = $x',        // 2
+            'end',           // 3
+        ].join('\n');
+        writeFileSync(file_path, content);
+        const uri = URI.file(file_path).toString();
+        await document_store.open(uri, content, 1);
+        const character = content.split('\n')[2].indexOf('x');
+        const hover = await hover_provider.get_hover(
+            document_store.get(uri)!,
+            { line: 2, character },
+        );
+        const value = (hover?.contents as { value?: string })?.value ?? '';
+        expect(value).toContain('Global Macro');
+    });
+});

--- a/tests/property/helpers/document-utils.ts
+++ b/tests/property/helpers/document-utils.ts
@@ -11,7 +11,7 @@ import { ContextTracker } from '../../../src/context-tracker';
 import { Token, TriviaNode } from '../../../src/types';
 import { undefined_symbol_data_fields } from '../../../src/utils/undefined-symbol-diagnostic';
 import { Position, Range } from 'vscode-languageserver-textdocument';
-import { DiagnosticSeverity } from 'vscode-languageserver';
+import { DiagnosticSeverity, Location } from 'vscode-languageserver';
 
 // Counter for generating unique URIs to avoid cache collisions
 let document_counter = 0;
@@ -288,4 +288,17 @@ export function find_all_positions_of(my_source: string, my_search: string): Pos
   }
 
   return my_positions;
+}
+/**
+ * Normalize an LSP Definition result (Location | Location[] | null)
+ * into a flat array for assertions. Shared by the scoped-local-macro
+ * integration and property suites.
+ */
+export function as_locations(
+  my_result: Location | Location[] | null
+): Location[] {
+  if (!my_result) {
+    return [];
+  }
+  return Array.isArray(my_result) ? my_result : [my_result];
 }

--- a/tests/property/scoped-local-macro-providers.prop.test.ts
+++ b/tests/property/scoped-local-macro-providers.prop.test.ts
@@ -71,9 +71,11 @@ describe('scoped local-macro provider invariants (#270)', () => {
                         prog_a, prog_b, name, my_scenario.with_dofile_def
                     );
                 const document_state = create_document_state(source);
+                // Anchor on the backtick: short generated names (e.g.
+                // 'a') can also occur inside the word 'display'.
                 const character = source
                     .split('\n')[reference_line]
-                    .indexOf(name);
+                    .indexOf('`') + 1;
 
                 const the_definition = await definition_provider.get_definition(
                     document_state,

--- a/tests/property/scoped-local-macro-providers.prop.test.ts
+++ b/tests/property/scoped-local-macro-providers.prop.test.ts
@@ -14,15 +14,11 @@ import { HoverProvider } from '../../src/providers/hover';
 import { CompletionProvider } from '../../src/providers/completion';
 import { CommandDatabase } from '../../src/commands';
 import { arbitrary_non_reserved_identifier } from './generators';
-import { create_document_state } from './helpers/document-utils';
-import { Location } from 'vscode-languageserver';
+import {
+    as_locations,
+    create_document_state,
+} from './helpers/document-utils';
 
-function as_locations(
-    result: Location | Location[] | null
-): Location[] {
-    if (!result) return [];
-    return Array.isArray(result) ? result : [result];
-}
 
 // Two sibling programs both defining `name`, an optional do-file
 // definition BEFORE the programs (so the shadowing axis is live: the

--- a/tests/property/scoped-local-macro-providers.prop.test.ts
+++ b/tests/property/scoped-local-macro-providers.prop.test.ts
@@ -25,37 +25,50 @@ function as_locations(
 }
 
 // Two sibling programs both defining `name`, an optional do-file
-// definition, and a reference inside the second program.
+// definition BEFORE the programs (so the shadowing axis is live: the
+// do-file symbol is positionally resolved at the reference and must
+// still lose to the program's own resolved local), and a reference
+// inside the second program after its own definition.
 function build_source(
     prog_a: string,
     prog_b: string,
     name: string,
     with_dofile_def: boolean
 ): { source: string; reference_line: number; own_def_line: number } {
-    const the_lines = [
-        `program define ${prog_a}`,        // 0
-        `    local ${name} sibling_val`,   // 1
-        'end',                             // 2
-        `program define ${prog_b}`,        // 3
-        `    local ${name} own_val`,       // 4
-        `    display \`${name}'`,          // 5
-        'end',                             // 6
-    ];
-    if (with_dofile_def) {
-        the_lines.push(`local ${name} dofile_val`); // 7
-    }
+    const the_lines = with_dofile_def
+        ? [`local ${name} dofile_val`]
+        : [];
+    const offset = the_lines.length;
+    the_lines.push(
+        `program define ${prog_a}`,        // offset + 0
+        `    local ${name} sibling_val`,   // offset + 1
+        'end',                             // offset + 2
+        `program define ${prog_b}`,        // offset + 3
+        `    local ${name} own_val`,       // offset + 4
+        `    display \`${name}'`,          // offset + 5
+        'end',                             // offset + 6
+    );
     return {
         source: the_lines.join('\n'),
-        reference_line: 5,
-        own_def_line: 4,
+        reference_line: offset + 5,
+        own_def_line: offset + 4,
     };
 }
 
+// Statement-position keywords would mis-parse when interpolated into
+// `program define <name>` / `local <name>` / `display \`<name>'` —
+// exclude them so a counterexample is never a malformed fixture.
+const STATEMENT_KEYWORDS = new Set([
+    'program', 'define', 'end', 'local', 'global', 'di', 'display',
+]);
+
 const arbitrary_scenario = fc.record({
-    the_names: fc.uniqueArray(arbitrary_non_reserved_identifier(), {
-        minLength: 3,
-        maxLength: 3,
-    }),
+    the_names: fc.uniqueArray(
+        arbitrary_non_reserved_identifier().filter(
+            my_name => !STATEMENT_KEYWORDS.has(my_name)
+        ),
+        { minLength: 3, maxLength: 3 }
+    ),
     with_dofile_def: fc.boolean(),
 });
 
@@ -109,19 +122,21 @@ describe('scoped local-macro provider invariants (#270)', () => {
         await fc.assert(
             fc.asyncProperty(arbitrary_scenario, async (my_scenario) => {
                 const [prog_a, prog_b, name] = my_scenario.the_names;
-                const { source } = build_source(
+                const { source, own_def_line } = build_source(
                     prog_a, prog_b, name, my_scenario.with_dofile_def
                 );
                 // Complete right after a backtick appended inside
-                // prog_b's body (before `end`).
+                // prog_b's body (after its own definition, before
+                // `end`).
+                const insert_line = own_def_line + 1;
                 const the_lines = source.split('\n');
-                the_lines.splice(6, 0, '    di "`');
+                the_lines.splice(insert_line, 0, '    di "`');
                 const patched = the_lines.join('\n');
                 const document_state = create_document_state(patched);
                 const the_completions =
                     await completion_provider.get_completions(
                         document_state,
-                        { line: 6, character: 9 },
+                        { line: insert_line, character: 9 },
                         '`',
                     );
                 const the_item = the_completions.find(

--- a/tests/property/scoped-local-macro-providers.prop.test.ts
+++ b/tests/property/scoped-local-macro-providers.prop.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Property-Based Tests for Scope-Aware Local-Macro Providers (#270)
+ *
+ * Invariant: hover, go-to-definition, and completion queried from a
+ * position inside program P for local macro N only ever surface N's
+ * definition owned by P (or the do-file scope when P doesn't define
+ * N) — never a sibling program's same-named local.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import * as fc from 'fast-check';
+import { DefinitionProvider } from '../../src/providers/definition';
+import { HoverProvider } from '../../src/providers/hover';
+import { CompletionProvider } from '../../src/providers/completion';
+import { CommandDatabase } from '../../src/commands';
+import { arbitrary_non_reserved_identifier } from './generators';
+import { create_document_state } from './helpers/document-utils';
+import { Location } from 'vscode-languageserver';
+
+function as_locations(
+    result: Location | Location[] | null
+): Location[] {
+    if (!result) return [];
+    return Array.isArray(result) ? result : [result];
+}
+
+// Two sibling programs both defining `name`, an optional do-file
+// definition, and a reference inside the second program.
+function build_source(
+    prog_a: string,
+    prog_b: string,
+    name: string,
+    with_dofile_def: boolean
+): { source: string; reference_line: number; own_def_line: number } {
+    const the_lines = [
+        `program define ${prog_a}`,        // 0
+        `    local ${name} sibling_val`,   // 1
+        'end',                             // 2
+        `program define ${prog_b}`,        // 3
+        `    local ${name} own_val`,       // 4
+        `    display \`${name}'`,          // 5
+        'end',                             // 6
+    ];
+    if (with_dofile_def) {
+        the_lines.push(`local ${name} dofile_val`); // 7
+    }
+    return {
+        source: the_lines.join('\n'),
+        reference_line: 5,
+        own_def_line: 4,
+    };
+}
+
+const arbitrary_scenario = fc.record({
+    the_names: fc.uniqueArray(arbitrary_non_reserved_identifier(), {
+        minLength: 3,
+        maxLength: 3,
+    }),
+    with_dofile_def: fc.boolean(),
+});
+
+describe('scoped local-macro provider invariants (#270)', () => {
+    it('definition and hover from inside a program never surface a sibling\'s definition', async () => {
+        const definition_provider = new DefinitionProvider();
+        const hover_provider = new HoverProvider(new CommandDatabase());
+        await fc.assert(
+            fc.asyncProperty(arbitrary_scenario, async (my_scenario) => {
+                const [prog_a, prog_b, name] = my_scenario.the_names;
+                const { source, reference_line, own_def_line } =
+                    build_source(
+                        prog_a, prog_b, name, my_scenario.with_dofile_def
+                    );
+                const document_state = create_document_state(source);
+                const character = source
+                    .split('\n')[reference_line]
+                    .indexOf(name);
+
+                const the_definition = await definition_provider.get_definition(
+                    document_state,
+                    { line: reference_line, character },
+                );
+                const the_lines = as_locations(the_definition).map(
+                    my_loc => my_loc.range.start.line
+                );
+                // Only the program's own definition — never the
+                // sibling's (line 1), never the do-file's (shadowed).
+                expect(the_lines).toEqual([own_def_line]);
+
+                const the_hover = await hover_provider.get_hover(
+                    document_state,
+                    { line: reference_line, character },
+                );
+                const hover_text =
+                    (the_hover?.contents as { value?: string })?.value ?? '';
+                expect(hover_text).toContain('own_val');
+                expect(hover_text).not.toContain('sibling_val');
+                expect(hover_text).not.toContain('dofile_val');
+            }),
+            { numRuns: 25 }
+        );
+    });
+
+    it('completion inside a program offers its own local with its own value', async () => {
+        const completion_provider = new CompletionProvider(
+            new CommandDatabase()
+        );
+        await fc.assert(
+            fc.asyncProperty(arbitrary_scenario, async (my_scenario) => {
+                const [prog_a, prog_b, name] = my_scenario.the_names;
+                const { source } = build_source(
+                    prog_a, prog_b, name, my_scenario.with_dofile_def
+                );
+                // Complete right after a backtick appended inside
+                // prog_b's body (before `end`).
+                const the_lines = source.split('\n');
+                the_lines.splice(6, 0, '    di "`');
+                const patched = the_lines.join('\n');
+                const document_state = create_document_state(patched);
+                const the_completions =
+                    await completion_provider.get_completions(
+                        document_state,
+                        { line: 6, character: 9 },
+                        '`',
+                    );
+                const the_item = the_completions.find(
+                    my_item => my_item.label === name
+                );
+                expect(the_item).toBeDefined();
+                expect(the_item!.documentation).toBe('Value: own_val');
+            }),
+            { numRuns: 25 }
+        );
+    });
+});

--- a/tests/unit/scoped-local-macro-identity.test.ts
+++ b/tests/unit/scoped-local-macro-identity.test.ts
@@ -193,6 +193,39 @@ end
         expect(symbol_a).not.toBe(symbol_b);
         expect(symbol_a!.additional_definitions ?? []).toHaveLength(0);
         expect(symbol_b!.additional_definitions ?? []).toHaveLength(0);
+        // First read-path coverage for the identity plumbing (#270):
+        // scope_id matches the owning ScopeInfo.id and
+        // containing_program_name names the defining program.
+        expect(symbol_a!.scope_id).toBe(the_program_scopes[0].id);
+        expect(symbol_b!.scope_id).toBe(the_program_scopes[1].id);
+        expect(symbol_a!.scope_id).not.toBe(symbol_b!.scope_id);
+        expect(symbol_a!.containing_program_name).toBe('prog_a');
+        expect(symbol_b!.containing_program_name).toBe('prog_b');
+    });
+
+    it('dofile-scope locals carry scope_id 0 and no program name', () => {
+        const result = analyze_code(`local top_y 1`);
+        const flat_y = result.symbols.localMacros.get('top_y');
+        expect(flat_y).toBeDefined();
+        expect(flat_y!.scope_id).toBe(0);
+        expect(flat_y!.scope_id).toBe(result.scopes[0].id);
+        expect(flat_y!.containing_program_name).toBeUndefined();
+    });
+
+    it('redeclared body registers its own syntax implicit locals', () => {
+        // Pins the corrected process_program comment: implicit locals
+        // from `syntax` are registered per body by analyze_syntax_node,
+        // independent of the first-def-wins signature gate — body #2's
+        // own `` `b' `` must not warn.
+        const result = analyze_code(`
+program define p
+end
+program define p, rclass
+    syntax varlist, B(string)
+    display \`b'
+end
+`);
+        expect(undefined_macro_diagnostics(result, 'b')).toHaveLength(0);
     });
 });
 

--- a/tests/unit/utils/scoped-locals.test.ts
+++ b/tests/unit/utils/scoped-locals.test.ts
@@ -206,3 +206,59 @@ describe('enumerate_scoped_local_macros', () => {
         expect(the_entries.map(([my_name]) => my_name)).toEqual(['x']);
     });
 });
+
+// Round-1 gate regression: resolution must honor definition order —
+// a not-yet-defined program local must not shadow an already-defined
+// do-file local (mirrors the analyzer's macro_resolves_at_reference).
+describe('position-aware resolution (forward order)', () => {
+    const FORWARD_SHADOW = `
+local x top
+program define p
+    di "\`x'"
+    local x body
+end
+`;
+
+    it('reference before the program definition resolves to the do-file symbol', () => {
+        const doc = create_document_state(FORWARD_SHADOW);
+        const position = find_position_of(FORWARD_SHADOW, 'di "`x')!;
+        const result = lookup_scoped_local_macro(doc.scopes, position, 'x');
+        expect(result.symbol?.value).toBe('top');
+        expect(result.symbol?.containingScope).toBe('dofile');
+    });
+
+    it('reference after the program definition resolves to the program symbol', () => {
+        const source = `
+local x top
+program define p
+    local x body
+    di "\`x'"
+end
+`;
+        const doc = create_document_state(source);
+        const position = find_position_of(source, 'di "`x')!;
+        const result = lookup_scoped_local_macro(doc.scopes, position, 'x');
+        expect(result.symbol?.value).toBe('body');
+    });
+
+    it('forward-only same-scope reference keeps the program symbol as identity target', () => {
+        const source = `
+program define p
+    di "\`x'"
+    local x body
+end
+`;
+        const doc = create_document_state(source);
+        const position = find_position_of(source, 'di "`x')!;
+        const result = lookup_scoped_local_macro(doc.scopes, position, 'x');
+        expect(result.symbol?.value).toBe('body');
+        expect(result.out_of_scope).toBe(false);
+    });
+
+    it('collect_visible_local_macros prefers the resolved do-file symbol', () => {
+        const doc = create_document_state(FORWARD_SHADOW);
+        const position = find_position_of(FORWARD_SHADOW, 'di "`x')!;
+        const the_macros = collect_visible_local_macros(doc.scopes, position);
+        expect(the_macros.get('x')?.value).toBe('top');
+    });
+});

--- a/tests/unit/utils/scoped-locals.test.ts
+++ b/tests/unit/utils/scoped-locals.test.ts
@@ -3,6 +3,7 @@ import {
     get_visible_local_scopes,
     collect_visible_local_macros,
     lookup_scoped_local_macro,
+    enumerate_scoped_local_macros,
 } from '../../../src/utils/scoped-locals';
 import {
     create_document_state,
@@ -178,5 +179,30 @@ end
         const position = find_position_of(source, "display `x'")!;
         const result = lookup_scoped_local_macro(doc.scopes, position, 'x');
         expect(result.symbol?.value).toBe('second');
+    });
+});
+
+describe('enumerate_scoped_local_macros', () => {
+    it('yields one entry per owning scope for a shared name', () => {
+        const doc = create_document_state(SIBLING_PROGRAMS);
+        const the_entries = enumerate_scoped_local_macros(
+            doc.scopes, doc.symbols.localMacros
+        );
+        const the_shared_values = the_entries
+            .filter(([my_name]) => my_name === 'shared')
+            .map(([, my_symbol]) => my_symbol.value)
+            .sort();
+        expect(the_shared_values).toEqual(['1', '2']);
+        expect(
+            the_entries.some(([my_name]) => my_name === 'top_only')
+        ).toBe(true);
+    });
+
+    it('falls back to the flat map when scopes are empty', () => {
+        const doc = create_document_state('local x 1');
+        const the_entries = enumerate_scoped_local_macros(
+            [], doc.symbols.localMacros
+        );
+        expect(the_entries.map(([my_name]) => my_name)).toEqual(['x']);
     });
 });

--- a/tests/unit/utils/scoped-locals.test.ts
+++ b/tests/unit/utils/scoped-locals.test.ts
@@ -85,16 +85,18 @@ end
         const doc = create_document_state(source);
         const position = find_position_of(source, "display `x'")!;
         const the_macros = collect_visible_local_macros(doc.scopes, position);
-        expect(the_macros.get('x')?.value).toBe('body');
-        expect(the_macros.get('x')?.containingScope).toBe('program');
+        expect(the_macros.resolved.get('x')?.value).toBe('body');
+        expect(the_macros.resolved.get('x')?.containingScope).toBe('program');
     });
 
     it('includes do-file locals not shadowed by the program', () => {
         const doc = create_document_state(SIBLING_PROGRAMS);
         const position = find_position_of(SIBLING_PROGRAMS, "display `shared'")!;
         const the_macros = collect_visible_local_macros(doc.scopes, position);
-        expect(the_macros.get('top_only')).toBeDefined();
-        expect(the_macros.get('shared')?.value).toBe('2');
+        // top_only is declared AFTER the cursor in the fixture, so it
+        // is visible only as a forward identity target.
+        expect(the_macros.forward.get('top_only')).toBeDefined();
+        expect(the_macros.resolved.get('shared')?.value).toBe('2');
     });
 
     it('never includes sibling-program locals', () => {
@@ -109,7 +111,8 @@ end
         const doc = create_document_state(source);
         const position = find_position_of(source, "display `only_a'")!;
         const the_macros = collect_visible_local_macros(doc.scopes, position);
-        expect(the_macros.has('only_a')).toBe(false);
+        expect(the_macros.resolved.has('only_a')).toBe(false);
+        expect(the_macros.forward.has('only_a')).toBe(false);
     });
 });
 
@@ -118,7 +121,9 @@ describe('lookup_scoped_local_macro', () => {
         const result = lookup_scoped_local_macro(
             [], { line: 0, character: 0 }, 'x'
         );
-        expect(result).toEqual({ symbol: undefined, out_of_scope: false });
+        expect(result).toEqual({
+            symbol: undefined, forward_only: false, out_of_scope: false,
+        });
     });
 
     it('resolves the enclosing program symbol over the flat winner', () => {
@@ -150,7 +155,9 @@ describe('lookup_scoped_local_macro', () => {
         const doc = create_document_state(SIBLING_PROGRAMS);
         const position = find_position_of(SIBLING_PROGRAMS, "display `shared'")!;
         const result = lookup_scoped_local_macro(doc.scopes, position, 'ghost');
-        expect(result).toEqual({ symbol: undefined, out_of_scope: false });
+        expect(result).toEqual({
+            symbol: undefined, forward_only: false, out_of_scope: false,
+        });
     });
 
     it('no opinion on positional argument names', () => {
@@ -162,7 +169,9 @@ end
         const doc = create_document_state(source);
         const position = find_position_of(source, "display `1'")!;
         const result = lookup_scoped_local_macro(doc.scopes, position, '1');
-        expect(result).toEqual({ symbol: undefined, out_of_scope: false });
+        expect(result).toEqual({
+            symbol: undefined, forward_only: false, out_of_scope: false,
+        });
     });
 
     it('redeclared bodies resolve to their own body symbol', () => {
@@ -252,6 +261,7 @@ end
         const position = find_position_of(source, 'di "`x')!;
         const result = lookup_scoped_local_macro(doc.scopes, position, 'x');
         expect(result.symbol?.value).toBe('body');
+        expect(result.forward_only).toBe(true);
         expect(result.out_of_scope).toBe(false);
     });
 
@@ -259,6 +269,7 @@ end
         const doc = create_document_state(FORWARD_SHADOW);
         const position = find_position_of(FORWARD_SHADOW, 'di "`x')!;
         const the_macros = collect_visible_local_macros(doc.scopes, position);
-        expect(the_macros.get('x')?.value).toBe('top');
+        expect(the_macros.resolved.get('x')?.value).toBe('top');
+        expect(the_macros.forward.has('x')).toBe(false);
     });
 });

--- a/tests/unit/utils/scoped-locals.test.ts
+++ b/tests/unit/utils/scoped-locals.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'bun:test';
+import {
+    get_visible_local_scopes,
+    collect_visible_local_macros,
+    lookup_scoped_local_macro,
+} from '../../../src/utils/scoped-locals';
+import {
+    create_document_state,
+    find_position_of,
+} from '../../property/helpers/document-utils';
+
+const SIBLING_PROGRAMS = `
+program define prog_a
+    local shared 1
+end
+program define prog_b
+    local shared 2
+    display \`shared'
+end
+local top_only 9
+`;
+
+describe('get_visible_local_scopes', () => {
+    it('returns [] for empty scopes (degenerate states)', () => {
+        expect(
+            get_visible_local_scopes([], { line: 0, character: 0 })
+        ).toEqual([]);
+    });
+
+    it('top-level position sees only the do-file scope', () => {
+        const doc = create_document_state(SIBLING_PROGRAMS);
+        const position = find_position_of(SIBLING_PROGRAMS, 'local top_only')!;
+        const the_visible = get_visible_local_scopes(doc.scopes, position);
+        expect(the_visible).toHaveLength(1);
+        expect(the_visible[0].type).toBe('dofile');
+    });
+
+    it('program-body position sees its program scope then the do-file scope', () => {
+        const doc = create_document_state(SIBLING_PROGRAMS);
+        const position = find_position_of(SIBLING_PROGRAMS, "display `shared'")!;
+        const the_visible = get_visible_local_scopes(doc.scopes, position);
+        expect(the_visible).toHaveLength(2);
+        expect(the_visible[0].type).toBe('program');
+        expect(the_visible[0].program_name).toBe('prog_b');
+        expect(the_visible[1].type).toBe('dofile');
+    });
+
+    it('a program header line resolves to the enclosing frame (#273)', () => {
+        const doc = create_document_state(SIBLING_PROGRAMS);
+        const position = find_position_of(SIBLING_PROGRAMS, 'define prog_b')!;
+        const the_visible = get_visible_local_scopes(doc.scopes, position);
+        expect(the_visible).toHaveLength(1);
+        expect(the_visible[0].type).toBe('dofile');
+    });
+
+    it('a nested program body sees the innermost scope, not the middle one', () => {
+        const source = `
+program define outer
+    local x outer_val
+    program define inner
+        local y inner_val
+        display \`y'
+    end
+end
+`;
+        const doc = create_document_state(source);
+        const position = find_position_of(source, "display `y'")!;
+        const the_visible = get_visible_local_scopes(doc.scopes, position);
+        expect(the_visible).toHaveLength(2);
+        expect(the_visible[0].program_name).toBe('inner');
+        expect(the_visible[1].type).toBe('dofile');
+    });
+});
+
+describe('collect_visible_local_macros', () => {
+    it('shadows the do-file symbol with the enclosing program symbol', () => {
+        const source = `
+local x top
+program define p
+    local x body
+    display \`x'
+end
+`;
+        const doc = create_document_state(source);
+        const position = find_position_of(source, "display `x'")!;
+        const the_macros = collect_visible_local_macros(doc.scopes, position);
+        expect(the_macros.get('x')?.value).toBe('body');
+        expect(the_macros.get('x')?.containingScope).toBe('program');
+    });
+
+    it('includes do-file locals not shadowed by the program', () => {
+        const doc = create_document_state(SIBLING_PROGRAMS);
+        const position = find_position_of(SIBLING_PROGRAMS, "display `shared'")!;
+        const the_macros = collect_visible_local_macros(doc.scopes, position);
+        expect(the_macros.get('top_only')).toBeDefined();
+        expect(the_macros.get('shared')?.value).toBe('2');
+    });
+
+    it('never includes sibling-program locals', () => {
+        const source = `
+program define prog_a
+    local only_a 1
+end
+program define prog_b
+    display \`only_a'
+end
+`;
+        const doc = create_document_state(source);
+        const position = find_position_of(source, "display `only_a'")!;
+        const the_macros = collect_visible_local_macros(doc.scopes, position);
+        expect(the_macros.has('only_a')).toBe(false);
+    });
+});
+
+describe('lookup_scoped_local_macro', () => {
+    it('no opinion on empty scopes', () => {
+        const result = lookup_scoped_local_macro(
+            [], { line: 0, character: 0 }, 'x'
+        );
+        expect(result).toEqual({ symbol: undefined, out_of_scope: false });
+    });
+
+    it('resolves the enclosing program symbol over the flat winner', () => {
+        const doc = create_document_state(SIBLING_PROGRAMS);
+        const position = find_position_of(SIBLING_PROGRAMS, "display `shared'")!;
+        const result = lookup_scoped_local_macro(doc.scopes, position, 'shared');
+        expect(result.out_of_scope).toBe(false);
+        expect(result.symbol?.value).toBe('2');
+        expect(result.symbol?.containing_program_name).toBe('prog_b');
+    });
+
+    it('flags a sibling-only name as out_of_scope', () => {
+        const doc = create_document_state(SIBLING_PROGRAMS);
+        const position = find_position_of(SIBLING_PROGRAMS, 'local top_only')!;
+        const result = lookup_scoped_local_macro(doc.scopes, position, 'shared');
+        expect(result.symbol).toBeUndefined();
+        expect(result.out_of_scope).toBe(true);
+    });
+
+    it('program-body lookup still sees do-file locals (permissive)', () => {
+        const doc = create_document_state(SIBLING_PROGRAMS);
+        const position = find_position_of(SIBLING_PROGRAMS, "display `shared'")!;
+        const result = lookup_scoped_local_macro(doc.scopes, position, 'top_only');
+        expect(result.symbol?.value).toBe('9');
+        expect(result.out_of_scope).toBe(false);
+    });
+
+    it('no opinion on a name untracked anywhere in the file', () => {
+        const doc = create_document_state(SIBLING_PROGRAMS);
+        const position = find_position_of(SIBLING_PROGRAMS, "display `shared'")!;
+        const result = lookup_scoped_local_macro(doc.scopes, position, 'ghost');
+        expect(result).toEqual({ symbol: undefined, out_of_scope: false });
+    });
+
+    it('no opinion on positional argument names', () => {
+        const source = `
+program define p
+    display \`1'
+end
+`;
+        const doc = create_document_state(source);
+        const position = find_position_of(source, "display `1'")!;
+        const result = lookup_scoped_local_macro(doc.scopes, position, '1');
+        expect(result).toEqual({ symbol: undefined, out_of_scope: false });
+    });
+
+    it('redeclared bodies resolve to their own body symbol', () => {
+        const source = `
+program define foo
+    local x first
+end
+program define foo
+    local x second
+    display \`x'
+end
+`;
+        const doc = create_document_state(source);
+        const position = find_position_of(source, "display `x'")!;
+        const result = lookup_scoped_local_macro(doc.scopes, position, 'x');
+        expect(result.symbol?.value).toBe('second');
+    });
+});


### PR DESCRIPTION
Closes #270.

## What this does

PR #272's scoped environment model gave local macros per-program-scope identity, but hover, go-to-definition, find-references, and completion still resolved through the flat one-representative-per-name `symbols.localMacros` view, surfacing scope-wrong symbols (both repros from the issue). This PR makes all consumers position-aware, plus two more the pattern sweep caught: the document outline and workspace symbol search for open documents.

## Design

**THE effective resolution order** for names tracked in the current file, single-sourced in `classify_effective_local` (`src/utils/dofile-locals.ts`) and consumed by every provider:

1. **Positionally RESOLVED winner** in `[enclosing program scope (body-only, #273), do-file scope]` — mirrors the analyzer's `lookup_local_macro` + `macro_resolves_at_reference` (lockstep comments pin the mirror). A resolved **program-scoped** local is unconditionally authoritative (#271: program locals never cross files) — definition/references skip cross-file scans, hover withholds the redefinition footer's indexer.
2. else the **cross-file INHERITED do-file local** — call-line-gated, with the resolver's exact merge precedence (chain far-to-near by depth/lattermost-directive/sort_key; executed include sites last-wins overriding the chain). The analyzer's cross-file suppression treats such references as defined, so this outranks a not-yet-defined same-scope local.
3. else the nearest visible scope's **FORWARD identity target** (same-scope references before the definition keep navigation working).
4. else nothing — out-of-scope names (tracked only in sibling scopes) resolve to nothing; **untracked** names stay with the pre-existing resolved-scope/flat machinery.

A resolved **do-file-scoped** result deliberately defers to the pre-existing resolved-scope/flat paths, which own cross-file execution-order shadowing.

Supporting infrastructure: `src/utils/scoped-locals.ts` (visibility, position-aware resolution, enumeration — built strictly on `find_enclosing_scope`), the outline now enumerates per owning scope and places by range containment (redeclared program bodies get per-body containers), diagnostics' inline visibility computation deduped onto the shared helper, the analyzer's visibility ternary likewise, and embedded-language (Mata/Python) macro paths now preserve delimiter intent (an explicit `` `x' `` never falls through to the global namespace).

Also fixes the stale "Known limitation" comment above `process_program`'s first-def-wins gate (its false-positive prediction was factually wrong; the real residual gap is signature metadata only) and adds the first read-path assertions for `MacroSymbol.scope_id` / `containing_program_name`.

## Review gate

Fifteen alternating rounds of Codex task-mode review + multi-agent /code-review; every finding fixed in-branch with a both-ways-verified regression test; **rounds 14 and 15 both returned zero findings from both reviewers on the final diff**. Highlights of what the gate caught and fixed along the way: forward-order resolution, per-body outline containers, inherited-vs-forward precedence (confirmed empirically against diagnostics), last-include-wins/nearer-parent-wins precedence, effective-type (not written-type) backward inheritance, winner-only declarations, per-occurrence line-gated identity, LSP sibling-range overlap in the outline, and the embedded delimiter-intent leak.

## Known approximations (deliberate, documented)

- The workspace indexer stores no `ScopeInfo`, so occurrence scans and symbol search over **closed** files remain name-based/flat (per the issue's own note and the design decision in review).
- **Untracked** (purely cross-file inherited) names keep pre-existing entity semantics — one frame-local under `include`-splice semantics, so multi-include declaration pooling and name-based occurrence grouping match how same-file redefinitions behave.
- Completion's downstream visibility filter is line-granular (pre-existing; same-line `#delimit ;` forward locals).
- `#delimit ;` files build no program scopes (pre-existing `scope-position.ts` limitation); everything degrades to do-file scope as before.
- `hover.ts` contains pre-existing dead private methods (e.g. `get_macro_hover`) — untouched to keep the diff scoped.

## Testing

7,148 tests green (`bun run test`), `bun run lint` clean (not in CI — run manually). New coverage: module unit tests (`tests/unit/utils/scoped-locals.test.ts`), provider-level integration tests mirroring the analyzer identity scenarios plus one regression block per gate round (`tests/integration/scoped-local-macro-providers.test.ts`), a cross-provider property test (`tests/property/scoped-local-macro-providers.prop.test.ts`), and analyzer read-path assertions. Every gate-round fix was verified to fail against the pre-fix code.

https://claude.ai/code/session_01P71qmrgd5zWSvM6kP6YkhR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macro handling across definition, hover, completion, references, and symbol search so results now respect the current scope and include-file context.

* **Bug Fixes**
  * Fixed incorrect macro matches when names are shadowed across programs or files.
  * Improved behavior for out-of-scope and forward references, reducing misleading navigation and completion results.
  * Made embedded-language macro lookups more accurate by honoring explicit local vs global references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->