### PR TITLE
Make cross-file directive side effects transactional (#184)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,11 @@ separate from connection wiring for testability). Contains DEFAULT_SETTINGS for 
 **Document Store** (`src/document-store.ts`): Manages open document state.
 Stores tokens, AST, symbols, diagnostics, context ranges, and line offsets.
 Includes LRU eviction and `wait_for_update(uri)` to avoid race conditions between
-`didChange` processing and requests.
+`didChange` processing and requests. Cross-file directive side effects
+(backward-directive registration + indexer overlay) are transactional (#184):
+staged during the parse and applied only after `commit_state`'s guards pass,
+with a non-registering working-directory probe and a disk re-sync on close.
+See docs/cross-file.md "Backward-Directive Registration Timing".
 
 **Debounce Manager** (`src/utils/debounce-manager.ts`): Batches rapid document
 changes with backpressure handling and metrics.

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -797,12 +797,15 @@ a separate best-effort recovery path (issue #184):
   auto edges. Effective ⊇ raw, so ancestor reads can only add edges
   relative to the pre-#286 behavior. Registration remains a parse-path
   side effect, with one exception: each file-cache entry is stamped with
-  the mode its registration ran under, and an `'auto'`-mode cache hit on
-  an `'explicit'`-registered entry applies effective registration once
-  and re-stamps (`upgrade_registration_on_cache_hit`). Without that
-  upgrade, the indexer's explicit WD walk priming the cache would leave a
-  directive-less ancestor's auto edges unregistered for as long as the
-  content stayed unchanged. Explicit-mode hits never downgrade, and memo
+  the mode its registration ran under (plus the dependency-graph version
+  it read), and an `'auto'`-mode cache hit re-applies effective
+  registration when the entry was `'explicit'`-registered or its
+  `'auto'` registration predates a graph change, then re-stamps
+  (`upgrade_registration_on_cache_hit`). Without that upgrade, the
+  indexer's explicit WD walk priming the cache would leave a
+  directive-less ancestor's auto edges unregistered — and a graph edge
+  added after the stamp would never reach `backward_directive_children`
+  — for as long as the content stayed unchanged. Explicit-mode hits never downgrade, and memo
   serves still perform no registration (files reached only through a
   served closure re-register when the memo entry is evicted or their
   content changes).

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -769,6 +769,42 @@ on; it is enforced by the memo correctness gate
 (`tests/integration/forward-closure-memo-gate.test.ts`), which checks that a
 file's forward closure is identical across distinct callers given the same inputs.
 
+## Backward-Directive Registration Timing (Transactional Side Effects)
+
+The resolver keeps a live map of backward-directive relationships
+(`parent → children`) that drives transitive diagnostics revalidation, plus a
+buffer-directives overlay in the workspace indexer that makes unsaved
+`@lsp-done-by`/`@lsp-included-by` edits visible to find-references. Both are
+updated **only at commit time** (issue #184):
+
+- While a document parses, its directives and the scope-resolver config in
+  force are **staged** (`StagedCrossFileEffects`), not applied. The
+  working-directory probe the parse runs (`resolve()` with
+  `register_dependencies: false`) never registers the file's own edges;
+  ancestor files read from disk during the walk still register *their own*
+  directives (disk-derived, correct regardless of this parse's fate).
+- `commit_state` applies the staged effects synchronously, after its
+  disposed/closed-generation/version guards pass. A parse discarded by a
+  racing `close()` (or by `dispose()`) therefore never mutates shared
+  cross-file state — no stale edge is added, and no valid edge is dropped by
+  the discarded parse's clear-then-register.
+- Commit-time registration uses **effective** directives — explicit
+  directives plus parents auto-synthesized from the dependency graph —
+  computed at apply time against live graph state. This also covers files
+  with their own `@lsp-cd` (which never run the probe) uniformly.
+- On document close, the server re-syncs the closed file's edges from its
+  **on-disk** content (best-effort), so a header change saved just before
+  closing converges even though the racing reparse was discarded. The re-sync
+  skips applying if the document was reopened while the disk read was in
+  flight; a read error keeps the existing edges, a missing file clears them.
+- Parses that fail before directive parsing (lexer/parser error or timeout)
+  stage nothing: a committed error state keeps the previous registrations on
+  purpose, so a transiently broken buffer does not wipe cross-file edges.
+
+See `tests/unit/document-store-commit-time-cross-file-effects.test.ts` for
+the race scenarios this guarantees (stale-add, valid-edge-drop across an
+A→B→C chain, dispose-during-parse, probe cache interaction, disk re-sync).
+
 ## Configuration
 
 Cross-file resolution is configured via `sight.toml` in your project root.

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -801,7 +801,10 @@ a separate best-effort recovery path (issue #184):
   it read), and an `'auto'`-mode cache hit re-applies effective
   registration when the entry was `'explicit'`-registered or its
   `'auto'` registration predates a graph change, then re-stamps
-  (`upgrade_registration_on_cache_hit`). Without that upgrade, the
+  (`upgrade_registration_on_cache_hit`). Entries whose content has
+  explicit backward directives skip the version re-check: their
+  effective registration is graph-independent, so graph churn never
+  costs them registration work. Without that upgrade, the
   indexer's explicit WD walk priming the cache would leave a
   directive-less ancestor's auto edges unregistered — and a graph edge
   added after the stamp would never reach `backward_directive_children`

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -797,18 +797,23 @@ a separate best-effort recovery path (issue #184):
   auto edges. Effective ⊇ raw, so ancestor reads can only add edges
   relative to the pre-#286 behavior. Registration remains a parse-path
   side effect, with one exception: each file-cache entry is stamped with
-  the mode its registration ran under (plus the dependency-graph version
-  it read), and an `'auto'`-mode cache hit re-applies effective
-  registration when the entry was `'explicit'`-registered or its
-  `'auto'` registration predates a graph change, then re-stamps
-  (`upgrade_registration_on_cache_hit`). Entries whose content has
-  explicit backward directives skip the version re-check: their
-  effective registration is graph-independent, so graph churn never
-  costs them registration work. Without that upgrade, the
+  the mode its registration ran under, and an `'auto'`-mode cache hit
+  re-applies effective registration and re-stamps
+  (`upgrade_registration_on_cache_hit`). Directive-less entries re-sync
+  on **every** `'auto'` hit rather than trusting the stamp: the file
+  cache can hold several entries for one URI (different inherited
+  working directories) while backward registration is one global map
+  per URI, so another cache-key variant — or an explicit-mode parse —
+  can replace the URI's registration without touching this entry's
+  stamp or the dependency-graph version. The re-sync is idempotent and
+  also picks up graph edges added after the stamp. Entries whose content
+  has explicit backward directives skip repeat work once
+  `'auto'`-stamped: their effective registration is graph-independent
+  (explicit directives win), and same-URI variants share content, so any
+  variant registers the same raw directives. Without that upgrade, the
   indexer's explicit WD walk priming the cache would leave a
-  directive-less ancestor's auto edges unregistered — and a graph edge
-  added after the stamp would never reach `backward_directive_children`
-  — for as long as the content stayed unchanged. Explicit-mode hits never downgrade, and memo
+  directive-less ancestor's auto edges unregistered for as long as the
+  content stayed unchanged. Explicit-mode hits never downgrade, and memo
   serves still perform no registration (files reached only through a
   served closure re-register when the memo entry is evicted or their
   content changes).

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -783,7 +783,21 @@ a separate best-effort recovery path (issue #184):
   working-directory probe the parse runs (`resolve()` with
   `register_dependencies: false`) never registers the file's own edges;
   ancestor files read from disk during the walk still register *their own*
-  directives (disk-derived, correct regardless of this parse's fate).
+  edges (disk-derived, correct regardless of this parse's fate).
+- Ancestor-level registration inside `get_parsed_file` uses **effective**
+  directives under the resolution's `backward_dependencies` mode, threaded
+  through every read path — backward walks, forward callee reads, and
+  forward-closure memo builds (issue #286). In `'auto'` mode a file with no
+  explicit directives keeps (or gains) its dependency-graph parents when it
+  is read as an ancestor of another file's resolution, instead of having
+  those auto edges wiped by the clear-then-register sync until its next
+  commit. An `'explicit'`-mode resolution registers raw directives only and
+  never synthesizes graph parents; the indexer's working-directory walk
+  forces `'explicit'` for scan-order determinism and so never registers
+  auto edges. Effective ⊇ raw, so ancestor reads can only add edges
+  relative to the pre-#286 behavior. Registration remains a parse-path
+  side effect: cache hits (file cache, request cache, memo serves) do not
+  re-register.
 - `commit_state` applies the staged effects synchronously, after its
   disposed/closed-generation/version guards pass. A parse discarded by a
   racing `close()` (or by `dispose()`) therefore never mutates shared
@@ -804,7 +818,9 @@ a separate best-effort recovery path (issue #184):
 
 See `tests/unit/document-store-commit-time-cross-file-effects.test.ts` for
 the race scenarios this guarantees (stale-add, valid-edge-drop across an
-A→B→C chain, dispose-during-parse, probe cache interaction, disk re-sync).
+A→B→C chain, dispose-during-parse, probe cache interaction, disk re-sync),
+and `tests/unit/scope-resolver-ancestor-effective-sync.test.ts` for the
+ancestor-level effective-sync behavior (issue #286).
 
 ## Configuration
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -796,8 +796,16 @@ a separate best-effort recovery path (issue #184):
   forces `'explicit'` for scan-order determinism and so never registers
   auto edges. Effective ⊇ raw, so ancestor reads can only add edges
   relative to the pre-#286 behavior. Registration remains a parse-path
-  side effect: cache hits (file cache, request cache, memo serves) do not
-  re-register.
+  side effect, with one exception: each file-cache entry is stamped with
+  the mode its registration ran under, and an `'auto'`-mode cache hit on
+  an `'explicit'`-registered entry applies effective registration once
+  and re-stamps (`upgrade_registration_on_cache_hit`). Without that
+  upgrade, the indexer's explicit WD walk priming the cache would leave a
+  directive-less ancestor's auto edges unregistered for as long as the
+  content stayed unchanged. Explicit-mode hits never downgrade, and memo
+  serves still perform no registration (files reached only through a
+  served closure re-register when the memo entry is evicted or their
+  content changes).
 - `commit_state` applies the staged effects synchronously, after its
   disposed/closed-generation/version guards pass. A parse discarded by a
   racing `close()` (or by `dispose()`) therefore never mutates shared

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -774,8 +774,9 @@ file's forward closure is identical across distinct callers given the same input
 The resolver keeps a live map of backward-directive relationships
 (`parent → children`) that drives transitive diagnostics revalidation, plus a
 buffer-directives overlay in the workspace indexer that makes unsaved
-`@lsp-done-by`/`@lsp-included-by` edits visible to find-references. Both are
-updated **only at commit time** (issue #184):
+`@lsp-done-by`/`@lsp-included-by` edits visible to find-references. Parse-time
+effects are staged and applied **only at commit time**; close-time re-sync is
+a separate best-effort recovery path (issue #184):
 
 - While a document parses, its directives and the scope-resolver config in
   force are **staged** (`StagedCrossFileEffects`), not applied. The

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -11,6 +11,7 @@ import {
   ParseError,
   ScopeResolverConfig,
   ScopeInfo,
+  StagedCrossFileEffects,
 } from './types';
 import { undefined_symbol_data_fields } from './utils/undefined-symbol-diagnostic';
 import { diagnostic_code_description_fields } from './utils/diagnostic-code-description';
@@ -66,6 +67,19 @@ export interface DocumentState {
 
   // Lines suppressed by @lsp-ignore / @lsp-ignore-next directives
   ignored_lines: Set<number>;
+}
+
+/**
+ * Result of create_document_state: the parsed state plus any cross-file
+ * side effects staged for commit-time application (issue #184). Effects are
+ * undefined when the parse failed before directive parsing (lexer/parser
+ * error or timeout) — a committed error state keeps the previous
+ * registrations on purpose (a transiently broken buffer must not wipe
+ * cross-file edges).
+ */
+export interface ParseOutcome {
+  state: DocumentState;
+  staged_effects: StagedCrossFileEffects | undefined;
 }
 
 export class DocumentStore {
@@ -132,9 +146,15 @@ export class DocumentStore {
       for (const my_state of this.documents.values()) {
         try {
           const directive_result = directive_parser.parse(my_state.content, my_state.uri);
-          this.scope_resolver.sync_backward_directive_dependencies(
+          // Same effective (raw + auto-synthesized) registration as the
+          // commit-time path. In normal server startup the DependencyGraph
+          // is attached after this runs, so auto-synthesis only matters for
+          // late resolver swaps; using the canonical method keeps warm-sync
+          // and commit-time registration computed identically.
+          this.scope_resolver.apply_backward_directive_registration(
             my_state.uri,
-            directive_result.directives
+            directive_result.directives,
+            this.scope_resolver_config
           );
         } catch {
           // Ignore directive parsing errors during warm-sync
@@ -228,14 +248,14 @@ export class DocumentStore {
         return;
       }
       this.evict_if_needed(content.length);
-      const state = await this.create_document_state(
+      const outcome = await this.create_document_state(
         uri,
         content,
         version,
         workspace_symbols,
         scope_resolver_config
       );
-      this.commit_state(uri, state, generation);
+      this.commit_state(uri, outcome, generation);
     };
 
     const promise = operation();
@@ -325,14 +345,14 @@ export class DocumentStore {
       }
 
       // Create new state with fresh parse
-      const new_state = await this.create_document_state(
+      const new_outcome = await this.create_document_state(
         uri,
         new_content,
         version,
         workspace_symbols,
         scope_resolver_config
       );
-      this.commit_state(uri, new_state, generation);
+      this.commit_state(uri, new_outcome, generation);
     };
 
     const promise = operation();
@@ -390,19 +410,32 @@ export class DocumentStore {
   }
 
   /**
-   * Commit a document state, guarded by generation counter.
+   * Commit a parse outcome, guarded by generation counter.
    * Discards stale updates if the document was closed after
    * this update started, or if a newer update has already
    * committed. (Req 16.2)
+   *
+   * Cross-file side effects staged during the parse are applied here,
+   * only after every guard passes, and synchronously with the state
+   * write — no await separates the guards from the application, so a
+   * close() can never interleave (issue #184). A discarded parse
+   * therefore never touches shared ScopeResolver/indexer state.
+   *
+   * @returns true if the outcome was committed, false if discarded.
    */
   private commit_state(
     uri: string,
-    state: DocumentState,
+    outcome: ParseOutcome,
     generation: number
-  ): void {
+  ): boolean {
+    // A parse that was already past the operation closure's disposed
+    // check must not mutate shared resolver/indexer state mid-shutdown.
+    if (this.disposed) {
+      return false;
+    }
     const closed_gen = this.closed_generations.get(uri);
     if (closed_gen !== undefined && generation <= closed_gen) {
-      return; // Discard stale update (document closed)
+      return false; // Discard stale update (document closed)
     }
     // Operation generations increment per call, not per document
     // version. A later-started older-version update can therefore
@@ -411,24 +444,52 @@ export class DocumentStore {
     // are allowed for same-version reparses such as scope config
     // changes and error-state recovery.
     const existing = this.documents.get(uri);
-    if (existing && existing.version > state.version) {
-      return;
+    if (existing && existing.version > outcome.state.version) {
+      return false;
     }
 
     // Discard if a newer update has already committed (Req 16.2)
     const current_gen = this.committed_generations.get(uri) ?? 0;
     if (
       generation < current_gen &&
-      (!existing || existing.version >= state.version)
+      (!existing || existing.version >= outcome.state.version)
     ) {
-      return; // A newer update has already committed
+      return false; // A newer update has already committed
     }
-    this.documents.set(uri, state);
+    this.documents.set(uri, outcome.state);
     this.committed_generations.set(
       uri,
       Math.max(current_gen, generation)
     );
     this.touch_access(uri);
+    if (outcome.staged_effects) {
+      this.apply_staged_cross_file_effects(uri, outcome.staged_effects);
+    }
+    return true;
+  }
+
+  /**
+   * Apply cross-file side effects staged during create_document_state.
+   * Called only from commit_state's accept path (issue #184): the
+   * ScopeResolver backward-directive map and the indexer overlay are
+   * updated together, from the same staged directives, exactly once per
+   * committed parse. Effective-directive computation happens here, at
+   * apply time, against live DependencyGraph state.
+   */
+  private apply_staged_cross_file_effects(
+    uri: string,
+    staged: StagedCrossFileEffects
+  ): void {
+    if (this.scope_resolver) {
+      this.scope_resolver.apply_backward_directive_registration(
+        uri,
+        staged.raw_backward_directives,
+        staged.scope_resolver_config
+      );
+    }
+    if (this.on_backward_directives_parsed) {
+      this.on_backward_directives_parsed(uri, staged.raw_backward_directives);
+    }
   }
 
   /**
@@ -630,7 +691,7 @@ export class DocumentStore {
     version: number,
     workspace_symbols?: SymbolTable,
     scope_resolver_config?: Partial<ScopeResolverConfig>
-  ): Promise<DocumentState> {
+  ): Promise<ParseOutcome> {
     const start_time = Date.now();
     this.metrics.parse_count++;
 
@@ -646,13 +707,16 @@ export class DocumentStore {
 
     if (!lex_result.success || lex_result.timed_out) {
       // Return minimal state on timeout/error
-      return this.create_error_state(
-        uri,
-        content,
-        version,
-        lex_result.error || 'Lexer timeout',
-        lex_result.result?.line_offsets
-      );
+      return {
+        state: this.create_error_state(
+          uri,
+          content,
+          version,
+          lex_result.error || 'Lexer timeout',
+          lex_result.result?.line_offsets
+        ),
+        staged_effects: undefined,
+      };
     }
 
     // Initialize context tracker using lexer tokens (no re-scan)
@@ -669,41 +733,36 @@ export class DocumentStore {
     );
 
     if (!parse_result.success || parse_result.timed_out) {
-      return this.create_error_state(
-        uri,
-        content,
-        version,
-        parse_result.error || 'Parser timeout',
-        lex_result.result!.line_offsets
-      );
+      return {
+        state: this.create_error_state(
+          uri,
+          content,
+          version,
+          parse_result.error || 'Parser timeout',
+          lex_result.result!.line_offsets
+        ),
+        staged_effects: undefined,
+      };
     }
 
-    // Parse directives to get working_directory and check for backward directives.
-    //
-    // KNOWN LIMITATION (tracked in https://github.com/jbearak/sight/issues/184):
-    // these cross-file side effects are applied during the parse, before
-    // commit_state decides whether the parse is accepted. Per-URI serialization
-    // makes a stale out-of-order *update* hit the read-time version guard before
-    // this runs, but a `close()` racing an in-flight parse is not serialized, so
-    // a parse finishing after close can briefly leave a stale backward-directive
-    // relationship until the next reparse/reindex. The full fix is to stage these
-    // side effects and apply them only after commit_state's guards pass (issue
-    // #184); it is deferred because the correct rollback requires a transactional
-    // refactor (including a non-registering resolve() probe), not a coarse clear.
+    // Parse directives to get working_directory and check for backward
+    // directives. Cross-file side effects (backward-directive registration
+    // and the indexer overlay callback) are STAGED here and applied only by
+    // commit_state after its guards pass (issue #184) — a parse discarded by
+    // a racing close() therefore never mutates shared cross-file state. The
+    // working-directory probe below is non-registering for the same reason.
     const directive_parser = new DirectiveParser();
     let resolved_working_directory: string | undefined;
+    let staged_effects: StagedCrossFileEffects | undefined;
+    const effective_scope_resolver_config =
+      scope_resolver_config ?? this.scope_resolver_config;
     try {
       const directive_result = directive_parser.parse(content, uri, lex_result.result!.tokens);
+      staged_effects = {
+        raw_backward_directives: directive_result.directives,
+        scope_resolver_config: effective_scope_resolver_config,
+      };
 
-      if (this.scope_resolver) {
-        this.scope_resolver.sync_backward_directive_dependencies(
-          uri,
-          directive_result.directives
-        );
-      }
-      if (this.on_backward_directives_parsed) {
-        this.on_backward_directives_parsed(uri, directive_result.directives);
-      }
       if (directive_result.working_directory) {
         // File has its own working directory directive
         resolved_working_directory = this.resolve_working_directory(
@@ -714,12 +773,12 @@ export class DocumentStore {
         // File has no own working directory. Try to inherit one from parent
         // files via ScopeResolver, including auto-discovered parents.
         try {
-          const effective_scope_resolver_config =
-            scope_resolver_config ?? this.scope_resolver_config;
           const scope_result = await this.scope_resolver.resolve(
             uri,
             content,
-            effective_scope_resolver_config
+            effective_scope_resolver_config,
+            undefined,
+            { register_dependencies: false }
           );
           if (scope_result.inherited_working_directory) {
             resolved_working_directory = scope_result.inherited_working_directory;
@@ -749,41 +808,46 @@ export class DocumentStore {
     this.metrics.parse_total_ms += elapsed_ms;
 
     if (!analyze_result.success || analyze_result.timed_out) {
-      // Return partial state with AST but no analysis
+      // Return partial state with AST but no analysis. Directive parsing
+      // already succeeded, so staged effects still apply on commit
+      // (matches the pre-staging behavior of this path).
       return {
-        uri,
-        version,
-        content,
-        tokens: lex_result.result!.tokens,
-        ast: parse_result.result!.ast,
-        symbols: {
-          programs: new Map(),
-          localMacros: new Map(),
-          globalMacros: new Map(),
-          variables: new Map(),
-          scalars: new Map(),
-          matrices: new Map(),
-        },
-        scopes: [],
-        diagnostics: [
-          {
-            severity: DiagnosticSeverity.Warning,
-            message: analyze_result.error || 'Analyzer timeout',
-            range: {
-              start: { line: 0, character: 0 },
-              end: { line: 0, character: 0 },
-            },
-            source: 'sight',
+        state: {
+          uri,
+          version,
+          content,
+          tokens: lex_result.result!.tokens,
+          ast: parse_result.result!.ast,
+          symbols: {
+            programs: new Map(),
+            localMacros: new Map(),
+            globalMacros: new Map(),
+            variables: new Map(),
+            scalars: new Map(),
+            matrices: new Map(),
           },
-        ],
-        context_ranges,
-        context_tracker: my_context_tracker,
-        line_offsets: lex_result.result!.line_offsets,
-        forward_calls: [],
-        token_line_index: this.build_token_line_index(
-          lex_result.result!.tokens
-        ),
-        ignored_lines: new Set<number>(),
+          scopes: [],
+          diagnostics: [
+            {
+              severity: DiagnosticSeverity.Warning,
+              message: analyze_result.error || 'Analyzer timeout',
+              range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 0 },
+              },
+              source: 'sight',
+            },
+          ],
+          context_ranges,
+          context_tracker: my_context_tracker,
+          line_offsets: lex_result.result!.line_offsets,
+          forward_calls: [],
+          token_line_index: this.build_token_line_index(
+            lex_result.result!.tokens
+          ),
+          ignored_lines: new Set<number>(),
+        },
+        staged_effects,
       };
     }
 
@@ -850,23 +914,26 @@ export class DocumentStore {
     }
 
     return {
-      uri,
-      version,
-      content,
-      tokens: lex_result.result!.tokens,
-      ast: parse_result.result!.ast,
-      symbols: analyze_result.result!.symbols,
-      scopes: analyze_result.result!.scopes,
-      diagnostics,
-      context_ranges,
-      context_tracker: my_context_tracker,
-      line_offsets: lex_result.result!.line_offsets,
-      forward_calls: all_forward_calls,
-      working_directory: resolved_working_directory,
-      token_line_index: this.build_token_line_index(
-        lex_result.result!.tokens
-      ),
-      ignored_lines: analyze_result.result!.ignored_lines,
+      state: {
+        uri,
+        version,
+        content,
+        tokens: lex_result.result!.tokens,
+        ast: parse_result.result!.ast,
+        symbols: analyze_result.result!.symbols,
+        scopes: analyze_result.result!.scopes,
+        diagnostics,
+        context_ranges,
+        context_tracker: my_context_tracker,
+        line_offsets: lex_result.result!.line_offsets,
+        forward_calls: all_forward_calls,
+        working_directory: resolved_working_directory,
+        token_line_index: this.build_token_line_index(
+          lex_result.result!.tokens
+        ),
+        ignored_lines: analyze_result.result!.ignored_lines,
+      },
+      staged_effects,
     };
   }
 

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -44,8 +44,10 @@ export interface ForwardScopeConfig {
      * backward-directive registration for callees read from disk matches
      * the chain's semantics. Purely a side-effect input: it never changes
      * resolved symbols, so it is deliberately absent from the
-     * forward-closure memo key. When unset, get_parsed_file defaults to
-     * 'explicit' (raw registration, the pre-#286 behavior).
+     * forward-closure memo key. ForwardScopeResolver.resolve() normalizes
+     * an unset mode to 'auto' before reading callees; get_parsed_file
+     * itself still defaults untracked direct callers to 'explicit' (raw
+     * registration, the pre-#286 behavior).
      */
     backward_dependencies?: 'auto' | 'explicit';
     diagnostics?: {
@@ -571,7 +573,14 @@ export class ForwardScopeResolver {
         config?: Partial<ForwardScopeConfig>,
         diagnostic_owner_uri?: string,
     ): Promise<ForwardResolvedScope> {
-        const resolved_config = { ...this.default_config, ...config };
+        const resolved_config = {
+            ...this.default_config,
+            ...config,
+            backward_dependencies:
+                config?.backward_dependencies ??
+                this.default_config.backward_dependencies ??
+                'auto',
+        };
         // Check cancellation at entry
         if (token?.isCancellationRequested) {
             return { symbols: create_empty_symbol_table(), call_sites: [], diagnostics: [] };

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -38,6 +38,16 @@ import { clone_symbol_table } from '../scope-resolver/visible-symbols';
 
 export interface ForwardScopeConfig {
     max_forward_depth: number;
+    /**
+     * The initiating resolution's effective backward-dependencies mode
+     * (issue #286). Threaded into get_parsed_file so the ancestor-level
+     * backward-directive registration for callees read from disk matches
+     * the chain's semantics. Purely a side-effect input: it never changes
+     * resolved symbols, so it is deliberately absent from the
+     * forward-closure memo key. When unset, get_parsed_file defaults to
+     * 'explicit' (raw registration, the pre-#286 behavior).
+     */
+    backward_dependencies?: 'auto' | 'explicit';
     diagnostics?: {
         max_depth?: 'error' | 'warning' | 'information' | 'off';
     };
@@ -830,7 +840,12 @@ export class ForwardScopeResolver {
             }
 
             // Get callee symbols
-            const callee_result = await this.get_callee_scope(resolved_path, callee_uri, effective_call_wd);
+            const callee_result = await this.get_callee_scope(
+                resolved_path,
+                callee_uri,
+                effective_call_wd,
+                resolved_config.backward_dependencies
+            );
 
             if (decision.action === 'boundary_only') {
                 // Dedup'd do/run re-visit at the outermost resolve()
@@ -1247,6 +1262,13 @@ export class ForwardScopeResolver {
                 token,
                 {
                     max_forward_depth: resolved_config.max_forward_depth,
+                    // Thread the initiating resolution's backward mode so
+                    // callee reads during this build register edges under
+                    // the same semantics as the live walk they replace
+                    // (issue #286). Side-effect-only: not in the memo key,
+                    // and serves never register.
+                    backward_dependencies:
+                        resolved_config.backward_dependencies,
                     // Force a non-'off' truncation severity: a cap-truncated
                     // closure is shaped by the cap but the SEVERITY setting
                     // is not in the key, so under 'off' it would look
@@ -1490,6 +1512,7 @@ export class ForwardScopeResolver {
             callee_fs_path,
             callee_uri,
             working_directory,
+            resolved_config.backward_dependencies,
         );
         if ('error' in callee_result) return new Map();
 
@@ -1630,7 +1653,8 @@ export class ForwardScopeResolver {
     private async get_callee_scope(
         fs_path: string,
         uri: string,
-        working_directory?: string
+        working_directory?: string,
+        backward_dependencies?: 'auto' | 'explicit'
     ): Promise<{ symbols: SymbolTable; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; content_hash?: string } | { error: string }> {
         let final_fs_path = fs_path;
         let final_uri = uri;
@@ -1656,7 +1680,7 @@ export class ForwardScopeResolver {
 
         // Only use cache-first mode for files within workspace roots
         const skip_disk_if_cached = this.is_within_workspace_roots(final_fs_path);
-        const parsed_result = await this.scope_resolver.get_parsed_file(final_uri, final_fs_path, { skip_disk_if_cached, working_directory });
+        const parsed_result = await this.scope_resolver.get_parsed_file(final_uri, final_fs_path, { skip_disk_if_cached, working_directory, backward_dependencies });
         if ('error' in parsed_result) {
             const paths_msg = paths_tried.length > 1 ? ` (tried: ${paths_tried.join(', ')})` : '';
             return { error: parsed_result.error + paths_msg };

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -182,14 +182,16 @@ export class ScopeResolver {
     private parser: StataParser;
     private analyzer: SemanticAnalyzer;
     // Cache key is "uri|working_directory" (or just "uri" if no working directory)
-    // registered_backward_mode: the backward_dependencies mode the entry's
-    // last parse-path registration ran under (issue #286). Undefined for
-    // entries written by parse_file (root-file parses, which register via
-    // resolve()/commit instead). Lets cache HITS upgrade an
-    // 'explicit'-registered entry to effective registration when first
-    // read by an 'auto'-mode resolution — see
-    // upgrade_registration_on_cache_hit.
-    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit' }>;
+    // registered_backward_mode / registered_graph_version: the
+    // backward_dependencies mode the entry's last parse-path registration
+    // ran under, and the DependencyGraph version it read (issue #286).
+    // Undefined for entries written by parse_file (root-file parses,
+    // which register via resolve()/commit instead). Lets cache HITS
+    // upgrade an 'explicit'-registered entry to effective registration
+    // when first read by an 'auto'-mode resolution, and re-sync an
+    // 'auto'-registered directive-less entry when the graph has changed
+    // since — see upgrade_registration_on_cache_hit.
+    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit'; registered_graph_version?: number }>;
     private scope_cache: Map<string, ScopeCacheEntry>;
     // Secondary index: uri -> Set<cache_keys> for O(1) scope cache invalidation by URI
     private uri_to_cache_keys: Map<string, Set<string>>;
@@ -2467,11 +2469,14 @@ export class ScopeResolver {
                 working_directory: parse_result.working_directory,
                 working_directory_directive: parse_result.working_directory_directive,
                 diagnostics: parse_result.diagnostics,
-                // Stamp the mode the registration below runs under, so
-                // later cache hits can upgrade an 'explicit'-registered
-                // entry (issue #286).
+                // Stamp the mode the registration below runs under (and
+                // the graph version it reads), so later cache hits can
+                // upgrade an 'explicit'-registered entry or re-sync a
+                // graph-stale 'auto' one (issue #286).
                 registered_backward_mode:
                     options?.backward_dependencies ?? 'explicit',
+                registered_graph_version:
+                    this.dependency_graph?.get_version(),
             });
 
             // Register backward directive dependencies from cached file
@@ -3418,29 +3423,43 @@ export class ScopeResolver {
      * dependency-graph parents unregistered for as long as 'auto'-mode
      * resolutions keep hitting the cache (until the content changes).
      * When an 'auto'-mode read hits such an entry, apply effective
-     * registration once and stamp the entry so repeat hits are free.
+     * registration and stamp the entry so repeat hits are free.
      * Effective ⊇ raw, so upgrading can only add edges. Explicit-mode
      * hits never downgrade: for them hit paths stay side-effect-free,
      * as before.
+     *
+     * The 'auto' stamp folds in the DependencyGraph version it was
+     * registered against: auto synthesis reads live graph state, so an
+     * entry stamped while the graph was partial (or before a parent
+     * added its do-call) must not latch — the next auto-mode hit after
+     * a graph change re-syncs. Entries whose cached content has explicit
+     * directives skip the version check entirely: for them effective
+     * registration is graph-independent (explicit directives win), so
+     * repeat hits stay free of registration work.
      */
     private upgrade_registration_on_cache_hit(
         uri: string,
         cached: {
             directives: Directive[];
             registered_backward_mode?: 'auto' | 'explicit';
+            registered_graph_version?: number;
         },
         requested_mode: 'auto' | 'explicit' | undefined
     ): void {
         if (requested_mode !== 'auto') {
             return;
         }
-        if (cached.registered_backward_mode === 'auto') {
+        const current_graph_version = this.dependency_graph?.get_version();
+        if (cached.registered_backward_mode === 'auto' &&
+            (cached.directives.length > 0 ||
+             cached.registered_graph_version === current_graph_version)) {
             return;
         }
         this.apply_backward_directive_registration(uri, cached.directives, {
             backward_dependencies: 'auto',
         });
         cached.registered_backward_mode = 'auto';
+        cached.registered_graph_version = current_graph_version;
     }
 
     /**

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -14,6 +14,7 @@ import {
     SymbolTable,
     ScopeChainEntry,
     ResolvedScope,
+    ResolveOptions,
     ScopeResolverConfig,
     OutOfScopeSymbol,
     ScopeCacheEntry,
@@ -934,7 +935,8 @@ export class ScopeResolver {
         file_uri: string,
         file_content: string,
         config: Partial<ScopeResolverConfig> = {},
-        token?: CancellationToken
+        token?: CancellationToken,
+        options?: ResolveOptions
     ): Promise<ResolvedScope> {
         const my_config = { ...DEFAULT_CONFIG, ...config };
         const cache_key = this.generate_cache_key(file_uri, file_content, my_config);
@@ -1004,23 +1006,14 @@ export class ScopeResolver {
             the_diagnostics
         );
 
-        // Register backward directive dependencies for this file
-        // Clear old dependencies first, then register new ones.
-        // Use real-cased URIs (M3): case-only directive targets register
-        // under the on-disk URI so edits to the real file invalidate the
-        // right scope-cache entries.
-        this.clear_backward_directive_dependencies(file_uri);
-        for (const my_directive of normalized_directives) {
-            const my_real = this.compute_directive_real_path(
-                my_directive, file_uri,
+        // Register backward directive dependencies for this file, unless the
+        // caller owns registration (DocumentStore's working-directory probe
+        // passes register_dependencies: false and applies the effective
+        // registration itself at commit time, issue #184).
+        if (options?.register_dependencies ?? true) {
+            this.apply_normalized_backward_directives(
+                file_uri, normalized_directives
             );
-            // Ambiguous outcome → two or more case-insensitive matches on
-            // disk; no concrete parent can be chosen, so skip registration.
-            if (my_real.outcome_kind === 'ambiguous') {
-                continue;
-            }
-            const my_parent_uri = URI.file(my_real.real_path).toString();
-            this.register_backward_directive_dependency(file_uri, my_parent_uri);
         }
 
         // Follow directive chain and get inherited working directory
@@ -2418,7 +2411,14 @@ export class ScopeResolver {
 
             // Register backward directive dependencies from cached file
             // This ensures transitive dependents are discoverable even when
-            // intermediate files are only read from disk (not opened in editor)
+            // intermediate files are only read from disk (not opened in editor).
+            // Intentionally the RAW variant (no auto-synthesis), unlike the
+            // commit-time effective registration in DocumentStore (issue #184):
+            // computing effective directives here would need the resolution's
+            // backward_dependencies mode threaded through get_parsed_file.
+            // Known consequence: for a file with auto-discovered parents that
+            // is also read as an ancestor, this clear-then-register drops its
+            // auto edges until its next commit — pre-existing behavior.
             this.sync_backward_directive_dependencies(actual_uri, parse_result.directives);
 
             // Register forward call relationships from cached file
@@ -3314,15 +3314,90 @@ export class ScopeResolver {
     sync_backward_directive_dependencies(child_uri: string, directives: Directive[]): void {
         // Normalize directives to match resolve() behavior (handles done-by + included-by collisions)
         const normalized = this.normalize_directives(directives, []);
+        this.apply_normalized_backward_directives(child_uri, normalized);
+    }
+
+    /**
+     * Effective-directive variant of sync_backward_directive_dependencies:
+     * consults get_effective_backward_directives (auto-synthesizes parents
+     * from the DependencyGraph when the file has no explicit directives and
+     * backward_dependencies is 'auto'). Canonical entry point for
+     * DocumentStore's commit-time cross-file side-effect application
+     * (issue #184) — registers without requiring a full resolve() call, and
+     * reads live DependencyGraph state at call time.
+     */
+    apply_backward_directive_registration(
+        child_uri: string,
+        raw_directives: Directive[],
+        config: Partial<ScopeResolverConfig> = {}
+    ): void {
+        const my_config = { ...DEFAULT_CONFIG, ...config };
+        const { directives: effective_directives } =
+            this.get_effective_backward_directives(
+                child_uri, raw_directives, my_config
+            );
+        const normalized = this.normalize_directives(effective_directives, []);
+        this.apply_normalized_backward_directives(child_uri, normalized);
+    }
+
+    /**
+     * Re-sync a file's backward-directive edges from its ON-DISK content
+     * (issue #184). Used by the server's close handler: a reparse racing a
+     * close is discarded by commit_state, so when a user saves a header
+     * change and closes immediately, nothing else re-syncs this file's
+     * child→parent edges until its next parse. Best-effort: read/parse
+     * failures keep the existing edges (can't know disk state, and wiping
+     * would reintroduce the #278 flicker); a missing file clears them.
+     *
+     * @param should_apply - checked after the disk read, immediately before
+     *   the synchronous registration; return false to skip (e.g. the
+     *   document was reopened while the read was in flight, so the
+     *   buffer-based commit-time registration must win).
+     */
+    async resync_backward_directive_dependencies_from_disk(
+        child_uri: string,
+        config: Partial<ScopeResolverConfig> = {},
+        should_apply?: () => boolean
+    ): Promise<void> {
+        let raw_directives: Directive[] = [];
+        try {
+            const file_exists = await this.content_provider.exists(child_uri);
+            if (file_exists) {
+                const disk_content =
+                    await this.content_provider.read_file(child_uri);
+                raw_directives = this.directive_parser.parse(
+                    disk_content, child_uri
+                ).directives;
+            }
+        } catch {
+            return;
+        }
+        if (should_apply && !should_apply()) {
+            return;
+        }
+        this.apply_backward_directive_registration(
+            child_uri, raw_directives, config
+        );
+    }
+
+    /**
+     * The single mutation point for per-child entries of
+     * backward_directive_children: clear the child's existing edges, then
+     * register one edge per normalized directive. Uses real-cased URIs (M3)
+     * so edits to the real file invalidate the right scope-cache entries
+     * even when the directive uses a different casing.
+     */
+    private apply_normalized_backward_directives(
+        child_uri: string,
+        normalized_directives: Directive[]
+    ): void {
         this.clear_backward_directive_dependencies(child_uri);
-        for (const my_directive of normalized) {
-            // Use real-cased URI (M3) so edits to the real file invalidate
-            // the right scope-cache entries even when the directive uses
-            // a different casing.
+        for (const my_directive of normalized_directives) {
             const my_real = this.compute_directive_real_path(
                 my_directive, child_uri,
             );
-            // Ambiguous outcome → no concrete parent to register.
+            // Ambiguous outcome → two or more case-insensitive matches on
+            // disk; no concrete parent can be chosen, so skip registration.
             if (my_real.outcome_kind === 'ambiguous') {
                 continue;
             }

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -182,16 +182,15 @@ export class ScopeResolver {
     private parser: StataParser;
     private analyzer: SemanticAnalyzer;
     // Cache key is "uri|working_directory" (or just "uri" if no working directory)
-    // registered_backward_mode / registered_graph_version: the
-    // backward_dependencies mode the entry's last parse-path registration
-    // ran under, and the DependencyGraph version it read (issue #286).
-    // Undefined for entries written by parse_file (root-file parses,
-    // which register via resolve()/commit instead). Lets cache HITS
-    // upgrade an 'explicit'-registered entry to effective registration
-    // when first read by an 'auto'-mode resolution, and re-sync an
-    // 'auto'-registered directive-less entry when the graph has changed
-    // since — see upgrade_registration_on_cache_hit.
-    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit'; registered_graph_version?: number }>;
+    // registered_backward_mode: the backward_dependencies mode the entry's
+    // last parse-path registration ran under (issue #286). Undefined for
+    // entries written by parse_file (root-file parses, which register via
+    // resolve()/commit instead). Lets cache HITS upgrade an
+    // 'explicit'-registered entry to effective registration when first read
+    // by an 'auto'-mode resolution. Directive-less auto-mode hits re-sync
+    // idempotently because registration is global per URI, not per
+    // file_cache entry — see upgrade_registration_on_cache_hit.
+    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit' }>;
     private scope_cache: Map<string, ScopeCacheEntry>;
     // Secondary index: uri -> Set<cache_keys> for O(1) scope cache invalidation by URI
     private uri_to_cache_keys: Map<string, Set<string>>;
@@ -2472,13 +2471,10 @@ export class ScopeResolver {
                 working_directory_directive: parse_result.working_directory_directive,
                 diagnostics: parse_result.diagnostics,
                 // Stamp the mode the registration below runs under (and
-                // the graph version it reads), so later cache hits can
-                // upgrade an 'explicit'-registered entry or re-sync a
-                // graph-stale 'auto' one (issue #286).
+                // upgrade an 'explicit'-registered entry on later
+                // auto-mode cache hits (issue #286).
                 registered_backward_mode:
                     options?.backward_dependencies ?? 'explicit',
-                registered_graph_version:
-                    this.dependency_graph?.get_version(),
             });
 
             // Register backward directive dependencies from cached file
@@ -3430,38 +3426,36 @@ export class ScopeResolver {
      * hits never downgrade: for them hit paths stay side-effect-free,
      * as before.
      *
-     * The 'auto' stamp folds in the DependencyGraph version it was
-     * registered against: auto synthesis reads live graph state, so an
-     * entry stamped while the graph was partial (or before a parent
-     * added its do-call) must not latch — the next auto-mode hit after
-     * a graph change re-syncs. Entries whose cached content has explicit
-     * directives skip the version check entirely: for them effective
-     * registration is graph-independent (explicit directives win), so
-     * repeat hits stay free of registration work.
+     * Directive-less auto-mode hits always re-sync idempotently. The
+     * file_cache may hold multiple entries for the same URI (different
+     * inherited working directories), while backward registration is one
+     * global map per URI; another cache-key variant can replace that map
+     * without changing this entry's stamp or the DependencyGraph version.
+     *
+     * Entries whose cached content has explicit directives can still use
+     * the stamp: effective registration is graph-independent for them
+     * (explicit directives win), and another same-content cache variant
+     * registers the same raw directives.
      */
     private upgrade_registration_on_cache_hit(
         uri: string,
         cached: {
             directives: Directive[];
             registered_backward_mode?: 'auto' | 'explicit';
-            registered_graph_version?: number;
         },
         requested_mode: 'auto' | 'explicit' | undefined
     ): void {
         if (requested_mode !== 'auto') {
             return;
         }
-        const current_graph_version = this.dependency_graph?.get_version();
-        if (cached.registered_backward_mode === 'auto' &&
-            (cached.directives.length > 0 ||
-             cached.registered_graph_version === current_graph_version)) {
+        if (cached.directives.length > 0 &&
+            cached.registered_backward_mode === 'auto') {
             return;
         }
         this.apply_backward_directive_registration(uri, cached.directives, {
             backward_dependencies: 'auto',
         });
         cached.registered_backward_mode = 'auto';
-        cached.registered_graph_version = current_graph_version;
     }
 
     /**

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -182,7 +182,14 @@ export class ScopeResolver {
     private parser: StataParser;
     private analyzer: SemanticAnalyzer;
     // Cache key is "uri|working_directory" (or just "uri" if no working directory)
-    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] }>;
+    // registered_backward_mode: the backward_dependencies mode the entry's
+    // last parse-path registration ran under (issue #286). Undefined for
+    // entries written by parse_file (root-file parses, which register via
+    // resolve()/commit instead). Lets cache HITS upgrade an
+    // 'explicit'-registered entry to effective registration when first
+    // read by an 'auto'-mode resolution — see
+    // upgrade_registration_on_cache_hit.
+    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit' }>;
     private scope_cache: Map<string, ScopeCacheEntry>;
     // Secondary index: uri -> Set<cache_keys> for O(1) scope cache invalidation by URI
     private uri_to_cache_keys: Map<string, Set<string>>;
@@ -2288,6 +2295,9 @@ export class ScopeResolver {
         if (options?.skip_disk_if_cached && cached) {
             this.log(`[get_parsed_file] file_cache HIT for ${cache_key} (skip_disk_if_cached)`);
             this.cache_metrics.file.hits++;
+            this.upgrade_registration_on_cache_hit(
+                uri, cached, options?.backward_dependencies
+            );
             return {
                 content: cached.content,
                 content_hash: cached.content_hash,
@@ -2315,6 +2325,9 @@ export class ScopeResolver {
                 cached.size !== undefined && cached.size === size) {
                 this.cache_metrics.file.hits++;
                 this.log(`[get_parsed_file] File cache HIT for ${uri} (mtime match, skipped read)`);
+                this.upgrade_registration_on_cache_hit(
+                    uri, cached, options?.backward_dependencies
+                );
                 return {
                     content: cached.content,
                     content_hash: cached.content_hash,
@@ -2354,6 +2367,11 @@ export class ScopeResolver {
                             fallback_cached.size !== undefined && fallback_cached.size === fallback_size) {
                             this.cache_metrics.file.hits++;
                             this.log(`[get_parsed_file] File cache HIT for ${fallback_uri} (mtime match, skipped read)`);
+                            this.upgrade_registration_on_cache_hit(
+                                fallback_uri,
+                                fallback_cached,
+                                options?.backward_dependencies
+                            );
                             return {
                                 content: fallback_cached.content,
                                 content_hash: fallback_cached.content_hash,
@@ -2400,6 +2418,9 @@ export class ScopeResolver {
         if (actual_cached && actual_cached.content_hash === disk_hash) {
             this.cache_metrics.file.hits++;
             this.log(`[get_parsed_file] File cache HIT for ${actual_uri} (hash match)`);
+            this.upgrade_registration_on_cache_hit(
+                actual_uri, actual_cached, options?.backward_dependencies
+            );
             // Return cached results with current content - don't mutate cache entry
             return {
                 content,
@@ -2446,6 +2467,11 @@ export class ScopeResolver {
                 working_directory: parse_result.working_directory,
                 working_directory_directive: parse_result.working_directory_directive,
                 diagnostics: parse_result.diagnostics,
+                // Stamp the mode the registration below runs under, so
+                // later cache hits can upgrade an 'explicit'-registered
+                // entry (issue #286).
+                registered_backward_mode:
+                    options?.backward_dependencies ?? 'explicit',
             });
 
             // Register backward directive dependencies from cached file
@@ -3382,6 +3408,39 @@ export class ScopeResolver {
             );
         const normalized = this.normalize_directives(effective_directives, []);
         this.apply_normalized_backward_directives(child_uri, normalized);
+    }
+
+    /**
+     * Registration upgrade on file-cache hit (issue #286). Hit paths do
+     * not re-parse, so an entry whose last parse-path registration ran
+     * under 'explicit' — e.g. primed by the indexer's forced-'explicit'
+     * working-directory walk — would leave a directive-less file's
+     * dependency-graph parents unregistered for as long as 'auto'-mode
+     * resolutions keep hitting the cache (until the content changes).
+     * When an 'auto'-mode read hits such an entry, apply effective
+     * registration once and stamp the entry so repeat hits are free.
+     * Effective ⊇ raw, so upgrading can only add edges. Explicit-mode
+     * hits never downgrade: for them hit paths stay side-effect-free,
+     * as before.
+     */
+    private upgrade_registration_on_cache_hit(
+        uri: string,
+        cached: {
+            directives: Directive[];
+            registered_backward_mode?: 'auto' | 'explicit';
+        },
+        requested_mode: 'auto' | 'explicit' | undefined
+    ): void {
+        if (requested_mode !== 'auto') {
+            return;
+        }
+        if (cached.registered_backward_mode === 'auto') {
+            return;
+        }
+        this.apply_backward_directive_registration(uri, cached.directives, {
+            backward_dependencies: 'auto',
+        });
+        cached.registered_backward_mode = 'auto';
     }
 
     /**

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -160,6 +160,8 @@ interface ForwardScopeResolverInterface {
         token?: import('vscode-languageserver').CancellationToken,
         config?: {
             max_forward_depth?: number;
+            /** See ForwardScopeConfig.backward_dependencies (issue #286). */
+            backward_dependencies?: 'auto' | 'explicit';
             diagnostics?: {
                 max_depth?: 'error' | 'warning' | 'information' | 'off';
             };
@@ -1104,6 +1106,12 @@ export class ScopeResolver {
                 token,
                 {
                     max_forward_depth: my_config.max_forward_depth,
+                    // Thread the resolution's backward mode so callee reads
+                    // register ancestor edges under the same semantics
+                    // (issue #286); ?? 'auto' mirrors
+                    // get_effective_backward_directives.
+                    backward_dependencies:
+                        my_config.backward_dependencies ?? 'auto',
                     diagnostics: {
                         max_depth: my_config.diagnostics?.max_depth,
                     },
@@ -1355,6 +1363,10 @@ export class ScopeResolver {
             token,
             {
                 max_forward_depth: remaining_depth,
+                // Thread the resolution's backward mode for ancestor-edge
+                // registration during callee reads (issue #286).
+                backward_dependencies:
+                    config.backward_dependencies ?? 'auto',
                 // Thread the depth-diagnostic severity/off setting so a
                 // parent's forward truncations honor `max_depth` too (#209).
                 diagnostics: { max_depth: config.diagnostics?.max_depth },
@@ -1495,7 +1507,15 @@ export class ScopeResolver {
                 my_parent_result = await this.get_parsed_file(
                     my_parent_uri,
                     my_real_path,
-                    { request_cache }
+                    {
+                        request_cache,
+                        // Thread the walk's mode so the ancestor-level
+                        // registration inside get_parsed_file matches the
+                        // resolution semantics (issue #286). ?? 'auto'
+                        // mirrors get_effective_backward_directives.
+                        backward_dependencies:
+                            config.backward_dependencies ?? 'auto',
+                    }
                 );
             } catch (error) {
                 my_parent_result = { error: String(error) };
@@ -1696,7 +1716,15 @@ export class ScopeResolver {
             const my_parent_result = await this.get_parsed_file(
                 my_parent_uri,
                 my_real_fs_path,
-                { working_directory: discovered_wd, request_cache }  // Pass discovered working directory
+                {
+                    working_directory: discovered_wd,  // Pass discovered working directory
+                    request_cache,
+                    // Thread the chain's mode for the ancestor-level
+                    // registration (issue #286); ?? 'auto' mirrors
+                    // get_effective_backward_directives.
+                    backward_dependencies:
+                        config.backward_dependencies ?? 'auto',
+                }
             );
 
             // Check for cancellation after file read
@@ -2207,11 +2235,22 @@ export class ScopeResolver {
      * @param options - Optional settings
      * @param options.skip_disk_if_cached - If true, return cached entry without disk read (cache-first mode)
      * @param options.working_directory - Inherited working directory for path resolution in nested files
+     * @param options.backward_dependencies - The resolution's effective
+     *   backward-dependencies mode (issue #286). Governs ONLY the
+     *   registration side effect on the parse path: 'auto' uses the
+     *   effective variant (auto-synthesizes DependencyGraph parents when
+     *   the file has no explicit directives), 'explicit' registers raw
+     *   directives only. Defaults to 'explicit' (the raw pre-#286
+     *   behavior) so untracked callers can never synthesize edges from a
+     *   mode they did not opt into. Callers inside a resolution must
+     *   thread the chain's mode (normalized with ?? 'auto', matching
+     *   get_effective_backward_directives). Deliberately NOT part of any
+     *   cache key: parsed content is mode-independent.
      */
     async get_parsed_file(
         uri: string,
         fs_path: string,
-        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache }
+        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache; backward_dependencies?: 'auto' | 'explicit' }
     ): Promise<ParsedFileResult> {
         // Use request cache if available to avoid duplicate reads/parses in same request
         if (options?.request_cache) {
@@ -2237,7 +2276,7 @@ export class ScopeResolver {
     private async _get_parsed_file_impl(
         uri: string,
         fs_path: string,
-        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache }
+        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache; backward_dependencies?: 'auto' | 'explicit' }
     ): Promise<ParsedFileResult> {
         const inherited_wd = options?.working_directory;
         const cache_key = this.make_file_cache_key(uri, inherited_wd);
@@ -2412,14 +2451,19 @@ export class ScopeResolver {
             // Register backward directive dependencies from cached file
             // This ensures transitive dependents are discoverable even when
             // intermediate files are only read from disk (not opened in editor).
-            // Intentionally the RAW variant (no auto-synthesis), unlike the
-            // commit-time effective registration in DocumentStore (issue #184):
-            // computing effective directives here would need the resolution's
-            // backward_dependencies mode threaded through get_parsed_file.
-            // Known consequence: for a file with auto-discovered parents that
-            // is also read as an ancestor, this clear-then-register drops its
-            // auto edges until its next commit — pre-existing behavior.
-            this.sync_backward_directive_dependencies(actual_uri, parse_result.directives);
+            // Uses the EFFECTIVE variant under the resolution's threaded
+            // backward_dependencies mode (issue #286): in 'auto' mode a file
+            // with no explicit directives keeps (or gains) its DependencyGraph
+            // parents instead of having them wiped by this clear-then-register,
+            // matching the commit-time effective registration in DocumentStore
+            // (issue #184). An unthreaded call defaults to 'explicit', which
+            // registers raw directives only — identical to the pre-#286 raw
+            // sync, so this can only ADD edges relative to that behavior.
+            this.apply_backward_directive_registration(
+                actual_uri,
+                parse_result.directives,
+                { backward_dependencies: options?.backward_dependencies ?? 'explicit' }
+            );
 
             // Register forward call relationships from cached file
             // This ensures callee_to_callers map includes relationships from cached files,

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -2423,7 +2423,9 @@ export class ScopeResolver {
             this.upgrade_registration_on_cache_hit(
                 actual_uri, actual_cached, options?.backward_dependencies
             );
-            // Return cached results with current content - don't mutate cache entry
+            // Return cached results with current content - don't mutate the
+            // entry's cached content/symbols (the registration stamp above
+            // is the one intentional entry mutation on this hit path)
             return {
                 content,
                 content_hash: disk_hash,

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -3353,12 +3353,15 @@ export class ScopeResolver {
      *   the synchronous registration; return false to skip (e.g. the
      *   document was reopened while the read was in flight, so the
      *   buffer-based commit-time registration must win).
+     * @returns true when registration was applied, false when skipped
+     *   (read error or should_apply veto) — callers use this to decide
+     *   whether dependents need revalidation.
      */
     async resync_backward_directive_dependencies_from_disk(
         child_uri: string,
         config: Partial<ScopeResolverConfig> = {},
         should_apply?: () => boolean
-    ): Promise<void> {
+    ): Promise<boolean> {
         let raw_directives: Directive[] = [];
         try {
             const file_exists = await this.content_provider.exists(child_uri);
@@ -3370,14 +3373,15 @@ export class ScopeResolver {
                 ).directives;
             }
         } catch {
-            return;
+            return false;
         }
         if (should_apply && !should_apply()) {
-            return;
+            return false;
         }
         this.apply_backward_directive_registration(
             child_uri, raw_directives, config
         );
+        return true;
     }
 
     /**

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1524,12 +1524,22 @@ export async function create_server(options: ServerOptions): Promise<void> {
             // converges to disk.
             void (async () => {
                 let my_settings = global_settings;
-                if (closed_document_settings) {
-                    try {
-                        my_settings = await closed_document_settings;
-                    } catch {
-                        // Fall back to global settings on a rejected fetch.
-                    }
+                try {
+                    // In configuration-capable clients global_settings does
+                    // not track scoped client config, and the cache can miss
+                    // (closed before the debounced validation ever fetched
+                    // settings, or cleared by a config refresh) — so fetch
+                    // scoped settings fresh when there is no captured entry.
+                    my_settings = await (closed_document_settings ??
+                        get_document_settings(e.document.uri));
+                } catch {
+                    // Fall back to global settings on a rejected fetch.
+                }
+                // get_document_settings caches its result; don't let
+                // entries for closed documents accumulate.
+                if (closed_document_settings === undefined &&
+                    documents.get(e.document.uri) === undefined) {
+                    document_settings.delete(e.document.uri);
                 }
                 await scope_resolver.resync_backward_directive_dependencies_from_disk(
                     e.document.uri,
@@ -1545,7 +1555,10 @@ export async function create_server(options: ServerOptions): Promise<void> {
                         }
                     }
                 );
-            })();
+            })().catch(() => {
+                // Fire-and-forget: a failed re-sync must never surface as
+                // an unhandled rejection; edges converge on the next parse.
+            });
         }
         // On close, the buffer's in-memory edges/symbols are discarded, so
         // callees that inherited from this file must re-resolve against its

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -193,9 +193,16 @@ export function resolve_scoped_client_settings(
 // re-scanning. `max_backward_depth` is included because the indexer's
 // inherited-WD walk (#218) uses it to key closed-file callee edges, so
 // a depth change must re-index for those edges to stay consistent with
-// the open-document path. (`backward_dependencies` is NOT needed: the
-// indexer walk forces explicit backward resolution, so it is
-// independent of the auto/explicit mode.)
+// the open-document path. (`backward_dependencies` is NOT included even
+// though, since #286, the mode steers the parse-path registration side
+// effect in get_parsed_file: a re-scan would not re-run that
+// registration anyway (the file cache is content-keyed and unaffected
+// by settings), so including it buys a costly teardown without the
+// convergence it implies. A mid-session flip instead self-heals per
+// file: explicit→auto is healed by the cache-hit registration upgrade
+// (see upgrade_registration_on_cache_hit) and each file's next
+// parse/commit; auto→explicit leaves vestigial auto edges until the
+// next parse — benign over-revalidation, never a false suppression.)
 //
 // This signature is compared on BOTH config-change paths against a
 // single shared `last_applied_indexing_signature`: the `sight.toml`

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1479,6 +1479,10 @@ export async function create_server(options: ServerOptions): Promise<void> {
 
     // Document close handler
     documents.onDidClose((e) => {
+        // Captured before the delete below so the disk re-sync can use the
+        // URI-scoped config (a scoped backwardDependencies override must not
+        // be re-synced under the global mode).
+        const closed_document_settings = document_settings.get(e.document.uri);
         document_settings.delete(e.document.uri);
         document_store.close(e.document.uri);
         debounce_manager.on_close(e.document.uri);
@@ -1508,22 +1512,40 @@ export async function create_server(options: ServerOptions): Promise<void> {
             // (issue #184): a reparse racing this close is discarded by
             // commit_state, so a header change saved just before closing
             // would otherwise leave pre-save edges until the file's next
-            // parse. Guarded so a quick close→reopen's buffer-based
-            // commit-time registration is never clobbered by this slower
-            // disk read. Uses global_settings (not per-document settings):
-            // document_settings for this URI was deleted above, and only
-            // the backward_dependencies mode affects this path.
-            void scope_resolver.resync_backward_directive_dependencies_from_disk(
-                e.document.uri,
-                scope_resolver_config_for(global_settings),
-                () => {
+            // parse. Guarded so a quick close→reopen's registration is
+            // owned by the reopened buffer's commit, never this slower
+            // disk read: the guard checks BOTH TextDocuments (repopulated
+            // synchronously on reopen, before the debounced open() commits
+            // — and the content provider prefers open buffers, so a
+            // mid-read reopen could otherwise apply uncommitted buffer
+            // content) and the document store. A reopen-then-reclose while
+            // the read is in flight can still apply transient buffer
+            // content, but the re-close fires its own re-sync, which
+            // converges to disk.
+            void (async () => {
+                let my_settings = global_settings;
+                if (closed_document_settings) {
                     try {
-                        return document_store.get(e.document.uri) === undefined;
+                        my_settings = await closed_document_settings;
                     } catch {
-                        return false; // store disposed — do not mutate
+                        // Fall back to global settings on a rejected fetch.
                     }
                 }
-            );
+                await scope_resolver.resync_backward_directive_dependencies_from_disk(
+                    e.document.uri,
+                    scope_resolver_config_for(my_settings),
+                    () => {
+                        if (documents.get(e.document.uri) !== undefined) {
+                            return false; // reopened — buffer commit owns it
+                        }
+                        try {
+                            return document_store.get(e.document.uri) === undefined;
+                        } catch {
+                            return false; // store disposed — do not mutate
+                        }
+                    }
+                );
+            })();
         }
         // On close, the buffer's in-memory edges/symbols are discarded, so
         // callees that inherited from this file must re-resolve against its

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1213,10 +1213,14 @@ export async function create_server(options: ServerOptions): Promise<void> {
     // Wire initialized handler
     connection.onInitialized(
         create_initialized_handler(() => {
-            // Initialize Logger - route to stderr for stdio transport, suppress if quiet
+            // Initialize Logger - route to stderr for stdio transport,
+            // suppress if quiet. With an injected connection the stdio
+            // transport flag says nothing about the host's real stdio, so
+            // never write to process.stderr in that case — route through
+            // the injected connection's console instead.
             const log_fn = quiet
                 ? () => { } // Suppress all startup messages
-                : transport === 'stdio'
+                : transport === 'stdio' && options.connection === undefined
                     ? (msg: string) => process.stderr.write(msg + '\n')
                     : log_channel || ((msg: string) => connection.console.log(msg));
 

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1504,6 +1504,24 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 preserve_forward_call_relationships: true,
                 preserve_backward_directive_dependencies: true,
             });
+            // Converge the preserved backward-directive map to DISK state
+            // (issue #184): a reparse racing this close is discarded by
+            // commit_state, so a header change saved just before closing
+            // would otherwise leave pre-save edges until the file's next
+            // parse. Guarded so a quick close→reopen's buffer-based
+            // commit-time registration is never clobbered by this slower
+            // disk read.
+            void scope_resolver.resync_backward_directive_dependencies_from_disk(
+                e.document.uri,
+                scope_resolver_config_for(global_settings),
+                () => {
+                    try {
+                        return document_store.get(e.document.uri) === undefined;
+                    } catch {
+                        return false; // store disposed — do not mutate
+                    }
+                }
+            );
         }
         // On close, the buffer's in-memory edges/symbols are discarded, so
         // callees that inherited from this file must re-resolve against its

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -90,6 +90,15 @@ export interface ServerOptions {
     transport: TransportType;
     quiet?: boolean;
     log_channel?: (msg: string) => void;
+    /**
+     * Test-only injection seam: when provided, this connection is used
+     * instead of creating a transport connection, so handler-level
+     * integration tests can capture the real registered LSP handlers
+     * (e.g. the onDidClose disk re-sync wiring, issue #287) and drive
+     * them without a live client process. Production entry points
+     * (cli.ts, server.ts) never set this.
+     */
+    connection?: Connection;
 }
 
 /**
@@ -229,8 +238,9 @@ export function indexing_affecting_signature(
 export async function create_server(options: ServerOptions): Promise<void> {
     const { transport, quiet, log_channel } = options;
 
-    // Create connection based on transport type
-    const connection = create_transport_connection(transport);
+    // Create connection based on transport type (tests may inject one)
+    const connection =
+        options.connection ?? create_transport_connection(transport);
 
     // Create a simple text document manager
     const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1510,7 +1510,9 @@ export async function create_server(options: ServerOptions): Promise<void> {
             // would otherwise leave pre-save edges until the file's next
             // parse. Guarded so a quick close→reopen's buffer-based
             // commit-time registration is never clobbered by this slower
-            // disk read.
+            // disk read. Uses global_settings (not per-document settings):
+            // document_settings for this URI was deleted above, and only
+            // the backward_dependencies mode affects this path.
             void scope_resolver.resync_backward_directive_dependencies_from_disk(
                 e.document.uri,
                 scope_resolver_config_for(global_settings),

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1541,20 +1541,41 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     documents.get(e.document.uri) === undefined) {
                     document_settings.delete(e.document.uri);
                 }
-                await scope_resolver.resync_backward_directive_dependencies_from_disk(
-                    e.document.uri,
-                    scope_resolver_config_for(my_settings),
-                    () => {
-                        if (documents.get(e.document.uri) !== undefined) {
-                            return false; // reopened — buffer commit owns it
+                const my_applied = await scope_resolver
+                    .resync_backward_directive_dependencies_from_disk(
+                        e.document.uri,
+                        scope_resolver_config_for(my_settings),
+                        () => {
+                            if (documents.get(e.document.uri) !== undefined) {
+                                // Reopened — buffer commit owns registration.
+                                return false;
+                            }
+                            try {
+                                return document_store.get(e.document.uri) ===
+                                    undefined;
+                            } catch {
+                                return false; // store disposed — do not mutate
+                            }
                         }
-                        try {
-                            return document_store.get(e.document.uri) === undefined;
-                        } catch {
-                            return false; // store disposed — do not mutate
-                        }
+                    );
+                // A close-cancelled validation never fans out an interface
+                // change, and the watched-files path only revalidates
+                // forward callers — so open files inheriting THROUGH the
+                // closed file would keep stale diagnostics until another
+                // trigger. Revalidate them when the re-sync applied.
+                if (my_applied) {
+                    const my_backward_children = scope_resolver
+                        .get_transitive_backward_directive_children(
+                            e.document.uri
+                        );
+                    if (my_backward_children.size > 0) {
+                        schedule_caller_revalidation(
+                            my_backward_children,
+                            e.document.uri,
+                            my_settings
+                        );
                     }
-                );
+                }
             })().catch(() => {
                 // Fire-and-forget: a failed re-sync must never surface as
                 // an unhandled rejection; edges converge on the next parse.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -795,6 +795,43 @@ export interface ScopeResolverConfig {
   };
 }
 
+/**
+ * Options controlling ScopeResolver.resolve()'s side effects, distinct from
+ * ScopeResolverConfig (which controls resolution behavior/limits). Intended
+ * to grow additional fields (e.g. issue #208 standalone-mode inputs).
+ */
+export interface ResolveOptions {
+  /**
+   * When false, skip registering file_uri's OWN backward-directive
+   * dependency edges as a side effect of this call. Ancestor-level
+   * registration performed inside get_parsed_file is unaffected.
+   *
+   * Passing false transfers registration ownership to the caller. The only
+   * intended such caller is DocumentStore's working-directory probe
+   * (issue #184): every accepted parse applies effective registration
+   * synchronously in commit_state, so a probe-populated scope-cache entry
+   * always corresponds to content that either committed (registration
+   * applied) or was discarded on close (not registering is the intent).
+   * Deliberately NOT part of generate_cache_key.
+   *
+   * Default: true.
+   */
+  register_dependencies?: boolean;
+}
+
+/**
+ * Cross-file side effects discovered while parsing a document, staged for
+ * application only after DocumentStore.commit_state's guards accept the
+ * parse (issue #184). Both fields are pure functions of the parsed content
+ * snapshot; effective-directive computation (raw + auto-synthesized parents)
+ * is deliberately deferred to apply time so it reads live DependencyGraph
+ * state rather than a snapshot from when parsing started.
+ */
+export interface StagedCrossFileEffects {
+  raw_backward_directives: Directive[];
+  scope_resolver_config: Partial<ScopeResolverConfig>;
+}
+
 export interface ScopeCacheEntry {
   resolved_scope: ResolvedScope;
   content_hash: string;

--- a/tests/integration/send-to-stata-integrated-terminal.test.ts
+++ b/tests/integration/send-to-stata-integrated-terminal.test.ts
@@ -9,6 +9,7 @@ import {
 } from 'bun:test';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
+import { wait_until } from '../wait-until';
 
 const SEND_TO_STATA_DIR = path.resolve(
     import.meta.dir,
@@ -123,19 +124,13 @@ function create_vscode_mock_state(
     };
 }
 
-async function wait_for_condition(
+// Shared polling helper (tests/wait-until.ts); these call sites keep the
+// pre-extraction timing: a tight 200ms budget with 0ms yields.
+function wait_for_condition(
     predicate: () => boolean,
-    timeout_ms = 200
+    description: string
 ): Promise<void> {
-    const start_time_ms = Date.now();
-    while (!predicate()) {
-        if (Date.now() - start_time_ms > timeout_ms) {
-            throw new Error('Timed out waiting for test condition.');
-        }
-        await new Promise(resolve => {
-            setTimeout(resolve, 0);
-        });
-    }
+    return wait_until(predicate, description, 200, 0);
 }
 
 async function import_terminal_manager_module(
@@ -307,7 +302,7 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
 
         await wait_for_condition(() => {
             return vscode_state.create_terminal_calls === 1;
-        });
+        }, 'the send to create the Stata terminal');
 
         expect(vscode_state.create_terminal_calls).toBe(1);
         expect(vscode_state.the_show_calls).toEqual([true]);
@@ -382,7 +377,7 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
 
         await wait_for_condition(() => {
             return vscode_state.create_terminal_calls === 1;
-        });
+        }, 'the send to create the Stata terminal');
 
         expect(vscode_state.create_terminal_calls).toBe(1);
         expect(vscode_state.the_send_calls).toEqual([]);
@@ -418,7 +413,7 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
 
         await wait_for_condition(() => {
             return vscode_state.create_terminal_calls === 1;
-        });
+        }, 'the send to create the Stata terminal');
 
         for (const my_listener of vscode_state.the_close_listeners) {
             my_listener(vscode_state.terminal);
@@ -454,7 +449,7 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
         );
         await wait_for_condition(() => {
             return vscode_state.the_show_calls.length === 1;
-        });
+        }, 'the profile terminal to be revealed');
 
         // Must NOT type into the still-starting Stata yet.
         expect(vscode_state.the_send_calls).toEqual([]);

--- a/tests/integration/server-close-resync-wiring.test.ts
+++ b/tests/integration/server-close-resync-wiring.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Handler-level integration test for the onDidClose disk re-sync wiring
+ * (issue #287, deferred from #184's review).
+ *
+ * All prior coverage of `resync_backward_directive_dependencies_from_disk`
+ * is at the ScopeResolver unit level; nothing drove the REAL
+ * `documents.onDidClose` handler registered in `create_server`
+ * (src/server-factory.ts), so a wiring mistake — wrong URI variable,
+ * wrong config source (global instead of the URI-scoped settings
+ * captured before the `document_settings` delete), a broken
+ * reopen-aware guard against TextDocuments, or a dropped dependent
+ * revalidation — would not be caught.
+ *
+ * This test starts the real server via `create_server` with an injected
+ * stub connection (the test-only `ServerOptions.connection` seam),
+ * drives the captured LSP notification handlers exactly as a client
+ * would (initialize / initialized / didOpen / didClose), and asserts
+ * on the live ScopeResolver instance:
+ *   1. closing a document whose buffer header disagrees with disk
+ *      converges the backward-directive edges to DISK state, and the
+ *      re-sync receives the closed document's URI and its URI-scoped
+ *      settings (a scoped `crossFile.backwardDependencies` override,
+ *      not the global default);
+ *   2. a quick close -> reopen makes the reopen guard veto the re-sync
+ *      (the reopened buffer's commit owns registration), leaving the
+ *      buffer-time edges intact;
+ *   3. when the re-sync applies, open files that depend on the closed
+ *      file via backward directives are revalidated (diagnostics are
+ *      republished for them).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import type {
+    Connection,
+    InitializeParams,
+    DidOpenTextDocumentParams,
+    DidCloseTextDocumentParams,
+    PublishDiagnosticsParams,
+} from 'vscode-languageserver/node';
+import { create_server } from '../../src/server-factory';
+import { ScopeResolver } from '../../src/scope-resolver';
+import type { ScopeResolverConfig } from '../../src/types';
+
+// ---------------------------------------------------------------------------
+// ScopeResolver instrumentation: the resolver is created inside
+// create_server's onInitialized closure, so capture the instance (and spy
+// on the close-time re-sync) via prototype wrapping, restored after each
+// test.
+// ---------------------------------------------------------------------------
+
+interface ResyncCall {
+    uri: string;
+    config: Partial<ScopeResolverConfig> | undefined;
+    result: Promise<boolean>;
+}
+
+let captured_resolver: ScopeResolver | undefined;
+let the_resync_calls: ResyncCall[] = [];
+let workspace_roots_seen: string[] = [];
+
+const original_set_dependency_graph =
+    ScopeResolver.prototype.set_dependency_graph;
+const original_set_workspace_roots =
+    ScopeResolver.prototype.set_workspace_roots;
+const original_resync =
+    ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk;
+
+function install_resolver_spies(): void {
+    captured_resolver = undefined;
+    the_resync_calls = [];
+    workspace_roots_seen = [];
+    ScopeResolver.prototype.set_dependency_graph = function (
+        ...args: Parameters<typeof original_set_dependency_graph>
+    ) {
+        captured_resolver = this;
+        return original_set_dependency_graph.apply(this, args);
+    };
+    ScopeResolver.prototype.set_workspace_roots = function (
+        ...args: Parameters<typeof original_set_workspace_roots>
+    ) {
+        workspace_roots_seen.push(...args[0]);
+        return original_set_workspace_roots.apply(this, args);
+    };
+    ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk =
+        function (...args: Parameters<typeof original_resync>) {
+            const result = original_resync.apply(this, args);
+            the_resync_calls.push({
+                uri: args[0],
+                config: args[1],
+                result,
+            });
+            return result;
+        };
+}
+
+function restore_resolver_spies(): void {
+    ScopeResolver.prototype.set_dependency_graph =
+        original_set_dependency_graph;
+    ScopeResolver.prototype.set_workspace_roots =
+        original_set_workspace_roots;
+    ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk =
+        original_resync;
+}
+
+// ---------------------------------------------------------------------------
+// Stub connection: captures the handlers create_server registers so the
+// test can invoke them directly, and records published diagnostics.
+// ---------------------------------------------------------------------------
+
+interface CapturedHandlers {
+    initialize?: (params: InitializeParams) => unknown;
+    initialized?: () => void;
+    did_open?: (params: DidOpenTextDocumentParams) => void;
+    did_close?: (params: DidCloseTextDocumentParams) => void;
+    shutdown?: () => unknown;
+}
+
+interface StubConnectionOptions {
+    workspace_folder_uri: string;
+    /** Returns the public `sight` config subtree for a scope URI. */
+    get_scoped_config: (scope_uri: string | undefined) => unknown;
+    published_uris: string[];
+}
+
+function noop_disposable(): { dispose: () => void } {
+    return { dispose: () => { } };
+}
+
+function make_stub_connection(options: StubConnectionOptions): {
+    connection: Connection;
+    handlers: CapturedHandlers;
+} {
+    const handlers: CapturedHandlers = {};
+    const capture_nothing = () => noop_disposable();
+    const connection_stub = {
+        console: {
+            log: () => { },
+            warn: () => { },
+            error: () => { },
+            info: () => { },
+        },
+        onInitialize: (handler: CapturedHandlers['initialize']) => {
+            handlers.initialize = handler;
+        },
+        onInitialized: (handler: CapturedHandlers['initialized']) => {
+            handlers.initialized = handler;
+        },
+        onDidChangeConfiguration: capture_nothing,
+        onDidChangeWatchedFiles: capture_nothing,
+        onCompletion: capture_nothing,
+        onCompletionResolve: capture_nothing,
+        onHover: capture_nothing,
+        onDefinition: capture_nothing,
+        onReferences: capture_nothing,
+        onDocumentSymbol: capture_nothing,
+        onWorkspaceSymbol: capture_nothing,
+        onDocumentFormatting: capture_nothing,
+        onDocumentRangeFormatting: capture_nothing,
+        onExecuteCommand: capture_nothing,
+        onShutdown: (handler: CapturedHandlers['shutdown']) => {
+            handlers.shutdown = handler;
+        },
+        onExit: capture_nothing,
+        onRequest: capture_nothing,
+        sendDiagnostics: (params: PublishDiagnosticsParams) => {
+            options.published_uris.push(params.uri);
+        },
+        // Surface used by TextDocuments.listen(connection):
+        onDidOpenTextDocument: (
+            handler: CapturedHandlers['did_open']
+        ) => {
+            handlers.did_open = handler;
+            return noop_disposable();
+        },
+        onDidChangeTextDocument: capture_nothing,
+        onDidCloseTextDocument: (
+            handler: CapturedHandlers['did_close']
+        ) => {
+            handlers.did_close = handler;
+            return noop_disposable();
+        },
+        onWillSaveTextDocument: capture_nothing,
+        onWillSaveTextDocumentWaitUntil: capture_nothing,
+        onDidSaveTextDocument: capture_nothing,
+        client: {
+            register: () => Promise.resolve(noop_disposable()),
+        },
+        workspace: {
+            getConfiguration: (item?: { scopeUri?: string }) =>
+                Promise.resolve(options.get_scoped_config(item?.scopeUri)),
+            getWorkspaceFolders: () => Promise.resolve([
+                { uri: options.workspace_folder_uri, name: 'test-ws' },
+            ]),
+            onDidChangeWorkspaceFolders: capture_nothing,
+        },
+        listen: () => { },
+    };
+    return {
+        connection: connection_stub as unknown as Connection,
+        handlers,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+async function wait_until(
+    predicate: () => boolean,
+    description: string,
+    timeout_ms = 5000,
+    interval_ms = 20
+): Promise<void> {
+    const deadline_ms = Date.now() + timeout_ms;
+    while (!predicate()) {
+        if (Date.now() > deadline_ms) {
+            throw new Error(`Timed out waiting for: ${description}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, interval_ms));
+    }
+}
+
+let tmp_dir: string;
+let published_uris: string[] = [];
+let active_handlers: CapturedHandlers | undefined;
+
+// Disable workspace indexing so no scan-time dependency-graph edges or
+// timers interfere; only explicit @lsp-done-by directives are in play.
+const GLOBAL_PUBLIC_CONFIG = { crossFile: { indexWorkspace: false } };
+
+async function start_test_server(
+    get_scoped_config: (scope_uri: string | undefined) => unknown
+): Promise<CapturedHandlers> {
+    const workspace_folder_uri = URI.file(tmp_dir).toString();
+    const { connection, handlers } = make_stub_connection({
+        workspace_folder_uri,
+        get_scoped_config,
+        published_uris,
+    });
+    await create_server({ transport: 'stdio', quiet: true, connection });
+    expect(handlers.initialize).toBeDefined();
+    expect(handlers.initialized).toBeDefined();
+    expect(handlers.did_open).toBeDefined();
+    expect(handlers.did_close).toBeDefined();
+    handlers.initialize!({
+        processId: null,
+        rootUri: workspace_folder_uri,
+        capabilities: { workspace: { configuration: true } },
+        workspaceFolders: null,
+    } as InitializeParams);
+    handlers.initialized!();
+    // onInitialized creates the providers synchronously, then finishes
+    // workspace setup asynchronously (getWorkspaceFolders -> settings ->
+    // configure). Wait for both before opening documents.
+    await wait_until(
+        () => captured_resolver !== undefined &&
+            workspace_roots_seen.includes(tmp_dir),
+        'server initialization to reach the workspace-roots refresh'
+    );
+    active_handlers = handlers;
+    return handlers;
+}
+
+function write_workspace_files(): void {
+    fs.writeFileSync(
+        path.join(tmp_dir, 'parent_disk.do'),
+        'display "parent disk"\n'
+    );
+    fs.writeFileSync(
+        path.join(tmp_dir, 'parent_buffer.do'),
+        'display "parent buffer"\n'
+    );
+    fs.writeFileSync(
+        path.join(tmp_dir, 'child.do'),
+        '// @lsp-done-by: "parent_disk.do"\ndisplay "child"\n'
+    );
+    fs.writeFileSync(
+        path.join(tmp_dir, 'grandchild.do'),
+        '// @lsp-done-by: "child.do"\ndisplay "grandchild"\n'
+    );
+}
+
+function file_uri(name: string): string {
+    return URI.file(path.join(tmp_dir, name)).toString();
+}
+
+function open_document(
+    handlers: CapturedHandlers,
+    uri: string,
+    text: string,
+    version = 1
+): void {
+    handlers.did_open!({
+        textDocument: { uri, languageId: 'stata', version, text },
+    });
+}
+
+const CHILD_BUFFER_TEXT =
+    '// @lsp-done-by: "parent_buffer.do"\ndisplay "child"\n';
+
+describe('server onDidClose disk re-sync wiring (#287)', () => {
+    beforeEach(() => {
+        install_resolver_spies();
+        published_uris = [];
+        active_handlers = undefined;
+        tmp_dir = fs.realpathSync(
+            fs.mkdtempSync(path.join(os.tmpdir(), 'close-resync-wiring-'))
+        );
+        write_workspace_files();
+    });
+
+    afterEach(async () => {
+        try {
+            await active_handlers?.shutdown?.();
+        } finally {
+            restore_resolver_spies();
+            fs.rmSync(tmp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('converges backward edges to disk on close, passing the closed ' +
+        "document's URI and its URI-scoped settings", async () => {
+        const child_uri = file_uri('child.do');
+        const parent_disk_uri = file_uri('parent_disk.do');
+        const parent_buffer_uri = file_uri('parent_buffer.do');
+        // The child's scope carries a backwardDependencies override that
+        // the global scope does not: the re-sync must run under the
+        // scoped mode, not the global default ('auto').
+        const handlers = await start_test_server((scope_uri) =>
+            scope_uri === child_uri
+                ? {
+                    crossFile: {
+                        indexWorkspace: false,
+                        backwardDependencies: 'explicit',
+                    },
+                }
+                : GLOBAL_PUBLIC_CONFIG
+        );
+
+        // Open the child with a buffer header that points at a DIFFERENT
+        // parent than the on-disk header.
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT);
+        await wait_until(
+            () => captured_resolver!
+                .get_backward_directive_children(parent_buffer_uri)
+                .has(child_uri),
+            'buffer-based registration of child under parent_buffer'
+        );
+
+        handlers.did_close!({ textDocument: { uri: child_uri } });
+
+        // The close-time re-sync reads DISK content and re-registers the
+        // on-disk parent, clearing the buffer-time edge.
+        await wait_until(
+            () => captured_resolver!
+                .get_backward_directive_children(parent_disk_uri)
+                .has(child_uri),
+            'disk re-sync to register child under parent_disk'
+        );
+        expect(
+            captured_resolver!
+                .get_backward_directive_children(parent_buffer_uri)
+                .has(child_uri)
+        ).toBe(false);
+
+        expect(the_resync_calls).toHaveLength(1);
+        expect(the_resync_calls[0].uri).toBe(child_uri);
+        // Wrong-config-source guard: global settings say 'auto'; only the
+        // child's URI-scoped settings say 'explicit'.
+        expect(the_resync_calls[0].config?.backward_dependencies)
+            .toBe('explicit');
+        expect(await the_resync_calls[0].result).toBe(true);
+    });
+
+    it('vetoes the re-sync when the document is reopened while the disk ' +
+        'read is in flight (reopen guard)', async () => {
+        const child_uri = file_uri('child.do');
+        const parent_disk_uri = file_uri('parent_disk.do');
+        const parent_buffer_uri = file_uri('parent_buffer.do');
+        const handlers = await start_test_server(
+            () => GLOBAL_PUBLIC_CONFIG
+        );
+
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT);
+        await wait_until(
+            () => captured_resolver!
+                .get_backward_directive_children(parent_buffer_uri)
+                .has(child_uri),
+            'buffer-based registration of child under parent_buffer'
+        );
+
+        // Close, then reopen synchronously — before the close handler's
+        // async settings fetch and disk read resume. TextDocuments is
+        // repopulated immediately, so the should_apply guard must veto
+        // the re-sync: the reopened buffer's commit owns registration.
+        handlers.did_close!({ textDocument: { uri: child_uri } });
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT, 2);
+
+        // The re-sync is invoked inside the close handler's async block
+        // (after the settings fetch), so wait for the spied call.
+        await wait_until(
+            () => the_resync_calls.length === 1,
+            'the close handler to invoke the disk re-sync'
+        );
+        expect(await the_resync_calls[0].result).toBe(false);
+
+        // Buffer-time edges survive; the disk parent was never applied.
+        expect(
+            captured_resolver!
+                .get_backward_directive_children(parent_buffer_uri)
+                .has(child_uri)
+        ).toBe(true);
+        expect(
+            captured_resolver!
+                .get_backward_directive_children(parent_disk_uri)
+                .has(child_uri)
+        ).toBe(false);
+    });
+
+    it('revalidates open backward-directive dependents after the re-sync ' +
+        'applies', async () => {
+        const child_uri = file_uri('child.do');
+        const grandchild_uri = file_uri('grandchild.do');
+        const parent_buffer_uri = file_uri('parent_buffer.do');
+        const handlers = await start_test_server(
+            () => GLOBAL_PUBLIC_CONFIG
+        );
+
+        // Open the grandchild (depends on child.do via @lsp-done-by) and
+        // the child (buffer header disagrees with disk so the close-time
+        // re-sync APPLIES a change).
+        open_document(
+            handlers,
+            grandchild_uri,
+            fs.readFileSync(
+                path.join(tmp_dir, 'grandchild.do'), 'utf8'
+            )
+        );
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT);
+        await wait_until(
+            () => captured_resolver!
+                .get_backward_directive_children(child_uri)
+                .has(grandchild_uri) &&
+                captured_resolver!
+                    .get_backward_directive_children(parent_buffer_uri)
+                    .has(child_uri),
+            'both open buffers to commit their backward registrations'
+        );
+
+        // Let in-flight validation publishes settle so any new grandchild
+        // publish below is attributable to the close-path revalidation.
+        let last_count = -1;
+        await wait_until(() => {
+            const current_count = published_uris.length;
+            const stable = current_count === last_count;
+            last_count = current_count;
+            return stable;
+        }, 'diagnostic publishes to go quiescent', 5000, 150);
+
+        const grandchild_publishes_before = published_uris
+            .filter((my_uri) => my_uri === grandchild_uri).length;
+
+        handlers.did_close!({ textDocument: { uri: child_uri } });
+
+        await wait_until(
+            () => the_resync_calls.length === 1,
+            'the close handler to invoke the disk re-sync'
+        );
+        expect(await the_resync_calls[0].result).toBe(true);
+
+        // The applied re-sync must fan out to open dependents THROUGH the
+        // closed file: grandchild gets revalidated and republished.
+        await wait_until(
+            () => published_uris
+                .filter((my_uri) => my_uri === grandchild_uri).length >
+                grandchild_publishes_before,
+            'grandchild diagnostics republish after close re-sync'
+        );
+    });
+});

--- a/tests/integration/server-close-resync-wiring.test.ts
+++ b/tests/integration/server-close-resync-wiring.test.ts
@@ -44,6 +44,7 @@ import type {
 import { create_server } from '../../src/server-factory';
 import { ScopeResolver } from '../../src/scope-resolver';
 import type { ScopeResolverConfig } from '../../src/types';
+import { wait_until } from '../wait-until';
 
 // ---------------------------------------------------------------------------
 // ScopeResolver instrumentation: the resolver is created inside
@@ -209,20 +210,12 @@ function make_stub_connection(options: StubConnectionOptions): {
 // Test harness
 // ---------------------------------------------------------------------------
 
-async function wait_until(
-    predicate: () => boolean,
-    description: string,
-    timeout_ms = 5000,
-    interval_ms = 20
-): Promise<void> {
-    const deadline_ms = Date.now() + timeout_ms;
-    while (!predicate()) {
-        if (Date.now() > deadline_ms) {
-            throw new Error(`Timed out waiting for: ${description}`);
-        }
-        await new Promise((resolve) => setTimeout(resolve, interval_ms));
-    }
-}
+// Every wait in this file must stay below TEST_TIMEOUT_MS so wait_until's
+// descriptive error surfaces instead of bun's generic test timeout; each
+// it() below passes TEST_TIMEOUT_MS explicitly because the default 5000ms
+// budget is too tight for the chained waits on slow CI.
+const TEST_TIMEOUT_MS = 30000;
+const WAIT_TIMEOUT_MS = 10000;
 
 let tmp_dir: string;
 let published_uris: string[] = [];
@@ -242,6 +235,9 @@ async function start_test_server(
         published_uris,
     });
     await create_server({ transport: 'stdio', quiet: true, connection });
+    // Assign before any wait/assertion can fail, so afterEach still runs
+    // the shutdown handler and no server timers outlive a failing test.
+    active_handlers = handlers;
     expect(handlers.initialize).toBeDefined();
     expect(handlers.initialized).toBeDefined();
     expect(handlers.did_open).toBeDefined();
@@ -259,9 +255,9 @@ async function start_test_server(
     await wait_until(
         () => captured_resolver !== undefined &&
             workspace_roots_seen.includes(tmp_dir),
-        'server initialization to reach the workspace-roots refresh'
+        'server initialization to reach the workspace-roots refresh',
+        WAIT_TIMEOUT_MS
     );
-    active_handlers = handlers;
     return handlers;
 }
 
@@ -348,7 +344,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             () => captured_resolver!
                 .get_backward_directive_children(parent_buffer_uri)
                 .has(child_uri),
-            'buffer-based registration of child under parent_buffer'
+            'buffer-based registration of child under parent_buffer',
+            WAIT_TIMEOUT_MS
         );
 
         handlers.did_close!({ textDocument: { uri: child_uri } });
@@ -359,7 +356,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             () => captured_resolver!
                 .get_backward_directive_children(parent_disk_uri)
                 .has(child_uri),
-            'disk re-sync to register child under parent_disk'
+            'disk re-sync to register child under parent_disk',
+            WAIT_TIMEOUT_MS
         );
         expect(
             captured_resolver!
@@ -374,7 +372,7 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
         expect(the_resync_calls[0].config?.backward_dependencies)
             .toBe('explicit');
         expect(await the_resync_calls[0].result).toBe(true);
-    });
+    }, TEST_TIMEOUT_MS);
 
     it('vetoes the re-sync when the document is reopened while the disk ' +
         'read is in flight (reopen guard)', async () => {
@@ -390,7 +388,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             () => captured_resolver!
                 .get_backward_directive_children(parent_buffer_uri)
                 .has(child_uri),
-            'buffer-based registration of child under parent_buffer'
+            'buffer-based registration of child under parent_buffer',
+            WAIT_TIMEOUT_MS
         );
 
         // Close, then reopen synchronously — before the close handler's
@@ -404,7 +403,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
         // (after the settings fetch), so wait for the spied call.
         await wait_until(
             () => the_resync_calls.length === 1,
-            'the close handler to invoke the disk re-sync'
+            'the close handler to invoke the disk re-sync',
+            WAIT_TIMEOUT_MS
         );
         expect(await the_resync_calls[0].result).toBe(false);
 
@@ -419,7 +419,7 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
                 .get_backward_directive_children(parent_disk_uri)
                 .has(child_uri)
         ).toBe(false);
-    });
+    }, TEST_TIMEOUT_MS);
 
     it('revalidates open backward-directive dependents after the re-sync ' +
         'applies', async () => {
@@ -448,18 +448,38 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
                 captured_resolver!
                     .get_backward_directive_children(parent_buffer_uri)
                     .has(child_uri),
-            'both open buffers to commit their backward registrations'
+            'both open buffers to commit their backward registrations',
+            WAIT_TIMEOUT_MS
         );
 
-        // Let in-flight validation publishes settle so any new grandchild
-        // publish below is attributable to the close-path revalidation.
-        let last_count = -1;
+        // Barrier against a false pass: any new grandchild publish after
+        // did_close below must be attributable to the CLOSE-path
+        // revalidation, not a straggler from the open-time validation
+        // cascade. Two conditions: (1) both documents' initial validation
+        // cycles have published (registration above happens BEFORE the
+        // publish within the same debounced cycle, so wait for the
+        // publishes too), and (2) no publish at all for three consecutive
+        // 150ms samples (~450ms of silence, several times the 100ms
+        // debounce window), so no revalidation scheduled pre-close is
+        // still in flight.
+        await wait_until(
+            () => published_uris.includes(grandchild_uri) &&
+                published_uris.includes(child_uri),
+            'initial validation publishes for both open documents',
+            WAIT_TIMEOUT_MS
+        );
+        let stable_samples = 0;
+        let last_count = published_uris.length;
         await wait_until(() => {
             const current_count = published_uris.length;
-            const stable = current_count === last_count;
-            last_count = current_count;
-            return stable;
-        }, 'diagnostic publishes to go quiescent', 5000, 150);
+            if (current_count === last_count) {
+                stable_samples++;
+            } else {
+                stable_samples = 0;
+                last_count = current_count;
+            }
+            return stable_samples >= 3;
+        }, 'diagnostic publishes to go quiescent', WAIT_TIMEOUT_MS, 150);
 
         const grandchild_publishes_before = published_uris
             .filter((my_uri) => my_uri === grandchild_uri).length;
@@ -468,7 +488,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
 
         await wait_until(
             () => the_resync_calls.length === 1,
-            'the close handler to invoke the disk re-sync'
+            'the close handler to invoke the disk re-sync',
+            WAIT_TIMEOUT_MS
         );
         expect(await the_resync_calls[0].result).toBe(true);
 
@@ -478,7 +499,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             () => published_uris
                 .filter((my_uri) => my_uri === grandchild_uri).length >
                 grandchild_publishes_before,
-            'grandchild diagnostics republish after close re-sync'
+            'grandchild diagnostics republish after close re-sync',
+            WAIT_TIMEOUT_MS
         );
-    });
+    }, TEST_TIMEOUT_MS);
 });

--- a/tests/integration/server-close-resync-wiring.test.ts
+++ b/tests/integration/server-close-resync-wiring.test.ts
@@ -28,9 +28,11 @@
  *      file via backward directives — including transitively, two hops
  *      away — are revalidated (diagnostics are republished for them);
  *   4. the DOCUMENT-STORE half of the should_apply guard vetoes on its
- *      own (a store entry recreated while the disk read is in flight,
+ *      own (a store entry recreated while the re-sync is held at entry,
  *      with TextDocuments still empty), and a vetoed re-sync does NOT
- *      revalidate open dependents.
+ *      revalidate open dependents. (The resolver-internal contract that
+ *      the guard is consulted AFTER the disk read is unit-tested in
+ *      tests/unit/document-store-commit-time-cross-file-effects.test.ts.)
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -625,12 +627,17 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
         const grandchild_publishes_before = published_uris
             .filter((my_uri) => my_uri === grandchild_uri).length;
 
-        // Hold the re-sync at its entry so the race is deterministic:
-        // while it is held, recreate the document-store entry (as a
-        // commit racing the close would) WITHOUT reopening the document
-        // in TextDocuments. When released, should_apply must veto on the
-        // store clause alone — TextDocuments says closed, the store says
-        // a buffer commit owns registration.
+        // Hold the re-sync at its ENTRY (before its disk read) so the
+        // race is deterministic: while it is held, recreate the
+        // document-store entry (as a commit racing the close would)
+        // WITHOUT reopening the document in TextDocuments. When
+        // released, should_apply must veto on the store clause alone —
+        // TextDocuments says closed, the store says a buffer commit owns
+        // registration. This pins the HANDLER's guard wiring; the
+        // resolver-internal ordering (guard consulted after the read, so
+        // a mid-read reopen still vetoes) is pinned by the deferred-read
+        // unit test in
+        // tests/unit/document-store-commit-time-cross-file-effects.test.ts.
         let release_gate: (() => void) | undefined;
         resync_gate = new Promise((resolve) => {
             release_gate = resolve;

--- a/tests/integration/server-close-resync-wiring.test.ts
+++ b/tests/integration/server-close-resync-wiring.test.ts
@@ -25,8 +25,12 @@
  *      (the reopened buffer's commit owns registration), leaving the
  *      buffer-time edges intact;
  *   3. when the re-sync applies, open files that depend on the closed
- *      file via backward directives are revalidated (diagnostics are
- *      republished for them).
+ *      file via backward directives — including transitively, two hops
+ *      away — are revalidated (diagnostics are republished for them);
+ *   4. the DOCUMENT-STORE half of the should_apply guard vetoes on its
+ *      own (a store entry recreated while the disk read is in flight,
+ *      with TextDocuments still empty), and a vetoed re-sync does NOT
+ *      revalidate open dependents.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -43,6 +47,8 @@ import type {
 } from 'vscode-languageserver/node';
 import { create_server } from '../../src/server-factory';
 import { ScopeResolver } from '../../src/scope-resolver';
+import { DocumentStore } from '../../src/document-store';
+import { Logger } from '../../src/utils/logger';
 import type { ScopeResolverConfig } from '../../src/types';
 import { wait_until } from '../wait-until';
 
@@ -60,8 +66,13 @@ interface ResyncCall {
 }
 
 let captured_resolver: ScopeResolver | undefined;
+let captured_document_store: DocumentStore | undefined;
 let the_resync_calls: ResyncCall[] = [];
 let workspace_roots_seen: string[] = [];
+// When set, the spied re-sync records its call, then holds before running
+// the real method until this promise resolves — letting a test create
+// race conditions deterministically (test 4). Undefined = no hold.
+let resync_gate: Promise<void> | undefined;
 
 const original_set_dependency_graph =
     ScopeResolver.prototype.set_dependency_graph;
@@ -69,11 +80,15 @@ const original_set_workspace_roots =
     ScopeResolver.prototype.set_workspace_roots;
 const original_resync =
     ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk;
+const original_set_scope_resolver =
+    DocumentStore.prototype.set_scope_resolver;
 
 function install_resolver_spies(): void {
     captured_resolver = undefined;
+    captured_document_store = undefined;
     the_resync_calls = [];
     workspace_roots_seen = [];
+    resync_gate = undefined;
     ScopeResolver.prototype.set_dependency_graph = function (
         ...args: Parameters<typeof original_set_dependency_graph>
     ) {
@@ -88,7 +103,13 @@ function install_resolver_spies(): void {
     };
     ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk =
         function (...args: Parameters<typeof original_resync>) {
-            const result = original_resync.apply(this, args);
+            const gate = resync_gate;
+            const result = (async () => {
+                if (gate) {
+                    await gate;
+                }
+                return original_resync.apply(this, args);
+            })();
             the_resync_calls.push({
                 uri: args[0],
                 config: args[1],
@@ -96,6 +117,12 @@ function install_resolver_spies(): void {
             });
             return result;
         };
+    DocumentStore.prototype.set_scope_resolver = function (
+        ...args: Parameters<typeof original_set_scope_resolver>
+    ) {
+        captured_document_store = this;
+        return original_set_scope_resolver.apply(this, args);
+    };
 }
 
 function restore_resolver_spies(): void {
@@ -105,6 +132,8 @@ function restore_resolver_spies(): void {
         original_set_workspace_roots;
     ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk =
         original_resync;
+    DocumentStore.prototype.set_scope_resolver =
+        original_set_scope_resolver;
 }
 
 // ---------------------------------------------------------------------------
@@ -278,6 +307,10 @@ function write_workspace_files(): void {
         path.join(tmp_dir, 'grandchild.do'),
         '// @lsp-done-by: "child.do"\ndisplay "grandchild"\n'
     );
+    fs.writeFileSync(
+        path.join(tmp_dir, 'greatgrandchild.do'),
+        '// @lsp-done-by: "grandchild.do"\ndisplay "greatgrandchild"\n'
+    );
 }
 
 function file_uri(name: string): string {
@@ -298,6 +331,27 @@ function open_document(
 const CHILD_BUFFER_TEXT =
     '// @lsp-done-by: "parent_buffer.do"\ndisplay "child"\n';
 
+/**
+ * Wait until no diagnostic publish lands for three consecutive 150ms
+ * samples (~450ms of silence, several times the 100ms debounce window),
+ * so nothing scheduled earlier is still in flight. The counter resets on
+ * every new publish, so the window is measured from the LAST publish.
+ */
+async function wait_for_publish_quiescence(): Promise<void> {
+    let stable_samples = 0;
+    let last_count = published_uris.length;
+    await wait_until(() => {
+        const current_count = published_uris.length;
+        if (current_count === last_count) {
+            stable_samples++;
+        } else {
+            stable_samples = 0;
+            last_count = current_count;
+        }
+        return stable_samples >= 3;
+    }, 'diagnostic publishes to go quiescent', WAIT_TIMEOUT_MS, 150);
+}
+
 describe('server onDidClose disk re-sync wiring (#287)', () => {
     beforeEach(() => {
         install_resolver_spies();
@@ -314,7 +368,19 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             await active_handlers?.shutdown?.();
         } finally {
             restore_resolver_spies();
-            fs.rmSync(tmp_dir, { recursive: true, force: true });
+            // create_server({ quiet: true }) silences the process-wide
+            // Logger singleton; restore its defaults (info verbosity,
+            // console.debug fallback channel) so later tests in this
+            // process see the out-of-the-box behavior.
+            Logger.initialize({
+                verbosity: 'info',
+                channel: (message: string) => console.debug(message),
+            });
+            // Guarded so a beforeEach failure before tmp_dir is assigned
+            // reports itself instead of an rmSync TypeError.
+            if (tmp_dir) {
+                fs.rmSync(tmp_dir, { recursive: true, force: true });
+            }
         }
     });
 
@@ -421,18 +487,115 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
         ).toBe(false);
     }, TEST_TIMEOUT_MS);
 
-    it('revalidates open backward-directive dependents after the re-sync ' +
-        'applies', async () => {
+    it('revalidates open backward-directive dependents (including ' +
+        'two-hop transitive ones) after the re-sync applies', async () => {
         const child_uri = file_uri('child.do');
         const grandchild_uri = file_uri('grandchild.do');
+        const greatgrandchild_uri = file_uri('greatgrandchild.do');
         const parent_buffer_uri = file_uri('parent_buffer.do');
         const handlers = await start_test_server(
             () => GLOBAL_PUBLIC_CONFIG
         );
 
-        // Open the grandchild (depends on child.do via @lsp-done-by) and
-        // the child (buffer header disagrees with disk so the close-time
-        // re-sync APPLIES a change).
+        // Open the dependent chain (greatgrandchild -> grandchild ->
+        // child via @lsp-done-by; the two-hop greatgrandchild
+        // distinguishes the handler's TRANSITIVE dependent lookup from a
+        // direct-children one) and the child itself (buffer header
+        // disagrees with disk so the close-time re-sync APPLIES a
+        // change).
+        open_document(
+            handlers,
+            grandchild_uri,
+            fs.readFileSync(
+                path.join(tmp_dir, 'grandchild.do'), 'utf8'
+            )
+        );
+        open_document(
+            handlers,
+            greatgrandchild_uri,
+            fs.readFileSync(
+                path.join(tmp_dir, 'greatgrandchild.do'), 'utf8'
+            )
+        );
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT);
+        await wait_until(
+            () => captured_resolver!
+                .get_backward_directive_children(child_uri)
+                .has(grandchild_uri) &&
+                captured_resolver!
+                    .get_backward_directive_children(grandchild_uri)
+                    .has(greatgrandchild_uri) &&
+                captured_resolver!
+                    .get_backward_directive_children(parent_buffer_uri)
+                    .has(child_uri),
+            'all open buffers to commit their backward registrations',
+            WAIT_TIMEOUT_MS
+        );
+
+        // Barrier against a false pass: any new dependent publish after
+        // did_close below must be attributable to the CLOSE-path
+        // revalidation, not a straggler from the open-time validation
+        // cascade. Two conditions: (1) every document's initial
+        // validation cycle has published (registration above happens
+        // BEFORE the publish within the same debounced cycle, so wait
+        // for the publishes too), and (2) no publish at all for three
+        // consecutive 150ms samples (~450ms of silence, several times
+        // the 100ms debounce window), so no revalidation scheduled
+        // pre-close is still in flight.
+        await wait_until(
+            () => published_uris.includes(grandchild_uri) &&
+                published_uris.includes(greatgrandchild_uri) &&
+                published_uris.includes(child_uri),
+            'initial validation publishes for all open documents',
+            WAIT_TIMEOUT_MS
+        );
+        await wait_for_publish_quiescence();
+
+        const grandchild_publishes_before = published_uris
+            .filter((my_uri) => my_uri === grandchild_uri).length;
+        const greatgrandchild_publishes_before = published_uris
+            .filter((my_uri) => my_uri === greatgrandchild_uri).length;
+
+        handlers.did_close!({ textDocument: { uri: child_uri } });
+
+        await wait_until(
+            () => the_resync_calls.length === 1,
+            'the close handler to invoke the disk re-sync',
+            WAIT_TIMEOUT_MS
+        );
+        expect(await the_resync_calls[0].result).toBe(true);
+
+        // The applied re-sync must fan out to open dependents THROUGH the
+        // closed file: both the direct grandchild and the two-hop
+        // greatgrandchild get revalidated and republished.
+        await wait_until(
+            () => published_uris
+                .filter((my_uri) => my_uri === grandchild_uri).length >
+                grandchild_publishes_before,
+            'grandchild diagnostics republish after close re-sync',
+            WAIT_TIMEOUT_MS
+        );
+        await wait_until(
+            () => published_uris
+                .filter((my_uri) => my_uri === greatgrandchild_uri)
+                .length > greatgrandchild_publishes_before,
+            'greatgrandchild diagnostics republish after close re-sync',
+            WAIT_TIMEOUT_MS
+        );
+    }, TEST_TIMEOUT_MS);
+
+    it('vetoes via the document-store guard clause alone and does not ' +
+        'revalidate dependents on a vetoed re-sync', async () => {
+        const child_uri = file_uri('child.do');
+        const grandchild_uri = file_uri('grandchild.do');
+        const parent_disk_uri = file_uri('parent_disk.do');
+        const parent_buffer_uri = file_uri('parent_buffer.do');
+        const handlers = await start_test_server(
+            () => GLOBAL_PUBLIC_CONFIG
+        );
+
+        // An open dependent, so the vetoed branch has a live dependent it
+        // must NOT revalidate.
         open_document(
             handlers,
             grandchild_uri,
@@ -451,56 +614,61 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             'both open buffers to commit their backward registrations',
             WAIT_TIMEOUT_MS
         );
-
-        // Barrier against a false pass: any new grandchild publish after
-        // did_close below must be attributable to the CLOSE-path
-        // revalidation, not a straggler from the open-time validation
-        // cascade. Two conditions: (1) both documents' initial validation
-        // cycles have published (registration above happens BEFORE the
-        // publish within the same debounced cycle, so wait for the
-        // publishes too), and (2) no publish at all for three consecutive
-        // 150ms samples (~450ms of silence, several times the 100ms
-        // debounce window), so no revalidation scheduled pre-close is
-        // still in flight.
         await wait_until(
             () => published_uris.includes(grandchild_uri) &&
                 published_uris.includes(child_uri),
             'initial validation publishes for both open documents',
             WAIT_TIMEOUT_MS
         );
-        let stable_samples = 0;
-        let last_count = published_uris.length;
-        await wait_until(() => {
-            const current_count = published_uris.length;
-            if (current_count === last_count) {
-                stable_samples++;
-            } else {
-                stable_samples = 0;
-                last_count = current_count;
-            }
-            return stable_samples >= 3;
-        }, 'diagnostic publishes to go quiescent', WAIT_TIMEOUT_MS, 150);
+        await wait_for_publish_quiescence();
 
         const grandchild_publishes_before = published_uris
             .filter((my_uri) => my_uri === grandchild_uri).length;
 
-        handlers.did_close!({ textDocument: { uri: child_uri } });
+        // Hold the re-sync at its entry so the race is deterministic:
+        // while it is held, recreate the document-store entry (as a
+        // commit racing the close would) WITHOUT reopening the document
+        // in TextDocuments. When released, should_apply must veto on the
+        // store clause alone — TextDocuments says closed, the store says
+        // a buffer commit owns registration.
+        let release_gate: (() => void) | undefined;
+        resync_gate = new Promise((resolve) => {
+            release_gate = resolve;
+        });
 
+        handlers.did_close!({ textDocument: { uri: child_uri } });
         await wait_until(
             () => the_resync_calls.length === 1,
             'the close handler to invoke the disk re-sync',
             WAIT_TIMEOUT_MS
         );
-        expect(await the_resync_calls[0].result).toBe(true);
-
-        // The applied re-sync must fan out to open dependents THROUGH the
-        // closed file: grandchild gets revalidated and republished.
-        await wait_until(
-            () => published_uris
-                .filter((my_uri) => my_uri === grandchild_uri).length >
-                grandchild_publishes_before,
-            'grandchild diagnostics republish after close re-sync',
-            WAIT_TIMEOUT_MS
+        await captured_document_store!.open(
+            child_uri, CHILD_BUFFER_TEXT, 3
         );
+        release_gate!();
+
+        expect(await the_resync_calls[0].result).toBe(false);
+
+        // Vetoed: buffer-time edges survive, the disk parent was never
+        // applied.
+        expect(
+            captured_resolver!
+                .get_backward_directive_children(parent_buffer_uri)
+                .has(child_uri)
+        ).toBe(true);
+        expect(
+            captured_resolver!
+                .get_backward_directive_children(parent_disk_uri)
+                .has(child_uri)
+        ).toBe(false);
+
+        // A vetoed re-sync must NOT fan out revalidation: after a settle
+        // window several times the debounce, the open dependent has no
+        // new publish.
+        await wait_for_publish_quiescence();
+        expect(
+            published_uris
+                .filter((my_uri) => my_uri === grandchild_uri).length
+        ).toBe(grandchild_publishes_before);
     }, TEST_TIMEOUT_MS);
 });

--- a/tests/property/ast-formatter-token-spacing.prop.test.ts
+++ b/tests/property/ast-formatter-token-spacing.prop.test.ts
@@ -22,8 +22,14 @@ import { arbitrary_non_reserved_identifier } from './generators';
 
 /**
  * Generate valid Stata identifiers (excluding reserved qualifier keywords).
+ * Also exclude EXPRESSION_KEYWORDS ('of', 'in' — see
+ * src/pretty-printer/expression-spacing.ts): the formatter adds spaces
+ * around them, so an identifier that collides with one (e.g. `of[A]` →
+ * `of [A]`) violates the bracket-spacing properties by design.
  */
-const identifier_arb = arbitrary_non_reserved_identifier();
+const identifier_arb = arbitrary_non_reserved_identifier().filter(
+    (id) => id !== 'of'
+);
 
 /**
  * Generate simple numbers.

--- a/tests/unit/document-store-commit-time-cross-file-effects.test.ts
+++ b/tests/unit/document-store-commit-time-cross-file-effects.test.ts
@@ -1,0 +1,488 @@
+// Issue #184: cross-file directive side effects (ScopeResolver
+// backward-directive registration + WorkspaceIndexer overlay) must be
+// staged during create_document_state and applied only after commit_state's
+// guards accept the parse. A close() racing an in-flight parse is not
+// serialized with the per-URI operation chain, so before the fix a
+// discarded parse still mutated shared cross-file state (stale-add) or
+// wiped edges a committed parse had set (valid-edge-drop).
+//
+// Race idiom: fire open()/update() WITHOUT awaiting, call close()
+// synchronously, then await. close() is synchronous while the parse
+// suspends on its first with_parse_timeout await (setImmediate), so the
+// parse machinery — where the old code applied side effects — always runs
+// after the close.
+import { describe, expect, it } from 'bun:test';
+import { DocumentStore } from '../../src/document-store';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { ScopeResolver } from '../../src/scope-resolver';
+import type { ContentProvider } from '../../src/types';
+import { URI } from 'vscode-uri';
+
+function make_content_provider(
+    content_by_uri: Map<string, string>
+): ContentProvider {
+    return {
+        read_file: async (uri) => content_by_uri.get(uri) ?? '',
+        exists: async (uri) => content_by_uri.has(uri),
+        stat: async (uri) => {
+            const content = content_by_uri.get(uri);
+            return content === undefined
+                ? undefined
+                : { mtimeMs: 0, size: content.length };
+        },
+    };
+}
+
+function make_harness(content_by_uri: Map<string, string>) {
+    const document_store = new DocumentStore();
+    const workspace_indexer = new WorkspaceIndexer();
+    const dependency_graph = new DependencyGraph();
+    const scope_resolver = new ScopeResolver(
+        undefined,
+        make_content_provider(content_by_uri)
+    );
+    workspace_indexer.set_dependency_graph(dependency_graph);
+    scope_resolver.set_dependency_graph(dependency_graph);
+    document_store.set_scope_resolver(scope_resolver);
+    document_store.set_on_backward_directives_parsed((uri, directives) => {
+        workspace_indexer.set_buffer_directives(uri, directives);
+    });
+    return {
+        document_store,
+        workspace_indexer,
+        dependency_graph,
+        scope_resolver,
+    };
+}
+
+describe('DocumentStore commit-time cross-file effects (issue #184)', () => {
+    it('close racing a directive-adding reparse leaves no stale edge or overlay entry', async () => {
+        const parent_path = '/tmp/sight-184-stale-parent.do';
+        const parent_uri = URI.file(parent_path).toString();
+        const child_uri = URI.file('/tmp/sight-184-stale-child.do').toString();
+        const content_by_uri = new Map<string, string>([
+            [parent_uri, 'display 0\n'],
+        ]);
+        const { document_store, workspace_indexer, scope_resolver } =
+            make_harness(content_by_uri);
+
+        await document_store.open(child_uri, 'display 1\n', 1);
+
+        const content_with_directive =
+            `// @lsp-done-by: "${parent_path}"\n` +
+            'display 2\n';
+        const update_promise = document_store.update(
+            child_uri,
+            [{ text: content_with_directive }],
+            2
+        );
+        document_store.close(child_uri);
+        await update_promise;
+
+        expect(document_store.get(child_uri)).toBeUndefined();
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(false);
+        expect(
+            workspace_indexer.get_related_uris(parent_uri).has(child_uri)
+        ).toBe(false);
+    });
+
+    it('close racing a directive-removing reparse preserves committed edges (A -> B -> C)', async () => {
+        const c_path = '/tmp/sight-184-chain-c.do';
+        const b_path = '/tmp/sight-184-chain-b.do';
+        const a_path = '/tmp/sight-184-chain-a.do';
+        const c_uri = URI.file(c_path).toString();
+        const b_uri = URI.file(b_path).toString();
+        const a_uri = URI.file(a_path).toString();
+        const c_content = 'display "c"\n';
+        const b_content = `// @lsp-done-by: "${c_path}"\ndisplay "b"\n`;
+        const a_content = `// @lsp-done-by: "${b_path}"\ndisplay "a"\n`;
+        const content_by_uri = new Map<string, string>([
+            [c_uri, c_content],
+            [b_uri, b_content],
+            [a_uri, a_content],
+        ]);
+        const { document_store, workspace_indexer, scope_resolver } =
+            make_harness(content_by_uri);
+
+        await document_store.open(c_uri, c_content, 1);
+        await document_store.open(b_uri, b_content, 1);
+        await document_store.open(a_uri, a_content, 1);
+
+        expect(
+            scope_resolver.get_backward_directive_children(c_uri).has(b_uri)
+        ).toBe(true);
+        expect(
+            scope_resolver.get_backward_directive_children(b_uri).has(a_uri)
+        ).toBe(true);
+        const transitive_before =
+            scope_resolver.get_transitive_backward_directive_children(c_uri);
+        expect(transitive_before.has(b_uri)).toBe(true);
+        expect(transitive_before.has(a_uri)).toBe(true);
+
+        // Discarded parse would clear-then-register B with NO directives,
+        // dropping the valid C -> B edge before the fix.
+        const update_promise = document_store.update(
+            b_uri,
+            [{ text: 'display "b edited"\n' }],
+            2
+        );
+        document_store.close(b_uri);
+        await update_promise;
+
+        expect(
+            scope_resolver.get_backward_directive_children(c_uri).has(b_uri)
+        ).toBe(true);
+        expect(
+            scope_resolver.get_backward_directive_children(b_uri).has(a_uri)
+        ).toBe(true);
+        const transitive_after =
+            scope_resolver.get_transitive_backward_directive_children(c_uri);
+        expect(transitive_after.has(b_uri)).toBe(true);
+        expect(transitive_after.has(a_uri)).toBe(true);
+        // Overlay entry from B's committed open must survive the discarded
+        // reparse (the real server clears it separately in onDidClose).
+        expect(
+            workspace_indexer.get_related_uris(c_uri).has(b_uri)
+        ).toBe(true);
+    });
+
+    it('registers auto-discovered parents at commit (no explicit directives)', async () => {
+        const parent_uri = URI.file('/tmp/sight-184-auto-parent.do').toString();
+        const child_path = '/tmp/sight-184-auto-child.do';
+        const child_uri = URI.file(child_path).toString();
+        const content_by_uri = new Map<string, string>([
+            [parent_uri, 'do sight-184-auto-child.do\n'],
+        ]);
+        const { document_store, dependency_graph, scope_resolver } =
+            make_harness(content_by_uri);
+
+        dependency_graph.update_caller(parent_uri, [{
+            type: 'do',
+            raw_path: 'sight-184-auto-child.do',
+            is_static: true,
+            call_site_line: 0,
+            range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 10 },
+            },
+            source: 'command',
+        }]);
+        expect(dependency_graph.get_parents(child_uri)).toHaveLength(1);
+
+        await document_store.open(child_uri, 'display 1\n', 1);
+
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+    });
+
+    it('registers auto-discovered parents even when the file has its own working directory (probe skipped)', async () => {
+        // A file with its own @lsp-cd never runs the WD probe, so before the
+        // fix only the RAW parse-time sync ran and auto-discovered parents
+        // were never registered from the document-store path.
+        const parent_uri = URI.file('/tmp/sight-184-owncd-parent.do').toString();
+        const child_path = '/tmp/sight-184-owncd-child.do';
+        const child_uri = URI.file(child_path).toString();
+        const content_by_uri = new Map<string, string>([
+            [parent_uri, 'do sight-184-owncd-child.do\n'],
+        ]);
+        const { document_store, dependency_graph, scope_resolver } =
+            make_harness(content_by_uri);
+
+        dependency_graph.update_caller(parent_uri, [{
+            type: 'do',
+            raw_path: 'sight-184-owncd-child.do',
+            is_static: true,
+            call_site_line: 0,
+            range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 10 },
+            },
+            source: 'command',
+        }]);
+
+        await document_store.open(
+            child_uri,
+            '// @lsp-cd: "/tmp"\ndisplay 1\n',
+            1
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+    });
+
+    it('a registering resolve that cache-hits the probe-populated entry still observes registered edges', async () => {
+        const parent_path = '/tmp/sight-184-probe-parent.do';
+        const parent_uri = URI.file(parent_path).toString();
+        const child_uri = URI.file('/tmp/sight-184-probe-child.do').toString();
+        const child_content =
+            `// @lsp-done-by: "${parent_path}"\ndisplay 1\n`;
+        const content_by_uri = new Map<string, string>([
+            [parent_uri, 'display 0\n'],
+        ]);
+        const { document_store, scope_resolver } =
+            make_harness(content_by_uri);
+
+        // open() runs the non-registering WD probe, which populates the
+        // scope cache for (child_uri, child_content, {}); commit_state then
+        // applies the effective registration.
+        await document_store.open(child_uri, child_content, 1);
+
+        const hits_before = scope_resolver.get_cache_metrics().scope.hits;
+        await scope_resolver.resolve(child_uri, child_content, {});
+        const hits_after = scope_resolver.get_cache_metrics().scope.hits;
+
+        // The default resolve must have HIT the probe's cache entry (same
+        // key, no invalidation in between) — the sharp poisoning scenario.
+        expect(hits_after).toBe(hits_before + 1);
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+    });
+
+    it('interface-change invalidation followed by a default resolve restores edges', async () => {
+        const parent_path = '/tmp/sight-184-inval-parent.do';
+        const parent_uri = URI.file(parent_path).toString();
+        const child_uri = URI.file('/tmp/sight-184-inval-child.do').toString();
+        const child_content =
+            `// @lsp-done-by: "${parent_path}"\ndisplay 1\n`;
+        const content_by_uri = new Map<string, string>([
+            [parent_uri, 'display 0\n'],
+        ]);
+        const { document_store, scope_resolver } =
+            make_harness(content_by_uri);
+
+        await document_store.open(child_uri, child_content, 1);
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+
+        // validate_text_document's interface-change path clears the child's
+        // edges (preserve_backward_directive_dependencies NOT set) but also
+        // invalidates the scope cache, so the next default resolve is a
+        // MISS and re-registers.
+        scope_resolver.invalidate_file_cache(child_uri, {
+            preserve_forward_call_relationships: true,
+        });
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(false);
+
+        await scope_resolver.resolve(child_uri, child_content, {});
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+    });
+
+    it('dispose blocks staged effect application from an in-flight parse', async () => {
+        const parent_path = '/tmp/sight-184-dispose-parent.do';
+        const parent_uri = URI.file(parent_path).toString();
+        const child_uri = URI.file('/tmp/sight-184-dispose-child.do').toString();
+        const content_by_uri = new Map<string, string>([
+            [parent_uri, 'display 0\n'],
+        ]);
+        const { document_store, workspace_indexer, scope_resolver } =
+            make_harness(content_by_uri);
+
+        await document_store.open(child_uri, 'display 1\n', 1);
+
+        const content_with_directive =
+            `// @lsp-done-by: "${parent_path}"\ndisplay 2\n`;
+        const update_promise = document_store.update(
+            child_uri,
+            [{ text: content_with_directive }],
+            2
+        );
+        await document_store.dispose();
+        await update_promise;
+
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(false);
+        expect(
+            workspace_indexer.get_related_uris(parent_uri).has(child_uri)
+        ).toBe(false);
+    });
+});
+
+describe('ScopeResolver non-registering probe mode (issue #184)', () => {
+    it('register_dependencies: false skips only the top-level registration', async () => {
+        const grandparent_path = '/tmp/sight-184-flag-grandparent.do';
+        const parent_path = '/tmp/sight-184-flag-parent.do';
+        const grandparent_uri = URI.file(grandparent_path).toString();
+        const parent_uri = URI.file(parent_path).toString();
+        const child_uri = URI.file('/tmp/sight-184-flag-child.do').toString();
+        const child_content =
+            `// @lsp-done-by: "${parent_path}"\ndisplay 1\n`;
+        const content_by_uri = new Map<string, string>([
+            [grandparent_uri, 'display 0\n'],
+            [parent_uri, `// @lsp-done-by: "${grandparent_path}"\ndisplay 0\n`],
+        ]);
+        const scope_resolver = new ScopeResolver(
+            undefined,
+            make_content_provider(content_by_uri)
+        );
+
+        await scope_resolver.resolve(
+            child_uri,
+            child_content,
+            {},
+            undefined,
+            { register_dependencies: false }
+        );
+
+        // The child's own edge is NOT registered...
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(false);
+        // ...but the ancestor-level sync inside get_parsed_file still
+        // registers the parent's own directives (disk-derived, correct
+        // regardless of this parse's fate).
+        expect(
+            scope_resolver.get_backward_directive_children(grandparent_uri)
+                .has(parent_uri)
+        ).toBe(true);
+
+        // A default resolve after invalidation registers the child's edge.
+        scope_resolver.invalidate_scope_cache(child_uri);
+        await scope_resolver.resolve(child_uri, child_content, {});
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+    });
+});
+
+describe('ScopeResolver disk re-sync on close (issue #184)', () => {
+    it('converges edges to disk state after a discarded save-then-close reparse', async () => {
+        const old_parent_path = '/tmp/sight-184-resync-old.do';
+        const new_parent_path = '/tmp/sight-184-resync-new.do';
+        const old_parent_uri = URI.file(old_parent_path).toString();
+        const new_parent_uri = URI.file(new_parent_path).toString();
+        const child_uri = URI.file('/tmp/sight-184-resync-child.do').toString();
+        const content_by_uri = new Map<string, string>([
+            [old_parent_uri, 'display 0\n'],
+            [new_parent_uri, 'display 0\n'],
+        ]);
+        const scope_resolver = new ScopeResolver(
+            undefined,
+            make_content_provider(content_by_uri)
+        );
+
+        // Pre-close committed state points at the OLD parent.
+        await scope_resolver.resolve(
+            child_uri,
+            `// @lsp-done-by: "${old_parent_path}"\ndisplay 1\n`,
+            {}
+        );
+        expect(
+            scope_resolver.get_backward_directive_children(old_parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+
+        // Disk now has the saved header change (directive to NEW parent);
+        // the reparse that would have registered it was discarded by close.
+        content_by_uri.set(
+            child_uri,
+            `// @lsp-done-by: "${new_parent_path}"\ndisplay 1\n`
+        );
+        await scope_resolver.resync_backward_directive_dependencies_from_disk(
+            child_uri
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(new_parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+        expect(
+            scope_resolver.get_backward_directive_children(old_parent_uri)
+                .has(child_uri)
+        ).toBe(false);
+    });
+
+    it('clears edges when the file no longer exists on disk', async () => {
+        const parent_path = '/tmp/sight-184-resync-gone-parent.do';
+        const parent_uri = URI.file(parent_path).toString();
+        const child_uri =
+            URI.file('/tmp/sight-184-resync-gone-child.do').toString();
+        const content_by_uri = new Map<string, string>([
+            [parent_uri, 'display 0\n'],
+        ]);
+        const scope_resolver = new ScopeResolver(
+            undefined,
+            make_content_provider(content_by_uri)
+        );
+
+        await scope_resolver.resolve(
+            child_uri,
+            `// @lsp-done-by: "${parent_path}"\ndisplay 1\n`,
+            {}
+        );
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+
+        // child_uri was never in content_by_uri, so exists() is false.
+        await scope_resolver.resync_backward_directive_dependencies_from_disk(
+            child_uri
+        );
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(false);
+    });
+
+    it('skips applying when should_apply reports a reopen', async () => {
+        const disk_parent_path = '/tmp/sight-184-resync-guard-disk.do';
+        const buffer_parent_path = '/tmp/sight-184-resync-guard-buf.do';
+        const disk_parent_uri = URI.file(disk_parent_path).toString();
+        const buffer_parent_uri = URI.file(buffer_parent_path).toString();
+        const child_uri =
+            URI.file('/tmp/sight-184-resync-guard-child.do').toString();
+        const content_by_uri = new Map<string, string>([
+            [disk_parent_uri, 'display 0\n'],
+            [buffer_parent_uri, 'display 0\n'],
+            [child_uri, `// @lsp-done-by: "${disk_parent_path}"\ndisplay 1\n`],
+        ]);
+        const scope_resolver = new ScopeResolver(
+            undefined,
+            make_content_provider(content_by_uri)
+        );
+
+        // The quick reopen's buffer-based commit registered the BUFFER
+        // parent; the slower disk read must not clobber it.
+        await scope_resolver.resolve(
+            child_uri,
+            `// @lsp-done-by: "${buffer_parent_path}"\ndisplay 1\n`,
+            {}
+        );
+        await scope_resolver.resync_backward_directive_dependencies_from_disk(
+            child_uri,
+            {},
+            () => false
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(buffer_parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+        expect(
+            scope_resolver.get_backward_directive_children(disk_parent_uri)
+                .has(child_uri)
+        ).toBe(false);
+    });
+});

--- a/tests/unit/document-store-commit-time-cross-file-effects.test.ts
+++ b/tests/unit/document-store-commit-time-cross-file-effects.test.ts
@@ -18,6 +18,7 @@ import { WorkspaceIndexer } from '../../src/indexer';
 import { ScopeResolver } from '../../src/scope-resolver';
 import type { ContentProvider } from '../../src/types';
 import { URI } from 'vscode-uri';
+import { wait_until } from '../wait-until';
 
 function make_content_provider(
     content_by_uri: Map<string, string>
@@ -487,9 +488,12 @@ describe('ScopeResolver disk re-sync on close (issue #184)', () => {
                 {},
                 () => !reopened
             );
-        while (release_read === undefined) {
-            await new Promise((resolve) => setTimeout(resolve, 0));
-        }
+        await wait_until(
+            () => release_read !== undefined,
+            'the re-sync to start its deferred disk read',
+            4000,
+            0
+        );
         // ...the reopen lands while the disk read is in flight.
         reopened = true;
         release_read!(child_disk_content);

--- a/tests/unit/document-store-commit-time-cross-file-effects.test.ts
+++ b/tests/unit/document-store-commit-time-cross-file-effects.test.ts
@@ -450,6 +450,59 @@ describe('ScopeResolver disk re-sync on close (issue #184)', () => {
         ).toBe(false);
     });
 
+    it('consults should_apply AFTER the disk read, so a reopen landing ' +
+        'mid-read still vetoes', async () => {
+        // The docstring contract — "checked after the disk read,
+        // immediately before the synchronous registration" — is the
+        // actual protection: a guard consulted before the read would
+        // miss a reopen that lands while the read is in flight and
+        // clobber the reopened buffer's registration (#287 round-3
+        // review). Pin the ordering with a read the test releases.
+        const disk_parent_path = '/tmp/sight-184-resync-order-disk.do';
+        const disk_parent_uri = URI.file(disk_parent_path).toString();
+        const child_uri =
+            URI.file('/tmp/sight-184-resync-order-child.do').toString();
+        const child_disk_content =
+            `// @lsp-done-by: "${disk_parent_path}"\ndisplay 1\n`;
+        let release_read: ((content: string) => void) | undefined;
+        const gated_content_provider: ContentProvider = {
+            exists: async () => true,
+            read_file: (uri) => uri === child_uri
+                ? new Promise<string>((resolve) => {
+                    release_read = resolve;
+                })
+                : Promise.resolve('display 0\n'),
+            stat: async () => ({ mtimeMs: 0, size: 0 }),
+        };
+        const scope_resolver = new ScopeResolver(
+            undefined,
+            gated_content_provider
+        );
+
+        // No reopen yet when the re-sync starts...
+        let reopened = false;
+        const resync_promise = scope_resolver
+            .resync_backward_directive_dependencies_from_disk(
+                child_uri,
+                {},
+                () => !reopened
+            );
+        while (release_read === undefined) {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+        // ...the reopen lands while the disk read is in flight.
+        reopened = true;
+        release_read!(child_disk_content);
+
+        // A guard consulted before (or captured at) the read would have
+        // seen "no reopen" and applied the disk edges.
+        expect(await resync_promise).toBe(false);
+        expect(
+            scope_resolver.get_backward_directive_children(disk_parent_uri)
+                .has(child_uri)
+        ).toBe(false);
+    });
+
     it('skips applying when should_apply reports a reopen', async () => {
         const disk_parent_path = '/tmp/sight-184-resync-guard-disk.do';
         const buffer_parent_path = '/tmp/sight-184-resync-guard-buf.do';

--- a/tests/unit/document-store-commit-time-cross-file-effects.test.ts
+++ b/tests/unit/document-store-commit-time-cross-file-effects.test.ts
@@ -399,9 +399,11 @@ describe('ScopeResolver disk re-sync on close (issue #184)', () => {
             child_uri,
             `// @lsp-done-by: "${new_parent_path}"\ndisplay 1\n`
         );
-        await scope_resolver.resync_backward_directive_dependencies_from_disk(
-            child_uri
-        );
+        const my_applied =
+            await scope_resolver.resync_backward_directive_dependencies_from_disk(
+                child_uri
+            );
+        expect(my_applied).toBe(true);
 
         expect(
             scope_resolver.get_backward_directive_children(new_parent_uri)
@@ -437,9 +439,11 @@ describe('ScopeResolver disk re-sync on close (issue #184)', () => {
         ).toBe(true);
 
         // child_uri was never in content_by_uri, so exists() is false.
-        await scope_resolver.resync_backward_directive_dependencies_from_disk(
-            child_uri
-        );
+        const my_applied =
+            await scope_resolver.resync_backward_directive_dependencies_from_disk(
+                child_uri
+            );
+        expect(my_applied).toBe(true);
         expect(
             scope_resolver.get_backward_directive_children(parent_uri)
                 .has(child_uri)
@@ -470,11 +474,13 @@ describe('ScopeResolver disk re-sync on close (issue #184)', () => {
             `// @lsp-done-by: "${buffer_parent_path}"\ndisplay 1\n`,
             {}
         );
-        await scope_resolver.resync_backward_directive_dependencies_from_disk(
-            child_uri,
-            {},
-            () => false
-        );
+        const my_applied =
+            await scope_resolver.resync_backward_directive_dependencies_from_disk(
+                child_uri,
+                {},
+                () => false
+            );
+        expect(my_applied).toBe(false);
 
         expect(
             scope_resolver.get_backward_directive_children(buffer_parent_uri)

--- a/tests/unit/document-store-version-guard.test.ts
+++ b/tests/unit/document-store-version-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { DocumentState, DocumentStore } from '../../src/document-store';
+import { DocumentState, DocumentStore, ParseOutcome } from '../../src/document-store';
 import { DependencyGraph } from '../../src/dependency-graph';
 import { WorkspaceIndexer } from '../../src/indexer';
 import { ScopeResolver } from '../../src/scope-resolver';
@@ -11,14 +11,14 @@ type InspectableDocumentStore = DocumentStore & {
     generations: Map<string, number>;
     commit_state(
         uri: string,
-        state: DocumentState,
+        outcome: ParseOutcome,
         generation: number
-    ): void;
+    ): boolean;
     create_document_state(
         uri: string,
         content: string,
         version: number
-    ): Promise<DocumentState>;
+    ): Promise<ParseOutcome>;
 };
 
 describe('DocumentStore version guard', () => {
@@ -36,7 +36,11 @@ describe('DocumentStore version guard', () => {
             version: 2,
             content: 'content v2',
         };
-        store.commit_state(uri, stale_state_v2, 2);
+        store.commit_state(
+            uri,
+            { state: stale_state_v2, staged_effects: undefined },
+            2
+        );
 
         expect(store.documents.get(uri)).toBe(state_v3);
         expect(store.documents.get(uri)!.version).toBe(3);
@@ -46,7 +50,11 @@ describe('DocumentStore version guard', () => {
             ...state_v3!,
             content: 'content v3 reparse',
         };
-        store.commit_state(uri, reparse_state_v3, 3);
+        store.commit_state(
+            uri,
+            { state: reparse_state_v3, staged_effects: undefined },
+            3
+        );
 
         expect(store.documents.get(uri)).toBe(reparse_state_v3);
         expect(store.documents.get(uri)!.version).toBe(3);

--- a/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
+++ b/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
@@ -1,0 +1,222 @@
+// Issue #286: get_parsed_file's ancestor-level backward-directive sync used
+// the RAW variant (sync_backward_directive_dependencies, no auto-synthesis).
+// Registration is clear-then-register, so a file whose
+// backward_directive_children edges came from auto-discovery (DependencyGraph
+// parents, no explicit directives) had those edges WIPED whenever it was read
+// from disk as an ancestor of another file's resolution — until its next
+// commit re-registered them. Consequence: interface-change revalidation
+// fan-out (get_transitive_backward_directive_children) silently skipped the
+// wiped file's descendants.
+//
+// The fix threads the resolution's effective backward_dependencies mode into
+// get_parsed_file and switches the ancestor sync to the effective variant
+// (apply_backward_directive_registration). Effective ⊇ raw, so the change can
+// only ADD edges; an 'explicit'-mode resolution must NOT auto-register graph
+// parents for ancestors.
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { DirectiveParser } from '../../src/directive-parser';
+import { DocumentStore } from '../../src/document-store';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { create_test_scope_resolver_logger } from '../test-logger';
+
+describe('issue #286 — ancestor-level effective backward-directive sync', () => {
+    let temp_dir: string;
+    let document_store: DocumentStore;
+    let dependency_graph: DependencyGraph;
+    let scope_resolver: ScopeResolver;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sight-286-'));
+        document_store = new DocumentStore();
+        dependency_graph = new DependencyGraph();
+        scope_resolver = new ScopeResolver(create_test_scope_resolver_logger());
+        const forward_resolver = new ForwardScopeResolver(scope_resolver);
+        scope_resolver.set_forward_scope_resolver(forward_resolver);
+        scope_resolver.set_dependency_graph(dependency_graph);
+        document_store.set_scope_resolver(scope_resolver);
+    });
+
+    afterEach(async () => {
+        await document_store.dispose();
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    const create_file = (name: string, content: string): string => {
+        const file_path = path.join(temp_dir, name);
+        fs.writeFileSync(file_path, content);
+        return file_path;
+    };
+    const to_uri = (file_path: string): string =>
+        URI.file(file_path).toString();
+
+    /**
+     * Seed a dependency-graph edge parent → child, as the workspace scan
+     * would after seeing `do child.do` in the parent.
+     */
+    const seed_auto_parent = (parent_uri: string, child_name: string): void => {
+        dependency_graph.update_caller(parent_uri, [{
+            type: 'do',
+            raw_path: child_name,
+            is_static: true,
+            call_site_line: 0,
+            range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 10 },
+            },
+            source: 'command',
+        }]);
+    };
+
+    it('auto-discovered edges survive a backward ancestor read (regression)', async () => {
+        // A --do--> B (auto-discovered, no explicit directives in B).
+        const b_path = create_file('b.do', 'display "b on disk"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+        expect(dependency_graph.get_parents(b_uri)).toHaveLength(1);
+
+        // Open B with buffer content that differs from disk (unsaved edit),
+        // so a later ancestor read of B is a file-cache STALE → full parse.
+        // Commit-time effective registration (issue #184) adds A → B.
+        await document_store.open(b_uri, 'display "b in buffer"\n', 1);
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+
+        // Resolve C, whose chain reads B from disk as an ancestor. Before
+        // the fix, the RAW clear-then-register sync inside get_parsed_file
+        // wiped B's auto edges (B has no explicit directives).
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(
+            c_uri,
+            `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`,
+            {}
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+        expect(
+            scope_resolver.get_backward_directive_children(b_uri).has(c_uri)
+        ).toBe(true);
+        // Fan-out consequence: revalidation from A must reach C through B.
+        const the_transitive =
+            scope_resolver.get_transitive_backward_directive_children(a_uri);
+        expect(the_transitive.has(b_uri)).toBe(true);
+        expect(the_transitive.has(c_uri)).toBe(true);
+    });
+
+    it('auto-discovered edges survive a forward callee read (regression)', async () => {
+        const b_path = create_file('b.do', 'display "b on disk"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        await document_store.open(b_uri, 'display "b in buffer"\n', 1);
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+
+        // C reads B as a forward callee (do command), which goes through
+        // ForwardScopeResolver.get_callee_scope → get_parsed_file.
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(c_uri, `do "${b_path}"\n`, {});
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+    });
+
+    it('auto-mode resolution registers an ancestor\'s auto parents even when never opened (effective ⊇ raw)', async () => {
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(
+            c_uri,
+            `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`,
+            {}
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+    });
+
+    it('explicit-mode resolution does NOT auto-register graph parents for ancestors', async () => {
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(
+            c_uri,
+            `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`,
+            { backward_dependencies: 'explicit' }
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+        // The explicit directive in C itself still registers.
+        expect(
+            scope_resolver.get_backward_directive_children(b_uri).has(c_uri)
+        ).toBe(true);
+    });
+
+    it('explicit-mode resolution does NOT auto-register graph parents for forward callees', async () => {
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(
+            c_uri,
+            `do "${b_path}"\n`,
+            { backward_dependencies: 'explicit' }
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+    });
+
+    it('resolve_inherited_working_directory (indexer walk) never auto-registers ancestor graph parents', async () => {
+        // The indexer's WD walk forces backward_dependencies: 'explicit' to
+        // stay deterministic during a partial scan; the ancestor sync must
+        // honor that and not synthesize edges from the half-built graph.
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        const c_content = `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`;
+        const the_directives = new DirectiveParser()
+            .parse(c_content, c_uri).directives;
+        await scope_resolver.resolve_inherited_working_directory(
+            the_directives,
+            c_uri
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+    });
+});

--- a/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
+++ b/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
@@ -196,6 +196,66 @@ describe('issue #286 — ancestor-level effective backward-directive sync', () =
         ).toBe(false);
     });
 
+    it('auto-mode cache hit upgrades registration primed by the explicit WD walk', async () => {
+        // The indexer's forced-'explicit' WD walk can be the FIRST read of a
+        // directive-less ancestor: it parses + caches the file and registers
+        // nothing (correct for explicit mode). A later auto-mode resolution
+        // then cache-HITS that entry — and hit paths do not re-parse — so
+        // without the registration-upgrade-on-hit the auto edge would stay
+        // missing until the ancestor's content changed (review finding on
+        // issue #286: mixed explicit/auto workspaces, library files never
+        // opened directly).
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        const c_content = `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`;
+        const the_directives = new DirectiveParser()
+            .parse(c_content, c_uri).directives;
+        await scope_resolver.resolve_inherited_working_directory(
+            the_directives,
+            c_uri
+        );
+        // The explicit walk itself must not register auto edges...
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+
+        // ...but the subsequent auto-mode resolution that HITS the
+        // walk-primed cache entry must upgrade the registration.
+        await scope_resolver.resolve(c_uri, c_content, {});
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+    });
+
+    it('memo standalone-closure build registers ancestor auto parents (auto mode)', async () => {
+        // Nested forward closures build through the forward-closure memo
+        // (#234, on by default, gated on scan completion). The standalone
+        // build threads the initiating resolution's mode, so a
+        // directive-less file read during the build keeps its
+        // dependency-graph parents registered.
+        dependency_graph.mark_scan_complete();
+        const d_path = create_file('d.do', 'display "d"\n');
+        const a_path = create_file('a.do', 'do d.do\n');
+        const b_path = create_file('b.do', `do "${d_path}"\n`);
+        const a_uri = to_uri(a_path);
+        const d_uri = to_uri(d_path);
+        seed_auto_parent(a_uri, 'd.do');
+
+        // C's forward call to B makes B's own forward calls a NESTED
+        // closure (depth >= 1), which is where the memo hooks.
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(c_uri, `do "${b_path}"\n`, {});
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(d_uri)
+        ).toBe(true);
+    });
+
     it('resolve_inherited_working_directory (indexer walk) never auto-registers ancestor graph parents', async () => {
         // The indexer's WD walk forces backward_dependencies: 'explicit' to
         // stay deterministic during a partial scan; the ancestor sync must

--- a/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
+++ b/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
@@ -232,6 +232,37 @@ describe('issue #286 — ancestor-level effective backward-directive sync', () =
         ).toBe(true);
     });
 
+    it('auto-mode cache hit re-registers after the dependency graph gains a parent', async () => {
+        // The 'auto' stamp must fold in the dependency-graph version:
+        // an entry stamped while the graph was partial (or before a
+        // parent added its do-call) must not latch — the next auto-mode
+        // hit after a graph change re-runs effective registration
+        // (codex round-2 finding on issue #286).
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+
+        // First auto-mode resolution parses B with NO graph parents:
+        // stamps 'auto' at the current graph version, registers nothing.
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        const c_content = `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`;
+        await scope_resolver.resolve(c_uri, c_content, {});
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+
+        // The graph then gains A → B (version bump). The auto-mode scope
+        // cache key folds in the graph version, so this resolve re-walks
+        // and cache-HITS B — the hit must re-register from live graph
+        // state instead of skipping on the stale 'auto' stamp.
+        seed_auto_parent(a_uri, 'b.do');
+        await scope_resolver.resolve(c_uri, c_content, {});
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+    });
+
     it('memo standalone-closure build registers ancestor auto parents (auto mode)', async () => {
         // Nested forward closures build through the forward-closure memo
         // (#234, on by default, gated on scan completion). The standalone

--- a/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
+++ b/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
@@ -30,13 +30,14 @@ describe('issue #286 — ancestor-level effective backward-directive sync', () =
     let document_store: DocumentStore;
     let dependency_graph: DependencyGraph;
     let scope_resolver: ScopeResolver;
+    let forward_resolver: ForwardScopeResolver;
 
     beforeEach(() => {
         temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sight-286-'));
         document_store = new DocumentStore();
         dependency_graph = new DependencyGraph();
         scope_resolver = new ScopeResolver(create_test_scope_resolver_logger());
-        const forward_resolver = new ForwardScopeResolver(scope_resolver);
+        forward_resolver = new ForwardScopeResolver(scope_resolver);
         scope_resolver.set_forward_scope_resolver(forward_resolver);
         scope_resolver.set_dependency_graph(dependency_graph);
         document_store.set_scope_resolver(scope_resolver);
@@ -134,6 +135,35 @@ describe('issue #286 — ancestor-level effective backward-directive sync', () =
             scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
         ).toBe(true);
     });
+
+    it(
+        'direct forward resolve defaults to auto-mode callee registration',
+        async () => {
+            const b_path = create_file('b.do', 'display "b"\n');
+            const a_path = create_file('a.do', 'do b.do\n');
+            const c_path = create_file('c.do', `do "${b_path}"\n`);
+            const a_uri = to_uri(a_path);
+            const b_uri = to_uri(b_path);
+            const c_uri = to_uri(c_path);
+            seed_auto_parent(a_uri, 'b.do');
+
+            await forward_resolver.resolve(c_uri, [{
+                type: 'do',
+                raw_path: b_path,
+                is_static: true,
+                call_site_line: 0,
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: b_path.length + 5 },
+                },
+                source: 'command',
+            }]);
+
+            expect(
+                scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+            ).toBe(true);
+        }
+    );
 
     it('auto-mode resolution registers an ancestor\'s auto parents even when never opened (effective ⊇ raw)', async () => {
         const b_path = create_file('b.do', 'display "b"\n');
@@ -262,6 +292,51 @@ describe('issue #286 — ancestor-level effective backward-directive sync', () =
             scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
         ).toBe(true);
     });
+
+    it(
+        'directive-less auto cache hit re-registers after another cache ' +
+        'variant clears it',
+        async () => {
+            // file_cache is keyed by uri|working_directory, but backward
+            // directive registration is global per URI. An explicit parse of a
+            // second cache-key variant can clear the auto-synthesized parent
+            // edge for the URI without changing the dependency-graph version;
+            // the original auto cache entry must not assume its per-entry
+            // stamp still represents the global registration map.
+            const b_path = create_file('b.do', 'display "b"\n');
+            const a_path = create_file('a.do', 'do b.do\n');
+            const a_uri = to_uri(a_path);
+            const b_uri = to_uri(b_path);
+            const wd1 = path.join(temp_dir, 'wd1');
+            const wd2 = path.join(temp_dir, 'wd2');
+            seed_auto_parent(a_uri, 'b.do');
+
+            await scope_resolver.get_parsed_file(b_uri, b_path, {
+                working_directory: wd1,
+                backward_dependencies: 'auto',
+            });
+            expect(
+                scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+            ).toBe(true);
+
+            await scope_resolver.get_parsed_file(b_uri, b_path, {
+                working_directory: wd2,
+                backward_dependencies: 'explicit',
+            });
+            expect(
+                scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+            ).toBe(false);
+
+            await scope_resolver.get_parsed_file(b_uri, b_path, {
+                skip_disk_if_cached: true,
+                working_directory: wd1,
+                backward_dependencies: 'auto',
+            });
+            expect(
+                scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+            ).toBe(true);
+        }
+    );
 
     it('memo standalone-closure build registers ancestor auto parents (auto mode)', async () => {
         // Nested forward closures build through the forward-closure memo

--- a/tests/wait-until.ts
+++ b/tests/wait-until.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared predicate-polling helper for tests that must wait on
+ * asynchronous state (debounced validation, watcher events, terminal
+ * side effects) without racing it.
+ *
+ * Extracted so test files stop growing bespoke copies with drifting
+ * defaults (issue #287 review). Keep per-call timeouts BELOW the
+ * enclosing test's timeout (bun's default is 5000ms unless the test
+ * passes an explicit timeout to it()) so this helper's descriptive
+ * error surfaces instead of bun's generic "test timed out".
+ */
+export async function wait_until(
+    predicate: () => boolean,
+    description: string,
+    timeout_ms = 4000,
+    interval_ms = 20
+): Promise<void> {
+    const deadline_ms = Date.now() + timeout_ms;
+    while (!predicate()) {
+        if (Date.now() > deadline_ms) {
+            throw new Error(`Timed out waiting for: ${description}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, interval_ms));
+    }
+}


### PR DESCRIPTION
Closes #184. Prep work for #208.

## Problem

`DocumentStore.create_document_state` applied three cross-file side effects mid-parse, before `commit_state` decided whether the parse was accepted: backward-directive registration (raw sync), the indexer buffer-directives overlay callback, and the working-directory probe's internal effective registration inside `resolve()`. `close()` is synchronous and not part of the per-URI operation chain, so a parse finishing after close still applied all three — leaving a stale parent↔child edge (stale-add) or wiping edges a newer committed parse had set via clear-then-register (valid-edge-drop).

## Fix

- **Staged effects**: `create_document_state` returns `ParseOutcome { state, staged_effects }`; the mid-parse side effects are gone. `StagedCrossFileEffects` carries the raw directives + the scope-resolver config in force (pure functions of the parsed content).
- **Commit-time application**: `commit_state` (now returning `boolean`, with a new `disposed` guard) applies staged effects synchronously after all guards pass — no await separates guards from application, so `close()` can never interleave. A discarded parse never touches shared state.
- **Effective registration**: the canonical write is the new `ScopeResolver.apply_backward_directive_registration` — effective directives (raw + auto-synthesized from the DependencyGraph) computed at apply time against live graph state. This also closes a pre-existing gap: files with their own `@lsp-cd` (which never run the WD probe) now get auto-parent registration too. `apply_normalized_backward_directives` is the single mutation point for the backward map; the raw `sync_backward_directive_dependencies` routes through it unchanged.
- **Non-registering probe**: `resolve()` gains `options?: ResolveOptions` with `register_dependencies` (default true; deliberately NOT part of the cache key). The WD probe passes `false`, skipping only resolve's own top-level registration; ancestor-level syncs in `get_parsed_file` are unchanged (disk-derived, correct regardless of this parse's fate).
- **Close-time disk re-sync**: the `onDidClose` handler converges the (deliberately preserved, #278) backward map to disk state, so a header change saved just before closing isn't lost when the racing reparse is discarded. Guarded against quick reopen (checks both `TextDocuments` and the document store at apply time), uses URI-scoped settings (cached entry captured before deletion, else a fresh scoped fetch), and the fire-and-forget path can't produce an unhandled rejection.

Docs: new "Backward-Directive Registration Timing" section in `docs/cross-file.md` + CLAUDE.md pointer.

## Tests

New `tests/unit/document-store-commit-time-cross-file-effects.test.ts` (11 tests): close-mid-parse stale-add (map + overlay), valid-edge-drop across an A→B→C chain, dispose-during-parse, auto-parents at commit (incl. the own-`@lsp-cd` before/after variant), the probe-populated cache-hit scenario, interface-change invalidation restore, non-registering probe scope (top-level only, ancestors still sync), and disk re-sync semantics (convergence, missing file clears, reopen guard). Fault-injection confirmed the three race tests fail against the pre-fix behavior. Full gate: typecheck + 7154 tests + eslint clean.

## Review gate

Adversarial plan review (codex) before implementation; then three rounds on the diff: round 1 (codex 2 findings — reopen-aware guard, URI-scoped config — both fixed; 2 independent opus reviews clean), round 2 (codex 1 finding — scoped-settings fetch when the cache misses — fixed, plus a defensive IIFE catch), round 3 (codex CLEAN + opus CLEAN on the final diff).

## Deferrals

- #286 — pre-existing: the raw ancestor sync in `get_parsed_file` can drop auto-discovered edges (needs config threading; effective ⊇ raw so the fix is additive).
- #287 — optional hardening: no handler-level integration test drives the real `onDidClose` wiring (matches the existing project-wide close-path test style).

https://claude.ai/code/session_01DFizcojLhW3h59HXRo8Lbv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Staged cross-file directive side effects during parsing and applied them only after a guarded commit, preventing stale/lost dependency edges during open/update/close/reopen races.
  * Improved close-time convergence to on-disk directives with safeguards for reopened documents, in-flight reads, and disposal; also ensures correct dependent revalidation after resync.
* **Documentation**
  * Expanded cross-file timing guidance, including transactional staging/application and backward-dependency “auto” vs “explicit” behavior.
* **Tests**
  * Added unit/integration coverage for commit-time effects, cache-hit upgrades, ancestor effective sync, and close-resync wiring; introduced shared `wait_until` test helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->