### PR TITLE
Fix #286: ancestor-level backward-directive sync uses effective directives

### DIFF
--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -797,12 +797,15 @@ a separate best-effort recovery path (issue #184):
   auto edges. Effective ⊇ raw, so ancestor reads can only add edges
   relative to the pre-#286 behavior. Registration remains a parse-path
   side effect, with one exception: each file-cache entry is stamped with
-  the mode its registration ran under, and an `'auto'`-mode cache hit on
-  an `'explicit'`-registered entry applies effective registration once
-  and re-stamps (`upgrade_registration_on_cache_hit`). Without that
-  upgrade, the indexer's explicit WD walk priming the cache would leave a
-  directive-less ancestor's auto edges unregistered for as long as the
-  content stayed unchanged. Explicit-mode hits never downgrade, and memo
+  the mode its registration ran under (plus the dependency-graph version
+  it read), and an `'auto'`-mode cache hit re-applies effective
+  registration when the entry was `'explicit'`-registered or its
+  `'auto'` registration predates a graph change, then re-stamps
+  (`upgrade_registration_on_cache_hit`). Without that upgrade, the
+  indexer's explicit WD walk priming the cache would leave a
+  directive-less ancestor's auto edges unregistered — and a graph edge
+  added after the stamp would never reach `backward_directive_children`
+  — for as long as the content stayed unchanged. Explicit-mode hits never downgrade, and memo
   serves still perform no registration (files reached only through a
   served closure re-register when the memo entry is evicted or their
   content changes).

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -801,7 +801,10 @@ a separate best-effort recovery path (issue #184):
   it read), and an `'auto'`-mode cache hit re-applies effective
   registration when the entry was `'explicit'`-registered or its
   `'auto'` registration predates a graph change, then re-stamps
-  (`upgrade_registration_on_cache_hit`). Without that upgrade, the
+  (`upgrade_registration_on_cache_hit`). Entries whose content has
+  explicit backward directives skip the version re-check: their
+  effective registration is graph-independent, so graph churn never
+  costs them registration work. Without that upgrade, the
   indexer's explicit WD walk priming the cache would leave a
   directive-less ancestor's auto edges unregistered — and a graph edge
   added after the stamp would never reach `backward_directive_children`

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -783,7 +783,21 @@ a separate best-effort recovery path (issue #184):
   working-directory probe the parse runs (`resolve()` with
   `register_dependencies: false`) never registers the file's own edges;
   ancestor files read from disk during the walk still register *their own*
-  directives (disk-derived, correct regardless of this parse's fate).
+  edges (disk-derived, correct regardless of this parse's fate).
+- Ancestor-level registration inside `get_parsed_file` uses **effective**
+  directives under the resolution's `backward_dependencies` mode, threaded
+  through every read path — backward walks, forward callee reads, and
+  forward-closure memo builds (issue #286). In `'auto'` mode a file with no
+  explicit directives keeps (or gains) its dependency-graph parents when it
+  is read as an ancestor of another file's resolution, instead of having
+  those auto edges wiped by the clear-then-register sync until its next
+  commit. An `'explicit'`-mode resolution registers raw directives only and
+  never synthesizes graph parents; the indexer's working-directory walk
+  forces `'explicit'` for scan-order determinism and so never registers
+  auto edges. Effective ⊇ raw, so ancestor reads can only add edges
+  relative to the pre-#286 behavior. Registration remains a parse-path
+  side effect: cache hits (file cache, request cache, memo serves) do not
+  re-register.
 - `commit_state` applies the staged effects synchronously, after its
   disposed/closed-generation/version guards pass. A parse discarded by a
   racing `close()` (or by `dispose()`) therefore never mutates shared
@@ -804,7 +818,9 @@ a separate best-effort recovery path (issue #184):
 
 See `tests/unit/document-store-commit-time-cross-file-effects.test.ts` for
 the race scenarios this guarantees (stale-add, valid-edge-drop across an
-A→B→C chain, dispose-during-parse, probe cache interaction, disk re-sync).
+A→B→C chain, dispose-during-parse, probe cache interaction, disk re-sync),
+and `tests/unit/scope-resolver-ancestor-effective-sync.test.ts` for the
+ancestor-level effective-sync behavior (issue #286).
 
 ## Configuration
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -796,8 +796,16 @@ a separate best-effort recovery path (issue #184):
   forces `'explicit'` for scan-order determinism and so never registers
   auto edges. Effective ⊇ raw, so ancestor reads can only add edges
   relative to the pre-#286 behavior. Registration remains a parse-path
-  side effect: cache hits (file cache, request cache, memo serves) do not
-  re-register.
+  side effect, with one exception: each file-cache entry is stamped with
+  the mode its registration ran under, and an `'auto'`-mode cache hit on
+  an `'explicit'`-registered entry applies effective registration once
+  and re-stamps (`upgrade_registration_on_cache_hit`). Without that
+  upgrade, the indexer's explicit WD walk priming the cache would leave a
+  directive-less ancestor's auto edges unregistered for as long as the
+  content stayed unchanged. Explicit-mode hits never downgrade, and memo
+  serves still perform no registration (files reached only through a
+  served closure re-register when the memo entry is evicted or their
+  content changes).
 - `commit_state` applies the staged effects synchronously, after its
   disposed/closed-generation/version guards pass. A parse discarded by a
   racing `close()` (or by `dispose()`) therefore never mutates shared

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -38,6 +38,16 @@ import { clone_symbol_table } from '../scope-resolver/visible-symbols';
 
 export interface ForwardScopeConfig {
     max_forward_depth: number;
+    /**
+     * The initiating resolution's effective backward-dependencies mode
+     * (issue #286). Threaded into get_parsed_file so the ancestor-level
+     * backward-directive registration for callees read from disk matches
+     * the chain's semantics. Purely a side-effect input: it never changes
+     * resolved symbols, so it is deliberately absent from the
+     * forward-closure memo key. When unset, get_parsed_file defaults to
+     * 'explicit' (raw registration, the pre-#286 behavior).
+     */
+    backward_dependencies?: 'auto' | 'explicit';
     diagnostics?: {
         max_depth?: 'error' | 'warning' | 'information' | 'off';
     };
@@ -830,7 +840,12 @@ export class ForwardScopeResolver {
             }
 
             // Get callee symbols
-            const callee_result = await this.get_callee_scope(resolved_path, callee_uri, effective_call_wd);
+            const callee_result = await this.get_callee_scope(
+                resolved_path,
+                callee_uri,
+                effective_call_wd,
+                resolved_config.backward_dependencies
+            );
 
             if (decision.action === 'boundary_only') {
                 // Dedup'd do/run re-visit at the outermost resolve()
@@ -1247,6 +1262,13 @@ export class ForwardScopeResolver {
                 token,
                 {
                     max_forward_depth: resolved_config.max_forward_depth,
+                    // Thread the initiating resolution's backward mode so
+                    // callee reads during this build register edges under
+                    // the same semantics as the live walk they replace
+                    // (issue #286). Side-effect-only: not in the memo key,
+                    // and serves never register.
+                    backward_dependencies:
+                        resolved_config.backward_dependencies,
                     // Force a non-'off' truncation severity: a cap-truncated
                     // closure is shaped by the cap but the SEVERITY setting
                     // is not in the key, so under 'off' it would look
@@ -1490,6 +1512,7 @@ export class ForwardScopeResolver {
             callee_fs_path,
             callee_uri,
             working_directory,
+            resolved_config.backward_dependencies,
         );
         if ('error' in callee_result) return new Map();
 
@@ -1630,7 +1653,8 @@ export class ForwardScopeResolver {
     private async get_callee_scope(
         fs_path: string,
         uri: string,
-        working_directory?: string
+        working_directory?: string,
+        backward_dependencies?: 'auto' | 'explicit'
     ): Promise<{ symbols: SymbolTable; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; content_hash?: string } | { error: string }> {
         let final_fs_path = fs_path;
         let final_uri = uri;
@@ -1656,7 +1680,7 @@ export class ForwardScopeResolver {
 
         // Only use cache-first mode for files within workspace roots
         const skip_disk_if_cached = this.is_within_workspace_roots(final_fs_path);
-        const parsed_result = await this.scope_resolver.get_parsed_file(final_uri, final_fs_path, { skip_disk_if_cached, working_directory });
+        const parsed_result = await this.scope_resolver.get_parsed_file(final_uri, final_fs_path, { skip_disk_if_cached, working_directory, backward_dependencies });
         if ('error' in parsed_result) {
             const paths_msg = paths_tried.length > 1 ? ` (tried: ${paths_tried.join(', ')})` : '';
             return { error: parsed_result.error + paths_msg };

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -182,14 +182,16 @@ export class ScopeResolver {
     private parser: StataParser;
     private analyzer: SemanticAnalyzer;
     // Cache key is "uri|working_directory" (or just "uri" if no working directory)
-    // registered_backward_mode: the backward_dependencies mode the entry's
-    // last parse-path registration ran under (issue #286). Undefined for
-    // entries written by parse_file (root-file parses, which register via
-    // resolve()/commit instead). Lets cache HITS upgrade an
-    // 'explicit'-registered entry to effective registration when first
-    // read by an 'auto'-mode resolution — see
-    // upgrade_registration_on_cache_hit.
-    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit' }>;
+    // registered_backward_mode / registered_graph_version: the
+    // backward_dependencies mode the entry's last parse-path registration
+    // ran under, and the DependencyGraph version it read (issue #286).
+    // Undefined for entries written by parse_file (root-file parses,
+    // which register via resolve()/commit instead). Lets cache HITS
+    // upgrade an 'explicit'-registered entry to effective registration
+    // when first read by an 'auto'-mode resolution, and re-sync an
+    // 'auto'-registered directive-less entry when the graph has changed
+    // since — see upgrade_registration_on_cache_hit.
+    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit'; registered_graph_version?: number }>;
     private scope_cache: Map<string, ScopeCacheEntry>;
     // Secondary index: uri -> Set<cache_keys> for O(1) scope cache invalidation by URI
     private uri_to_cache_keys: Map<string, Set<string>>;
@@ -2467,11 +2469,14 @@ export class ScopeResolver {
                 working_directory: parse_result.working_directory,
                 working_directory_directive: parse_result.working_directory_directive,
                 diagnostics: parse_result.diagnostics,
-                // Stamp the mode the registration below runs under, so
-                // later cache hits can upgrade an 'explicit'-registered
-                // entry (issue #286).
+                // Stamp the mode the registration below runs under (and
+                // the graph version it reads), so later cache hits can
+                // upgrade an 'explicit'-registered entry or re-sync a
+                // graph-stale 'auto' one (issue #286).
                 registered_backward_mode:
                     options?.backward_dependencies ?? 'explicit',
+                registered_graph_version:
+                    this.dependency_graph?.get_version(),
             });
 
             // Register backward directive dependencies from cached file
@@ -3418,29 +3423,43 @@ export class ScopeResolver {
      * dependency-graph parents unregistered for as long as 'auto'-mode
      * resolutions keep hitting the cache (until the content changes).
      * When an 'auto'-mode read hits such an entry, apply effective
-     * registration once and stamp the entry so repeat hits are free.
+     * registration and stamp the entry so repeat hits are free.
      * Effective ⊇ raw, so upgrading can only add edges. Explicit-mode
      * hits never downgrade: for them hit paths stay side-effect-free,
      * as before.
+     *
+     * The 'auto' stamp folds in the DependencyGraph version it was
+     * registered against: auto synthesis reads live graph state, so an
+     * entry stamped while the graph was partial (or before a parent
+     * added its do-call) must not latch — the next auto-mode hit after
+     * a graph change re-syncs. Entries whose cached content has explicit
+     * directives skip the version check entirely: for them effective
+     * registration is graph-independent (explicit directives win), so
+     * repeat hits stay free of registration work.
      */
     private upgrade_registration_on_cache_hit(
         uri: string,
         cached: {
             directives: Directive[];
             registered_backward_mode?: 'auto' | 'explicit';
+            registered_graph_version?: number;
         },
         requested_mode: 'auto' | 'explicit' | undefined
     ): void {
         if (requested_mode !== 'auto') {
             return;
         }
-        if (cached.registered_backward_mode === 'auto') {
+        const current_graph_version = this.dependency_graph?.get_version();
+        if (cached.registered_backward_mode === 'auto' &&
+            (cached.directives.length > 0 ||
+             cached.registered_graph_version === current_graph_version)) {
             return;
         }
         this.apply_backward_directive_registration(uri, cached.directives, {
             backward_dependencies: 'auto',
         });
         cached.registered_backward_mode = 'auto';
+        cached.registered_graph_version = current_graph_version;
     }
 
     /**

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -182,7 +182,14 @@ export class ScopeResolver {
     private parser: StataParser;
     private analyzer: SemanticAnalyzer;
     // Cache key is "uri|working_directory" (or just "uri" if no working directory)
-    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] }>;
+    // registered_backward_mode: the backward_dependencies mode the entry's
+    // last parse-path registration ran under (issue #286). Undefined for
+    // entries written by parse_file (root-file parses, which register via
+    // resolve()/commit instead). Lets cache HITS upgrade an
+    // 'explicit'-registered entry to effective registration when first
+    // read by an 'auto'-mode resolution — see
+    // upgrade_registration_on_cache_hit.
+    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit' }>;
     private scope_cache: Map<string, ScopeCacheEntry>;
     // Secondary index: uri -> Set<cache_keys> for O(1) scope cache invalidation by URI
     private uri_to_cache_keys: Map<string, Set<string>>;
@@ -2288,6 +2295,9 @@ export class ScopeResolver {
         if (options?.skip_disk_if_cached && cached) {
             this.log(`[get_parsed_file] file_cache HIT for ${cache_key} (skip_disk_if_cached)`);
             this.cache_metrics.file.hits++;
+            this.upgrade_registration_on_cache_hit(
+                uri, cached, options?.backward_dependencies
+            );
             return {
                 content: cached.content,
                 content_hash: cached.content_hash,
@@ -2315,6 +2325,9 @@ export class ScopeResolver {
                 cached.size !== undefined && cached.size === size) {
                 this.cache_metrics.file.hits++;
                 this.log(`[get_parsed_file] File cache HIT for ${uri} (mtime match, skipped read)`);
+                this.upgrade_registration_on_cache_hit(
+                    uri, cached, options?.backward_dependencies
+                );
                 return {
                     content: cached.content,
                     content_hash: cached.content_hash,
@@ -2354,6 +2367,11 @@ export class ScopeResolver {
                             fallback_cached.size !== undefined && fallback_cached.size === fallback_size) {
                             this.cache_metrics.file.hits++;
                             this.log(`[get_parsed_file] File cache HIT for ${fallback_uri} (mtime match, skipped read)`);
+                            this.upgrade_registration_on_cache_hit(
+                                fallback_uri,
+                                fallback_cached,
+                                options?.backward_dependencies
+                            );
                             return {
                                 content: fallback_cached.content,
                                 content_hash: fallback_cached.content_hash,
@@ -2400,6 +2418,9 @@ export class ScopeResolver {
         if (actual_cached && actual_cached.content_hash === disk_hash) {
             this.cache_metrics.file.hits++;
             this.log(`[get_parsed_file] File cache HIT for ${actual_uri} (hash match)`);
+            this.upgrade_registration_on_cache_hit(
+                actual_uri, actual_cached, options?.backward_dependencies
+            );
             // Return cached results with current content - don't mutate cache entry
             return {
                 content,
@@ -2446,6 +2467,11 @@ export class ScopeResolver {
                 working_directory: parse_result.working_directory,
                 working_directory_directive: parse_result.working_directory_directive,
                 diagnostics: parse_result.diagnostics,
+                // Stamp the mode the registration below runs under, so
+                // later cache hits can upgrade an 'explicit'-registered
+                // entry (issue #286).
+                registered_backward_mode:
+                    options?.backward_dependencies ?? 'explicit',
             });
 
             // Register backward directive dependencies from cached file
@@ -3382,6 +3408,39 @@ export class ScopeResolver {
             );
         const normalized = this.normalize_directives(effective_directives, []);
         this.apply_normalized_backward_directives(child_uri, normalized);
+    }
+
+    /**
+     * Registration upgrade on file-cache hit (issue #286). Hit paths do
+     * not re-parse, so an entry whose last parse-path registration ran
+     * under 'explicit' — e.g. primed by the indexer's forced-'explicit'
+     * working-directory walk — would leave a directive-less file's
+     * dependency-graph parents unregistered for as long as 'auto'-mode
+     * resolutions keep hitting the cache (until the content changes).
+     * When an 'auto'-mode read hits such an entry, apply effective
+     * registration once and stamp the entry so repeat hits are free.
+     * Effective ⊇ raw, so upgrading can only add edges. Explicit-mode
+     * hits never downgrade: for them hit paths stay side-effect-free,
+     * as before.
+     */
+    private upgrade_registration_on_cache_hit(
+        uri: string,
+        cached: {
+            directives: Directive[];
+            registered_backward_mode?: 'auto' | 'explicit';
+        },
+        requested_mode: 'auto' | 'explicit' | undefined
+    ): void {
+        if (requested_mode !== 'auto') {
+            return;
+        }
+        if (cached.registered_backward_mode === 'auto') {
+            return;
+        }
+        this.apply_backward_directive_registration(uri, cached.directives, {
+            backward_dependencies: 'auto',
+        });
+        cached.registered_backward_mode = 'auto';
     }
 
     /**

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -160,6 +160,8 @@ interface ForwardScopeResolverInterface {
         token?: import('vscode-languageserver').CancellationToken,
         config?: {
             max_forward_depth?: number;
+            /** See ForwardScopeConfig.backward_dependencies (issue #286). */
+            backward_dependencies?: 'auto' | 'explicit';
             diagnostics?: {
                 max_depth?: 'error' | 'warning' | 'information' | 'off';
             };
@@ -1104,6 +1106,12 @@ export class ScopeResolver {
                 token,
                 {
                     max_forward_depth: my_config.max_forward_depth,
+                    // Thread the resolution's backward mode so callee reads
+                    // register ancestor edges under the same semantics
+                    // (issue #286); ?? 'auto' mirrors
+                    // get_effective_backward_directives.
+                    backward_dependencies:
+                        my_config.backward_dependencies ?? 'auto',
                     diagnostics: {
                         max_depth: my_config.diagnostics?.max_depth,
                     },
@@ -1355,6 +1363,10 @@ export class ScopeResolver {
             token,
             {
                 max_forward_depth: remaining_depth,
+                // Thread the resolution's backward mode for ancestor-edge
+                // registration during callee reads (issue #286).
+                backward_dependencies:
+                    config.backward_dependencies ?? 'auto',
                 // Thread the depth-diagnostic severity/off setting so a
                 // parent's forward truncations honor `max_depth` too (#209).
                 diagnostics: { max_depth: config.diagnostics?.max_depth },
@@ -1495,7 +1507,15 @@ export class ScopeResolver {
                 my_parent_result = await this.get_parsed_file(
                     my_parent_uri,
                     my_real_path,
-                    { request_cache }
+                    {
+                        request_cache,
+                        // Thread the walk's mode so the ancestor-level
+                        // registration inside get_parsed_file matches the
+                        // resolution semantics (issue #286). ?? 'auto'
+                        // mirrors get_effective_backward_directives.
+                        backward_dependencies:
+                            config.backward_dependencies ?? 'auto',
+                    }
                 );
             } catch (error) {
                 my_parent_result = { error: String(error) };
@@ -1696,7 +1716,15 @@ export class ScopeResolver {
             const my_parent_result = await this.get_parsed_file(
                 my_parent_uri,
                 my_real_fs_path,
-                { working_directory: discovered_wd, request_cache }  // Pass discovered working directory
+                {
+                    working_directory: discovered_wd,  // Pass discovered working directory
+                    request_cache,
+                    // Thread the chain's mode for the ancestor-level
+                    // registration (issue #286); ?? 'auto' mirrors
+                    // get_effective_backward_directives.
+                    backward_dependencies:
+                        config.backward_dependencies ?? 'auto',
+                }
             );
 
             // Check for cancellation after file read
@@ -2207,11 +2235,22 @@ export class ScopeResolver {
      * @param options - Optional settings
      * @param options.skip_disk_if_cached - If true, return cached entry without disk read (cache-first mode)
      * @param options.working_directory - Inherited working directory for path resolution in nested files
+     * @param options.backward_dependencies - The resolution's effective
+     *   backward-dependencies mode (issue #286). Governs ONLY the
+     *   registration side effect on the parse path: 'auto' uses the
+     *   effective variant (auto-synthesizes DependencyGraph parents when
+     *   the file has no explicit directives), 'explicit' registers raw
+     *   directives only. Defaults to 'explicit' (the raw pre-#286
+     *   behavior) so untracked callers can never synthesize edges from a
+     *   mode they did not opt into. Callers inside a resolution must
+     *   thread the chain's mode (normalized with ?? 'auto', matching
+     *   get_effective_backward_directives). Deliberately NOT part of any
+     *   cache key: parsed content is mode-independent.
      */
     async get_parsed_file(
         uri: string,
         fs_path: string,
-        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache }
+        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache; backward_dependencies?: 'auto' | 'explicit' }
     ): Promise<ParsedFileResult> {
         // Use request cache if available to avoid duplicate reads/parses in same request
         if (options?.request_cache) {
@@ -2237,7 +2276,7 @@ export class ScopeResolver {
     private async _get_parsed_file_impl(
         uri: string,
         fs_path: string,
-        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache }
+        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache; backward_dependencies?: 'auto' | 'explicit' }
     ): Promise<ParsedFileResult> {
         const inherited_wd = options?.working_directory;
         const cache_key = this.make_file_cache_key(uri, inherited_wd);
@@ -2412,14 +2451,19 @@ export class ScopeResolver {
             // Register backward directive dependencies from cached file
             // This ensures transitive dependents are discoverable even when
             // intermediate files are only read from disk (not opened in editor).
-            // Intentionally the RAW variant (no auto-synthesis), unlike the
-            // commit-time effective registration in DocumentStore (issue #184):
-            // computing effective directives here would need the resolution's
-            // backward_dependencies mode threaded through get_parsed_file.
-            // Known consequence: for a file with auto-discovered parents that
-            // is also read as an ancestor, this clear-then-register drops its
-            // auto edges until its next commit — pre-existing behavior.
-            this.sync_backward_directive_dependencies(actual_uri, parse_result.directives);
+            // Uses the EFFECTIVE variant under the resolution's threaded
+            // backward_dependencies mode (issue #286): in 'auto' mode a file
+            // with no explicit directives keeps (or gains) its DependencyGraph
+            // parents instead of having them wiped by this clear-then-register,
+            // matching the commit-time effective registration in DocumentStore
+            // (issue #184). An unthreaded call defaults to 'explicit', which
+            // registers raw directives only — identical to the pre-#286 raw
+            // sync, so this can only ADD edges relative to that behavior.
+            this.apply_backward_directive_registration(
+                actual_uri,
+                parse_result.directives,
+                { backward_dependencies: options?.backward_dependencies ?? 'explicit' }
+            );
 
             // Register forward call relationships from cached file
             // This ensures callee_to_callers map includes relationships from cached files,

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -2423,7 +2423,9 @@ export class ScopeResolver {
             this.upgrade_registration_on_cache_hit(
                 actual_uri, actual_cached, options?.backward_dependencies
             );
-            // Return cached results with current content - don't mutate cache entry
+            // Return cached results with current content - don't mutate the
+            // entry's cached content/symbols (the registration stamp above
+            // is the one intentional entry mutation on this hit path)
             return {
                 content,
                 content_hash: disk_hash,

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -193,9 +193,16 @@ export function resolve_scoped_client_settings(
 // re-scanning. `max_backward_depth` is included because the indexer's
 // inherited-WD walk (#218) uses it to key closed-file callee edges, so
 // a depth change must re-index for those edges to stay consistent with
-// the open-document path. (`backward_dependencies` is NOT needed: the
-// indexer walk forces explicit backward resolution, so it is
-// independent of the auto/explicit mode.)
+// the open-document path. (`backward_dependencies` is NOT included even
+// though, since #286, the mode steers the parse-path registration side
+// effect in get_parsed_file: a re-scan would not re-run that
+// registration anyway (the file cache is content-keyed and unaffected
+// by settings), so including it buys a costly teardown without the
+// convergence it implies. A mid-session flip instead self-heals per
+// file: explicit→auto is healed by the cache-hit registration upgrade
+// (see upgrade_registration_on_cache_hit) and each file's next
+// parse/commit; auto→explicit leaves vestigial auto edges until the
+// next parse — benign over-revalidation, never a false suppression.)
 //
 // This signature is compared on BOTH config-change paths against a
 // single shared `last_applied_indexing_signature`: the `sight.toml`

--- a/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
+++ b/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
@@ -1,0 +1,222 @@
+// Issue #286: get_parsed_file's ancestor-level backward-directive sync used
+// the RAW variant (sync_backward_directive_dependencies, no auto-synthesis).
+// Registration is clear-then-register, so a file whose
+// backward_directive_children edges came from auto-discovery (DependencyGraph
+// parents, no explicit directives) had those edges WIPED whenever it was read
+// from disk as an ancestor of another file's resolution — until its next
+// commit re-registered them. Consequence: interface-change revalidation
+// fan-out (get_transitive_backward_directive_children) silently skipped the
+// wiped file's descendants.
+//
+// The fix threads the resolution's effective backward_dependencies mode into
+// get_parsed_file and switches the ancestor sync to the effective variant
+// (apply_backward_directive_registration). Effective ⊇ raw, so the change can
+// only ADD edges; an 'explicit'-mode resolution must NOT auto-register graph
+// parents for ancestors.
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { URI } from 'vscode-uri';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { DirectiveParser } from '../../src/directive-parser';
+import { DocumentStore } from '../../src/document-store';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { create_test_scope_resolver_logger } from '../test-logger';
+
+describe('issue #286 — ancestor-level effective backward-directive sync', () => {
+    let temp_dir: string;
+    let document_store: DocumentStore;
+    let dependency_graph: DependencyGraph;
+    let scope_resolver: ScopeResolver;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sight-286-'));
+        document_store = new DocumentStore();
+        dependency_graph = new DependencyGraph();
+        scope_resolver = new ScopeResolver(create_test_scope_resolver_logger());
+        const forward_resolver = new ForwardScopeResolver(scope_resolver);
+        scope_resolver.set_forward_scope_resolver(forward_resolver);
+        scope_resolver.set_dependency_graph(dependency_graph);
+        document_store.set_scope_resolver(scope_resolver);
+    });
+
+    afterEach(async () => {
+        await document_store.dispose();
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    const create_file = (name: string, content: string): string => {
+        const file_path = path.join(temp_dir, name);
+        fs.writeFileSync(file_path, content);
+        return file_path;
+    };
+    const to_uri = (file_path: string): string =>
+        URI.file(file_path).toString();
+
+    /**
+     * Seed a dependency-graph edge parent → child, as the workspace scan
+     * would after seeing `do child.do` in the parent.
+     */
+    const seed_auto_parent = (parent_uri: string, child_name: string): void => {
+        dependency_graph.update_caller(parent_uri, [{
+            type: 'do',
+            raw_path: child_name,
+            is_static: true,
+            call_site_line: 0,
+            range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 10 },
+            },
+            source: 'command',
+        }]);
+    };
+
+    it('auto-discovered edges survive a backward ancestor read (regression)', async () => {
+        // A --do--> B (auto-discovered, no explicit directives in B).
+        const b_path = create_file('b.do', 'display "b on disk"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+        expect(dependency_graph.get_parents(b_uri)).toHaveLength(1);
+
+        // Open B with buffer content that differs from disk (unsaved edit),
+        // so a later ancestor read of B is a file-cache STALE → full parse.
+        // Commit-time effective registration (issue #184) adds A → B.
+        await document_store.open(b_uri, 'display "b in buffer"\n', 1);
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+
+        // Resolve C, whose chain reads B from disk as an ancestor. Before
+        // the fix, the RAW clear-then-register sync inside get_parsed_file
+        // wiped B's auto edges (B has no explicit directives).
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(
+            c_uri,
+            `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`,
+            {}
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+        expect(
+            scope_resolver.get_backward_directive_children(b_uri).has(c_uri)
+        ).toBe(true);
+        // Fan-out consequence: revalidation from A must reach C through B.
+        const the_transitive =
+            scope_resolver.get_transitive_backward_directive_children(a_uri);
+        expect(the_transitive.has(b_uri)).toBe(true);
+        expect(the_transitive.has(c_uri)).toBe(true);
+    });
+
+    it('auto-discovered edges survive a forward callee read (regression)', async () => {
+        const b_path = create_file('b.do', 'display "b on disk"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        await document_store.open(b_uri, 'display "b in buffer"\n', 1);
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+
+        // C reads B as a forward callee (do command), which goes through
+        // ForwardScopeResolver.get_callee_scope → get_parsed_file.
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(c_uri, `do "${b_path}"\n`, {});
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+    });
+
+    it('auto-mode resolution registers an ancestor\'s auto parents even when never opened (effective ⊇ raw)', async () => {
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(
+            c_uri,
+            `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`,
+            {}
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+    });
+
+    it('explicit-mode resolution does NOT auto-register graph parents for ancestors', async () => {
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(
+            c_uri,
+            `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`,
+            { backward_dependencies: 'explicit' }
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+        // The explicit directive in C itself still registers.
+        expect(
+            scope_resolver.get_backward_directive_children(b_uri).has(c_uri)
+        ).toBe(true);
+    });
+
+    it('explicit-mode resolution does NOT auto-register graph parents for forward callees', async () => {
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(
+            c_uri,
+            `do "${b_path}"\n`,
+            { backward_dependencies: 'explicit' }
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+    });
+
+    it('resolve_inherited_working_directory (indexer walk) never auto-registers ancestor graph parents', async () => {
+        // The indexer's WD walk forces backward_dependencies: 'explicit' to
+        // stay deterministic during a partial scan; the ancestor sync must
+        // honor that and not synthesize edges from the half-built graph.
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        const c_content = `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`;
+        const the_directives = new DirectiveParser()
+            .parse(c_content, c_uri).directives;
+        await scope_resolver.resolve_inherited_working_directory(
+            the_directives,
+            c_uri
+        );
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+    });
+});

--- a/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
+++ b/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
@@ -196,6 +196,66 @@ describe('issue #286 — ancestor-level effective backward-directive sync', () =
         ).toBe(false);
     });
 
+    it('auto-mode cache hit upgrades registration primed by the explicit WD walk', async () => {
+        // The indexer's forced-'explicit' WD walk can be the FIRST read of a
+        // directive-less ancestor: it parses + caches the file and registers
+        // nothing (correct for explicit mode). A later auto-mode resolution
+        // then cache-HITS that entry — and hit paths do not re-parse — so
+        // without the registration-upgrade-on-hit the auto edge would stay
+        // missing until the ancestor's content changed (review finding on
+        // issue #286: mixed explicit/auto workspaces, library files never
+        // opened directly).
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        const c_content = `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`;
+        const the_directives = new DirectiveParser()
+            .parse(c_content, c_uri).directives;
+        await scope_resolver.resolve_inherited_working_directory(
+            the_directives,
+            c_uri
+        );
+        // The explicit walk itself must not register auto edges...
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+
+        // ...but the subsequent auto-mode resolution that HITS the
+        // walk-primed cache entry must upgrade the registration.
+        await scope_resolver.resolve(c_uri, c_content, {});
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+    });
+
+    it('memo standalone-closure build registers ancestor auto parents (auto mode)', async () => {
+        // Nested forward closures build through the forward-closure memo
+        // (#234, on by default, gated on scan completion). The standalone
+        // build threads the initiating resolution's mode, so a
+        // directive-less file read during the build keeps its
+        // dependency-graph parents registered.
+        dependency_graph.mark_scan_complete();
+        const d_path = create_file('d.do', 'display "d"\n');
+        const a_path = create_file('a.do', 'do d.do\n');
+        const b_path = create_file('b.do', `do "${d_path}"\n`);
+        const a_uri = to_uri(a_path);
+        const d_uri = to_uri(d_path);
+        seed_auto_parent(a_uri, 'd.do');
+
+        // C's forward call to B makes B's own forward calls a NESTED
+        // closure (depth >= 1), which is where the memo hooks.
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(c_uri, `do "${b_path}"\n`, {});
+
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(d_uri)
+        ).toBe(true);
+    });
+
     it('resolve_inherited_working_directory (indexer walk) never auto-registers ancestor graph parents', async () => {
         // The indexer's WD walk forces backward_dependencies: 'explicit' to
         // stay deterministic during a partial scan; the ancestor sync must

--- a/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
+++ b/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
@@ -232,6 +232,37 @@ describe('issue #286 — ancestor-level effective backward-directive sync', () =
         ).toBe(true);
     });
 
+    it('auto-mode cache hit re-registers after the dependency graph gains a parent', async () => {
+        // The 'auto' stamp must fold in the dependency-graph version:
+        // an entry stamped while the graph was partial (or before a
+        // parent added its do-call) must not latch — the next auto-mode
+        // hit after a graph change re-runs effective registration
+        // (codex round-2 finding on issue #286).
+        const b_path = create_file('b.do', 'display "b"\n');
+        const a_path = create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(a_path);
+        const b_uri = to_uri(b_path);
+
+        // First auto-mode resolution parses B with NO graph parents:
+        // stamps 'auto' at the current graph version, registers nothing.
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        const c_content = `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`;
+        await scope_resolver.resolve(c_uri, c_content, {});
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+
+        // The graph then gains A → B (version bump). The auto-mode scope
+        // cache key folds in the graph version, so this resolve re-walks
+        // and cache-HITS B — the hit must re-register from live graph
+        // state instead of skipping on the stale 'auto' stamp.
+        seed_auto_parent(a_uri, 'b.do');
+        await scope_resolver.resolve(c_uri, c_content, {});
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(true);
+    });
+
     it('memo standalone-closure build registers ancestor auto parents (auto mode)', async () => {
         // Nested forward closures build through the forward-closure memo
         // (#234, on by default, gated on scan completion). The standalone


### PR DESCRIPTION
Closes #286.

> [!IMPORTANT]
> **Stacked PR** — based on `issue184` because #288 is unmerged. Merge after #288, or retarget to `main` once #288 lands (the diff shown here is exactly the #286 work either way).

## Problem

`get_parsed_file`'s parse-path registration used the RAW variant (`sync_backward_directive_dependencies`, no auto-synthesis). Registration is clear-then-register, so a file whose `backward_directive_children` edges came from auto-discovery (DependencyGraph parents, no explicit directives) had those edges **wiped** whenever it was read from disk as an ancestor of another file's resolution. Consequence: `get_transitive_backward_directive_children` missed the file, so interface-change revalidation fan-out (`schedule_caller_revalidation`) silently skipped its descendants until its next commit. Documented and deferred during #184.

## Fix

1. **Thread the resolution's effective `backward_dependencies` mode into `get_parsed_file`** and switch the ancestor sync to `apply_backward_directive_registration` (the effective variant from #184). Swept **all** consumers: backward walk (`discover_working_directory`, `follow_directives`), forward callee reads (`get_callee_scope`, both call sites), the forward-closure memo standalone build, and both `ForwardScopeResolver.resolve` invocations (`ForwardScopeConfig` gains the field). Unthreaded callers default to `'explicit'`, which is exactly the old raw sync — so the change can only **add** edges. An `'explicit'`-mode resolution never synthesizes graph parents; the indexer's WD walk keeps its forced `'explicit'` (scan-order determinism).
2. **Registration upgrade on cache hit** (review round 1, all three reviewers converged): file-cache entries are stamped with the mode their registration ran under; an `'auto'`-mode hit on an `'explicit'`-stamped (or unstamped) entry applies effective registration once and re-stamps. Without this, the indexer's forced-`'explicit'` WD walk priming the cache left a directive-less ancestor's auto edges unregistered until its content changed.
3. **Graph-version-aware stamp** (codex round 2): the `'auto'` stamp records the DependencyGraph version; a hit re-syncs when the version moved (entry stamped during a partial scan, or a parent added its call later). Directive-ful entries skip the version check — their effective registration is graph-independent.

Docs: `docs/cross-file.md` "Backward-Directive Registration Timing" updated; stale comments corrected (including `server-factory.ts`'s `indexing_affecting_signature` rationale).

## Tests

`tests/unit/scope-resolver-ancestor-effective-sync.test.ts` (9 tests), each regression fault-checked (fails on the pre-fix tree):
- auto edges survive a backward ancestor read / a forward callee read (the #286 repro)
- auto mode registers a never-opened ancestor's graph parents (effective ⊇ raw)
- explicit mode never auto-registers (backward + forward + indexer WD walk)
- explicit-primed cache entry upgrades on the first auto-mode hit
- auto stamp re-syncs after the graph gains a parent (version-aware stamp)
- memo standalone-closure build registers under the threaded mode

`bun run test` (typecheck + 7168 tests) and `bun run lint` clean.

## Review gate

3 rounds of codex + 2 directly-spawned reviewer subagents (one cold, one invariant-primed) per round, findings fixed in-branch each round; round 3 returned CLEAN from all three (remaining nits were comment/docs-only, folded in).

## Known limitations (adjudicated, pre-existing semantics)

- **Memo serves perform no registration**: files reached only through a served forward-closure re-register when the memo entry is evicted or their content changes (memo evicts in lockstep with the scope cache and dep-graph versioning).
- **`backward_dependencies` stays out of `indexing_affecting_signature`**: a mid-session mode flip self-heals per file (explicit→auto via the hit upgrade and each file's next parse/commit; auto→explicit leaves vestigial edges = benign over-revalidation, never a false suppression). The comment now explains why inclusion wouldn't deliver convergence anyway.
- **Reader-mode threading is the issue's specified design**: ancestor registration uses the reading resolution's mode; commit-time registration under the file's own scoped config remains authoritative.
- **Explicit-mode parse of a directive-less ancestor still clears its committed auto edges** — pre-existing raw semantics required by "explicit must not auto-register"; now healed by the next auto-mode hit upgrade.
- Observed once during gating: a pre-existing seed-dependent flake in `tests/property/malformed-expression-errors.prop.test.ts` ("should not report errors for well-formed expressions") — 0/25 failures in isolation on both branches, unrelated to this diff (expression diagnostics; this diff only touches registration side effects).

https://claude.ai/code/session_01DFizcojLhW3h59HXRo8Lbv
