### PR TITLE
Handler-level integration test for the onDidClose disk re-sync wiring (#287)

### DIFF
--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1213,10 +1213,14 @@ export async function create_server(options: ServerOptions): Promise<void> {
     // Wire initialized handler
     connection.onInitialized(
         create_initialized_handler(() => {
-            // Initialize Logger - route to stderr for stdio transport, suppress if quiet
+            // Initialize Logger - route to stderr for stdio transport,
+            // suppress if quiet. With an injected connection the stdio
+            // transport flag says nothing about the host's real stdio, so
+            // never write to process.stderr in that case — route through
+            // the injected connection's console instead.
             const log_fn = quiet
                 ? () => { } // Suppress all startup messages
-                : transport === 'stdio'
+                : transport === 'stdio' && options.connection === undefined
                     ? (msg: string) => process.stderr.write(msg + '\n')
                     : log_channel || ((msg: string) => connection.console.log(msg));
 

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -90,6 +90,15 @@ export interface ServerOptions {
     transport: TransportType;
     quiet?: boolean;
     log_channel?: (msg: string) => void;
+    /**
+     * Test-only injection seam: when provided, this connection is used
+     * instead of creating a transport connection, so handler-level
+     * integration tests can capture the real registered LSP handlers
+     * (e.g. the onDidClose disk re-sync wiring, issue #287) and drive
+     * them without a live client process. Production entry points
+     * (cli.ts, server.ts) never set this.
+     */
+    connection?: Connection;
 }
 
 /**
@@ -229,8 +238,9 @@ export function indexing_affecting_signature(
 export async function create_server(options: ServerOptions): Promise<void> {
     const { transport, quiet, log_channel } = options;
 
-    // Create connection based on transport type
-    const connection = create_transport_connection(transport);
+    // Create connection based on transport type (tests may inject one)
+    const connection =
+        options.connection ?? create_transport_connection(transport);
 
     // Create a simple text document manager
     const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);

--- a/tests/integration/send-to-stata-integrated-terminal.test.ts
+++ b/tests/integration/send-to-stata-integrated-terminal.test.ts
@@ -9,6 +9,7 @@ import {
 } from 'bun:test';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
+import { wait_until } from '../wait-until';
 
 const SEND_TO_STATA_DIR = path.resolve(
     import.meta.dir,
@@ -123,19 +124,13 @@ function create_vscode_mock_state(
     };
 }
 
-async function wait_for_condition(
+// Shared polling helper (tests/wait-until.ts); these call sites keep the
+// pre-extraction timing: a tight 200ms budget with 0ms yields.
+function wait_for_condition(
     predicate: () => boolean,
-    timeout_ms = 200
+    description: string
 ): Promise<void> {
-    const start_time_ms = Date.now();
-    while (!predicate()) {
-        if (Date.now() - start_time_ms > timeout_ms) {
-            throw new Error('Timed out waiting for test condition.');
-        }
-        await new Promise(resolve => {
-            setTimeout(resolve, 0);
-        });
-    }
+    return wait_until(predicate, description, 200, 0);
 }
 
 async function import_terminal_manager_module(
@@ -307,7 +302,7 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
 
         await wait_for_condition(() => {
             return vscode_state.create_terminal_calls === 1;
-        });
+        }, 'the send to create the Stata terminal');
 
         expect(vscode_state.create_terminal_calls).toBe(1);
         expect(vscode_state.the_show_calls).toEqual([true]);
@@ -382,7 +377,7 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
 
         await wait_for_condition(() => {
             return vscode_state.create_terminal_calls === 1;
-        });
+        }, 'the send to create the Stata terminal');
 
         expect(vscode_state.create_terminal_calls).toBe(1);
         expect(vscode_state.the_send_calls).toEqual([]);
@@ -418,7 +413,7 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
 
         await wait_for_condition(() => {
             return vscode_state.create_terminal_calls === 1;
-        });
+        }, 'the send to create the Stata terminal');
 
         for (const my_listener of vscode_state.the_close_listeners) {
             my_listener(vscode_state.terminal);
@@ -454,7 +449,7 @@ describe.serial('Feature: integrated terminal first-send reliability', () => {
         );
         await wait_for_condition(() => {
             return vscode_state.the_show_calls.length === 1;
-        });
+        }, 'the profile terminal to be revealed');
 
         // Must NOT type into the still-starting Stata yet.
         expect(vscode_state.the_send_calls).toEqual([]);

--- a/tests/integration/server-close-resync-wiring.test.ts
+++ b/tests/integration/server-close-resync-wiring.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Handler-level integration test for the onDidClose disk re-sync wiring
+ * (issue #287, deferred from #184's review).
+ *
+ * All prior coverage of `resync_backward_directive_dependencies_from_disk`
+ * is at the ScopeResolver unit level; nothing drove the REAL
+ * `documents.onDidClose` handler registered in `create_server`
+ * (src/server-factory.ts), so a wiring mistake — wrong URI variable,
+ * wrong config source (global instead of the URI-scoped settings
+ * captured before the `document_settings` delete), a broken
+ * reopen-aware guard against TextDocuments, or a dropped dependent
+ * revalidation — would not be caught.
+ *
+ * This test starts the real server via `create_server` with an injected
+ * stub connection (the test-only `ServerOptions.connection` seam),
+ * drives the captured LSP notification handlers exactly as a client
+ * would (initialize / initialized / didOpen / didClose), and asserts
+ * on the live ScopeResolver instance:
+ *   1. closing a document whose buffer header disagrees with disk
+ *      converges the backward-directive edges to DISK state, and the
+ *      re-sync receives the closed document's URI and its URI-scoped
+ *      settings (a scoped `crossFile.backwardDependencies` override,
+ *      not the global default);
+ *   2. a quick close -> reopen makes the reopen guard veto the re-sync
+ *      (the reopened buffer's commit owns registration), leaving the
+ *      buffer-time edges intact;
+ *   3. when the re-sync applies, open files that depend on the closed
+ *      file via backward directives are revalidated (diagnostics are
+ *      republished for them).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import type {
+    Connection,
+    InitializeParams,
+    DidOpenTextDocumentParams,
+    DidCloseTextDocumentParams,
+    PublishDiagnosticsParams,
+} from 'vscode-languageserver/node';
+import { create_server } from '../../src/server-factory';
+import { ScopeResolver } from '../../src/scope-resolver';
+import type { ScopeResolverConfig } from '../../src/types';
+
+// ---------------------------------------------------------------------------
+// ScopeResolver instrumentation: the resolver is created inside
+// create_server's onInitialized closure, so capture the instance (and spy
+// on the close-time re-sync) via prototype wrapping, restored after each
+// test.
+// ---------------------------------------------------------------------------
+
+interface ResyncCall {
+    uri: string;
+    config: Partial<ScopeResolverConfig> | undefined;
+    result: Promise<boolean>;
+}
+
+let captured_resolver: ScopeResolver | undefined;
+let the_resync_calls: ResyncCall[] = [];
+let workspace_roots_seen: string[] = [];
+
+const original_set_dependency_graph =
+    ScopeResolver.prototype.set_dependency_graph;
+const original_set_workspace_roots =
+    ScopeResolver.prototype.set_workspace_roots;
+const original_resync =
+    ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk;
+
+function install_resolver_spies(): void {
+    captured_resolver = undefined;
+    the_resync_calls = [];
+    workspace_roots_seen = [];
+    ScopeResolver.prototype.set_dependency_graph = function (
+        ...args: Parameters<typeof original_set_dependency_graph>
+    ) {
+        captured_resolver = this;
+        return original_set_dependency_graph.apply(this, args);
+    };
+    ScopeResolver.prototype.set_workspace_roots = function (
+        ...args: Parameters<typeof original_set_workspace_roots>
+    ) {
+        workspace_roots_seen.push(...args[0]);
+        return original_set_workspace_roots.apply(this, args);
+    };
+    ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk =
+        function (...args: Parameters<typeof original_resync>) {
+            const result = original_resync.apply(this, args);
+            the_resync_calls.push({
+                uri: args[0],
+                config: args[1],
+                result,
+            });
+            return result;
+        };
+}
+
+function restore_resolver_spies(): void {
+    ScopeResolver.prototype.set_dependency_graph =
+        original_set_dependency_graph;
+    ScopeResolver.prototype.set_workspace_roots =
+        original_set_workspace_roots;
+    ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk =
+        original_resync;
+}
+
+// ---------------------------------------------------------------------------
+// Stub connection: captures the handlers create_server registers so the
+// test can invoke them directly, and records published diagnostics.
+// ---------------------------------------------------------------------------
+
+interface CapturedHandlers {
+    initialize?: (params: InitializeParams) => unknown;
+    initialized?: () => void;
+    did_open?: (params: DidOpenTextDocumentParams) => void;
+    did_close?: (params: DidCloseTextDocumentParams) => void;
+    shutdown?: () => unknown;
+}
+
+interface StubConnectionOptions {
+    workspace_folder_uri: string;
+    /** Returns the public `sight` config subtree for a scope URI. */
+    get_scoped_config: (scope_uri: string | undefined) => unknown;
+    published_uris: string[];
+}
+
+function noop_disposable(): { dispose: () => void } {
+    return { dispose: () => { } };
+}
+
+function make_stub_connection(options: StubConnectionOptions): {
+    connection: Connection;
+    handlers: CapturedHandlers;
+} {
+    const handlers: CapturedHandlers = {};
+    const capture_nothing = () => noop_disposable();
+    const connection_stub = {
+        console: {
+            log: () => { },
+            warn: () => { },
+            error: () => { },
+            info: () => { },
+        },
+        onInitialize: (handler: CapturedHandlers['initialize']) => {
+            handlers.initialize = handler;
+        },
+        onInitialized: (handler: CapturedHandlers['initialized']) => {
+            handlers.initialized = handler;
+        },
+        onDidChangeConfiguration: capture_nothing,
+        onDidChangeWatchedFiles: capture_nothing,
+        onCompletion: capture_nothing,
+        onCompletionResolve: capture_nothing,
+        onHover: capture_nothing,
+        onDefinition: capture_nothing,
+        onReferences: capture_nothing,
+        onDocumentSymbol: capture_nothing,
+        onWorkspaceSymbol: capture_nothing,
+        onDocumentFormatting: capture_nothing,
+        onDocumentRangeFormatting: capture_nothing,
+        onExecuteCommand: capture_nothing,
+        onShutdown: (handler: CapturedHandlers['shutdown']) => {
+            handlers.shutdown = handler;
+        },
+        onExit: capture_nothing,
+        onRequest: capture_nothing,
+        sendDiagnostics: (params: PublishDiagnosticsParams) => {
+            options.published_uris.push(params.uri);
+        },
+        // Surface used by TextDocuments.listen(connection):
+        onDidOpenTextDocument: (
+            handler: CapturedHandlers['did_open']
+        ) => {
+            handlers.did_open = handler;
+            return noop_disposable();
+        },
+        onDidChangeTextDocument: capture_nothing,
+        onDidCloseTextDocument: (
+            handler: CapturedHandlers['did_close']
+        ) => {
+            handlers.did_close = handler;
+            return noop_disposable();
+        },
+        onWillSaveTextDocument: capture_nothing,
+        onWillSaveTextDocumentWaitUntil: capture_nothing,
+        onDidSaveTextDocument: capture_nothing,
+        client: {
+            register: () => Promise.resolve(noop_disposable()),
+        },
+        workspace: {
+            getConfiguration: (item?: { scopeUri?: string }) =>
+                Promise.resolve(options.get_scoped_config(item?.scopeUri)),
+            getWorkspaceFolders: () => Promise.resolve([
+                { uri: options.workspace_folder_uri, name: 'test-ws' },
+            ]),
+            onDidChangeWorkspaceFolders: capture_nothing,
+        },
+        listen: () => { },
+    };
+    return {
+        connection: connection_stub as unknown as Connection,
+        handlers,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+async function wait_until(
+    predicate: () => boolean,
+    description: string,
+    timeout_ms = 5000,
+    interval_ms = 20
+): Promise<void> {
+    const deadline_ms = Date.now() + timeout_ms;
+    while (!predicate()) {
+        if (Date.now() > deadline_ms) {
+            throw new Error(`Timed out waiting for: ${description}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, interval_ms));
+    }
+}
+
+let tmp_dir: string;
+let published_uris: string[] = [];
+let active_handlers: CapturedHandlers | undefined;
+
+// Disable workspace indexing so no scan-time dependency-graph edges or
+// timers interfere; only explicit @lsp-done-by directives are in play.
+const GLOBAL_PUBLIC_CONFIG = { crossFile: { indexWorkspace: false } };
+
+async function start_test_server(
+    get_scoped_config: (scope_uri: string | undefined) => unknown
+): Promise<CapturedHandlers> {
+    const workspace_folder_uri = URI.file(tmp_dir).toString();
+    const { connection, handlers } = make_stub_connection({
+        workspace_folder_uri,
+        get_scoped_config,
+        published_uris,
+    });
+    await create_server({ transport: 'stdio', quiet: true, connection });
+    expect(handlers.initialize).toBeDefined();
+    expect(handlers.initialized).toBeDefined();
+    expect(handlers.did_open).toBeDefined();
+    expect(handlers.did_close).toBeDefined();
+    handlers.initialize!({
+        processId: null,
+        rootUri: workspace_folder_uri,
+        capabilities: { workspace: { configuration: true } },
+        workspaceFolders: null,
+    } as InitializeParams);
+    handlers.initialized!();
+    // onInitialized creates the providers synchronously, then finishes
+    // workspace setup asynchronously (getWorkspaceFolders -> settings ->
+    // configure). Wait for both before opening documents.
+    await wait_until(
+        () => captured_resolver !== undefined &&
+            workspace_roots_seen.includes(tmp_dir),
+        'server initialization to reach the workspace-roots refresh'
+    );
+    active_handlers = handlers;
+    return handlers;
+}
+
+function write_workspace_files(): void {
+    fs.writeFileSync(
+        path.join(tmp_dir, 'parent_disk.do'),
+        'display "parent disk"\n'
+    );
+    fs.writeFileSync(
+        path.join(tmp_dir, 'parent_buffer.do'),
+        'display "parent buffer"\n'
+    );
+    fs.writeFileSync(
+        path.join(tmp_dir, 'child.do'),
+        '// @lsp-done-by: "parent_disk.do"\ndisplay "child"\n'
+    );
+    fs.writeFileSync(
+        path.join(tmp_dir, 'grandchild.do'),
+        '// @lsp-done-by: "child.do"\ndisplay "grandchild"\n'
+    );
+}
+
+function file_uri(name: string): string {
+    return URI.file(path.join(tmp_dir, name)).toString();
+}
+
+function open_document(
+    handlers: CapturedHandlers,
+    uri: string,
+    text: string,
+    version = 1
+): void {
+    handlers.did_open!({
+        textDocument: { uri, languageId: 'stata', version, text },
+    });
+}
+
+const CHILD_BUFFER_TEXT =
+    '// @lsp-done-by: "parent_buffer.do"\ndisplay "child"\n';
+
+describe('server onDidClose disk re-sync wiring (#287)', () => {
+    beforeEach(() => {
+        install_resolver_spies();
+        published_uris = [];
+        active_handlers = undefined;
+        tmp_dir = fs.realpathSync(
+            fs.mkdtempSync(path.join(os.tmpdir(), 'close-resync-wiring-'))
+        );
+        write_workspace_files();
+    });
+
+    afterEach(async () => {
+        try {
+            await active_handlers?.shutdown?.();
+        } finally {
+            restore_resolver_spies();
+            fs.rmSync(tmp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('converges backward edges to disk on close, passing the closed ' +
+        "document's URI and its URI-scoped settings", async () => {
+        const child_uri = file_uri('child.do');
+        const parent_disk_uri = file_uri('parent_disk.do');
+        const parent_buffer_uri = file_uri('parent_buffer.do');
+        // The child's scope carries a backwardDependencies override that
+        // the global scope does not: the re-sync must run under the
+        // scoped mode, not the global default ('auto').
+        const handlers = await start_test_server((scope_uri) =>
+            scope_uri === child_uri
+                ? {
+                    crossFile: {
+                        indexWorkspace: false,
+                        backwardDependencies: 'explicit',
+                    },
+                }
+                : GLOBAL_PUBLIC_CONFIG
+        );
+
+        // Open the child with a buffer header that points at a DIFFERENT
+        // parent than the on-disk header.
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT);
+        await wait_until(
+            () => captured_resolver!
+                .get_backward_directive_children(parent_buffer_uri)
+                .has(child_uri),
+            'buffer-based registration of child under parent_buffer'
+        );
+
+        handlers.did_close!({ textDocument: { uri: child_uri } });
+
+        // The close-time re-sync reads DISK content and re-registers the
+        // on-disk parent, clearing the buffer-time edge.
+        await wait_until(
+            () => captured_resolver!
+                .get_backward_directive_children(parent_disk_uri)
+                .has(child_uri),
+            'disk re-sync to register child under parent_disk'
+        );
+        expect(
+            captured_resolver!
+                .get_backward_directive_children(parent_buffer_uri)
+                .has(child_uri)
+        ).toBe(false);
+
+        expect(the_resync_calls).toHaveLength(1);
+        expect(the_resync_calls[0].uri).toBe(child_uri);
+        // Wrong-config-source guard: global settings say 'auto'; only the
+        // child's URI-scoped settings say 'explicit'.
+        expect(the_resync_calls[0].config?.backward_dependencies)
+            .toBe('explicit');
+        expect(await the_resync_calls[0].result).toBe(true);
+    });
+
+    it('vetoes the re-sync when the document is reopened while the disk ' +
+        'read is in flight (reopen guard)', async () => {
+        const child_uri = file_uri('child.do');
+        const parent_disk_uri = file_uri('parent_disk.do');
+        const parent_buffer_uri = file_uri('parent_buffer.do');
+        const handlers = await start_test_server(
+            () => GLOBAL_PUBLIC_CONFIG
+        );
+
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT);
+        await wait_until(
+            () => captured_resolver!
+                .get_backward_directive_children(parent_buffer_uri)
+                .has(child_uri),
+            'buffer-based registration of child under parent_buffer'
+        );
+
+        // Close, then reopen synchronously — before the close handler's
+        // async settings fetch and disk read resume. TextDocuments is
+        // repopulated immediately, so the should_apply guard must veto
+        // the re-sync: the reopened buffer's commit owns registration.
+        handlers.did_close!({ textDocument: { uri: child_uri } });
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT, 2);
+
+        // The re-sync is invoked inside the close handler's async block
+        // (after the settings fetch), so wait for the spied call.
+        await wait_until(
+            () => the_resync_calls.length === 1,
+            'the close handler to invoke the disk re-sync'
+        );
+        expect(await the_resync_calls[0].result).toBe(false);
+
+        // Buffer-time edges survive; the disk parent was never applied.
+        expect(
+            captured_resolver!
+                .get_backward_directive_children(parent_buffer_uri)
+                .has(child_uri)
+        ).toBe(true);
+        expect(
+            captured_resolver!
+                .get_backward_directive_children(parent_disk_uri)
+                .has(child_uri)
+        ).toBe(false);
+    });
+
+    it('revalidates open backward-directive dependents after the re-sync ' +
+        'applies', async () => {
+        const child_uri = file_uri('child.do');
+        const grandchild_uri = file_uri('grandchild.do');
+        const parent_buffer_uri = file_uri('parent_buffer.do');
+        const handlers = await start_test_server(
+            () => GLOBAL_PUBLIC_CONFIG
+        );
+
+        // Open the grandchild (depends on child.do via @lsp-done-by) and
+        // the child (buffer header disagrees with disk so the close-time
+        // re-sync APPLIES a change).
+        open_document(
+            handlers,
+            grandchild_uri,
+            fs.readFileSync(
+                path.join(tmp_dir, 'grandchild.do'), 'utf8'
+            )
+        );
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT);
+        await wait_until(
+            () => captured_resolver!
+                .get_backward_directive_children(child_uri)
+                .has(grandchild_uri) &&
+                captured_resolver!
+                    .get_backward_directive_children(parent_buffer_uri)
+                    .has(child_uri),
+            'both open buffers to commit their backward registrations'
+        );
+
+        // Let in-flight validation publishes settle so any new grandchild
+        // publish below is attributable to the close-path revalidation.
+        let last_count = -1;
+        await wait_until(() => {
+            const current_count = published_uris.length;
+            const stable = current_count === last_count;
+            last_count = current_count;
+            return stable;
+        }, 'diagnostic publishes to go quiescent', 5000, 150);
+
+        const grandchild_publishes_before = published_uris
+            .filter((my_uri) => my_uri === grandchild_uri).length;
+
+        handlers.did_close!({ textDocument: { uri: child_uri } });
+
+        await wait_until(
+            () => the_resync_calls.length === 1,
+            'the close handler to invoke the disk re-sync'
+        );
+        expect(await the_resync_calls[0].result).toBe(true);
+
+        // The applied re-sync must fan out to open dependents THROUGH the
+        // closed file: grandchild gets revalidated and republished.
+        await wait_until(
+            () => published_uris
+                .filter((my_uri) => my_uri === grandchild_uri).length >
+                grandchild_publishes_before,
+            'grandchild diagnostics republish after close re-sync'
+        );
+    });
+});

--- a/tests/integration/server-close-resync-wiring.test.ts
+++ b/tests/integration/server-close-resync-wiring.test.ts
@@ -44,6 +44,7 @@ import type {
 import { create_server } from '../../src/server-factory';
 import { ScopeResolver } from '../../src/scope-resolver';
 import type { ScopeResolverConfig } from '../../src/types';
+import { wait_until } from '../wait-until';
 
 // ---------------------------------------------------------------------------
 // ScopeResolver instrumentation: the resolver is created inside
@@ -209,20 +210,12 @@ function make_stub_connection(options: StubConnectionOptions): {
 // Test harness
 // ---------------------------------------------------------------------------
 
-async function wait_until(
-    predicate: () => boolean,
-    description: string,
-    timeout_ms = 5000,
-    interval_ms = 20
-): Promise<void> {
-    const deadline_ms = Date.now() + timeout_ms;
-    while (!predicate()) {
-        if (Date.now() > deadline_ms) {
-            throw new Error(`Timed out waiting for: ${description}`);
-        }
-        await new Promise((resolve) => setTimeout(resolve, interval_ms));
-    }
-}
+// Every wait in this file must stay below TEST_TIMEOUT_MS so wait_until's
+// descriptive error surfaces instead of bun's generic test timeout; each
+// it() below passes TEST_TIMEOUT_MS explicitly because the default 5000ms
+// budget is too tight for the chained waits on slow CI.
+const TEST_TIMEOUT_MS = 30000;
+const WAIT_TIMEOUT_MS = 10000;
 
 let tmp_dir: string;
 let published_uris: string[] = [];
@@ -242,6 +235,9 @@ async function start_test_server(
         published_uris,
     });
     await create_server({ transport: 'stdio', quiet: true, connection });
+    // Assign before any wait/assertion can fail, so afterEach still runs
+    // the shutdown handler and no server timers outlive a failing test.
+    active_handlers = handlers;
     expect(handlers.initialize).toBeDefined();
     expect(handlers.initialized).toBeDefined();
     expect(handlers.did_open).toBeDefined();
@@ -259,9 +255,9 @@ async function start_test_server(
     await wait_until(
         () => captured_resolver !== undefined &&
             workspace_roots_seen.includes(tmp_dir),
-        'server initialization to reach the workspace-roots refresh'
+        'server initialization to reach the workspace-roots refresh',
+        WAIT_TIMEOUT_MS
     );
-    active_handlers = handlers;
     return handlers;
 }
 
@@ -348,7 +344,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             () => captured_resolver!
                 .get_backward_directive_children(parent_buffer_uri)
                 .has(child_uri),
-            'buffer-based registration of child under parent_buffer'
+            'buffer-based registration of child under parent_buffer',
+            WAIT_TIMEOUT_MS
         );
 
         handlers.did_close!({ textDocument: { uri: child_uri } });
@@ -359,7 +356,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             () => captured_resolver!
                 .get_backward_directive_children(parent_disk_uri)
                 .has(child_uri),
-            'disk re-sync to register child under parent_disk'
+            'disk re-sync to register child under parent_disk',
+            WAIT_TIMEOUT_MS
         );
         expect(
             captured_resolver!
@@ -374,7 +372,7 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
         expect(the_resync_calls[0].config?.backward_dependencies)
             .toBe('explicit');
         expect(await the_resync_calls[0].result).toBe(true);
-    });
+    }, TEST_TIMEOUT_MS);
 
     it('vetoes the re-sync when the document is reopened while the disk ' +
         'read is in flight (reopen guard)', async () => {
@@ -390,7 +388,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             () => captured_resolver!
                 .get_backward_directive_children(parent_buffer_uri)
                 .has(child_uri),
-            'buffer-based registration of child under parent_buffer'
+            'buffer-based registration of child under parent_buffer',
+            WAIT_TIMEOUT_MS
         );
 
         // Close, then reopen synchronously — before the close handler's
@@ -404,7 +403,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
         // (after the settings fetch), so wait for the spied call.
         await wait_until(
             () => the_resync_calls.length === 1,
-            'the close handler to invoke the disk re-sync'
+            'the close handler to invoke the disk re-sync',
+            WAIT_TIMEOUT_MS
         );
         expect(await the_resync_calls[0].result).toBe(false);
 
@@ -419,7 +419,7 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
                 .get_backward_directive_children(parent_disk_uri)
                 .has(child_uri)
         ).toBe(false);
-    });
+    }, TEST_TIMEOUT_MS);
 
     it('revalidates open backward-directive dependents after the re-sync ' +
         'applies', async () => {
@@ -448,18 +448,38 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
                 captured_resolver!
                     .get_backward_directive_children(parent_buffer_uri)
                     .has(child_uri),
-            'both open buffers to commit their backward registrations'
+            'both open buffers to commit their backward registrations',
+            WAIT_TIMEOUT_MS
         );
 
-        // Let in-flight validation publishes settle so any new grandchild
-        // publish below is attributable to the close-path revalidation.
-        let last_count = -1;
+        // Barrier against a false pass: any new grandchild publish after
+        // did_close below must be attributable to the CLOSE-path
+        // revalidation, not a straggler from the open-time validation
+        // cascade. Two conditions: (1) both documents' initial validation
+        // cycles have published (registration above happens BEFORE the
+        // publish within the same debounced cycle, so wait for the
+        // publishes too), and (2) no publish at all for three consecutive
+        // 150ms samples (~450ms of silence, several times the 100ms
+        // debounce window), so no revalidation scheduled pre-close is
+        // still in flight.
+        await wait_until(
+            () => published_uris.includes(grandchild_uri) &&
+                published_uris.includes(child_uri),
+            'initial validation publishes for both open documents',
+            WAIT_TIMEOUT_MS
+        );
+        let stable_samples = 0;
+        let last_count = published_uris.length;
         await wait_until(() => {
             const current_count = published_uris.length;
-            const stable = current_count === last_count;
-            last_count = current_count;
-            return stable;
-        }, 'diagnostic publishes to go quiescent', 5000, 150);
+            if (current_count === last_count) {
+                stable_samples++;
+            } else {
+                stable_samples = 0;
+                last_count = current_count;
+            }
+            return stable_samples >= 3;
+        }, 'diagnostic publishes to go quiescent', WAIT_TIMEOUT_MS, 150);
 
         const grandchild_publishes_before = published_uris
             .filter((my_uri) => my_uri === grandchild_uri).length;
@@ -468,7 +488,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
 
         await wait_until(
             () => the_resync_calls.length === 1,
-            'the close handler to invoke the disk re-sync'
+            'the close handler to invoke the disk re-sync',
+            WAIT_TIMEOUT_MS
         );
         expect(await the_resync_calls[0].result).toBe(true);
 
@@ -478,7 +499,8 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             () => published_uris
                 .filter((my_uri) => my_uri === grandchild_uri).length >
                 grandchild_publishes_before,
-            'grandchild diagnostics republish after close re-sync'
+            'grandchild diagnostics republish after close re-sync',
+            WAIT_TIMEOUT_MS
         );
-    });
+    }, TEST_TIMEOUT_MS);
 });

--- a/tests/integration/server-close-resync-wiring.test.ts
+++ b/tests/integration/server-close-resync-wiring.test.ts
@@ -28,9 +28,11 @@
  *      file via backward directives — including transitively, two hops
  *      away — are revalidated (diagnostics are republished for them);
  *   4. the DOCUMENT-STORE half of the should_apply guard vetoes on its
- *      own (a store entry recreated while the disk read is in flight,
+ *      own (a store entry recreated while the re-sync is held at entry,
  *      with TextDocuments still empty), and a vetoed re-sync does NOT
- *      revalidate open dependents.
+ *      revalidate open dependents. (The resolver-internal contract that
+ *      the guard is consulted AFTER the disk read is unit-tested in
+ *      tests/unit/document-store-commit-time-cross-file-effects.test.ts.)
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -625,12 +627,17 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
         const grandchild_publishes_before = published_uris
             .filter((my_uri) => my_uri === grandchild_uri).length;
 
-        // Hold the re-sync at its entry so the race is deterministic:
-        // while it is held, recreate the document-store entry (as a
-        // commit racing the close would) WITHOUT reopening the document
-        // in TextDocuments. When released, should_apply must veto on the
-        // store clause alone — TextDocuments says closed, the store says
-        // a buffer commit owns registration.
+        // Hold the re-sync at its ENTRY (before its disk read) so the
+        // race is deterministic: while it is held, recreate the
+        // document-store entry (as a commit racing the close would)
+        // WITHOUT reopening the document in TextDocuments. When
+        // released, should_apply must veto on the store clause alone —
+        // TextDocuments says closed, the store says a buffer commit owns
+        // registration. This pins the HANDLER's guard wiring; the
+        // resolver-internal ordering (guard consulted after the read, so
+        // a mid-read reopen still vetoes) is pinned by the deferred-read
+        // unit test in
+        // tests/unit/document-store-commit-time-cross-file-effects.test.ts.
         let release_gate: (() => void) | undefined;
         resync_gate = new Promise((resolve) => {
             release_gate = resolve;

--- a/tests/integration/server-close-resync-wiring.test.ts
+++ b/tests/integration/server-close-resync-wiring.test.ts
@@ -25,8 +25,12 @@
  *      (the reopened buffer's commit owns registration), leaving the
  *      buffer-time edges intact;
  *   3. when the re-sync applies, open files that depend on the closed
- *      file via backward directives are revalidated (diagnostics are
- *      republished for them).
+ *      file via backward directives — including transitively, two hops
+ *      away — are revalidated (diagnostics are republished for them);
+ *   4. the DOCUMENT-STORE half of the should_apply guard vetoes on its
+ *      own (a store entry recreated while the disk read is in flight,
+ *      with TextDocuments still empty), and a vetoed re-sync does NOT
+ *      revalidate open dependents.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -43,6 +47,8 @@ import type {
 } from 'vscode-languageserver/node';
 import { create_server } from '../../src/server-factory';
 import { ScopeResolver } from '../../src/scope-resolver';
+import { DocumentStore } from '../../src/document-store';
+import { Logger } from '../../src/utils/logger';
 import type { ScopeResolverConfig } from '../../src/types';
 import { wait_until } from '../wait-until';
 
@@ -60,8 +66,13 @@ interface ResyncCall {
 }
 
 let captured_resolver: ScopeResolver | undefined;
+let captured_document_store: DocumentStore | undefined;
 let the_resync_calls: ResyncCall[] = [];
 let workspace_roots_seen: string[] = [];
+// When set, the spied re-sync records its call, then holds before running
+// the real method until this promise resolves — letting a test create
+// race conditions deterministically (test 4). Undefined = no hold.
+let resync_gate: Promise<void> | undefined;
 
 const original_set_dependency_graph =
     ScopeResolver.prototype.set_dependency_graph;
@@ -69,11 +80,15 @@ const original_set_workspace_roots =
     ScopeResolver.prototype.set_workspace_roots;
 const original_resync =
     ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk;
+const original_set_scope_resolver =
+    DocumentStore.prototype.set_scope_resolver;
 
 function install_resolver_spies(): void {
     captured_resolver = undefined;
+    captured_document_store = undefined;
     the_resync_calls = [];
     workspace_roots_seen = [];
+    resync_gate = undefined;
     ScopeResolver.prototype.set_dependency_graph = function (
         ...args: Parameters<typeof original_set_dependency_graph>
     ) {
@@ -88,7 +103,13 @@ function install_resolver_spies(): void {
     };
     ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk =
         function (...args: Parameters<typeof original_resync>) {
-            const result = original_resync.apply(this, args);
+            const gate = resync_gate;
+            const result = (async () => {
+                if (gate) {
+                    await gate;
+                }
+                return original_resync.apply(this, args);
+            })();
             the_resync_calls.push({
                 uri: args[0],
                 config: args[1],
@@ -96,6 +117,12 @@ function install_resolver_spies(): void {
             });
             return result;
         };
+    DocumentStore.prototype.set_scope_resolver = function (
+        ...args: Parameters<typeof original_set_scope_resolver>
+    ) {
+        captured_document_store = this;
+        return original_set_scope_resolver.apply(this, args);
+    };
 }
 
 function restore_resolver_spies(): void {
@@ -105,6 +132,8 @@ function restore_resolver_spies(): void {
         original_set_workspace_roots;
     ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk =
         original_resync;
+    DocumentStore.prototype.set_scope_resolver =
+        original_set_scope_resolver;
 }
 
 // ---------------------------------------------------------------------------
@@ -278,6 +307,10 @@ function write_workspace_files(): void {
         path.join(tmp_dir, 'grandchild.do'),
         '// @lsp-done-by: "child.do"\ndisplay "grandchild"\n'
     );
+    fs.writeFileSync(
+        path.join(tmp_dir, 'greatgrandchild.do'),
+        '// @lsp-done-by: "grandchild.do"\ndisplay "greatgrandchild"\n'
+    );
 }
 
 function file_uri(name: string): string {
@@ -298,6 +331,27 @@ function open_document(
 const CHILD_BUFFER_TEXT =
     '// @lsp-done-by: "parent_buffer.do"\ndisplay "child"\n';
 
+/**
+ * Wait until no diagnostic publish lands for three consecutive 150ms
+ * samples (~450ms of silence, several times the 100ms debounce window),
+ * so nothing scheduled earlier is still in flight. The counter resets on
+ * every new publish, so the window is measured from the LAST publish.
+ */
+async function wait_for_publish_quiescence(): Promise<void> {
+    let stable_samples = 0;
+    let last_count = published_uris.length;
+    await wait_until(() => {
+        const current_count = published_uris.length;
+        if (current_count === last_count) {
+            stable_samples++;
+        } else {
+            stable_samples = 0;
+            last_count = current_count;
+        }
+        return stable_samples >= 3;
+    }, 'diagnostic publishes to go quiescent', WAIT_TIMEOUT_MS, 150);
+}
+
 describe('server onDidClose disk re-sync wiring (#287)', () => {
     beforeEach(() => {
         install_resolver_spies();
@@ -314,7 +368,19 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             await active_handlers?.shutdown?.();
         } finally {
             restore_resolver_spies();
-            fs.rmSync(tmp_dir, { recursive: true, force: true });
+            // create_server({ quiet: true }) silences the process-wide
+            // Logger singleton; restore its defaults (info verbosity,
+            // console.debug fallback channel) so later tests in this
+            // process see the out-of-the-box behavior.
+            Logger.initialize({
+                verbosity: 'info',
+                channel: (message: string) => console.debug(message),
+            });
+            // Guarded so a beforeEach failure before tmp_dir is assigned
+            // reports itself instead of an rmSync TypeError.
+            if (tmp_dir) {
+                fs.rmSync(tmp_dir, { recursive: true, force: true });
+            }
         }
     });
 
@@ -421,18 +487,115 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
         ).toBe(false);
     }, TEST_TIMEOUT_MS);
 
-    it('revalidates open backward-directive dependents after the re-sync ' +
-        'applies', async () => {
+    it('revalidates open backward-directive dependents (including ' +
+        'two-hop transitive ones) after the re-sync applies', async () => {
         const child_uri = file_uri('child.do');
         const grandchild_uri = file_uri('grandchild.do');
+        const greatgrandchild_uri = file_uri('greatgrandchild.do');
         const parent_buffer_uri = file_uri('parent_buffer.do');
         const handlers = await start_test_server(
             () => GLOBAL_PUBLIC_CONFIG
         );
 
-        // Open the grandchild (depends on child.do via @lsp-done-by) and
-        // the child (buffer header disagrees with disk so the close-time
-        // re-sync APPLIES a change).
+        // Open the dependent chain (greatgrandchild -> grandchild ->
+        // child via @lsp-done-by; the two-hop greatgrandchild
+        // distinguishes the handler's TRANSITIVE dependent lookup from a
+        // direct-children one) and the child itself (buffer header
+        // disagrees with disk so the close-time re-sync APPLIES a
+        // change).
+        open_document(
+            handlers,
+            grandchild_uri,
+            fs.readFileSync(
+                path.join(tmp_dir, 'grandchild.do'), 'utf8'
+            )
+        );
+        open_document(
+            handlers,
+            greatgrandchild_uri,
+            fs.readFileSync(
+                path.join(tmp_dir, 'greatgrandchild.do'), 'utf8'
+            )
+        );
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT);
+        await wait_until(
+            () => captured_resolver!
+                .get_backward_directive_children(child_uri)
+                .has(grandchild_uri) &&
+                captured_resolver!
+                    .get_backward_directive_children(grandchild_uri)
+                    .has(greatgrandchild_uri) &&
+                captured_resolver!
+                    .get_backward_directive_children(parent_buffer_uri)
+                    .has(child_uri),
+            'all open buffers to commit their backward registrations',
+            WAIT_TIMEOUT_MS
+        );
+
+        // Barrier against a false pass: any new dependent publish after
+        // did_close below must be attributable to the CLOSE-path
+        // revalidation, not a straggler from the open-time validation
+        // cascade. Two conditions: (1) every document's initial
+        // validation cycle has published (registration above happens
+        // BEFORE the publish within the same debounced cycle, so wait
+        // for the publishes too), and (2) no publish at all for three
+        // consecutive 150ms samples (~450ms of silence, several times
+        // the 100ms debounce window), so no revalidation scheduled
+        // pre-close is still in flight.
+        await wait_until(
+            () => published_uris.includes(grandchild_uri) &&
+                published_uris.includes(greatgrandchild_uri) &&
+                published_uris.includes(child_uri),
+            'initial validation publishes for all open documents',
+            WAIT_TIMEOUT_MS
+        );
+        await wait_for_publish_quiescence();
+
+        const grandchild_publishes_before = published_uris
+            .filter((my_uri) => my_uri === grandchild_uri).length;
+        const greatgrandchild_publishes_before = published_uris
+            .filter((my_uri) => my_uri === greatgrandchild_uri).length;
+
+        handlers.did_close!({ textDocument: { uri: child_uri } });
+
+        await wait_until(
+            () => the_resync_calls.length === 1,
+            'the close handler to invoke the disk re-sync',
+            WAIT_TIMEOUT_MS
+        );
+        expect(await the_resync_calls[0].result).toBe(true);
+
+        // The applied re-sync must fan out to open dependents THROUGH the
+        // closed file: both the direct grandchild and the two-hop
+        // greatgrandchild get revalidated and republished.
+        await wait_until(
+            () => published_uris
+                .filter((my_uri) => my_uri === grandchild_uri).length >
+                grandchild_publishes_before,
+            'grandchild diagnostics republish after close re-sync',
+            WAIT_TIMEOUT_MS
+        );
+        await wait_until(
+            () => published_uris
+                .filter((my_uri) => my_uri === greatgrandchild_uri)
+                .length > greatgrandchild_publishes_before,
+            'greatgrandchild diagnostics republish after close re-sync',
+            WAIT_TIMEOUT_MS
+        );
+    }, TEST_TIMEOUT_MS);
+
+    it('vetoes via the document-store guard clause alone and does not ' +
+        'revalidate dependents on a vetoed re-sync', async () => {
+        const child_uri = file_uri('child.do');
+        const grandchild_uri = file_uri('grandchild.do');
+        const parent_disk_uri = file_uri('parent_disk.do');
+        const parent_buffer_uri = file_uri('parent_buffer.do');
+        const handlers = await start_test_server(
+            () => GLOBAL_PUBLIC_CONFIG
+        );
+
+        // An open dependent, so the vetoed branch has a live dependent it
+        // must NOT revalidate.
         open_document(
             handlers,
             grandchild_uri,
@@ -451,56 +614,61 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             'both open buffers to commit their backward registrations',
             WAIT_TIMEOUT_MS
         );
-
-        // Barrier against a false pass: any new grandchild publish after
-        // did_close below must be attributable to the CLOSE-path
-        // revalidation, not a straggler from the open-time validation
-        // cascade. Two conditions: (1) both documents' initial validation
-        // cycles have published (registration above happens BEFORE the
-        // publish within the same debounced cycle, so wait for the
-        // publishes too), and (2) no publish at all for three consecutive
-        // 150ms samples (~450ms of silence, several times the 100ms
-        // debounce window), so no revalidation scheduled pre-close is
-        // still in flight.
         await wait_until(
             () => published_uris.includes(grandchild_uri) &&
                 published_uris.includes(child_uri),
             'initial validation publishes for both open documents',
             WAIT_TIMEOUT_MS
         );
-        let stable_samples = 0;
-        let last_count = published_uris.length;
-        await wait_until(() => {
-            const current_count = published_uris.length;
-            if (current_count === last_count) {
-                stable_samples++;
-            } else {
-                stable_samples = 0;
-                last_count = current_count;
-            }
-            return stable_samples >= 3;
-        }, 'diagnostic publishes to go quiescent', WAIT_TIMEOUT_MS, 150);
+        await wait_for_publish_quiescence();
 
         const grandchild_publishes_before = published_uris
             .filter((my_uri) => my_uri === grandchild_uri).length;
 
-        handlers.did_close!({ textDocument: { uri: child_uri } });
+        // Hold the re-sync at its entry so the race is deterministic:
+        // while it is held, recreate the document-store entry (as a
+        // commit racing the close would) WITHOUT reopening the document
+        // in TextDocuments. When released, should_apply must veto on the
+        // store clause alone — TextDocuments says closed, the store says
+        // a buffer commit owns registration.
+        let release_gate: (() => void) | undefined;
+        resync_gate = new Promise((resolve) => {
+            release_gate = resolve;
+        });
 
+        handlers.did_close!({ textDocument: { uri: child_uri } });
         await wait_until(
             () => the_resync_calls.length === 1,
             'the close handler to invoke the disk re-sync',
             WAIT_TIMEOUT_MS
         );
-        expect(await the_resync_calls[0].result).toBe(true);
-
-        // The applied re-sync must fan out to open dependents THROUGH the
-        // closed file: grandchild gets revalidated and republished.
-        await wait_until(
-            () => published_uris
-                .filter((my_uri) => my_uri === grandchild_uri).length >
-                grandchild_publishes_before,
-            'grandchild diagnostics republish after close re-sync',
-            WAIT_TIMEOUT_MS
+        await captured_document_store!.open(
+            child_uri, CHILD_BUFFER_TEXT, 3
         );
+        release_gate!();
+
+        expect(await the_resync_calls[0].result).toBe(false);
+
+        // Vetoed: buffer-time edges survive, the disk parent was never
+        // applied.
+        expect(
+            captured_resolver!
+                .get_backward_directive_children(parent_buffer_uri)
+                .has(child_uri)
+        ).toBe(true);
+        expect(
+            captured_resolver!
+                .get_backward_directive_children(parent_disk_uri)
+                .has(child_uri)
+        ).toBe(false);
+
+        // A vetoed re-sync must NOT fan out revalidation: after a settle
+        // window several times the debounce, the open dependent has no
+        // new publish.
+        await wait_for_publish_quiescence();
+        expect(
+            published_uris
+                .filter((my_uri) => my_uri === grandchild_uri).length
+        ).toBe(grandchild_publishes_before);
     }, TEST_TIMEOUT_MS);
 });

--- a/tests/unit/document-store-commit-time-cross-file-effects.test.ts
+++ b/tests/unit/document-store-commit-time-cross-file-effects.test.ts
@@ -18,6 +18,7 @@ import { WorkspaceIndexer } from '../../src/indexer';
 import { ScopeResolver } from '../../src/scope-resolver';
 import type { ContentProvider } from '../../src/types';
 import { URI } from 'vscode-uri';
+import { wait_until } from '../wait-until';
 
 function make_content_provider(
     content_by_uri: Map<string, string>
@@ -487,9 +488,12 @@ describe('ScopeResolver disk re-sync on close (issue #184)', () => {
                 {},
                 () => !reopened
             );
-        while (release_read === undefined) {
-            await new Promise((resolve) => setTimeout(resolve, 0));
-        }
+        await wait_until(
+            () => release_read !== undefined,
+            'the re-sync to start its deferred disk read',
+            4000,
+            0
+        );
         // ...the reopen lands while the disk read is in flight.
         reopened = true;
         release_read!(child_disk_content);

--- a/tests/unit/document-store-commit-time-cross-file-effects.test.ts
+++ b/tests/unit/document-store-commit-time-cross-file-effects.test.ts
@@ -450,6 +450,59 @@ describe('ScopeResolver disk re-sync on close (issue #184)', () => {
         ).toBe(false);
     });
 
+    it('consults should_apply AFTER the disk read, so a reopen landing ' +
+        'mid-read still vetoes', async () => {
+        // The docstring contract — "checked after the disk read,
+        // immediately before the synchronous registration" — is the
+        // actual protection: a guard consulted before the read would
+        // miss a reopen that lands while the read is in flight and
+        // clobber the reopened buffer's registration (#287 round-3
+        // review). Pin the ordering with a read the test releases.
+        const disk_parent_path = '/tmp/sight-184-resync-order-disk.do';
+        const disk_parent_uri = URI.file(disk_parent_path).toString();
+        const child_uri =
+            URI.file('/tmp/sight-184-resync-order-child.do').toString();
+        const child_disk_content =
+            `// @lsp-done-by: "${disk_parent_path}"\ndisplay 1\n`;
+        let release_read: ((content: string) => void) | undefined;
+        const gated_content_provider: ContentProvider = {
+            exists: async () => true,
+            read_file: (uri) => uri === child_uri
+                ? new Promise<string>((resolve) => {
+                    release_read = resolve;
+                })
+                : Promise.resolve('display 0\n'),
+            stat: async () => ({ mtimeMs: 0, size: 0 }),
+        };
+        const scope_resolver = new ScopeResolver(
+            undefined,
+            gated_content_provider
+        );
+
+        // No reopen yet when the re-sync starts...
+        let reopened = false;
+        const resync_promise = scope_resolver
+            .resync_backward_directive_dependencies_from_disk(
+                child_uri,
+                {},
+                () => !reopened
+            );
+        while (release_read === undefined) {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+        // ...the reopen lands while the disk read is in flight.
+        reopened = true;
+        release_read!(child_disk_content);
+
+        // A guard consulted before (or captured at) the read would have
+        // seen "no reopen" and applied the disk edges.
+        expect(await resync_promise).toBe(false);
+        expect(
+            scope_resolver.get_backward_directive_children(disk_parent_uri)
+                .has(child_uri)
+        ).toBe(false);
+    });
+
     it('skips applying when should_apply reports a reopen', async () => {
         const disk_parent_path = '/tmp/sight-184-resync-guard-disk.do';
         const buffer_parent_path = '/tmp/sight-184-resync-guard-buf.do';

--- a/tests/wait-until.ts
+++ b/tests/wait-until.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared predicate-polling helper for tests that must wait on
+ * asynchronous state (debounced validation, watcher events, terminal
+ * side effects) without racing it.
+ *
+ * Extracted so test files stop growing bespoke copies with drifting
+ * defaults (issue #287 review). Keep per-call timeouts BELOW the
+ * enclosing test's timeout (bun's default is 5000ms unless the test
+ * passes an explicit timeout to it()) so this helper's descriptive
+ * error surfaces instead of bun's generic "test timed out".
+ */
+export async function wait_until(
+    predicate: () => boolean,
+    description: string,
+    timeout_ms = 4000,
+    interval_ms = 20
+): Promise<void> {
+    const deadline_ms = Date.now() + timeout_ms;
+    while (!predicate()) {
+        if (Date.now() > deadline_ms) {
+            throw new Error(`Timed out waiting for: ${description}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, interval_ms));
+    }
+}


### PR DESCRIPTION
Closes #287.

#287's remaining item (the per-document-settings half was already fixed in-branch on #184): all coverage of the close-time disk re-sync (`resync_backward_directive_dependencies_from_disk`) was at the ScopeResolver unit level; nothing drove the real `documents.onDidClose` handler, so a wiring mistake would not be caught.

## What this adds

**Test-only injection seam** (`src/server-factory.ts`): `ServerOptions.connection?` lets a test inject a stub connection so `create_server` registers its real handlers against it. Production entry points (`cli.ts`, `server.ts`) never set it. Companion hardening: when a connection is injected, startup logs route through it instead of `process.stderr` (the `transport === 'stdio'` flag says nothing about the host's real stdio in that case).

**Handler-level integration test** (`tests/integration/server-close-resync-wiring.test.ts`): starts the real server with a stub connection and drives initialize/didOpen/didClose through the real `TextDocuments`, asserting on the live `ScopeResolver`:
1. Close converges backward-directive edges to disk state, and the re-sync receives the closed document's URI and its **URI-scoped** settings (scoped `crossFile.backwardDependencies: 'explicit'` vs global auto — catches a wrong-config-source regression).
2. A quick close→reopen makes the reopen-aware guard veto the re-sync (deterministic by JS ordering: the synchronous reopen lands before the close handler's first `await` resumes).
3. An applied re-sync revalidates open backward-directive dependents, including a two-hop transitive one, behind a publish-quiescence barrier (initial publishes for all docs + 3 stable 150 ms samples) so the republish is attributable to the close path.
4. The document-store half of the `should_apply` guard vetoes on its own (re-sync held at entry via a spy gate while the store entry is recreated with `TextDocuments` empty), and a vetoed re-sync does **not** revalidate dependents.

**Ordering unit test** (`tests/unit/document-store-commit-time-cross-file-effects.test.ts`): pins the resolver-internal contract that `should_apply` is consulted **after** the disk read (a deferred-read content provider flips the guard mid-read; a guard hoisted above the read fails it).

**Shared test helper** (`tests/wait-until.ts`): extracted predicate-polling helper (descriptive timeout errors, defaults below bun's 5 s test timeout); the `wait_for_condition` twin in `send-to-stata-integrated-terminal.test.ts` now delegates to it with its original 200 ms/0 ms timing.

## Mutation verification

Each targeted regression fails at least one test: disabled reopen guard; `global_settings` instead of scoped settings; dropped `if (my_applied)` revalidation; dropped/forced document-store guard clause; always-revalidate-on-veto; guard hoisted above the disk read. (One reviewer-suggested mutation — direct instead of transitive children at the close site — is behaviorally inert because `schedule_caller_revalidation` re-expands its input with transitive dependents; the two-hop assertion still pins the end-to-end fan-out.)

## Review

Four rounds of codex (task-mode) plus independent review subagents (one cold, one primed, one round-3 focused):
- R1 (codex Medium + subagent-confirmed): quiescence barrier false-pass window, `active_handlers` assigned too late for `afterEach` cleanup, `wait_until` 5 s default colliding with bun's 5 s test timeout, duplicated polling helper → all fixed.
- R2 (subagents): two coverage gaps (store-clause never deciding; `my_applied` false branch never exercised with a live dependent) → closed by test 4; Logger-singleton restore + guarded `tmp_dir` cleanup (codex Low) → fixed; stub fidelity, reopen determinism, `published_uris` isolation verified.
- R3 (codex Medium): entry-gate doesn't pin guard-after-read ordering → pinned by the new unit test; subagent round fully clean (gate hygiene, store-open commit-guard fidelity, revalidation caps, cleanup).
- R4 (codex): confirms R3 resolved; one Low (unbounded poll loop) → fixed. Diff otherwise clean.

No deferrals.

Gate: `bun run test` (typecheck + 7168 tests) and `bun run lint` clean.

---
Stacked on #288 (`issue184`); contains only the four commits above it.

https://claude.ai/code/session_01DFizcojLhW3h59HXRo8Lbv
