### PR TITLE
Add sight: standalone directive to opt out of inherited parent scope (#208)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,13 @@ user-facing examples):
 - `@lsp-done-by`, `@lsp-included-by`: Cross-file scope linking (header-only)
 - `@lsp-do`, `@lsp-run`, `@lsp-include`: Forward call directives (can appear
   anywhere in file comments, unlike header-only backward directives)
+- `@lsp-standalone` / `sight: standalone`: Header-only, no-argument marker
+  that opts a file out of ALL inherited backward parent scope and inherited
+  working directory (issue #208). Wins over explicit backward directives
+  (each ignored line gets a warning, emitted by resolve()'s root path).
+  Cut-everywhere: also honored when the file is walked as a mid-chain
+  ancestor. Forward calls, DependencyGraph edges, and find-references
+  connectivity are unchanged. See docs/cross-file.md "Standalone Files".
 
 **Dependency Graph** (`src/dependency-graph/`): Maintains a bidirectional graph
 of `do`/`run`/`include` relationships across the workspace. Populated during the

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -75,7 +75,9 @@ In this mode the LSP will not auto-discover parent files — you must add
 
 **Per-file opt-out:** Even in auto mode, adding an explicit backward directive
 to a file's header causes the LSP to skip auto-discovery for that file and use
-only the directives you specified.
+only the directives you specified. To opt a file out of parent inheritance
+entirely (auto-discovered *and* explicit), mark it
+[`sight: standalone`](#standalone-files).
 
 ## What the LSP Reads (Open Files vs Workspace)
 
@@ -225,6 +227,63 @@ Notes:
   preferred. The `@lsp-` forms remain permanent aliases.
 - `sight: run-by` and `sight: done-by` are functionally identical; use whichever
   matches the actual Stata command (`run` vs `do`) for semantic clarity.
+
+## Standalone Files
+
+Some files are meant to be checked in isolation: self-contained utilities,
+generated scripts called by many unrelated parents, or files in dense
+`do`/`run`/`include` graphs where inherited scope does more harm than good.
+Mark such a file with the header-only, no-argument **standalone** directive:
+
+```stata
+// sight: standalone
+```
+
+(`@lsp-standalone` is a permanent alias; a trailing colon is accepted; the
+marker must appear in the file header, like backward directives.)
+
+A standalone file's diagnostics are resolved **without any backward parent
+inheritance**:
+
+- **Auto-discovered parents are ignored.** Even when the workspace scan finds
+  callers, the file's own diagnostics treat it as having no parents (and its
+  undefined-symbol diagnostics are never deferred while the scan runs — there
+  is nothing to wait for).
+- **Explicit backward directives are ignored, with a warning.** If the header
+  also contains `sight: done-by` / `sight: run-by` / `sight: included-by`
+  lines, each ignored line gets a warning diagnostic in the standalone file
+  itself (never in other files that read it).
+- **Inherited working directory is cut.** The file keeps its own
+  `sight: working-directory` directive, if any, but never inherits one from a
+  parent. This also affects `sight/getWorkingDirectory` (Send to Stata `cd`
+  prepending).
+- **The cut applies everywhere in a chain.** When another file's resolution
+  walks a standalone file as an ancestor, the standalone file contributes its
+  *own* symbols but never conducts its ancestors' scope (or their working
+  directories) through to descendants.
+
+What standalone does **not** change:
+
+- **Forward calls from the file keep working.** Its own `do`/`run`/`include`
+  statements (and `sight: do`/`run`/`include` directives) resolve normally.
+- **What callers see.** A caller that runs the standalone file still inherits
+  the standalone file's own symbols at the call site, exactly as before.
+- **The dependency graph and find-references.** Graph edges record who calls
+  whom — raw facts about the callers — so find-references still traverses
+  connectivity involving standalone files (see
+  [Find References Across Files](#find-references-across-files)).
+- **Navigation conveniences.** Hover, go-to-definition, and completion treat a
+  standalone file like any other scope-resolved file with zero parents:
+  workspace symbols remain reachable as annotated out-of-scope entries and
+  navigation fallbacks, and never suppress diagnostics.
+
+Toggling the directive is picked up like any other header edit: caches are
+keyed by content hash, and files that inherit *through* the standalone file
+are re-resolved automatically.
+
+`sight check` honors the directive identically to the editor: the standalone
+file is validated in isolation, and the ignored-directive warnings appear in
+its report.
 
 ## Working Directory
 
@@ -757,17 +816,18 @@ map), so an earlier-sourced sibling's symbols are always visible to a later
 sibling in execution order — see
 `tests/integration/hub-heavy-sibling-visibility.test.ts`.
 
-**Interaction with a future per-file standalone opt-out.** A planned
-`sight: standalone` directive would let a file resolve its own diagnostics as
-if it had no parents (a *backward* concern). It does **not** introduce caller-dependence
-into the *forward* closure: standalone can change the file's *inherited working
-directory* and the *effective call type* it is entered under, but both are inputs
-the closure already depends on.
+**Interaction with the per-file standalone opt-out (issue #208).** The
+[`sight: standalone`](#standalone-files) directive resolves a file's own
+diagnostics as if it had no parents (a *backward* concern). It does **not**
+introduce caller-dependence into the *forward* closure: standalone changes the
+file's *inherited working directory* (cut to the file's own directive or
+none), an input the closure already depends on.
 Standalone introduces no other forward-closure variation, and never caller
-identity. This is the assumption a caller-independent forward-closure cache relies
-on; it is enforced by the memo correctness gate
+identity. This is the assumption the caller-independent forward-closure cache
+relies on; it is enforced by the memo correctness gate
 (`tests/integration/forward-closure-memo-gate.test.ts`), which checks that a
-file's forward closure is identical across distinct callers given the same inputs.
+file's forward closure is identical across distinct callers given the same
+inputs — including a standalone callee reached from two different callers.
 
 ## Backward-Directive Registration Timing (Transactional Side Effects)
 

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -854,8 +854,10 @@ a separate best-effort recovery path (issue #184):
   commit. An `'explicit'`-mode resolution registers raw directives only and
   never synthesizes graph parents; the indexer's working-directory walk
   forces `'explicit'` for scan-order determinism and so never registers
-  auto edges. Effective ⊇ raw, so ancestor reads can only add edges
-  relative to the pre-#286 behavior. Registration remains a parse-path
+  auto edges. Effective ⊇ raw — except for
+  [`sight: standalone`](#standalone-files) files, whose effective directives
+  are empty (issue #208) — so for non-standalone files ancestor reads can
+  only add edges relative to the pre-#286 behavior. Registration remains a parse-path
   side effect, with one exception: each file-cache entry is stamped with
   the mode its registration ran under, and an `'auto'`-mode cache hit
   re-applies effective registration and re-stamps

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -193,7 +193,24 @@ export class DirectiveParser {
                 // directive below it would be accepted as header content
                 // (#208 review round 1). Pure comment lines (including a
                 // trailing `//` line comment) stay inert and are skipped.
+                //
+                // Compute the line's commented column intervals ONCE, then
+                // scan characters against them (not per-char
+                // position_in_block_comment, which walks every range per
+                // call — #208 review round 2).
                 const my_block_line = get_line_text(doc, i);
+                const the_covered: Array<[number, number]> = [];
+                for (const my_range of the_block_ranges) {
+                    if (my_range.start.line > i || my_range.end.line < i) {
+                        continue;
+                    }
+                    the_covered.push([
+                        my_range.start.line < i ? 0 : my_range.start.character,
+                        my_range.end.line > i
+                            ? my_block_line.length
+                            : my_range.end.character,
+                    ]);
+                }
                 let my_code_col = -1;
                 for (let c = 0; c < my_block_line.length; c++) {
                     const my_char = my_block_line[c];
@@ -201,12 +218,16 @@ export class DirectiveParser {
                         my_char === '\r') {
                         continue;
                     }
-                    if (!position_in_block_comment(
-                        i, c, the_block_ranges
-                    )) {
+                    const my_covering = the_covered.find(
+                        ([my_start, my_end]) => c >= my_start && c < my_end
+                    );
+                    if (my_covering === undefined) {
                         my_code_col = c;
                         break;
                     }
+                    // Jump past the covering interval instead of testing
+                    // every commented character.
+                    c = my_covering[1] - 1;
                 }
                 if (my_code_col < 0) {
                     continue;

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -171,11 +171,51 @@ export class DirectiveParser {
         let standalone_directive: StandaloneDirective | undefined;
 
         // Continuation lines of multi-line comments carry no directives.
-        const block_lines = block_comment_lines(content, tokens);
+        // A single ranges computation serves both the "line leads with a
+        // block comment" test and the trailing-code scan below (avoids the
+        // extra lex block_comment_lines would add on the tokenless path).
+        const the_block_ranges = block_comment_ranges(content, tokens);
+        const leads_with_block_comment = (
+            line_index: number, line_text: string
+        ): boolean => {
+            const my_col = line_text.search(/\S/);
+            return my_col >= 0 && position_in_block_comment(
+                line_index, my_col, the_block_ranges
+            );
+        };
 
         for (let i = 0; i < line_count; i++) {
-            if (block_lines.has(i)) {
-                continue;
+            if (leads_with_block_comment(i, get_line_text(doc, i))) {
+                // The line LEADS with a block comment, but executable code
+                // may follow the comment on the same physical line
+                // (`/* c */ gen x = 1`). Such trailing code ends the
+                // header, exactly like a plain code line — otherwise a
+                // directive below it would be accepted as header content
+                // (#208 review round 1). Pure comment lines (including a
+                // trailing `//` line comment) stay inert and are skipped.
+                const my_block_line = get_line_text(doc, i);
+                let my_code_col = -1;
+                for (let c = 0; c < my_block_line.length; c++) {
+                    const my_char = my_block_line[c];
+                    if (my_char === ' ' || my_char === '\t' ||
+                        my_char === '\r') {
+                        continue;
+                    }
+                    if (!position_in_block_comment(
+                        i, c, the_block_ranges
+                    )) {
+                        my_code_col = c;
+                        break;
+                    }
+                }
+                if (my_code_col < 0) {
+                    continue;
+                }
+                const my_rest = my_block_line.slice(my_code_col);
+                if (my_rest.startsWith('//') || my_rest.startsWith('*')) {
+                    continue;
+                }
+                break;
             }
             const my_line = get_line_text(doc, i);
             const my_trimmed = my_line.trim();
@@ -237,7 +277,6 @@ export class DirectiveParser {
             if (my_standalone_match) {
                 if (!standalone_directive) {
                     standalone_directive = {
-                        directive_form: my_standalone_match[1],
                         range: {
                             start: { line: i, character: 0 },
                             end: { line: i, character: my_line.length },

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -16,6 +16,7 @@ import {
     DeclarationDirective,
     ForwardCallDirective,
     WorkingDirectoryDirective,
+    StandaloneDirective,
     Token,
 } from '../types';
 import {
@@ -35,6 +36,7 @@ import {
     FORWARD_DIRECTIVE_KEYWORDS,
     WORKING_DIR_DIRECTIVE_KEYWORDS,
     DECLARATION_DIRECTIVE_KEYWORDS,
+    STANDALONE_DIRECTIVE_KEYWORDS,
     CALL_SITE_PARAMS_FRAGMENT,
     make_directive_pattern,
     has_ignore_directive,
@@ -83,6 +85,22 @@ const FORWARD_CALL_DIRECTIVE_HEAD_PATTERN = make_directive_pattern(
 const WORKING_DIR_DIRECTIVE_PATTERN = make_directive_pattern(
     WORKING_DIR_DIRECTIVE_KEYWORDS,
     String.raw`:?\s+(?:"([^"]+)"|([^\s]+))\s*$`,
+);
+
+// Header-only, no-argument standalone marker (issue #208):
+// `// sight: standalone` / `// @lsp-standalone`, optional trailing colon.
+const STANDALONE_DIRECTIVE_PATTERN = make_directive_pattern(
+    STANDALONE_DIRECTIVE_KEYWORDS,
+    String.raw`:?\s*$`,
+);
+
+// Detects a standalone-directive head with unexpected trailing content
+// (e.g. `sight: standalone "foo.do"`) so the parser can report it as
+// malformed, mirroring BACKWARD_DIRECTIVE_HEAD_PATTERN. The `(?=:|\s|$)`
+// boundary keeps the keyword whole (it does not match `standalonex`).
+const STANDALONE_DIRECTIVE_HEAD_PATTERN = make_directive_pattern(
+    STANDALONE_DIRECTIVE_KEYWORDS,
+    String.raw`(?=:|\s|$)`,
 );
 
 const PARAM_LINE = /line=(\d+)/;
@@ -148,6 +166,10 @@ export class DirectiveParser {
         let working_directory: WorkingDirectoryDirective | undefined;
         let working_dir_count = 0;
 
+        // Track the standalone marker (issue #208); position-independent
+        // within the header, so first match wins and later ones are inert.
+        let standalone_directive: StandaloneDirective | undefined;
+
         // Continuation lines of multi-line comments carry no directives.
         const block_lines = block_comment_lines(content, tokens);
 
@@ -205,6 +227,36 @@ export class DirectiveParser {
                     range: my_range,
                     directive_form: my_directive_form,
                 };
+                continue;
+            }
+
+            // Standalone marker (issue #208): header-only, no argument.
+            const my_standalone_match = my_trimmed.match(
+                STANDALONE_DIRECTIVE_PATTERN
+            );
+            if (my_standalone_match) {
+                if (!standalone_directive) {
+                    standalone_directive = {
+                        directive_form: my_standalone_match[1],
+                        range: {
+                            start: { line: i, character: 0 },
+                            end: { line: i, character: my_line.length },
+                        },
+                    };
+                }
+                continue;
+            }
+            if (STANDALONE_DIRECTIVE_HEAD_PATTERN.test(my_trimmed)) {
+                // Keyword present but trailing content followed it.
+                the_diagnostics.push({
+                    message: 'Malformed directive. Expected: ' +
+                        '// sight: standalone (no arguments)',
+                    range: {
+                        start: { line: i, character: 0 },
+                        end: { line: i, character: my_line.length },
+                    },
+                    severity: 'warning',
+                });
                 continue;
             }
 
@@ -289,6 +341,7 @@ export class DirectiveParser {
             declaration_directives: declaration_result.declarations,
             forward_calls: forward_call_result.forward_calls,
             working_directory,
+            standalone: standalone_directive,
             diagnostics: the_diagnostics,
         };
     }

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -154,7 +154,8 @@ export class DocumentStore {
           this.scope_resolver.apply_backward_directive_registration(
             my_state.uri,
             directive_result.directives,
-            this.scope_resolver_config
+            this.scope_resolver_config,
+            directive_result.standalone !== undefined
           );
         } catch {
           // Ignore directive parsing errors during warm-sync
@@ -484,7 +485,8 @@ export class DocumentStore {
       this.scope_resolver.apply_backward_directive_registration(
         uri,
         staged.raw_backward_directives,
-        staged.scope_resolver_config
+        staged.scope_resolver_config,
+        staged.is_standalone
       );
     }
     if (this.on_backward_directives_parsed) {
@@ -761,6 +763,7 @@ export class DocumentStore {
       staged_effects = {
         raw_backward_directives: directive_result.directives,
         scope_resolver_config: effective_scope_resolver_config,
+        is_standalone: directive_result.standalone !== undefined,
       };
 
       if (directive_result.working_directory) {

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -7,6 +7,7 @@ import {
   ForwardCall,
   WorkingDirectoryDirective,
   Directive,
+  DirectiveParseResult,
   LexerError,
   ParseError,
   ScopeResolverConfig,
@@ -72,10 +73,9 @@ export interface DocumentState {
 /**
  * Result of create_document_state: the parsed state plus any cross-file
  * side effects staged for commit-time application (issue #184). Effects are
- * undefined when the parse failed before directive parsing (lexer/parser
- * error or timeout) — a committed error state keeps the previous
- * registrations on purpose (a transiently broken buffer must not wipe
- * cross-file edges).
+ * recoverable from header facts on lexer/parser failure when DirectiveParser
+ * recovery succeeds; undefined means recovery failed too, so commit leaves
+ * previous registrations unchanged.
  */
 export interface ParseOutcome {
   state: DocumentState;
@@ -494,6 +494,61 @@ export class DocumentStore {
     }
   }
 
+  private stage_cross_file_effects(
+    directive_result: DirectiveParseResult,
+    scope_resolver_config: Partial<ScopeResolverConfig>
+  ): StagedCrossFileEffects {
+    return {
+      raw_backward_directives: directive_result.directives,
+      scope_resolver_config,
+      is_standalone: directive_result.standalone !== undefined,
+    };
+  }
+
+  private recover_staged_effects_from_tokens(
+    content: string,
+    uri: string,
+    tokens: Token[],
+    scope_resolver_config: Partial<ScopeResolverConfig>
+  ): StagedCrossFileEffects | undefined {
+    try {
+      const my_directive_parser = new DirectiveParser();
+      const my_directive_result = my_directive_parser.parse(
+        content,
+        uri,
+        tokens
+      );
+      return this.stage_cross_file_effects(
+        my_directive_result,
+        scope_resolver_config
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async recover_staged_effects_with_timeout(
+    content: string,
+    uri: string,
+    scope_resolver_config: Partial<ScopeResolverConfig>
+  ): Promise<StagedCrossFileEffects | undefined> {
+    try {
+      const my_directive_parser = new DirectiveParser();
+      const my_result = await with_parse_timeout(() =>
+        my_directive_parser.parse(content, uri)
+      );
+      if (!my_result.success || my_result.timed_out || !my_result.result) {
+        return undefined;
+      }
+      return this.stage_cross_file_effects(
+        my_result.result,
+        scope_resolver_config
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
   /**
    * Increment in-flight operation count for a URI.
    */
@@ -701,6 +756,8 @@ export class DocumentStore {
     const lexer = new StataLexer();
     const parser = new StataParser();
     const analyzer = new SemanticAnalyzer();
+    const effective_scope_resolver_config =
+      scope_resolver_config ?? this.scope_resolver_config;
 
     // Lex with timeout
     const lex_result = await with_parse_timeout(() =>
@@ -708,6 +765,21 @@ export class DocumentStore {
     );
 
     if (!lex_result.success || lex_result.timed_out) {
+      // Recover header facts only when the lexer THREW (fast). On a
+      // TIMEOUT, the DirectiveParser's internal block-comment re-lex
+      // would run the same pathological tokenize again synchronously —
+      // with_parse_timeout cannot preempt synchronous work, so recovery
+      // would double the latency of the per-URI update chain. Staying
+      // unrecovered there keeps the previous registrations, matching the
+      // pre-recovery behavior for that (rare) case.
+      const recovered_staged_effects = lex_result.timed_out
+        ? undefined
+        : await this.recover_staged_effects_with_timeout(
+            content,
+            uri,
+            effective_scope_resolver_config
+          );
+
       // Return minimal state on timeout/error
       return {
         state: this.create_error_state(
@@ -717,7 +789,7 @@ export class DocumentStore {
           lex_result.error || 'Lexer timeout',
           lex_result.result?.line_offsets
         ),
-        staged_effects: undefined,
+        staged_effects: recovered_staged_effects,
       };
     }
 
@@ -735,6 +807,14 @@ export class DocumentStore {
     );
 
     if (!parse_result.success || parse_result.timed_out) {
+      const recovered_staged_effects =
+        this.recover_staged_effects_from_tokens(
+          content,
+          uri,
+          lex_result.result!.tokens,
+          effective_scope_resolver_config
+        );
+
       return {
         state: this.create_error_state(
           uri,
@@ -743,7 +823,7 @@ export class DocumentStore {
           parse_result.error || 'Parser timeout',
           lex_result.result!.line_offsets
         ),
-        staged_effects: undefined,
+        staged_effects: recovered_staged_effects,
       };
     }
 
@@ -756,15 +836,16 @@ export class DocumentStore {
     const directive_parser = new DirectiveParser();
     let resolved_working_directory: string | undefined;
     let staged_effects: StagedCrossFileEffects | undefined;
-    const effective_scope_resolver_config =
-      scope_resolver_config ?? this.scope_resolver_config;
     try {
-      const directive_result = directive_parser.parse(content, uri, lex_result.result!.tokens);
-      staged_effects = {
-        raw_backward_directives: directive_result.directives,
-        scope_resolver_config: effective_scope_resolver_config,
-        is_standalone: directive_result.standalone !== undefined,
-      };
+      const directive_result = directive_parser.parse(
+        content,
+        uri,
+        lex_result.result!.tokens
+      );
+      staged_effects = this.stage_cross_file_effects(
+        directive_result,
+        effective_scope_resolver_config
+      );
 
       if (directive_result.working_directory) {
         // File has its own working directory directive

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -489,6 +489,15 @@ export class DocumentStore {
         staged.is_standalone
       );
     }
+    // The indexer overlay deliberately receives RAW directives even for a
+    // standalone file (issue #208): it feeds get_related_uris, the
+    // find-references connectivity floor, which is raw-facts-based and
+    // standalone-independent by design (docs/cross-file.md "What
+    // standalone does not change"). The indexer's disk-side scan stores
+    // raw directives for the same file, so gating the overlay here would
+    // make an open buffer's connectivity diverge from the identical file
+    // on disk. Only the resolver registration above is effective/
+    // standalone-aware.
     if (this.on_backward_directives_parsed) {
       this.on_backward_directives_parsed(uri, staged.raw_backward_directives);
     }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -613,6 +613,7 @@ export class WorkspaceIndexer {
                         .resolve_inherited_working_directory(
                             directive_result.directives,
                             file_uri,
+                            directive_result.standalone !== undefined,
                             this.scope_resolver_config,
                         );
             }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -1055,7 +1055,15 @@ export class CompletionProvider {
                         position.line,
                     );
 
-                if (has_directives || has_auto_parents) {
+                // A standalone file (issue #208) uses Scope-Resolved mode:
+                // its chain is just itself (+ forward calls), so in-scope
+                // completions come from its own resolved scope rather than
+                // the Global-mode workspace merge. Workspace symbols still
+                // appear as out-of-scope entries via
+                // partition_symbols_for_completion, exactly as for a file
+                // with explicit directives.
+                if (has_directives || has_auto_parents ||
+                    temp_scope.is_standalone) {
                     // With directives: use reachable scope chain (precision).
                     // get_visible_symbols_at already resolves forward calls
                     // with correct precedence; re-merging visible_forward_overlay

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -367,12 +367,16 @@ export class DiagnosticsProvider {
         // (defer) rather than reading live state.
         const scan_complete_for_deferral =
             resolved_scope?.scan_complete_at_resolve_time ?? false;
+        // A standalone file (issue #208) never defers: it can never gain
+        // backward parents from the workspace scan, so there is nothing to
+        // wait for.
         const defer_undefined_diagnostics = backward_dep_mode === 'auto' &&
             this.dependency_graph &&
             !scan_complete_for_deferral &&
             resolved_scope &&
             !resolved_scope.has_directives &&
-            !resolved_scope.has_auto_parents;
+            !resolved_scope.has_auto_parents &&
+            !resolved_scope.is_standalone;
 
         for (const my_diagnostic of this.extract_semantic_diagnostics(document)) {
             // Suppress Stata-specific semantic diagnostics in embedded contexts

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -131,7 +131,18 @@ export function scope_resolver_config_for(
  * Cache for file parsing results within a single resolution request.
  * Ensures we only read/parse each file once per request.
  */
-type ParsedFileResult = { content: string; content_hash: string; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; is_standalone: boolean; diagnostics: DirectiveDiagnostic[] } | { error: string };
+type ParsedFileResult = {
+    content: string;
+    content_hash: string;
+    symbols: SymbolTable;
+    directives: Directive[];
+    forward_calls: ForwardCall[];
+    cd_commands: CdCommand[];
+    working_directory?: string;
+    working_directory_directive?: WorkingDirectoryDirective;
+    is_standalone: boolean;
+    diagnostics: DirectiveDiagnostic[];
+} | { error: string };
 type RequestCache = Map<string, Promise<ParsedFileResult>>;
 
 /**
@@ -2031,6 +2042,11 @@ export class ScopeResolver {
                     ...my_parse_diag,
                     source: {
                         source_file: parent_filename,
+                        // Full URI so remapping routes by identity, not
+                        // basename (#208 review round 2: two parents can
+                        // share a basename, or a parent's basename can
+                        // equal the active file's).
+                        source_uri: my_parent_uri,
                         source_line: my_parse_diag.range.start.line,
                         original_range: my_parse_diag.range,
                     },
@@ -2181,11 +2197,28 @@ export class ScopeResolver {
     private parse_file(
         uri: string,
         content: string
-    ): { symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory_directive?: WorkingDirectoryDirective; is_standalone: boolean; diagnostics: DirectiveDiagnostic[] } {
+    ): {
+        symbols: SymbolTable;
+        directives: Directive[];
+        forward_calls: ForwardCall[];
+        cd_commands: CdCommand[];
+        working_directory_directive?: WorkingDirectoryDirective;
+        is_standalone: boolean;
+        diagnostics: DirectiveDiagnostic[];
+    } {
         const content_hash = this.hash_content(content);
         const cached = this.file_cache.get(uri);
         if (cached && cached.content_hash === content_hash) {
-            return { symbols: cached.symbols, directives: cached.directives, forward_calls: cached.forward_calls, cd_commands: cached.cd_commands, working_directory_directive: cached.working_directory_directive, is_standalone: cached.is_standalone, diagnostics: cached.diagnostics };
+            return {
+                symbols: cached.symbols,
+                directives: cached.directives,
+                forward_calls: cached.forward_calls,
+                cd_commands: cached.cd_commands,
+                working_directory_directive:
+                    cached.working_directory_directive,
+                is_standalone: cached.is_standalone,
+                diagnostics: cached.diagnostics,
+            };
         }
 
         // New content observed for this URI: any forward-closure memo entry
@@ -2292,7 +2325,16 @@ export class ScopeResolver {
         uri: string,
         content: string,
         inherited_working_directory?: string
-    ): { symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; is_standalone: boolean; diagnostics: DirectiveDiagnostic[] } {
+    ): {
+        symbols: SymbolTable;
+        directives: Directive[];
+        forward_calls: ForwardCall[];
+        cd_commands: CdCommand[];
+        working_directory?: string;
+        working_directory_directive?: WorkingDirectoryDirective;
+        is_standalone: boolean;
+        diagnostics: DirectiveDiagnostic[];
+    } {
         const my_directive_result = this.directive_parser.parse(content, uri);
         const my_lex_result = this.lexer.tokenize(content);
         const my_parse_result = this.parser.parse(my_lex_result.tokens);
@@ -2620,7 +2662,10 @@ export class ScopeResolver {
             // matching the commit-time effective registration in DocumentStore
             // (issue #184). An unthreaded call defaults to 'explicit', which
             // registers raw directives only — identical to the pre-#286 raw
-            // sync, so this can only ADD edges relative to that behavior.
+            // sync, so this can only ADD edges relative to that behavior,
+            // with one exception: a `sight: standalone` file's effective
+            // directives are EMPTY (issue #208), so its raw done-by edges
+            // are deliberately not registered.
             this.apply_backward_directive_registration(
                 actual_uri,
                 parse_result.directives,
@@ -2894,11 +2939,18 @@ export class ScopeResolver {
 
         // Build a map from parent basename to directive range for targeted remapping
         const parent_to_directive = new Map<string, Range>();
+        // URI-keyed variant for diagnostics that carry source_uri: exact
+        // identity routing, immune to basename collisions (#208 round 2).
+        const parent_uri_to_directive = new Map<string, Range>();
         for (const my_directive of directives) {
             const parent_basename = path.basename(my_directive.path);
             // If multiple directives reference the same parent, use the first one
             if (!parent_to_directive.has(parent_basename)) {
                 parent_to_directive.set(parent_basename, my_directive.range);
+            }
+            const parent_uri = URI.file(my_directive.path).toString();
+            if (!parent_uri_to_directive.has(parent_uri)) {
+                parent_uri_to_directive.set(parent_uri, my_directive.range);
             }
         }
 
@@ -2911,8 +2963,13 @@ export class ScopeResolver {
                 return diagnostic;
             }
 
-            // Forward-call diagnostics (from current file) keep their original range
-            if (diagnostic.source.source_file === active_file_basename) {
+            // Forward-call diagnostics (from current file) keep their
+            // original range. Prefer the URI identity check when the
+            // source carries one — a PARENT whose basename happens to
+            // equal the active file's must still be remapped (#208 r2).
+            if (diagnostic.source.source_uri !== undefined
+                ? diagnostic.source.source_uri === active_file_uri
+                : diagnostic.source.source_file === active_file_basename) {
                 return diagnostic;
             }
 
@@ -2934,8 +2991,15 @@ export class ScopeResolver {
                 };
             }
 
-            // Find the specific directive that references the source file (rule b)
-            const target_range = parent_to_directive.get(diagnostic.source.source_file) ?? first_directive_range;
+            // Find the specific directive that references the source file
+            // (rule b): exact URI match first when available, then the
+            // basename map, then the first directive as a last resort.
+            const target_range =
+                (diagnostic.source.source_uri !== undefined
+                    ? parent_uri_to_directive.get(diagnostic.source.source_uri)
+                    : undefined) ??
+                parent_to_directive.get(diagnostic.source.source_file) ??
+                first_directive_range;
 
             // Update message to include source file and line info (rule c)
             const updated_message = diagnostic.message.includes(source_info)
@@ -3569,9 +3633,10 @@ export class ScopeResolver {
      * resolutions keep hitting the cache (until the content changes).
      * When an 'auto'-mode read hits such an entry, apply effective
      * registration and stamp the entry so repeat hits are free.
-     * Effective ⊇ raw, so upgrading can only add edges. Explicit-mode
-     * hits never downgrade: for them hit paths stay side-effect-free,
-     * as before.
+     * Effective ⊇ raw (except for `sight: standalone` files, whose
+     * effective directives are empty, issue #208), so upgrading can only
+     * add edges. Explicit-mode hits never downgrade: for them hit paths
+     * stay side-effect-free, as before.
      *
      * Directive-less auto-mode hits always re-sync idempotently. The
      * file_cache may hold multiple entries for the same URI (different

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -131,7 +131,7 @@ export function scope_resolver_config_for(
  * Cache for file parsing results within a single resolution request.
  * Ensures we only read/parse each file once per request.
  */
-type ParsedFileResult = { content: string; content_hash: string; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] } | { error: string };
+type ParsedFileResult = { content: string; content_hash: string; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; is_standalone: boolean; diagnostics: DirectiveDiagnostic[] } | { error: string };
 type RequestCache = Map<string, Promise<ParsedFileResult>>;
 
 /**
@@ -190,7 +190,7 @@ export class ScopeResolver {
     // by an 'auto'-mode resolution. Directive-less auto-mode hits re-sync
     // idempotently because registration is global per URI, not per
     // file_cache entry — see upgrade_registration_on_cache_hit.
-    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit' }>;
+    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; is_standalone: boolean; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit' }>;
     private scope_cache: Map<string, ScopeCacheEntry>;
     // Secondary index: uri -> Set<cache_keys> for O(1) scope cache invalidation by URI
     private uri_to_cache_keys: Map<string, Set<string>>;
@@ -287,17 +287,30 @@ export class ScopeResolver {
 
     /**
      * Determine the effective backward directives for a file at any recursion
-     * level. Explicit directives on the file take precedence over auto
-     * discovery, matching the root-level opt-out semantics.
+     * level. A `sight: standalone` header marker (issue #208) wins over
+     * everything: the file inherits nothing, regardless of mode or explicit
+     * directives. Otherwise explicit directives on the file take precedence
+     * over auto discovery, matching the root-level opt-out semantics.
+     *
+     * `is_standalone` is deliberately required (no default): every call site
+     * must consciously thread the file's own standalone flag, so a future
+     * call site cannot silently ignore it.
      */
     private get_effective_backward_directives(
         file_uri: string,
         parsed_directives: Directive[],
-        config: ScopeResolverConfig
+        config: ScopeResolverConfig,
+        is_standalone: boolean
     ): {
         directives: Directive[];
         used_auto_parents: boolean;
     } {
+        if (is_standalone) {
+            return {
+                directives: [],
+                used_auto_parents: false,
+            };
+        }
         const backward_mode = config.backward_dependencies ?? 'auto';
         if (backward_mode === 'explicit' || parsed_directives.length > 0) {
             return {
@@ -974,6 +987,24 @@ export class ScopeResolver {
 
         // Track whether the current file has directives declared (regardless of resolution)
         const has_directives = my_directives.length > 0;
+        const is_standalone = my_parse_result.is_standalone;
+
+        // Standalone wins over explicit backward directives, with a warning
+        // per ignored line (issue #208). Emitted here (root path) rather than
+        // by the DirectiveParser so it never rides ancestor parse results
+        // into a descendant's diagnostics — it appears only when the
+        // standalone file itself is diagnosed.
+        if (is_standalone) {
+            for (const my_ignored of my_directives) {
+                the_diagnostics.push({
+                    message: `Ignored '${my_ignored.type}' directive: this ` +
+                        `file is marked 'sight: standalone', which disables ` +
+                        `backward-directive inheritance.`,
+                    range: my_ignored.range,
+                    severity: 'warning',
+                });
+            }
+        }
 
         // Add current file to chain
         the_chain.push({
@@ -997,7 +1028,8 @@ export class ScopeResolver {
         } = this.get_effective_backward_directives(
             file_uri,
             my_directives,
-            my_config
+            my_config,
+            is_standalone
         );
 
         // Snapshot scan_complete at the SAME synchronous moment as
@@ -1049,6 +1081,7 @@ export class ScopeResolver {
                 diagnostics: [],
                 has_directives,
                 has_auto_parents,
+                is_standalone,
                 scan_complete_at_resolve_time,
             };
         }
@@ -1057,22 +1090,21 @@ export class ScopeResolver {
         const merged_symbols = this.merge_chain(the_chain);
 
         // Check if current file has its own working directory
-        // We need to parse directives again to get working_directory (parse_file doesn't return it)
-        const directive_parse_result = this.directive_parser.parse(file_content, file_uri);
+        // (parse_file forwards the header's working-directory directive).
         let own_working_directory: string | undefined;
-        if (directive_parse_result.working_directory) {
-            if (directive_parse_result.working_directory.is_workspace_relative) {
+        if (my_parse_result.working_directory_directive) {
+            if (my_parse_result.working_directory_directive.is_workspace_relative) {
                 const my_ws_root = get_workspace_root_for_uri(
                     this.workspace_roots, file_uri
                 );
                 if (my_ws_root) {
                     own_working_directory = path.normalize(path.join(
                         my_ws_root,
-                        directive_parse_result.working_directory.resolved_path
+                        my_parse_result.working_directory_directive.resolved_path
                     ));
                 }
             } else {
-                own_working_directory = directive_parse_result.working_directory.resolved_path;
+                own_working_directory = my_parse_result.working_directory_directive.resolved_path;
             }
         }
 
@@ -1150,6 +1182,7 @@ export class ScopeResolver {
             diagnostics: remapped_diagnostics,
             has_directives,
             has_auto_parents,
+            is_standalone,
             scan_complete_at_resolve_time,
             inherited_working_directory,
             forward_call_symbols,
@@ -1423,8 +1456,14 @@ export class ScopeResolver {
     async resolve_inherited_working_directory(
         directives: Directive[],
         current_uri: string,
+        is_standalone: boolean,
         config?: Partial<ScopeResolverConfig>,
     ): Promise<string | undefined> {
+        // A standalone file (issue #208) inherits no working directory,
+        // regardless of any (ignored) backward directives in its header.
+        if (is_standalone) {
+            return undefined;
+        }
         const the_backward_directives = directives.filter(
             d => d.type === 'done-by' || d.type === 'included-by',
         );
@@ -1574,12 +1613,16 @@ export class ScopeResolver {
                 return resolved_path;
             }
 
+            // A standalone parent's OWN working-directory directive (handled
+            // above) still flows to the child, but its ancestors' WD does
+            // not: the chokepoint returns [] for it (issue #208).
             const {
                 directives: effective_parent_directives,
             } = this.get_effective_backward_directives(
                 my_parent_uri,
                 my_parent_result.directives,
-                config
+                config,
+                my_parent_result.is_standalone
             );
 
             // Otherwise, recursively search deeper ancestors
@@ -1970,12 +2013,20 @@ export class ScopeResolver {
             // Mark as visited and recurse FIRST to get working directory from deeper ancestors
             // This ensures we have the correct working directory before resolving forward calls
             visited.add(my_parent_uri);
+            // A standalone parent (issue #208) contributes its own symbols
+            // (already parsed above) but never conducts its ancestors'
+            // scope: the chokepoint returns [] for it, so the recursion
+            // below iterates zero times and execution falls through to the
+            // unconditional chain push. Do NOT early-continue here — the
+            // parent must still land in the chain (and thus in the
+            // descendant's dependent_uris for cascade invalidation).
             const {
                 directives: effective_parent_directives,
             } = this.get_effective_backward_directives(
                 my_parent_uri,
                 my_parent_result.directives,
-                config
+                config,
+                my_parent_result.is_standalone
             );
             const normalized_parent_directives = this.normalize_directives(
                 effective_parent_directives,
@@ -2013,10 +2064,20 @@ export class ScopeResolver {
             // 1. Parent's own working directory (if it has one)
             // 2. Working directory from deeper ancestors (recursive_result)
             // 3. Working directory found at this level so far
+            //
+            // A standalone parent (issue #208) inherits no working
+            // directory: its forward calls resolve with its OWN WD or none.
+            // Without this guard, an EARLIER sibling parent's WD (held in
+            // found_working_directory) would leak into the standalone
+            // parent's forward-call resolution. found_working_directory
+            // itself is deliberately untouched — an earlier non-standalone
+            // sibling's WD must still reach the root file's inherited WD.
             const effective_working_directory =
-                my_parent_result.working_directory ??
-                recursive_result.working_directory ??
-                found_working_directory;
+                my_parent_result.is_standalone
+                    ? my_parent_result.working_directory
+                    : (my_parent_result.working_directory ??
+                       recursive_result.working_directory ??
+                       found_working_directory);
 
             // Update found_working_directory if we got one from deeper in chain
             if (!found_working_directory && recursive_result.working_directory) {
@@ -2079,11 +2140,11 @@ export class ScopeResolver {
     private parse_file(
         uri: string,
         content: string
-    ): { symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; diagnostics: DirectiveDiagnostic[] } {
+    ): { symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory_directive?: WorkingDirectoryDirective; is_standalone: boolean; diagnostics: DirectiveDiagnostic[] } {
         const content_hash = this.hash_content(content);
         const cached = this.file_cache.get(uri);
         if (cached && cached.content_hash === content_hash) {
-            return { symbols: cached.symbols, directives: cached.directives, forward_calls: cached.forward_calls, cd_commands: cached.cd_commands, diagnostics: cached.diagnostics };
+            return { symbols: cached.symbols, directives: cached.directives, forward_calls: cached.forward_calls, cd_commands: cached.cd_commands, working_directory_directive: cached.working_directory_directive, is_standalone: cached.is_standalone, diagnostics: cached.diagnostics };
         }
 
         // New content observed for this URI: any forward-closure memo entry
@@ -2111,6 +2172,7 @@ export class ScopeResolver {
                 cd_commands: my_parse_result.cd_commands,
                 working_directory: my_parse_result.working_directory,
                 working_directory_directive: my_parse_result.working_directory_directive,
+                is_standalone: my_parse_result.is_standalone,
                 diagnostics: my_parse_result.diagnostics,
             });
 
@@ -2119,6 +2181,8 @@ export class ScopeResolver {
                 directives: my_parse_result.directives,
                 forward_calls: my_parse_result.forward_calls,
                 cd_commands: my_parse_result.cd_commands,
+                working_directory_directive: my_parse_result.working_directory_directive,
+                is_standalone: my_parse_result.is_standalone,
                 diagnostics: my_parse_result.diagnostics,
             };
         } catch (error) {
@@ -2131,6 +2195,7 @@ export class ScopeResolver {
                 directives: [],
                 forward_calls: [],
                 cd_commands: [],
+                is_standalone: false,
                 diagnostics: [{
                     message: `Parse error in file: ${uri}`,
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
@@ -2152,7 +2217,7 @@ export class ScopeResolver {
         uri: string,
         content: string,
         inherited_working_directory?: string
-    ): { symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; diagnostics: DirectiveDiagnostic[] } {
+    ): { symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; is_standalone: boolean; diagnostics: DirectiveDiagnostic[] } {
         const my_directive_result = this.directive_parser.parse(content, uri);
         const my_lex_result = this.lexer.tokenize(content);
         const my_parse_result = this.parser.parse(my_lex_result.tokens);
@@ -2227,6 +2292,7 @@ export class ScopeResolver {
             cd_commands: my_analysis.cd_commands,
             working_directory: effective_working_directory,
             working_directory_directive: my_directive_result.working_directory,
+            is_standalone: my_directive_result.standalone !== undefined,
             diagnostics: my_directive_result.diagnostics,
         };
     }
@@ -2308,6 +2374,7 @@ export class ScopeResolver {
                 cd_commands: cached.cd_commands,
                 working_directory: cached.working_directory,
                 working_directory_directive: cached.working_directory_directive,
+                is_standalone: cached.is_standalone,
                 diagnostics: cached.diagnostics
             };
         }
@@ -2338,6 +2405,7 @@ export class ScopeResolver {
                     cd_commands: cached.cd_commands,
                     working_directory: cached.working_directory,
                     working_directory_directive: cached.working_directory_directive,
+                    is_standalone: cached.is_standalone,
                     diagnostics: cached.diagnostics
                 };
             }
@@ -2389,6 +2457,7 @@ export class ScopeResolver {
                                 // inheritance falls through to deeper
                                 // ancestors.
                                 working_directory_directive: fallback_cached.working_directory_directive,
+                                is_standalone: fallback_cached.is_standalone,
                                 diagnostics: fallback_cached.diagnostics
                             };
                         }
@@ -2434,6 +2503,7 @@ export class ScopeResolver {
                 cd_commands: actual_cached.cd_commands,
                 working_directory: actual_cached.working_directory,
                 working_directory_directive: actual_cached.working_directory_directive,
+                is_standalone: actual_cached.is_standalone,
                 diagnostics: actual_cached.diagnostics
             };
         } else if (actual_cached) {
@@ -2469,6 +2539,7 @@ export class ScopeResolver {
                 cd_commands: parse_result.cd_commands,
                 working_directory: parse_result.working_directory,
                 working_directory_directive: parse_result.working_directory_directive,
+                is_standalone: parse_result.is_standalone,
                 diagnostics: parse_result.diagnostics,
                 // Stamp the mode the registration below runs under (and
                 // upgrade an 'explicit'-registered entry on later
@@ -2491,7 +2562,8 @@ export class ScopeResolver {
             this.apply_backward_directive_registration(
                 actual_uri,
                 parse_result.directives,
-                { backward_dependencies: options?.backward_dependencies ?? 'explicit' }
+                { backward_dependencies: options?.backward_dependencies ?? 'explicit' },
+                parse_result.is_standalone
             );
 
             // Register forward call relationships from cached file
@@ -2513,6 +2585,7 @@ export class ScopeResolver {
                 forward_calls: [],
                 cd_commands: [],
                 working_directory: undefined,
+                is_standalone: false,
                 diagnostics: [{
                     message: `Parse error in file: ${actual_uri}`,
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
@@ -3385,6 +3458,10 @@ export class ScopeResolver {
      * and want to register dependencies without doing a full scope resolve.
      */
     sync_backward_directive_dependencies(child_uri: string, directives: Directive[]): void {
+        // Raw-sync helper: deliberately bypasses BOTH auto-discovery and the
+        // standalone gate (issue #208) — it registers exactly the directives
+        // given, unlike the effective-directive chokepoint. A future caller
+        // must not assume it is standalone-aware.
         // Normalize directives to match resolve() behavior (handles done-by + included-by collisions)
         const normalized = this.normalize_directives(directives, []);
         this.apply_normalized_backward_directives(child_uri, normalized);
@@ -3402,12 +3479,13 @@ export class ScopeResolver {
     apply_backward_directive_registration(
         child_uri: string,
         raw_directives: Directive[],
-        config: Partial<ScopeResolverConfig> = {}
+        config: Partial<ScopeResolverConfig>,
+        is_standalone: boolean
     ): void {
         const my_config = { ...DEFAULT_CONFIG, ...config };
         const { directives: effective_directives } =
             this.get_effective_backward_directives(
-                child_uri, raw_directives, my_config
+                child_uri, raw_directives, my_config, is_standalone
             );
         const normalized = this.normalize_directives(effective_directives, []);
         this.apply_normalized_backward_directives(child_uri, normalized);
@@ -3441,6 +3519,7 @@ export class ScopeResolver {
         uri: string,
         cached: {
             directives: Directive[];
+            is_standalone: boolean;
             registered_backward_mode?: 'auto' | 'explicit';
         },
         requested_mode: 'auto' | 'explicit' | undefined
@@ -3454,7 +3533,7 @@ export class ScopeResolver {
         }
         this.apply_backward_directive_registration(uri, cached.directives, {
             backward_dependencies: 'auto',
-        });
+        }, cached.is_standalone);
         cached.registered_backward_mode = 'auto';
     }
 
@@ -3481,14 +3560,17 @@ export class ScopeResolver {
         should_apply?: () => boolean
     ): Promise<boolean> {
         let raw_directives: Directive[] = [];
+        let disk_is_standalone = false;
         try {
             const file_exists = await this.content_provider.exists(child_uri);
             if (file_exists) {
                 const disk_content =
                     await this.content_provider.read_file(child_uri);
-                raw_directives = this.directive_parser.parse(
+                const disk_parse = this.directive_parser.parse(
                     disk_content, child_uri
-                ).directives;
+                );
+                raw_directives = disk_parse.directives;
+                disk_is_standalone = disk_parse.standalone !== undefined;
             }
         } catch {
             return false;
@@ -3497,7 +3579,7 @@ export class ScopeResolver {
             return false;
         }
         this.apply_backward_directive_registration(
-            child_uri, raw_directives, config
+            child_uri, raw_directives, config, disk_is_standalone
         );
         return true;
     }

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -135,6 +135,28 @@ type ParsedFileResult = { content: string; content_hash: string; symbols: Symbol
 type RequestCache = Map<string, Promise<ParsedFileResult>>;
 
 /**
+ * Value shape of ScopeResolver.file_cache. Kept as a named type so
+ * cache_entry_to_parsed_result can single-source the entry→result copy
+ * (a hand-copied literal once silently dropped a field on one cache-hit
+ * path only — see the working_directory_directive note from PR #278).
+ */
+type FileCacheEntry = {
+    content: string;
+    content_hash: string;
+    mtimeMs?: number;
+    size?: number;
+    symbols: SymbolTable;
+    directives: Directive[];
+    forward_calls: ForwardCall[];
+    cd_commands: CdCommand[];
+    working_directory?: string;
+    working_directory_directive?: WorkingDirectoryDirective;
+    is_standalone: boolean;
+    diagnostics: DirectiveDiagnostic[];
+    registered_backward_mode?: 'auto' | 'explicit';
+};
+
+/**
  * Interface for ForwardScopeResolver to avoid circular imports.
  * The actual ForwardScopeResolver is injected via set_forward_scope_resolver().
  */
@@ -190,7 +212,7 @@ export class ScopeResolver {
     // by an 'auto'-mode resolution. Directive-less auto-mode hits re-sync
     // idempotently because registration is global per URI, not per
     // file_cache entry — see upgrade_registration_on_cache_hit.
-    private file_cache: Map<string, { content: string; content_hash: string; mtimeMs?: number; size?: number; symbols: SymbolTable; directives: Directive[]; forward_calls: ForwardCall[]; cd_commands: CdCommand[]; working_directory?: string; working_directory_directive?: WorkingDirectoryDirective; is_standalone: boolean; diagnostics: DirectiveDiagnostic[]; registered_backward_mode?: 'auto' | 'explicit' }>;
+    private file_cache: Map<string, FileCacheEntry>;
     private scope_cache: Map<string, ScopeCacheEntry>;
     // Secondary index: uri -> Set<cache_keys> for O(1) scope cache invalidation by URI
     private uri_to_cache_keys: Map<string, Set<string>>;
@@ -995,10 +1017,13 @@ export class ScopeResolver {
         // into a descendant's diagnostics — it appears only when the
         // standalone file itself is diagnosed.
         if (is_standalone) {
+            // Do not name my_ignored.type here: the parser folds `run-by`
+            // into `done-by`, so the stored type can differ from the text
+            // on the flagged line (#208 review round 1).
             for (const my_ignored of my_directives) {
                 the_diagnostics.push({
-                    message: `Ignored '${my_ignored.type}' directive: this ` +
-                        `file is marked 'sight: standalone', which disables ` +
+                    message: `Ignored backward directive: this file is ` +
+                        `marked 'sight: standalone', which disables ` +
                         `backward-directive inheritance.`,
                     range: my_ignored.range,
                     severity: 'warning',
@@ -1994,7 +2019,23 @@ export class ScopeResolver {
             // Apply inheritance rules based on effective call type (not just directive type)
             const inheritance_type: 'done-by' | 'included-by' = effective_call_type === 'include' ? 'included-by' : 'done-by';
 
-            diagnostics.push(...my_parent_result.diagnostics);
+            // A parent's parser-level diagnostics (malformed directive,
+            // multiple-WD warning) carry ranges in the PARENT's coordinate
+            // space. Stamp source attribution so
+            // remap_diagnostics_to_active_file relocates them onto this
+            // file's directive line with a "…: parent.do line N" note,
+            // instead of publishing them on this file at the parent's raw
+            // coordinates (#208 review round 1).
+            for (const my_parse_diag of my_parent_result.diagnostics) {
+                diagnostics.push(my_parse_diag.source ? my_parse_diag : {
+                    ...my_parse_diag,
+                    source: {
+                        source_file: parent_filename,
+                        source_line: my_parse_diag.range.start.line,
+                        original_range: my_parse_diag.range,
+                    },
+                });
+            }
 
             // Apply inheritance rules and call site filtering
             const { filtered: my_filtered_symbols, excluded_locals } = this.apply_inheritance_rules(
@@ -2188,20 +2229,54 @@ export class ScopeResolver {
         } catch (error) {
             this.warn(`ScopeResolver: Parse error for ${uri}: ${error_message(error)}`);
 
-            // Return empty results on parse failure
+            // Return empty results on parse failure — but recover the
+            // header facts (directives, standalone marker, WD directive)
+            // via the directive parser, which is independent of the
+            // lexer/parser/analyzer failure. Without this, a parse error in
+            // a `sight: standalone` file silently re-enables auto-discovered
+            // parents (and a file with explicit directives falls back to
+            // auto-discovery) — #208 review round 1.
+            const my_recovered = this.recover_header_facts(uri, content);
             const empty_symbols = create_empty_symbol_table();
             return {
                 symbols: empty_symbols,
-                directives: [],
+                directives: my_recovered.directives,
                 forward_calls: [],
                 cd_commands: [],
-                is_standalone: false,
+                working_directory_directive:
+                    my_recovered.working_directory_directive,
+                is_standalone: my_recovered.is_standalone,
                 diagnostics: [{
                     message: `Parse error in file: ${uri}`,
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
                     severity: 'warning',
                 }],
             };
+        }
+    }
+
+    /**
+     * Best-effort recovery of header-only facts when the full
+     * lex/parse/analyze pipeline throws: the DirectiveParser scans only
+     * comment lines and is independent of the failure, so a broken file
+     * keeps its explicit directives, standalone marker, and own
+     * working-directory directive instead of silently falling back to
+     * auto-discovery (#208 review round 1).
+     */
+    private recover_header_facts(uri: string, content: string): {
+        directives: Directive[];
+        working_directory_directive?: WorkingDirectoryDirective;
+        is_standalone: boolean;
+    } {
+        try {
+            const my_result = this.directive_parser.parse(content, uri);
+            return {
+                directives: my_result.directives,
+                working_directory_directive: my_result.working_directory,
+                is_standalone: my_result.standalone !== undefined,
+            };
+        } catch {
+            return { directives: [], is_standalone: false };
         }
     }
 
@@ -2345,6 +2420,34 @@ export class ScopeResolver {
     }
 
     /**
+     * Build the ParsedFileResult view of a file_cache entry. The single
+     * point of copy for every cache-hit return path, so a future
+     * ParsedFileResult field cannot be silently dropped on one hit path
+     * only (that exact bug shipped once — working_directory_directive was
+     * missing from the .do-fallback hit alone; caught on PR #278).
+     * `content`/`content_hash` are parameters because the hash-match path
+     * returns the freshly read disk content rather than the entry's.
+     */
+    private cache_entry_to_parsed_result(
+        entry: FileCacheEntry,
+        content: string,
+        content_hash: string
+    ): ParsedFileResult {
+        return {
+            content,
+            content_hash,
+            symbols: entry.symbols,
+            directives: entry.directives,
+            forward_calls: entry.forward_calls,
+            cd_commands: entry.cd_commands,
+            working_directory: entry.working_directory,
+            working_directory_directive: entry.working_directory_directive,
+            is_standalone: entry.is_standalone,
+            diagnostics: entry.diagnostics,
+        };
+    }
+
+    /**
      * Internal implementation of get_parsed_file
      */
     private async _get_parsed_file_impl(
@@ -2365,18 +2468,9 @@ export class ScopeResolver {
             this.upgrade_registration_on_cache_hit(
                 uri, cached, options?.backward_dependencies
             );
-            return {
-                content: cached.content,
-                content_hash: cached.content_hash,
-                symbols: cached.symbols,
-                directives: cached.directives,
-                forward_calls: cached.forward_calls,
-                cd_commands: cached.cd_commands,
-                working_directory: cached.working_directory,
-                working_directory_directive: cached.working_directory_directive,
-                is_standalone: cached.is_standalone,
-                diagnostics: cached.diagnostics
-            };
+            return this.cache_entry_to_parsed_result(
+                cached, cached.content, cached.content_hash
+            );
         }
 
         // Optimization: check mtime and size if available BEFORE reading content
@@ -2396,18 +2490,9 @@ export class ScopeResolver {
                 this.upgrade_registration_on_cache_hit(
                     uri, cached, options?.backward_dependencies
                 );
-                return {
-                    content: cached.content,
-                    content_hash: cached.content_hash,
-                    symbols: cached.symbols,
-                    directives: cached.directives,
-                    forward_calls: cached.forward_calls,
-                    cd_commands: cached.cd_commands,
-                    working_directory: cached.working_directory,
-                    working_directory_directive: cached.working_directory_directive,
-                    is_standalone: cached.is_standalone,
-                    diagnostics: cached.diagnostics
-                };
+                return this.cache_entry_to_parsed_result(
+                    cached, cached.content, cached.content_hash
+                );
             }
         }
 
@@ -2441,25 +2526,11 @@ export class ScopeResolver {
                                 fallback_cached,
                                 options?.backward_dependencies
                             );
-                            return {
-                                content: fallback_cached.content,
-                                content_hash: fallback_cached.content_hash,
-                                symbols: fallback_cached.symbols,
-                                directives: fallback_cached.directives,
-                                forward_calls: fallback_cached.forward_calls,
-                                cd_commands: fallback_cached.cd_commands,
-                                working_directory: fallback_cached.working_directory,
-                                // Was missing from this HIT return alone
-                                // (coderabbit on PR #278): without it,
-                                // discover_working_directory cannot see a
-                                // parent's own WD directive when the parent
-                                // is served from this branch, and WD
-                                // inheritance falls through to deeper
-                                // ancestors.
-                                working_directory_directive: fallback_cached.working_directory_directive,
-                                is_standalone: fallback_cached.is_standalone,
-                                diagnostics: fallback_cached.diagnostics
-                            };
+                            return this.cache_entry_to_parsed_result(
+                                fallback_cached,
+                                fallback_cached.content,
+                                fallback_cached.content_hash
+                            );
                         }
                     }
 
@@ -2494,18 +2565,9 @@ export class ScopeResolver {
             // Return cached results with current content - don't mutate the
             // entry's cached content/symbols (the registration stamp above
             // is the one intentional entry mutation on this hit path)
-            return {
-                content,
-                content_hash: disk_hash,
-                symbols: actual_cached.symbols,
-                directives: actual_cached.directives,
-                forward_calls: actual_cached.forward_calls,
-                cd_commands: actual_cached.cd_commands,
-                working_directory: actual_cached.working_directory,
-                working_directory_directive: actual_cached.working_directory_directive,
-                is_standalone: actual_cached.is_standalone,
-                diagnostics: actual_cached.diagnostics
-            };
+            return this.cache_entry_to_parsed_result(
+                actual_cached, content, disk_hash
+            );
         } else if (actual_cached) {
             this.log(`[get_parsed_file] File cache STALE for ${actual_uri} (cached hash=${actual_cached.content_hash}, disk hash=${disk_hash})`);
             // New content observed without an invalidation event having
@@ -2577,15 +2639,22 @@ export class ScopeResolver {
 
             // Return empty results on parse failure
             const empty_symbols = create_empty_symbol_table();
+            // Recover header facts (directives, standalone, WD directive)
+            // via the directive parser — see recover_header_facts.
+            const my_recovered = this.recover_header_facts(
+                actual_uri, content
+            );
             return {
                 content,
                 content_hash: disk_hash,
                 symbols: empty_symbols,
-                directives: [],
+                directives: my_recovered.directives,
                 forward_calls: [],
                 cd_commands: [],
                 working_directory: undefined,
-                is_standalone: false,
+                working_directory_directive:
+                    my_recovered.working_directory_directive,
+                is_standalone: my_recovered.is_standalone,
                 diagnostics: [{
                     message: `Parse error in file: ${actual_uri}`,
                     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -2952,6 +2952,23 @@ export class ScopeResolver {
             if (!parent_uri_to_directive.has(parent_uri)) {
                 parent_uri_to_directive.set(parent_uri, my_directive.range);
             }
+            // The traversal stamps source_uri with the REAL-CASED URI from
+            // compute_directive_real_path (case-only match, .do fallback),
+            // which can differ from the parser-resolved directive.path.
+            // Key the map through the same chokepoint so the exact lookup
+            // cannot miss and silently fall back to basename routing
+            // (#208 review round 3).
+            const my_real = this.compute_directive_real_path(
+                my_directive, active_file_uri
+            );
+            if (my_real.outcome_kind !== 'ambiguous') {
+                const my_real_uri = URI.file(my_real.real_path).toString();
+                if (!parent_uri_to_directive.has(my_real_uri)) {
+                    parent_uri_to_directive.set(
+                        my_real_uri, my_directive.range
+                    );
+                }
+            }
         }
 
         // Fallback to first directive range if no specific match found

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -2300,6 +2300,13 @@ export class ScopeResolver {
         directives: Directive[];
         working_directory_directive?: WorkingDirectoryDirective;
         is_standalone: boolean;
+        /**
+         * False when the directive parse ITSELF threw: the empty facts
+         * are then a fallback, not a statement about the file's header,
+         * and must not drive registration (clearing edges on a failed
+         * recovery would be a silent wipe — bot-review follow-up).
+         */
+        recovered: boolean;
     } {
         try {
             const my_result = this.directive_parser.parse(content, uri);
@@ -2307,9 +2314,14 @@ export class ScopeResolver {
                 directives: my_result.directives,
                 working_directory_directive: my_result.working_directory,
                 is_standalone: my_result.standalone !== undefined,
+                recovered: true,
             };
         } catch {
-            return { directives: [], is_standalone: false };
+            return {
+                directives: [],
+                is_standalone: false,
+                recovered: false,
+            };
         }
     }
 
@@ -2689,6 +2701,21 @@ export class ScopeResolver {
             const my_recovered = this.recover_header_facts(
                 actual_uri, content
             );
+            // Register only when the header facts were actually
+            // recovered: a failed recovery must leave the previous
+            // registrations unchanged (mirroring DocumentStore's
+            // undefined-staged-effects semantics), never clear them.
+            if (my_recovered.recovered) {
+                this.apply_backward_directive_registration(
+                    actual_uri,
+                    my_recovered.directives,
+                    {
+                        backward_dependencies:
+                            options?.backward_dependencies ?? 'explicit',
+                    },
+                    my_recovered.is_standalone
+                );
+            }
             return {
                 content,
                 content_hash: disk_hash,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -698,8 +698,16 @@ export interface DeclarationDirective {
  * Source information for diagnostics that originate from parent files in directive chains.
  */
 export interface DiagnosticSource {
-  /** Filename where the error originated (basename only) */
+  /** Filename where the error originated (basename only, for display) */
   source_file: string;
+  /**
+   * Full URI of the originating file, when known. Used by
+   * remap_diagnostics_to_active_file to route the diagnostic to the
+   * directive referencing THAT file — basename routing alone collides
+   * when two parents share a basename, or skips remapping entirely when
+   * a parent's basename equals the active file's (#208 review round 2).
+   */
+  source_uri?: string;
   /** Line number in source file (0-indexed). Omit when call site is unknown. */
   source_line?: number;
   /** Original range in the source file */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -660,12 +660,29 @@ export interface WorkingDirectoryDirective {
   directive_form: string;
 }
 
+/**
+ * A file's `sight: standalone` header marker (issue #208): header-only, no
+ * argument. When present, the file's scope resolution skips ALL backward
+ * parent inheritance (auto-discovered and explicit) and inherits no working
+ * directory. Naming note: unrelated to the forward-scope-resolver's #234
+ * "standalone closure" memo terminology — this is a parsed header fact, not
+ * a caching concept.
+ */
+export interface StandaloneDirective {
+  /** Which directive keyword form matched (currently always "standalone") */
+  directive_form: string;
+
+  /** Source location for diagnostics */
+  range: Range;
+}
+
 export interface DirectiveParseResult {
   directives: Directive[];
   declaration_directives: DeclarationDirective[];
   diagnostics: DirectiveDiagnostic[];
   forward_calls?: ForwardCallDirective[];
   working_directory?: WorkingDirectoryDirective;
+  standalone?: StandaloneDirective;
 }
 
 // Declaration Directive Types
@@ -763,6 +780,18 @@ export interface ResolvedScope {
   has_directives: boolean;         // True if current file has directive comments (regardless of resolution)
   has_auto_parents: boolean;       // True if auto-discovered (not explicit directive) parents were used
   /**
+   * True when the file's own header declares `sight: standalone` (#208).
+   * `chain` then contains only this file — no backward ancestors are
+   * followed regardless of `backward_dependencies` mode or any explicit
+   * done-by/run-by/included-by directives in the header (those are instead
+   * flagged with a warning diagnostic emitted by resolve()'s root path).
+   * Distinct from has_directives/has_auto_parents: a standalone file can
+   * still have has_directives === true (an explicit directive was present,
+   * just ignored). Diagnostics deferral and completion-mode selection read
+   * this field directly. See docs/cross-file.md "Standalone Files".
+   */
+  is_standalone: boolean;
+  /**
    * Snapshot of `dependency_graph.is_scan_complete()` taken at the
    * same moment as `has_auto_parents`. Diagnostic deferral must use
    * THIS value, not a fresh `is_scan_complete()` read at publication
@@ -798,7 +827,10 @@ export interface ScopeResolverConfig {
 /**
  * Options controlling ScopeResolver.resolve()'s side effects, distinct from
  * ScopeResolverConfig (which controls resolution behavior/limits). Intended
- * to grow additional fields (e.g. issue #208 standalone-mode inputs).
+ * to grow additional side-effect toggles. Note: issue #208
+ * (`sight: standalone`) needed NO field here — standalone-ness is derived
+ * from `file_content` (already passed to resolve()), not a caller-supplied
+ * behavior toggle, so the content-hash cache key stays authoritative.
  */
 export interface ResolveOptions {
   /**
@@ -830,6 +862,12 @@ export interface ResolveOptions {
 export interface StagedCrossFileEffects {
   raw_backward_directives: Directive[];
   scope_resolver_config: Partial<ScopeResolverConfig>;
+  /**
+   * True when the parsed content carries a `sight: standalone` header
+   * marker (#208). Captured at parse time and applied only at commit time,
+   * where it makes the effective backward-directive registration empty.
+   */
+  is_standalone: boolean;
 }
 
 export interface ScopeCacheEntry {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -669,10 +669,10 @@ export interface WorkingDirectoryDirective {
  * a caching concept.
  */
 export interface StandaloneDirective {
-  /** Which directive keyword form matched (currently always "standalone") */
-  directive_form: string;
-
-  /** Source location for diagnostics */
+  /**
+   * Source location for diagnostics. (No directive_form field: unlike the
+   * working-directory directive, `standalone` has a single keyword form.)
+   */
   range: Range;
 }
 

--- a/src/utils/directives.ts
+++ b/src/utils/directives.ts
@@ -14,6 +14,10 @@ export const DIRECTIVE_PREFIX_PATTERN = String.raw`^\s*(?://|\*)\s*${DIRECTIVE_B
 
 export const FORWARD_DIRECTIVE_KEYWORDS = 'do|run|include';
 export const BACKWARD_DIRECTIVE_KEYWORDS = 'done-by|run-by|included-by';
+// Header-only, no-argument marker that opts a file out of inherited backward
+// parent scope (issue #208). Unrelated to the forward-scope-resolver's
+// "standalone closure" memo terminology (#234).
+export const STANDALONE_DIRECTIVE_KEYWORDS = 'standalone';
 
 // Trailing call-site parameters for path-bearing directives: zero or more
 // `line=<n>` / `match="<string>"` params. A `match=` string must be non-empty

--- a/tests/fs-content-provider.ts
+++ b/tests/fs-content-provider.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared fs-backed ContentProvider for tests that wire a real ScopeResolver
+ * against files in a temp directory. Extracted (#208 review round 1) so new
+ * tests stop copy-pasting the ~20-line read_file/exists/stat stub; older
+ * suites keep their local copies until touched.
+ */
+
+import * as fs from 'fs';
+import { URI } from 'vscode-uri';
+import type { ContentProvider } from '../src/types';
+
+export function make_fs_content_provider(): ContentProvider {
+    return {
+        read_file: async (uri: string) => {
+            return fs.promises.readFile(URI.parse(uri).fsPath, 'utf8');
+        },
+        exists: async (uri: string) => {
+            try {
+                await fs.promises.access(URI.parse(uri).fsPath);
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        stat: async (uri: string) => {
+            try {
+                const stats = await fs.promises.stat(URI.parse(uri).fsPath);
+                return { mtimeMs: stats.mtimeMs, size: stats.size };
+            } catch {
+                return undefined;
+            }
+        },
+    };
+}

--- a/tests/integration/callee-change-caller-revalidation.test.ts
+++ b/tests/integration/callee-change-caller-revalidation.test.ts
@@ -269,7 +269,7 @@ describe('Callee Change Caller Revalidation Integration', () => {
             // Add a scope cache entry for the caller
             const cache_key = `${caller_uri}:test-hash:config-hash`;
             const cache_entry = {
-                resolved_scope: { chain: [], symbols, out_of_scope_symbols: [], diagnostics: [], has_directives: false, has_auto_parents: false },
+                resolved_scope: { chain: [], symbols, out_of_scope_symbols: [], diagnostics: [], has_directives: false, has_auto_parents: false, is_standalone: false },
                 content_hash: 'test-hash',
                 timestamp: Date.now(),
                 dependent_uris: new Set([callee_uri]),

--- a/tests/integration/cli-check.test.ts
+++ b/tests/integration/cli-check.test.ts
@@ -47,6 +47,53 @@ describe('sight check integration', () => {
         );
     });
 
+    it('honors sight: standalone in batch mode (issue #208)', async () => {
+        // parent.do defines the macro and calls child.do; without the
+        // standalone marker the auto-discovered parent would suppress the
+        // undefined-macro warning. With it, child.do is checked in
+        // isolation and its ignored-directive warning also surfaces.
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'parent.do'), [
+            'global cfg "x"',
+            'do child.do',
+        ].join('\n') + '\n');
+        fs.writeFileSync(path.join(root, 'child.do'), [
+            '// sight: standalone',
+            '// sight: done-by: "parent.do"',
+            'display "$cfg"',
+        ].join('\n') + '\n');
+
+        const result = await run_capture(
+            ['--workspace', root, '--quiet'], root
+        );
+
+        expect(result.code).toBe(EXIT_CHECK_FAILED);
+        // The parent's global no longer suppresses the child's warning.
+        expect(result.stdout).toContain('child.do:3:');
+        expect(result.stdout).toContain(
+            `[${StataDiagnosticCode.UNDEFINED_MACRO.toLowerCase()}]`
+        );
+        // The ignored-directive warning is attributed to child.do line 2.
+        expect(result.stdout).toContain('child.do:2:');
+        expect(result.stdout).toContain('sight: standalone');
+    });
+
+    it('control: without standalone the parent suppresses the warning in batch mode', async () => {
+        const root = temp_dir();
+        fs.writeFileSync(path.join(root, 'parent.do'), [
+            'global cfg "x"',
+            'do child.do',
+        ].join('\n') + '\n');
+        fs.writeFileSync(path.join(root, 'child.do'),
+            'display "$cfg"\n');
+
+        const result = await run_capture(
+            ['--workspace', root, '--quiet'], root
+        );
+
+        expect(result.code).toBe(EXIT_OK);
+    });
+
     it('honors editor default undefinedVariable off', async () => {
         const root = temp_dir();
         fs.writeFileSync(path.join(root, 'main.do'), 'regress y x\n');

--- a/tests/integration/cross-file-diagnostic-flicker.test.ts
+++ b/tests/integration/cross-file-diagnostic-flicker.test.ts
@@ -238,4 +238,65 @@ describe('cross-file diagnostic flicker (regression for #175)', () => {
             diagnostics.some(d => d.code === StataDiagnosticCode.UNDEFINED_MACRO)
         ).toBe(true);
     });
+
+    it('never defers a standalone file, even mid-scan (issue #208)', async () => {
+        // A standalone file can never gain backward parents from the
+        // workspace scan, so its undefined-symbol diagnostics publish
+        // immediately instead of waiting for scan completion.
+        const child_path = path.join(tmp_dir, 'demo_child.do');
+        const child_content =
+            '// sight: standalone\ndi "fruit: `fruit\'"\n';
+        fs.writeFileSync(child_path, child_content);
+        const child_uri = URI.file(child_path).toString();
+
+        // Scan NOT complete — a non-standalone zero-parent file would
+        // defer here (see the first test in this file).
+        const graph = new DependencyGraph();
+        expect(graph.is_scan_complete()).toBe(false);
+
+        const scope_resolver = new ScopeResolver(undefined, {
+            read_file: async (uri: string) =>
+                fs.promises.readFile(URI.parse(uri).fsPath, 'utf8'),
+            exists: async (uri: string) => {
+                try {
+                    await fs.promises.access(URI.parse(uri).fsPath);
+                    return true;
+                } catch {
+                    return false;
+                }
+            },
+            stat: async (uri: string) => {
+                try {
+                    const stats = await fs.promises.stat(URI.parse(uri).fsPath);
+                    return { mtimeMs: stats.mtimeMs, size: stats.size };
+                } catch {
+                    return undefined;
+                }
+            },
+        });
+        scope_resolver.set_dependency_graph(graph);
+
+        const diagnostics_provider = new DiagnosticsProvider(
+            make_mock_connection(),
+        );
+        diagnostics_provider.set_dependency_graph(graph);
+
+        const document_store = new DocumentStore();
+        await document_store.open(child_uri, child_content, 1);
+        const document_state = document_store.get(child_uri);
+        if (!document_state) {
+            throw new Error('document state missing');
+        }
+
+        const diagnostics = await diagnostics_provider.get_diagnostics(
+            document_state,
+            build_config(),
+            undefined,
+            scope_resolver,
+        );
+
+        expect(
+            diagnostics.some(d => d.code === StataDiagnosticCode.UNDEFINED_MACRO)
+        ).toBe(true);
+    });
 });

--- a/tests/integration/cross-file-diagnostic-flicker.test.ts
+++ b/tests/integration/cross-file-diagnostic-flicker.test.ts
@@ -33,6 +33,7 @@ import { DocumentStore } from '../../src/document-store';
 import { DiagnosticsProvider } from '../../src/providers/diagnostics';
 import { ScopeResolver } from '../../src/scope-resolver';
 import { DependencyGraph } from '../../src/dependency-graph';
+import { make_fs_content_provider } from '../fs-content-provider';
 import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
 
 let tmp_dir: string;
@@ -254,26 +255,9 @@ describe('cross-file diagnostic flicker (regression for #175)', () => {
         const graph = new DependencyGraph();
         expect(graph.is_scan_complete()).toBe(false);
 
-        const scope_resolver = new ScopeResolver(undefined, {
-            read_file: async (uri: string) =>
-                fs.promises.readFile(URI.parse(uri).fsPath, 'utf8'),
-            exists: async (uri: string) => {
-                try {
-                    await fs.promises.access(URI.parse(uri).fsPath);
-                    return true;
-                } catch {
-                    return false;
-                }
-            },
-            stat: async (uri: string) => {
-                try {
-                    const stats = await fs.promises.stat(URI.parse(uri).fsPath);
-                    return { mtimeMs: stats.mtimeMs, size: stats.size };
-                } catch {
-                    return undefined;
-                }
-            },
-        });
+        const scope_resolver = new ScopeResolver(
+            undefined, make_fs_content_provider()
+        );
         scope_resolver.set_dependency_graph(graph);
 
         const diagnostics_provider = new DiagnosticsProvider(

--- a/tests/integration/find-references-standalone.test.ts
+++ b/tests/integration/find-references-standalone.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Find-references vs the standalone directive (issue #208, locked
+ * "consistent" decision): the dep-graph/raw-directive connectivity floor
+ * (get_related_uris) is deliberately UNCHANGED by standalone. References
+ * for a global still traverse raw do/run/include connectivity involving a
+ * standalone file — while that same file's own DIAGNOSTICS treat the
+ * parent-defined global as undefined (strict resolution). This test pins
+ * that the two behaviors coexist by design; see docs/find-references.md.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { ReferencesProvider } from '../../src/providers/references';
+import { DocumentStore } from '../../src/document-store';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { join } from 'path';
+import { writeFileSync, mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { URI } from 'vscode-uri';
+
+function build_pipeline() {
+    const the_indexer = new WorkspaceIndexer();
+    const the_dep_graph = new DependencyGraph();
+    the_indexer.set_dependency_graph(the_dep_graph);
+
+    const the_scope_resolver = new ScopeResolver();
+    the_scope_resolver.set_dependency_graph(the_dep_graph);
+
+    const the_forward_resolver = new ForwardScopeResolver(
+        the_scope_resolver, { max_forward_depth: 10 }
+    );
+    the_scope_resolver.set_forward_scope_resolver(the_forward_resolver);
+
+    const the_references_provider =
+        new ReferencesProvider(the_scope_resolver);
+    const the_document_store = new DocumentStore();
+
+    return {
+        indexer: the_indexer,
+        scope_resolver: the_scope_resolver,
+        forward_scope_resolver: the_forward_resolver,
+        references_provider: the_references_provider,
+        document_store: the_document_store,
+        dependency_graph: the_dep_graph,
+    };
+}
+
+describe('Find References - standalone files (issue #208)', () => {
+    let test_temp_dir: string;
+    let pipeline: ReturnType<typeof build_pipeline>;
+
+    beforeEach(() => {
+        test_temp_dir = mkdtempSync(join(tmpdir(), 'find-refs-standalone-'));
+        pipeline = build_pipeline();
+    });
+
+    afterEach(() => {
+        try {
+            pipeline?.scope_resolver?.dispose();
+        } catch {}
+        try {
+            pipeline?.forward_scope_resolver?.dispose();
+        } catch {}
+        if (existsSync(test_temp_dir)) {
+            rmSync(test_temp_dir, { recursive: true, force: true });
+        }
+    });
+
+    it('still reports occurrences inside a standalone callee via raw connectivity', async () => {
+        // parent.do defines $cfg and does child.do; child.do is standalone
+        // and uses $cfg. From the definition in parent.do, references must
+        // still surface the occurrence in child.do — the connectivity
+        // floor reads raw do/run/include facts, not effective scope.
+        const parent_path = join(test_temp_dir, 'parent.do');
+        const parent_content =
+            `global cfg "x"\n` +
+            `do "child.do"\n`;
+        writeFileSync(parent_path, parent_content);
+
+        const child_path = join(test_temp_dir, 'child.do');
+        const child_content =
+            `// sight: standalone\n` +
+            `display "$cfg"\n`;
+        writeFileSync(child_path, child_content);
+
+        await pipeline.indexer.initialize([test_temp_dir]);
+
+        const parent_uri = URI.file(parent_path).toString();
+        await pipeline.document_store.open(parent_uri, parent_content, 1);
+        const document_state = pipeline.document_store.get(parent_uri)!;
+
+        // Cursor on `cfg` in the definition on line 0.
+        const cursor_char = parent_content.split('\n')[0].indexOf('cfg') + 1;
+        const locations = await pipeline.references_provider.get_references(
+            document_state,
+            { line: 0, character: cursor_char },
+            { includeDeclaration: true },
+            pipeline.indexer,
+            document_state.context_tracker
+        );
+
+        const child_uri = URI.file(child_path).toString();
+        expect(locations.some(loc => loc.uri === child_uri)).toBe(true);
+    });
+});

--- a/tests/integration/forward-closure-memo-gate.test.ts
+++ b/tests/integration/forward-closure-memo-gate.test.ts
@@ -176,4 +176,46 @@ describe('issue #209/#208 — forward-closure memo gate', () => {
         // sanity: the battery actually exercises forward inheritance
         expect(on.symbols.globalMacros.has('hub_g')).toBe(true);
     });
+
+    it('(3) a standalone callee stays caller-independent (issue #208)', async () => {
+        // The standalone marker changes only already-keyed closure inputs
+        // (inherited WD, effective call type) — never caller identity. A
+        // hub marked `sight: standalone` (with a backward parent that
+        // would otherwise supply scope) must produce byte-identical
+        // forward closures across two disjoint callers.
+        const grand = create_file('grand.do',
+            `global grand_g 1\ndo "hub.do"\n`);
+        const helper = create_file('helper.do', `global helper_g 1\n`);
+        const hub = create_file('hub.do',
+            `// sight: standalone\n` +
+            `// sight: done-by: "${grand}"\n` +
+            `run "${helper}"\nglobal hub_g 1\n`);
+        const hub_uri = to_uri(hub);
+
+        const resolve_from = async (caller_uri: string) => {
+            const { scope, forward } = make_resolver();
+            const parsed = await scope.get_parsed_file(hub_uri, hub);
+            if ('error' in parsed) throw new Error(parsed.error);
+            return forward.resolve(
+                hub_uri,
+                parsed.forward_calls,
+                'do',
+                {
+                    visited: new Map(),
+                    effective_call_type: 'do',
+                    depth: 0,
+                    diagnostics: [],
+                    working_directory: undefined,
+                    call_chain: [],
+                },
+                new Set([caller_uri]),
+            );
+        };
+
+        const r1 = await resolve_from('file:///callers/c1.do');
+        const r2 = await resolve_from('file:///callers/c2.do');
+
+        expect(forward_surface(r1)).toEqual(forward_surface(r2));
+        expect(r1.symbols.globalMacros.has('helper_g')).toBe(true);
+    });
 });

--- a/tests/integration/forward-closure-memo-gate.test.ts
+++ b/tests/integration/forward-closure-memo-gate.test.ts
@@ -217,5 +217,17 @@ describe('issue #209/#208 — forward-closure memo gate', () => {
 
         expect(forward_surface(r1)).toEqual(forward_surface(r2));
         expect(r1.symbols.globalMacros.has('helper_g')).toBe(true);
+
+        // Teeth for the standalone gate itself (#208 review round 1: the
+        // forward-resolver path above never exercises backward cutting):
+        // resolving the hub through ScopeResolver must cut grand.do's
+        // scope despite the done-by directive.
+        const { scope: my_scope } = make_resolver();
+        const hub_scope = await my_scope.resolve(
+            hub_uri, fs.readFileSync(hub, 'utf8')
+        );
+        expect(hub_scope.is_standalone).toBe(true);
+        expect(hub_scope.symbols.globalMacros.has('grand_g')).toBe(false);
+        expect(hub_scope.symbols.globalMacros.has('hub_g')).toBe(true);
     });
 });

--- a/tests/integration/hover-out-of-scope.test.ts
+++ b/tests/integration/hover-out-of-scope.test.ts
@@ -169,7 +169,7 @@ display "\`country_name'"
                 },
                 out_of_scope_symbols,
                 diagnostics: [],
-                has_directives: true, has_auto_parents: false,
+                has_directives: true, has_auto_parents: false, is_standalone: false,
             };
 
             const mock_scope_resolver = {
@@ -256,7 +256,7 @@ display $country_name
                 },
                 out_of_scope_symbols,
                 diagnostics: [],
-                has_directives: true, has_auto_parents: false,
+                has_directives: true, has_auto_parents: false, is_standalone: false,
             };
 
             const mock_scope_resolver = {
@@ -338,7 +338,7 @@ display country_name
                 },
                 out_of_scope_symbols,
                 diagnostics: [],
-                has_directives: true, has_auto_parents: false,
+                has_directives: true, has_auto_parents: false, is_standalone: false,
             };
 
             const mock_scope_resolver = {
@@ -398,7 +398,7 @@ display "\`country_name'"
                 },
                 out_of_scope_symbols,
                 diagnostics: [],
-                has_directives: true, has_auto_parents: false,
+                has_directives: true, has_auto_parents: false, is_standalone: false,
             };
 
             const mock_scope_resolver = {

--- a/tests/integration/lsp-working-directory-option.test.ts
+++ b/tests/integration/lsp-working-directory-option.test.ts
@@ -257,6 +257,52 @@ display "helper"`);
             expect(result.workingDirectory).toBe(output_dir);
         });
 
+        it('should return null for a standalone child whose parent has a working directory (issue #208)', async () => {
+            // Same shape as the done-by inheritance test above, but the
+            // child is marked `sight: standalone`: inherited WD is cut, so
+            // send-to-stata gets no `cd` prepended for this file.
+            const data_dir = path.join(test_dir, 'data');
+            fs.mkdirSync(data_dir, { recursive: true });
+
+            write_file('scripts/parent.do', `// @lsp-cd: "../data"
+local myvar = 1
+do "child.do"`);
+
+            const child_path = write_file('scripts/child.do', `// sight: standalone
+// @lsp-done-by: "parent.do"
+display \`myvar'`);
+            const child_uri = URI.file(child_path).toString();
+
+            const child_content = fs.readFileSync(child_path, 'utf-8');
+            await document_store.open(child_uri, child_content, 1);
+
+            const deps = create_mock_dependencies(document_store);
+            const handler = create_get_working_directory_handler(deps);
+            const params: GetWorkingDirectoryParams = { uri: child_uri };
+            const result = await handler(params);
+
+            expect(result.workingDirectory).toBeNull();
+        });
+
+        it('should keep a standalone file\'s own working directory (issue #208)', async () => {
+            const data_dir = path.join(test_dir, 'data');
+            fs.mkdirSync(data_dir, { recursive: true });
+
+            const file_path = write_file('scripts/analysis.do', `// sight: standalone
+// @lsp-cd: "../data"
+display "hello"`);
+            const uri = URI.file(file_path).toString();
+
+            const content = fs.readFileSync(file_path, 'utf-8');
+            await document_store.open(uri, content, 1);
+
+            const deps = create_mock_dependencies(document_store);
+            const handler = create_get_working_directory_handler(deps);
+            const result = await handler({ uri });
+
+            expect(result.workingDirectory).toBe(data_dir);
+        });
+
         it('should return null when parent has no working directory', async () => {
             // Create parent.do without @lsp-cd directive
             write_file('scripts/parent.do', `local myvar = 1

--- a/tests/integration/standalone-completion-mode.test.ts
+++ b/tests/integration/standalone-completion-mode.test.ts
@@ -22,6 +22,7 @@ import { DocumentStore } from '../../src/document-store';
 import { DependencyGraph } from '../../src/dependency-graph';
 import { ScopeResolver } from '../../src/scope-resolver';
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { make_fs_content_provider } from '../fs-content-provider';
 
 describe('Standalone completion mode (issue #208)', () => {
     let tmp_root: string | null = null;
@@ -52,27 +53,9 @@ describe('Standalone completion mode (issue #208)', () => {
         indexer.set_dependency_graph(graph);
         await indexer.initialize([tmp_root]);
 
-        const scope_resolver = new ScopeResolver(undefined, {
-            read_file: async (uri: string) =>
-                fs.promises.readFile(URI.parse(uri).fsPath, 'utf8'),
-            exists: async (uri: string) => {
-                try {
-                    await fs.promises.access(URI.parse(uri).fsPath);
-                    return true;
-                } catch {
-                    return false;
-                }
-            },
-            stat: async (uri: string) => {
-                try {
-                    const stats =
-                        await fs.promises.stat(URI.parse(uri).fsPath);
-                    return { mtimeMs: stats.mtimeMs, size: stats.size };
-                } catch {
-                    return undefined;
-                }
-            },
-        });
+        const scope_resolver = new ScopeResolver(
+            undefined, make_fs_content_provider()
+        );
         scope_resolver.set_dependency_graph(graph);
         const forward_resolver = new ForwardScopeResolver(scope_resolver);
         scope_resolver.set_forward_scope_resolver(forward_resolver);

--- a/tests/integration/standalone-completion-mode.test.ts
+++ b/tests/integration/standalone-completion-mode.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Completion-mode selection for standalone files (issue #208).
+ *
+ * A standalone file uses Scope-Resolved mode (its chain is just itself).
+ * Workspace globals/programs are out-of-scope-annotated in BOTH modes, so
+ * the observable mode difference is VARIABLES: Global mode offers
+ * workspace variables in-scope (dataset columns are workspace-wide),
+ * while Scope-Resolved mode offers only the resolved chain's variables.
+ * ("Consistent" strictness decision: identical treatment to a file with
+ * explicit directives.)
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { URI } from 'vscode-uri';
+import { CompletionProvider } from '../../src/providers/completion';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { CommandDatabase } from '../../src/commands';
+import { DocumentStore } from '../../src/document-store';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+
+describe('Standalone completion mode (issue #208)', () => {
+    let tmp_root: string | null = null;
+
+    afterEach(() => {
+        if (tmp_root) {
+            fs.rmSync(tmp_root, { recursive: true, force: true });
+            tmp_root = null;
+        }
+    });
+
+    async function run_scenario(standalone: boolean) {
+        tmp_root = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'sight-standalone-completion-')
+        );
+        const main_path = path.join(tmp_root, 'main.do');
+        const other_path = path.join(tmp_root, 'other.do');
+
+        const the_main_lines = standalone
+            ? ['// sight: standalone', 'gen own_var = 1', 'summarize ']
+            : ['gen own_var = 1', 'summarize '];
+        fs.writeFileSync(main_path, the_main_lines.join('\n'));
+        fs.writeFileSync(other_path, 'gen unrelated_var = 1\n');
+
+        const command_db = new CommandDatabase();
+        const graph = new DependencyGraph();
+        const indexer = new WorkspaceIndexer();
+        indexer.set_dependency_graph(graph);
+        await indexer.initialize([tmp_root]);
+
+        const scope_resolver = new ScopeResolver(undefined, {
+            read_file: async (uri: string) =>
+                fs.promises.readFile(URI.parse(uri).fsPath, 'utf8'),
+            exists: async (uri: string) => {
+                try {
+                    await fs.promises.access(URI.parse(uri).fsPath);
+                    return true;
+                } catch {
+                    return false;
+                }
+            },
+            stat: async (uri: string) => {
+                try {
+                    const stats =
+                        await fs.promises.stat(URI.parse(uri).fsPath);
+                    return { mtimeMs: stats.mtimeMs, size: stats.size };
+                } catch {
+                    return undefined;
+                }
+            },
+        });
+        scope_resolver.set_dependency_graph(graph);
+        const forward_resolver = new ForwardScopeResolver(scope_resolver);
+        scope_resolver.set_forward_scope_resolver(forward_resolver);
+
+        const document_store = new DocumentStore();
+        const main_uri = URI.file(main_path).toString();
+        const main_content = fs.readFileSync(main_path, 'utf8');
+        await document_store.open(
+            main_uri, main_content, 1, indexer.get_all_symbols()
+        );
+        await document_store.wait_for_update(main_uri);
+        const doc = document_store.get(main_uri)!;
+
+        const provider = new CompletionProvider(command_db);
+        const cursor_line = standalone ? 2 : 1;
+        const completions = await provider.get_completions(
+            doc,
+            // In the varlist position after `summarize `.
+            { line: cursor_line, character: 10 },
+            undefined,
+            scope_resolver,
+            indexer.get_all_symbols(),
+            { backward_dependencies: 'auto' }
+        );
+        return completions.map(c => c.label);
+    }
+
+    it('a standalone file offers only its own chain\'s variables (Scope-Resolved mode)', async () => {
+        const the_labels = await run_scenario(true);
+        expect(the_labels).toContain('own_var');
+        expect(the_labels).not.toContain('unrelated_var');
+    });
+
+    it('control: a non-standalone zero-parent file offers workspace variables (Global mode)', async () => {
+        const the_labels = await run_scenario(false);
+        expect(the_labels).toContain('own_var');
+        expect(the_labels).toContain('unrelated_var');
+    });
+});

--- a/tests/integration/standalone-directive.test.ts
+++ b/tests/integration/standalone-directive.test.ts
@@ -153,6 +153,33 @@ describe('Standalone directive (issue #208)', () => {
             expect(the_ignored_warnings[0].range.start.line).toBe(1);
         });
 
+        it('the warning does not name the folded directive type for run-by', async () => {
+            // The parser folds `run-by` into `done-by`; the warning must
+            // not claim a 'done-by' exists on a line that says 'run-by'
+            // (#208 review round 2 regression test).
+            const parent_path = write_file(tmp_dir, 'parent.do', [
+                'global parent_global "yes"',
+                'run child.do',
+            ].join('\n'));
+            const child_path = write_file(tmp_dir, 'child.do', [
+                '// sight: standalone',
+                `// sight: run-by: "${parent_path}"`,
+                'display $parent_global',
+            ].join('\n'));
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(child_uri, child_content);
+
+            const the_ignored = scope.diagnostics.filter(
+                d => d.message.includes('Ignored backward directive')
+            );
+            expect(the_ignored).toHaveLength(1);
+            expect(the_ignored[0].message).not.toContain('done-by');
+            expect(the_ignored[0].range.start.line).toBe(1);
+        });
+
         it('directive order does not matter: done-by before standalone is still ignored', async () => {
             const parent_path = write_file(tmp_dir, 'parent.do', [
                 'global parent_global "yes"',
@@ -435,7 +462,12 @@ describe('Standalone directive (issue #208)', () => {
             // it must arrive remapped to the child's own directive line
             // with a "parent.do line N" note, never at the parent's raw
             // coordinates (#208 review round 1).
+            // The malformed line sits at parent line 1 while the child's
+            // directive sits at child line 0, so the range assertion below
+            // can only pass if remapping actually moved the diagnostic
+            // (round-2 fix: same line numbers made it tautological).
             const parent_path = write_file(tmp_dir, 'parent.do', [
+                '// a leading header comment',
                 '// sight: standalone v2',
                 'global parent_global "1"',
                 'do child.do',
@@ -455,11 +487,42 @@ describe('Standalone directive (issue #208)', () => {
                      d.message.includes('standalone')
             );
             expect(the_malformed).toHaveLength(1);
-            // Remapped onto the child's directive line (line 0), not the
-            // parent's raw line-0 coordinates published as-is.
+            // Remapped onto the child's directive line (line 0), away from
+            // the parent's raw line-1 coordinates.
             expect(the_malformed[0].range.start.line).toBe(0);
-            expect(the_malformed[0].message).toContain('parent.do line 1');
+            expect(the_malformed[0].message).toContain('parent.do line 2');
             expect(the_malformed[0].source?.source_file).toBe('parent.do');
+        });
+
+        it('routes attribution by URI even when the parent shares the child\'s basename', async () => {
+            // /sub/main.do is a PARENT of /main.do. With basename-only
+            // routing the parent's warning would be mistaken for a
+            // current-file diagnostic and published at the parent's raw
+            // coordinates (#208 review round 2).
+            const parent_path = write_file(
+                tmp_dir, path.join('sub', 'main.do'), [
+                    '// a leading header comment',
+                    '// sight: standalone v2',
+                    'global parent_global "1"',
+                    'do ../main.do',
+                ].join('\n'));
+            const child_path = write_file(tmp_dir, 'main.do', [
+                `// sight: done-by: "${parent_path}"`,
+                'display $parent_global',
+            ].join('\n'));
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(child_uri, child_content);
+
+            const the_malformed = scope.diagnostics.filter(
+                d => d.message.includes('Malformed directive') &&
+                     d.message.includes('standalone')
+            );
+            expect(the_malformed).toHaveLength(1);
+            expect(the_malformed[0].range.start.line).toBe(0);
+            expect(the_malformed[0].message).toContain('main.do line 2');
         });
     });
 

--- a/tests/integration/standalone-directive.test.ts
+++ b/tests/integration/standalone-directive.test.ts
@@ -18,6 +18,7 @@ import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
 import { DependencyGraph } from '../../src/dependency-graph';
 import { WorkspaceIndexer } from '../../src/indexer';
 import { URI } from 'vscode-uri';
+import { make_fs_content_provider } from '../fs-content-provider';
 
 let tmp_dir: string;
 
@@ -35,27 +36,7 @@ function write_file(dir: string, name: string, content: string): string {
 }
 
 function create_scope_resolver(): ScopeResolver {
-    return new ScopeResolver(undefined, {
-        read_file: async (uri: string) => {
-            return fs.promises.readFile(URI.parse(uri).fsPath, 'utf8');
-        },
-        exists: async (uri: string) => {
-            try {
-                await fs.promises.access(URI.parse(uri).fsPath);
-                return true;
-            } catch {
-                return false;
-            }
-        },
-        stat: async (uri: string) => {
-            try {
-                const stats = await fs.promises.stat(URI.parse(uri).fsPath);
-                return { mtimeMs: stats.mtimeMs, size: stats.size };
-            } catch {
-                return undefined;
-            }
-        },
-    });
+    return new ScopeResolver(undefined, make_fs_content_provider());
 }
 
 function create_resolver_with_forward(): ScopeResolver {
@@ -164,8 +145,7 @@ describe('Standalone directive (issue #208)', () => {
             expect(scope.symbols.globalMacros.has('parent_global')).toBe(false);
 
             const the_ignored_warnings = scope.diagnostics.filter(
-                d => d.message.includes('sight: standalone') &&
-                     d.message.includes('done-by')
+                d => d.message.includes('Ignored backward directive')
             );
             expect(the_ignored_warnings).toHaveLength(1);
             expect(the_ignored_warnings[0].severity).toBe('warning');
@@ -444,6 +424,79 @@ describe('Standalone directive (issue #208)', () => {
             const after = await resolver.resolve(d_uri, d_content);
             expect(after.symbols.globalMacros.has('g_global')).toBe(false);
             expect(after.symbols.globalMacros.has('c_global')).toBe(true);
+        });
+    });
+
+    describe('ancestor parser-diagnostic attribution', () => {
+        it('remaps a parent\'s malformed-standalone warning onto the child\'s directive line with attribution', async () => {
+            // parent.do has a MALFORMED standalone line (trailing content,
+            // so standalone is NOT set and parent still acts as a normal
+            // ancestor). The child inherits the parent's parser warning —
+            // it must arrive remapped to the child's own directive line
+            // with a "parent.do line N" note, never at the parent's raw
+            // coordinates (#208 review round 1).
+            const parent_path = write_file(tmp_dir, 'parent.do', [
+                '// sight: standalone v2',
+                'global parent_global "1"',
+                'do child.do',
+            ].join('\n'));
+            const child_path = write_file(tmp_dir, 'child.do', [
+                `// sight: done-by: "${parent_path}"`,
+                'display $parent_global',
+            ].join('\n'));
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(child_uri, child_content);
+
+            const the_malformed = scope.diagnostics.filter(
+                d => d.message.includes('Malformed directive') &&
+                     d.message.includes('standalone')
+            );
+            expect(the_malformed).toHaveLength(1);
+            // Remapped onto the child's directive line (line 0), not the
+            // parent's raw line-0 coordinates published as-is.
+            expect(the_malformed[0].range.start.line).toBe(0);
+            expect(the_malformed[0].message).toContain('parent.do line 1');
+            expect(the_malformed[0].source?.source_file).toBe('parent.do');
+        });
+    });
+
+    describe('parse-failure header-fact recovery', () => {
+        it('keeps standalone in force when the lex/parse pipeline throws', async () => {
+            write_file(tmp_dir, 'parent.do', [
+                'global my_global "hello"',
+                'do child.do',
+            ].join('\n'));
+            const child_path = write_file(tmp_dir, 'child.do', [
+                '// sight: standalone',
+                'display $my_global',
+            ].join('\n'));
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const graph = await build_graph(tmp_dir);
+            const resolver = create_resolver_with_forward();
+            resolver.set_dependency_graph(graph);
+
+            // Force the AST parser to throw; the DirectiveParser is
+            // independent of that failure and must still supply the
+            // standalone marker (otherwise the file silently regains its
+            // auto-discovered parent — #208 review round 1).
+            (resolver as unknown as {
+                parser: { parse: () => never };
+            }).parser.parse = () => {
+                throw new Error('injected parse failure');
+            };
+
+            const scope = await resolver.resolve(
+                child_uri, child_content, { backward_dependencies: 'auto' }
+            );
+
+            expect(scope.is_standalone).toBe(true);
+            expect(scope.has_auto_parents).toBe(false);
+            expect(scope.symbols.globalMacros.has('my_global')).toBe(false);
         });
     });
 

--- a/tests/integration/standalone-directive.test.ts
+++ b/tests/integration/standalone-directive.test.ts
@@ -748,10 +748,16 @@ describe('Standalone directive (issue #208)', () => {
                     my_resolver_internals.directive_parser.parse.bind(
                         my_resolver_internals.directive_parser
                     );
+                // Count x.do recovery attempts: the_p_has_x() is true
+                // BEFORE the resolve too, so without this the assertion
+                // below would pass vacuously if the walk never reached
+                // x.do (CodeRabbit follow-up).
+                let my_x_recovery_attempt_count = 0;
                 my_resolver_internals.directive_parser.parse = (
                     content: string, uri: string, tokens?: unknown
                 ) => {
                     if (uri === x_uri) {
+                        my_x_recovery_attempt_count += 1;
                         throw new Error(
                             'injected directive-parse failure'
                         );
@@ -761,8 +767,10 @@ describe('Standalone directive (issue #208)', () => {
 
                 await resolver.resolve(c_uri, c_content);
 
-                // The stale edge survives — a failed recovery must not
-                // wipe it.
+                // The failing recovery path was actually exercised …
+                expect(my_x_recovery_attempt_count).toBeGreaterThan(0);
+                // … and the stale edge survives — a failed recovery must
+                // not wipe it.
                 expect(the_p_has_x()).toBe(true);
             }
         );

--- a/tests/integration/standalone-directive.test.ts
+++ b/tests/integration/standalone-directive.test.ts
@@ -19,6 +19,7 @@ import { DependencyGraph } from '../../src/dependency-graph';
 import { WorkspaceIndexer } from '../../src/indexer';
 import { URI } from 'vscode-uri';
 import { make_fs_content_provider } from '../fs-content-provider';
+import type { RichResolveFs } from '../../src/utils/file-path-utils';
 
 let tmp_dir: string;
 
@@ -523,6 +524,85 @@ describe('Standalone directive (issue #208)', () => {
             expect(the_malformed).toHaveLength(1);
             expect(the_malformed[0].range.start.line).toBe(0);
             expect(the_malformed[0].message).toContain('main.do line 2');
+        });
+    });
+
+    describe('case-only attribution routing', () => {
+        it('routes by the real-cased URI when the directive path casing differs from disk', async () => {
+            // Disk has Parent.do; the child's SECOND directive types
+            // "parent.do" (case-only mismatch, simulated via an injected
+            // RichResolveFs so the test is host-regime independent).
+            // source_uri is stamped with the real-cased URI; the remap
+            // lookup must hit it via the real-path chokepoint. If it
+            // missed, the basename fallback ('Parent.do' vs the
+            // parser-cased 'parent.do' key) would also miss and the
+            // warning would land on the FIRST directive's line instead
+            // (#208 review round 3).
+            const other_path = write_file(tmp_dir, 'other.do', [
+                'global other_global "o"',
+                'do child.do',
+            ].join('\n'));
+            const parent_real_path = write_file(tmp_dir, 'Parent.do', [
+                '// a leading header comment',
+                '// sight: standalone v2',
+                'global parent_global "1"',
+                'do child.do',
+            ].join('\n'));
+            const parent_typed_path =
+                path.join(tmp_dir, 'parent.do');
+            const child_path = write_file(tmp_dir, 'child.do', [
+                `// sight: done-by: "${other_path}"`,
+                `// sight: done-by: "${parent_typed_path}"`,
+                'display $parent_global',
+            ].join('\n'));
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            // Present the directory with ONLY the real-cased name, so the
+            // typed 'parent.do' resolves case-only to 'Parent.do'
+            // regardless of the host filesystem's case regime.
+            const the_overrides = new Map([[tmp_dir, [
+                { name: 'other.do', is_file: true },
+                { name: 'Parent.do', is_file: true },
+                { name: 'child.do', is_file: true },
+            ]]]);
+            const patched_fs: RichResolveFs = {
+                readdirSync(dir: string) {
+                    const my_norm = path.normalize(dir);
+                    for (const [my_dir, my_entries] of the_overrides) {
+                        if (path.normalize(my_dir) === my_norm) {
+                            return my_entries.map(e => ({
+                                name: e.name,
+                                isFile: () => e.is_file,
+                                isDirectory: () => !e.is_file,
+                                isSymbolicLink: () => false,
+                            }));
+                        }
+                    }
+                    return fs.readdirSync(
+                        dir, { withFileTypes: true }
+                    ) as ReturnType<RichResolveFs['readdirSync']>;
+                },
+                existsSync: (p: string) => fs.existsSync(p),
+                statSync: (p: string) => fs.statSync(p),
+            };
+            resolver.set_resolve_fs(patched_fs);
+            resolver.set_workspace_roots([tmp_dir]);
+            void parent_real_path;
+
+            const scope = await resolver.resolve(child_uri, child_content);
+
+            const the_malformed = scope.diagnostics.filter(
+                d => d.message.includes('Malformed directive') &&
+                     d.message.includes('standalone')
+            );
+            expect(the_malformed).toHaveLength(1);
+            // Routed to the SECOND directive (line 1), the one that
+            // references Parent.do — not the first-directive fallback.
+            expect(the_malformed[0].range.start.line).toBe(1);
+            expect(the_malformed[0].message)
+                .toContain('Parent.do line 2');
         });
     });
 

--- a/tests/integration/standalone-directive.test.ts
+++ b/tests/integration/standalone-directive.test.ts
@@ -641,6 +641,131 @@ describe('Standalone directive (issue #208)', () => {
             expect(scope.has_auto_parents).toBe(false);
             expect(scope.symbols.globalMacros.has('my_global')).toBe(false);
         });
+
+        it(
+            'parse-failed ancestor applies recovered standalone registration',
+            async () => {
+                const p_path = write_file(tmp_dir, 'p.do',
+                    'global p_global "p"\n');
+                const x_path = write_file(tmp_dir, 'x.do', [
+                    `// sight: done-by: "${p_path}"`,
+                    'global x_global "x"',
+                ].join('\n'));
+                const c_path = write_file(tmp_dir, 'c.do', [
+                    `// sight: done-by: "${x_path}"`,
+                    'display $x_global $p_global',
+                ].join('\n'));
+                const p_uri = URI.file(p_path).toString();
+                const x_uri = URI.file(x_path).toString();
+                const c_uri = URI.file(c_path).toString();
+                const c_content = fs.readFileSync(c_path, 'utf8');
+
+                const resolver = create_resolver_with_forward();
+                const the_p_has_x = () =>
+                    resolver.get_backward_directive_children(p_uri).has(x_uri);
+                await resolver.resolve(c_uri, c_content);
+                expect(the_p_has_x()).toBe(true);
+
+                fs.writeFileSync(x_path, [
+                    '// sight: standalone',
+                    `// sight: done-by: "${p_path}"`,
+                    'global x_global "x"',
+                ].join('\n'), 'utf8');
+                resolver.invalidate_file_cache(x_uri, {
+                    preserve_backward_directive_dependencies: true,
+                });
+                expect(the_p_has_x()).toBe(true);
+
+                (resolver as unknown as {
+                    parser: { parse: () => never };
+                }).parser.parse = () => {
+                    throw new Error('injected parse failure');
+                };
+
+                await resolver.resolve(c_uri, c_content);
+
+                expect(the_p_has_x()).toBe(false);
+            }
+        );
+
+        it(
+            'a FAILED recovery leaves existing registrations unchanged',
+            async () => {
+                // When even the DirectiveParser throws, the recovered
+                // facts are a fallback, not a statement about the header:
+                // registration must be skipped, never cleared (mirrors
+                // DocumentStore's undefined-staged-effects semantics).
+                const p_path = write_file(tmp_dir, 'p.do',
+                    'global p_global "p"\n');
+                const x_path = write_file(tmp_dir, 'x.do', [
+                    `// sight: done-by: "${p_path}"`,
+                    'global x_global "x"',
+                ].join('\n'));
+                const c_path = write_file(tmp_dir, 'c.do', [
+                    `// sight: done-by: "${x_path}"`,
+                    'display $x_global',
+                ].join('\n'));
+                const p_uri = URI.file(p_path).toString();
+                const x_uri = URI.file(x_path).toString();
+                const c_uri = URI.file(c_path).toString();
+                const c_content = fs.readFileSync(c_path, 'utf8');
+
+                const resolver = create_resolver_with_forward();
+                const the_p_has_x = () =>
+                    resolver.get_backward_directive_children(p_uri).has(x_uri);
+                await resolver.resolve(c_uri, c_content);
+                expect(the_p_has_x()).toBe(true);
+
+                fs.writeFileSync(x_path, [
+                    '// sight: standalone',
+                    `// sight: done-by: "${p_path}"`,
+                    'global x_global "x"',
+                ].join('\n'), 'utf8');
+                resolver.invalidate_file_cache(x_uri, {
+                    preserve_backward_directive_dependencies: true,
+                });
+
+                // The AST parser throws for everything; the directive
+                // parser throws ONLY for x.do, so c.do's root resolution
+                // still recovers its own directives and actually walks
+                // c -> x — recovery then fails inside x's catch branch.
+                // (A global directive-parser mock would blank c's
+                // directives too and the walk would never reach x,
+                // making the assertion vacuous.)
+                (resolver as unknown as {
+                    parser: { parse: () => never };
+                }).parser.parse = () => {
+                    throw new Error('injected parse failure');
+                };
+                const my_resolver_internals = resolver as unknown as {
+                    directive_parser: {
+                        parse: (
+                            content: string, uri: string, tokens?: unknown
+                        ) => unknown;
+                    };
+                };
+                const original_directive_parse =
+                    my_resolver_internals.directive_parser.parse.bind(
+                        my_resolver_internals.directive_parser
+                    );
+                my_resolver_internals.directive_parser.parse = (
+                    content: string, uri: string, tokens?: unknown
+                ) => {
+                    if (uri === x_uri) {
+                        throw new Error(
+                            'injected directive-parse failure'
+                        );
+                    }
+                    return original_directive_parse(content, uri, tokens);
+                };
+
+                await resolver.resolve(c_uri, c_content);
+
+                // The stale edge survives — a failed recovery must not
+                // wipe it.
+                expect(the_p_has_x()).toBe(true);
+            }
+        );
     });
 
     describe('backward-directive registration', () => {

--- a/tests/integration/standalone-directive.test.ts
+++ b/tests/integration/standalone-directive.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Integration tests for the `sight: standalone` directive (issue #208).
+ *
+ * A header-only, no-argument marker that opts a file out of inherited
+ * backward parent scope: auto-discovered parents, explicit backward
+ * directives (ignored with a warning), inherited working directory, and —
+ * per the cut-everywhere decision — the file's own ancestors when it is
+ * walked as a mid-chain ancestor of another file's resolution. Forward
+ * calls FROM the standalone file keep working unchanged.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { WorkspaceIndexer } from '../../src/indexer';
+import { URI } from 'vscode-uri';
+
+let tmp_dir: string;
+
+function create_tmp_dir(): string {
+    return fs.mkdtempSync(
+        path.join(os.tmpdir(), 'standalone-directive-test-')
+    );
+}
+
+function write_file(dir: string, name: string, content: string): string {
+    const file_path = path.join(dir, name);
+    fs.mkdirSync(path.dirname(file_path), { recursive: true });
+    fs.writeFileSync(file_path, content, 'utf8');
+    return file_path;
+}
+
+function create_scope_resolver(): ScopeResolver {
+    return new ScopeResolver(undefined, {
+        read_file: async (uri: string) => {
+            return fs.promises.readFile(URI.parse(uri).fsPath, 'utf8');
+        },
+        exists: async (uri: string) => {
+            try {
+                await fs.promises.access(URI.parse(uri).fsPath);
+                return true;
+            } catch {
+                return false;
+            }
+        },
+        stat: async (uri: string) => {
+            try {
+                const stats = await fs.promises.stat(URI.parse(uri).fsPath);
+                return { mtimeMs: stats.mtimeMs, size: stats.size };
+            } catch {
+                return undefined;
+            }
+        },
+    });
+}
+
+function create_resolver_with_forward(): ScopeResolver {
+    const resolver = create_scope_resolver();
+    const forward_resolver = new ForwardScopeResolver(resolver);
+    resolver.set_forward_scope_resolver(forward_resolver);
+    return resolver;
+}
+
+async function build_graph(dir: string): Promise<DependencyGraph> {
+    const graph = new DependencyGraph();
+    const indexer = new WorkspaceIndexer();
+    indexer.set_dependency_graph(graph);
+    await indexer.initialize([dir]);
+    return graph;
+}
+
+describe('Standalone directive (issue #208)', () => {
+    beforeEach(() => {
+        tmp_dir = create_tmp_dir();
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmp_dir, { recursive: true, force: true });
+    });
+
+    describe('auto-discovered parents', () => {
+        it('cuts auto-discovered parent scope for a standalone file', async () => {
+            write_file(tmp_dir, 'parent.do', [
+                'global my_global "hello"',
+                'do child.do',
+            ].join('\n'));
+            const child_path = write_file(tmp_dir, 'child.do', [
+                '// sight: standalone',
+                'display $my_global',
+            ].join('\n'));
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const graph = await build_graph(tmp_dir);
+            // The dep-graph edge is a raw fact about the caller and must
+            // exist regardless of the child's standalone marker.
+            expect(graph.get_parents(child_uri)).toHaveLength(1);
+
+            const resolver = create_resolver_with_forward();
+            resolver.set_dependency_graph(graph);
+
+            const scope = await resolver.resolve(
+                child_uri, child_content, { backward_dependencies: 'auto' }
+            );
+
+            expect(scope.is_standalone).toBe(true);
+            expect(scope.has_auto_parents).toBe(false);
+            expect(scope.has_directives).toBe(false);
+            expect(scope.chain).toHaveLength(1);
+            expect(scope.symbols.globalMacros.has('my_global')).toBe(false);
+        });
+
+        it('control: without standalone the same file inherits the parent', async () => {
+            write_file(tmp_dir, 'parent.do', [
+                'global my_global "hello"',
+                'do child.do',
+            ].join('\n'));
+            const child_path = write_file(tmp_dir, 'child.do', [
+                'display $my_global',
+            ].join('\n'));
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const graph = await build_graph(tmp_dir);
+            const resolver = create_resolver_with_forward();
+            resolver.set_dependency_graph(graph);
+
+            const scope = await resolver.resolve(
+                child_uri, child_content, { backward_dependencies: 'auto' }
+            );
+
+            expect(scope.is_standalone).toBe(false);
+            expect(scope.has_auto_parents).toBe(true);
+            expect(scope.symbols.globalMacros.has('my_global')).toBe(true);
+        });
+    });
+
+    describe('explicit backward directives', () => {
+        it('standalone wins over an explicit done-by, with one warning per ignored directive', async () => {
+            const parent_path = write_file(tmp_dir, 'parent.do', [
+                'global parent_global "yes"',
+                'do child.do',
+            ].join('\n'));
+            const child_path = write_file(tmp_dir, 'child.do', [
+                '// sight: standalone',
+                `// sight: done-by: "${parent_path}"`,
+                'display $parent_global',
+            ].join('\n'));
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(child_uri, child_content);
+
+            expect(scope.is_standalone).toBe(true);
+            // The raw directive is still present textually …
+            expect(scope.has_directives).toBe(true);
+            // … but never followed.
+            expect(scope.chain).toHaveLength(1);
+            expect(scope.symbols.globalMacros.has('parent_global')).toBe(false);
+
+            const the_ignored_warnings = scope.diagnostics.filter(
+                d => d.message.includes('sight: standalone') &&
+                     d.message.includes('done-by')
+            );
+            expect(the_ignored_warnings).toHaveLength(1);
+            expect(the_ignored_warnings[0].severity).toBe('warning');
+            // Anchored on the ignored directive's line (line 1).
+            expect(the_ignored_warnings[0].range.start.line).toBe(1);
+        });
+
+        it('directive order does not matter: done-by before standalone is still ignored', async () => {
+            const parent_path = write_file(tmp_dir, 'parent.do', [
+                'global parent_global "yes"',
+                'do child.do',
+            ].join('\n'));
+            const child_path = write_file(tmp_dir, 'child.do', [
+                `// sight: done-by: "${parent_path}"`,
+                '// sight: standalone',
+                'display $parent_global',
+            ].join('\n'));
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(child_uri, child_content);
+
+            expect(scope.is_standalone).toBe(true);
+            expect(scope.symbols.globalMacros.has('parent_global')).toBe(false);
+            expect(scope.diagnostics.some(
+                d => d.message.includes('sight: standalone')
+            )).toBe(true);
+        });
+    });
+
+    describe('mid-chain cut (cut-everywhere semantics)', () => {
+        // D done-by P, P done-by C (standalone), C done-by G.
+        // D inherits P's and C's OWN symbols but never G's.
+        async function setup_chain(c_is_standalone: boolean) {
+            const g_path = write_file(tmp_dir, 'g.do', [
+                'global g_global "g"',
+                'do c.do',
+            ].join('\n'));
+            const c_header = c_is_standalone
+                ? ['// sight: standalone',
+                   `// sight: done-by: "${g_path}"`]
+                : [`// sight: done-by: "${g_path}"`];
+            const c_path = write_file(tmp_dir, 'c.do', [
+                ...c_header,
+                'global c_global "c"',
+                'do p.do',
+            ].join('\n'));
+            const p_path = write_file(tmp_dir, 'p.do', [
+                `// sight: done-by: "${c_path}"`,
+                'global p_global "p"',
+                'do d.do',
+            ].join('\n'));
+            const d_path = write_file(tmp_dir, 'd.do', [
+                `// sight: done-by: "${p_path}"`,
+                'display $p_global $c_global $g_global',
+            ].join('\n'));
+            return {
+                d_uri: URI.file(d_path).toString(),
+                d_content: fs.readFileSync(d_path, 'utf8'),
+                c_path,
+            };
+        }
+
+        it('a standalone mid-chain ancestor contributes its own symbols but cuts its ancestors', async () => {
+            const { d_uri, d_content } = await setup_chain(true);
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(d_uri, d_content);
+
+            expect(scope.symbols.globalMacros.has('p_global')).toBe(true);
+            expect(scope.symbols.globalMacros.has('c_global')).toBe(true);
+            expect(scope.symbols.globalMacros.has('g_global')).toBe(false);
+            // C itself is still in the chain (and thus in dependent_uris).
+            expect(scope.chain.some(e => e.uri.endsWith('c.do'))).toBe(true);
+            expect(scope.chain.some(e => e.uri.endsWith('g.do'))).toBe(false);
+        });
+
+        it('control: without standalone the grandparent symbols flow through', async () => {
+            const { d_uri, d_content } = await setup_chain(false);
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(d_uri, d_content);
+
+            expect(scope.symbols.globalMacros.has('g_global')).toBe(true);
+        });
+
+        it('a standalone ancestor\'s ignored-directive warning stays in that file, not descendants', async () => {
+            const { d_uri, d_content, c_path } = await setup_chain(true);
+            const resolver = create_resolver_with_forward();
+
+            const d_scope = await resolver.resolve(d_uri, d_content);
+            expect(d_scope.diagnostics.some(
+                d => d.message.includes('sight: standalone')
+            )).toBe(false);
+
+            // C's own resolution DOES carry the warning.
+            const c_uri = URI.file(c_path).toString();
+            const c_content = fs.readFileSync(c_path, 'utf8');
+            const c_scope = await resolver.resolve(c_uri, c_content);
+            expect(c_scope.diagnostics.some(
+                d => d.message.includes('sight: standalone')
+            )).toBe(true);
+        });
+    });
+
+    describe('working directory', () => {
+        it('does not inherit a parent working directory', async () => {
+            const wd_dir = path.join(tmp_dir, 'wd_target');
+            fs.mkdirSync(wd_dir, { recursive: true });
+            const parent_path = write_file(tmp_dir, 'parent.do', [
+                `// sight: cd "${wd_dir}"`,
+                'do child.do',
+            ].join('\n'));
+            const child_path = write_file(tmp_dir, 'child.do', [
+                '// sight: standalone',
+                `// sight: done-by: "${parent_path}"`,
+                'display "hi"',
+            ].join('\n'));
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(child_uri, child_content);
+            expect(scope.inherited_working_directory).toBeUndefined();
+        });
+
+        it('keeps the standalone file\'s own working-directory directive', async () => {
+            const wd_dir = path.join(tmp_dir, 'own_wd');
+            fs.mkdirSync(wd_dir, { recursive: true });
+            // Note: the cd path is script-relative (a leading / would mean
+            // workspace-relative in directive syntax).
+            const child_path = write_file(tmp_dir, 'child.do', [
+                '// sight: standalone',
+                '// sight: cd "own_wd"',
+                'do data/sub.do',
+            ].join('\n'));
+            write_file(wd_dir, path.join('data', 'sub.do'),
+                'global sub_global "s"\n');
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(child_uri, child_content);
+
+            // Own WD applies: the forward call resolves under own_wd.
+            expect(scope.forward_call_symbols).toBeDefined();
+            expect(scope.forward_call_symbols!.some(
+                cs => cs.callee_uri.includes('own_wd')
+            )).toBe(true);
+        });
+
+        it('does not leak an earlier sibling parent\'s WD into a standalone parent\'s forward calls', async () => {
+            // root has two backward parents at the same level: p1 (supplies
+            // a WD) then p2 (standalone, no own WD). p2 forward-calls
+            // data/sub.do, which exists only under p1's WD. Without the
+            // sibling guard, p2's forward call would resolve via p1's WD.
+            const wd_dir = path.join(tmp_dir, 'p1_wd');
+            write_file(wd_dir, path.join('data', 'sub.do'),
+                'global sub_global "s"\n');
+            // Script-relative cd path (leading / means workspace-relative).
+            const p1_path = write_file(tmp_dir, 'p1.do', [
+                '// sight: cd "p1_wd"',
+                'global p1_global "1"',
+                'do root.do',
+            ].join('\n'));
+            const p2_path = write_file(tmp_dir, 'p2.do', [
+                '// sight: standalone',
+                'do data/sub.do',
+                'global p2_global "2"',
+                'do root.do',
+            ].join('\n'));
+            const root_path = write_file(tmp_dir, 'root.do', [
+                `// sight: done-by: "${p1_path}"`,
+                `// sight: done-by: "${p2_path}"`,
+                'display $p1_global $p2_global',
+            ].join('\n'));
+            const root_uri = URI.file(root_path).toString();
+            const root_content = fs.readFileSync(root_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(root_uri, root_content);
+
+            // Both parents' own symbols are inherited.
+            expect(scope.symbols.globalMacros.has('p1_global')).toBe(true);
+            expect(scope.symbols.globalMacros.has('p2_global')).toBe(true);
+            // p2's forward call must NOT have resolved via p1's WD.
+            expect(scope.symbols.globalMacros.has('sub_global')).toBe(false);
+            // The root still inherits p1's WD (nearest non-standalone
+            // parent) — the guard must not clear the level-wide value.
+            expect(scope.inherited_working_directory).toBe(wd_dir);
+        });
+    });
+
+    describe('forward calls from a standalone file', () => {
+        it('keeps the standalone file\'s own do/run/include working', async () => {
+            write_file(tmp_dir, 'sub.do', 'global sub_global "s"\n');
+            const main_path = write_file(tmp_dir, 'main.do', [
+                '// sight: standalone',
+                'do sub.do',
+                'display $sub_global',
+            ].join('\n'));
+            const main_uri = URI.file(main_path).toString();
+            const main_content = fs.readFileSync(main_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const scope = await resolver.resolve(main_uri, main_content);
+
+            expect(scope.is_standalone).toBe(true);
+            expect(scope.forward_call_symbols).toBeDefined();
+            expect(scope.forward_call_symbols!.some(
+                cs => cs.symbols.globalMacros.has('sub_global')
+            )).toBe(true);
+        });
+    });
+
+    describe('cache invalidation on toggling', () => {
+        // D done-by C, C done-by G. Toggle standalone on mid-chain C and
+        // verify D's cached resolution is invalidated through BOTH
+        // invalidation entry points.
+        async function setup_toggle_chain() {
+            const g_path = write_file(tmp_dir, 'g.do', [
+                'global g_global "g"',
+                'do c.do',
+            ].join('\n'));
+            const c_path = write_file(tmp_dir, 'c.do', [
+                `// sight: done-by: "${g_path}"`,
+                'global c_global "c"',
+                'do d.do',
+            ].join('\n'));
+            const d_path = write_file(tmp_dir, 'd.do', [
+                `// sight: done-by: "${c_path}"`,
+                'display $c_global $g_global',
+            ].join('\n'));
+            return { g_path, c_path, d_path };
+        }
+
+        function standalone_c_content(g_path: string): string {
+            return [
+                '// sight: standalone',
+                `// sight: done-by: "${g_path}"`,
+                'global c_global "c"',
+                'do d.do',
+            ].join('\n');
+        }
+
+        it('invalidate_file_cache path (watcher/close)', async () => {
+            const { g_path, c_path, d_path } = await setup_toggle_chain();
+            const d_uri = URI.file(d_path).toString();
+            const c_uri = URI.file(c_path).toString();
+            const d_content = fs.readFileSync(d_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const before = await resolver.resolve(d_uri, d_content);
+            expect(before.symbols.globalMacros.has('g_global')).toBe(true);
+
+            fs.writeFileSync(c_path, standalone_c_content(g_path), 'utf8');
+            resolver.invalidate_file_cache(c_uri);
+
+            const after = await resolver.resolve(d_uri, d_content);
+            expect(after.symbols.globalMacros.has('g_global')).toBe(false);
+            expect(after.symbols.globalMacros.has('c_global')).toBe(true);
+        });
+
+        it('invalidate_scope_cache path (didChange)', async () => {
+            const { g_path, c_path, d_path } = await setup_toggle_chain();
+            const d_uri = URI.file(d_path).toString();
+            const c_uri = URI.file(c_path).toString();
+            const d_content = fs.readFileSync(d_path, 'utf8');
+
+            const resolver = create_resolver_with_forward();
+            const before = await resolver.resolve(d_uri, d_content);
+            expect(before.symbols.globalMacros.has('g_global')).toBe(true);
+
+            fs.writeFileSync(c_path, standalone_c_content(g_path), 'utf8');
+            resolver.invalidate_scope_cache(c_uri);
+
+            const after = await resolver.resolve(d_uri, d_content);
+            expect(after.symbols.globalMacros.has('g_global')).toBe(false);
+            expect(after.symbols.globalMacros.has('c_global')).toBe(true);
+        });
+    });
+
+    describe('backward-directive registration', () => {
+        it('a standalone child registers no backward edges (effective = empty)', async () => {
+            const parent_path = write_file(tmp_dir, 'parent.do',
+                'global x "1"\n');
+            const child_path = write_file(tmp_dir, 'child.do', [
+                '// sight: standalone',
+                `// sight: done-by: "${parent_path}"`,
+                'display "hi"',
+            ].join('\n'));
+            const parent_uri = URI.file(parent_path).toString();
+            const child_uri = URI.file(child_path).toString();
+            const child_content = fs.readFileSync(child_path, 'utf8');
+
+            const resolver = create_scope_resolver();
+            const parse = resolver['directive_parser'].parse(
+                child_content, child_uri
+            );
+
+            // Control: non-standalone registration creates the edge.
+            resolver.apply_backward_directive_registration(
+                child_uri, parse.directives, {}, false
+            );
+            expect(
+                resolver.get_backward_directive_children(parent_uri)
+                    .has(child_uri)
+            ).toBe(true);
+
+            // Standalone registration clears it (effective directives are
+            // empty; clear-then-register registers nothing).
+            resolver.apply_backward_directive_registration(
+                child_uri, parse.directives, {}, true
+            );
+            expect(
+                resolver.get_backward_directive_children(parent_uri)
+                    .has(child_uri)
+            ).toBe(false);
+        });
+    });
+});

--- a/tests/property/forward-call-relationships.prop.test.ts
+++ b/tests/property/forward-call-relationships.prop.test.ts
@@ -201,7 +201,7 @@ describe('Feature: callee-change-caller-revalidation', () => {
                         // Add scope cache entries for callers
                         const cache_key = `${my_caller_uri}:test-hash:config-hash`;
                         const cache_entry = {
-                            resolved_scope: { chain: [], symbols, out_of_scope_symbols: [], diagnostics: [], has_directives: false, has_auto_parents: false },
+                            resolved_scope: { chain: [], symbols, out_of_scope_symbols: [], diagnostics: [], has_directives: false, has_auto_parents: false, is_standalone: false },
                             content_hash: 'test-hash',
                             timestamp: Date.now(),
                             dependent_uris: new Set([callee_uri]),

--- a/tests/property/hover-out-of-scope.prop.test.ts
+++ b/tests/property/hover-out-of-scope.prop.test.ts
@@ -145,7 +145,7 @@ function create_resolved_scope_with_out_of_scope(
         symbols: create_empty_symbol_table(),
         out_of_scope_symbols,
         diagnostics: [],
-        has_directives: true, has_auto_parents: false,
+        has_directives: true, has_auto_parents: false, is_standalone: false,
     };
 }
 
@@ -197,7 +197,7 @@ function create_resolved_scope_with_in_scope(
         symbols: my_symbols,
         out_of_scope_symbols: [],
         diagnostics: [],
-        has_directives: true, has_auto_parents: false,
+        has_directives: true, has_auto_parents: false, is_standalone: false,
     };
 }
 

--- a/tests/property/standalone-directive.prop.test.ts
+++ b/tests/property/standalone-directive.prop.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Property tests for the `sight: standalone` directive (issue #208).
+ *
+ * A header-only, no-argument marker. Properties:
+ * 1. Both prefixes (`sight:` / `@lsp-`), both comment styles (`//` / `*`),
+ *    and the optional trailing colon all parse equivalently.
+ * 2. Header-only constraint: the marker is inert after the first
+ *    non-blank, non-comment line.
+ * 3. Combining with backward directives never filters the raw directive
+ *    list and never emits a parser-level diagnostic (the ignored-directive
+ *    warning is resolver-root-emitted).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import * as fc from 'fast-check';
+import { DirectiveParser } from '../../src/directive-parser';
+
+describe('Standalone Directive Property Tests', () => {
+    const parser = new DirectiveParser();
+
+    const prefix_gen = fc.constantFrom('sight: ', '@lsp-');
+    const comment_gen = fc.constantFrom('//', '*');
+    const colon_gen = fc.constantFrom('', ':');
+    const spaces_gen = fc.stringOf(fc.constant(' '), {
+        minLength: 0, maxLength: 3,
+    });
+
+    const path_gen = fc.stringOf(
+        fc.constantFrom(
+            ...'abcdefghijklmnopqrstuvwxyz0123456789_-./'.split('')
+        ),
+        { minLength: 1, maxLength: 20 }
+    ).filter(s => !s.includes('"') && !s.includes(' '));
+
+    describe('Property 1: All spelling forms parse equivalently', () => {
+        test('prefix x comment style x colon x whitespace all set standalone', () => {
+            fc.assert(
+                fc.property(
+                    prefix_gen, comment_gen, colon_gen, spaces_gen,
+                    (my_prefix, my_comment, my_colon, my_spaces) => {
+                        const my_line =
+                            `${my_comment} ${my_prefix}standalone` +
+                            `${my_colon}${my_spaces}`;
+                        const result = parser.parse(
+                            `${my_line}\ngen x = 1`,
+                            'file:///test/script.do'
+                        );
+                        expect(result.standalone).toBeDefined();
+                        expect(result.standalone!.directive_form)
+                            .toBe('standalone');
+                        expect(result.standalone!.range.start.line).toBe(0);
+                        expect(result.diagnostics.length).toBe(0);
+                    }
+                ),
+                { numRuns: 100 }
+            );
+        });
+    });
+
+    describe('Property 2: Header-only constraint', () => {
+        test('the marker after a code line is inert', () => {
+            fc.assert(
+                fc.property(
+                    prefix_gen, comment_gen,
+                    fc.integer({ min: 0, max: 5 }),
+                    (my_prefix, my_comment, my_leading_comments) => {
+                        const the_lines: string[] = [];
+                        for (let i = 0; i < my_leading_comments; i++) {
+                            the_lines.push('// a header comment');
+                        }
+                        the_lines.push('gen x = 1');
+                        the_lines.push(
+                            `${my_comment} ${my_prefix}standalone`
+                        );
+                        const result = parser.parse(
+                            the_lines.join('\n'),
+                            'file:///test/script.do'
+                        );
+                        expect(result.standalone).toBeUndefined();
+                    }
+                ),
+                { numRuns: 100 }
+            );
+        });
+
+        test('the marker below blank/comment header lines is recognized', () => {
+            fc.assert(
+                fc.property(
+                    prefix_gen,
+                    fc.integer({ min: 0, max: 5 }),
+                    (my_prefix, my_header_lines) => {
+                        const the_lines: string[] = [];
+                        for (let i = 0; i < my_header_lines; i++) {
+                            the_lines.push(i % 2 === 0
+                                ? '// a header comment'
+                                : '');
+                        }
+                        the_lines.push(`// ${my_prefix}standalone`);
+                        the_lines.push('gen x = 1');
+                        const result = parser.parse(
+                            the_lines.join('\n'),
+                            'file:///test/script.do'
+                        );
+                        expect(result.standalone).toBeDefined();
+                        expect(result.standalone!.range.start.line)
+                            .toBe(my_header_lines);
+                    }
+                ),
+                { numRuns: 100 }
+            );
+        });
+    });
+
+    describe('Property 3: Coexistence with backward directives', () => {
+        test('raw directives stay unfiltered; no parser-level diagnostic', () => {
+            fc.assert(
+                fc.property(
+                    prefix_gen,
+                    fc.constantFrom('done-by', 'run-by', 'included-by'),
+                    path_gen,
+                    fc.boolean(),
+                    (my_prefix, my_backward_type, my_path,
+                     standalone_first) => {
+                        const my_standalone_line =
+                            `// ${my_prefix}standalone`;
+                        const my_backward_line =
+                            `// ${my_prefix}${my_backward_type}: ` +
+                            `"${my_path}"`;
+                        const the_header = standalone_first
+                            ? [my_standalone_line, my_backward_line]
+                            : [my_backward_line, my_standalone_line];
+                        const result = parser.parse(
+                            [...the_header, 'gen x = 1'].join('\n'),
+                            'file:///test/script.do'
+                        );
+                        expect(result.standalone).toBeDefined();
+                        expect(result.directives.length).toBe(1);
+                        expect(result.diagnostics.length).toBe(0);
+                    }
+                ),
+                { numRuns: 100 }
+            );
+        });
+    });
+});

--- a/tests/property/standalone-directive.prop.test.ts
+++ b/tests/property/standalone-directive.prop.test.ts
@@ -25,12 +25,13 @@ describe('Standalone Directive Property Tests', () => {
         minLength: 0, maxLength: 3,
     });
 
+    // Charset contains no quote or space, so no filter is needed.
     const path_gen = fc.stringOf(
         fc.constantFrom(
             ...'abcdefghijklmnopqrstuvwxyz0123456789_-./'.split('')
         ),
         { minLength: 1, maxLength: 20 }
-    ).filter(s => !s.includes('"') && !s.includes(' '));
+    );
 
     describe('Property 1: All spelling forms parse equivalently', () => {
         test('prefix x comment style x colon x whitespace all set standalone', () => {
@@ -46,8 +47,6 @@ describe('Standalone Directive Property Tests', () => {
                             'file:///test/script.do'
                         );
                         expect(result.standalone).toBeDefined();
-                        expect(result.standalone!.directive_form)
-                            .toBe('standalone');
                         expect(result.standalone!.range.start.line).toBe(0);
                         expect(result.diagnostics.length).toBe(0);
                     }

--- a/tests/property/unify-forward-call-feeds.prop.test.ts
+++ b/tests/property/unify-forward-call-feeds.prop.test.ts
@@ -166,7 +166,7 @@ describe('Feature: unify-forward-call-feeds', () => {
                             out_of_scope_symbols: [],
                             diagnostics: [],
                             has_directives: false,
-                            has_auto_parents: false,
+                            has_auto_parents: false, is_standalone: false,
                             forward_call_symbols: [{
                                 callee_uri: URI.file(callee_path).toString(),
                                 call_line: call_line,
@@ -258,7 +258,7 @@ describe('Feature: unify-forward-call-feeds', () => {
                             out_of_scope_symbols: [],
                             diagnostics: [],
                             has_directives: false,
-                            has_auto_parents: false,
+                            has_auto_parents: false, is_standalone: false,
                             forward_call_symbols: [{
                                 callee_uri: URI.file(callee_path).toString(),
                                 call_line: 0,

--- a/tests/property/visible-symbols.prop.test.ts
+++ b/tests/property/visible-symbols.prop.test.ts
@@ -156,7 +156,7 @@ describe('get_visible_symbols_at equivalence with ForwardScopeResolver.get_symbo
                             out_of_scope_symbols: [],
                             diagnostics: [],
                             has_directives: false,
-                            has_auto_parents: false,
+                            has_auto_parents: false, is_standalone: false,
                             forward_call_symbols: sites,
                         } as ResolvedScope,
                         cursor_line,

--- a/tests/unit/completion.test.ts
+++ b/tests/unit/completion.test.ts
@@ -2026,7 +2026,7 @@ describe('partition_symbols_for_completion: resolved_scope out-of-scope filterin
             }],
             diagnostics: [],
             has_directives: false,
-            has_auto_parents: true,
+            has_auto_parents: true, is_standalone: false,
         };
 
         // Call the private method via bracket access.
@@ -2089,7 +2089,7 @@ describe('partition_symbols_for_completion: resolved_scope out-of-scope filterin
             }],
             diagnostics: [],
             has_directives: false,
-            has_auto_parents: true,
+            has_auto_parents: true, is_standalone: false,
         };
 
         const result = (provider as any).partition_symbols_for_completion(

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -797,7 +797,7 @@ display \`result'
                     severity: 'warning',
                 }],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
             };
             const stub_resolver = make_stub_scope_resolver(resolved_scope);
             const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG, undefined, stub_resolver);
@@ -820,7 +820,7 @@ display \`result'
                     severity: 'warning',
                 }],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
             };
             const stub_resolver = make_stub_scope_resolver(resolved_scope);
             const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG, undefined, stub_resolver);
@@ -842,7 +842,7 @@ display \`result'
                     severity: 'warning',
                 }],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
             };
             const stub_resolver = make_stub_scope_resolver(resolved_scope);
             const the_diagnostics = await provider.get_diagnostics(document, DEFAULT_CONFIG, undefined, stub_resolver);
@@ -864,7 +864,7 @@ display \`result'
                     severity: 'warning',
                 }],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
             };
             const stub_resolver = make_stub_scope_resolver(resolved_scope);
 
@@ -1041,7 +1041,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
             };
             const stub_resolver = make_stub_scope_resolver(resolved_scope);
 
@@ -1085,7 +1085,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///child.do',
                     call_line: 0,
@@ -1145,7 +1145,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
             };
             const stub_resolver = make_stub_scope_resolver(resolved_scope);
 
@@ -1275,7 +1275,7 @@ display \`result'
                 }],
                 diagnostics: [],
                 has_directives: true,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
             };
 
             const the_diagnostics = await provider.get_diagnostics(
@@ -1307,7 +1307,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///child.do',
                     call_line: 0,
@@ -1361,7 +1361,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///child.do',
                     call_line: 0,
@@ -1445,7 +1445,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: true,
+                has_auto_parents: true, is_standalone: false,
                 forward_call_symbols: [
                     {
                         callee_uri: 'file:///a.do',
@@ -1498,7 +1498,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: true,
+                has_auto_parents: true, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///b.do',
                     call_line: 1,
@@ -1568,7 +1568,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: true,
+                has_auto_parents: true, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///b.do',
                     call_line: 1,
@@ -1622,7 +1622,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: true,
+                has_auto_parents: true, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///b.do',
                     call_line: 1,
@@ -1681,7 +1681,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: true,
+                has_auto_parents: true, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///b.do',
                     call_line: 1,
@@ -1732,7 +1732,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: true,
+                has_auto_parents: true, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///b.do',
                     call_line: 0,
@@ -1789,7 +1789,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: true,
+                has_auto_parents: true, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///b.do',
                     call_line: 1,
@@ -1854,7 +1854,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: true,
+                has_auto_parents: true, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///b.do',
                     call_line: 1,
@@ -2005,7 +2005,7 @@ display \`result'
                     reason: 'inheritance_excludes_locals' as const,
                 }],
                 diagnostics: [],
-                has_directives: true, has_auto_parents: false,
+                has_directives: true, has_auto_parents: false, is_standalone: false,
             };
             
             const mock_scope_resolver = {
@@ -2053,7 +2053,7 @@ display \`result'
                     reason: 'after_call_site' as const,
                 }],
                 diagnostics: [],
-                has_directives: true, has_auto_parents: false,
+                has_directives: true, has_auto_parents: false, is_standalone: false,
             };
             
             const mock_scope_resolver = {
@@ -2101,7 +2101,7 @@ display \`result'
                     reason: 'inheritance_excludes_locals' as const,
                 }],
                 diagnostics: [],
-                has_directives: true, has_auto_parents: false,
+                has_directives: true, has_auto_parents: false, is_standalone: false,
             };
             
             const mock_scope_resolver = {
@@ -2153,7 +2153,7 @@ display \`result'
                     reason: 'after_call_site' as const,
                 }],
                 diagnostics: [],
-                has_directives: true, has_auto_parents: false,
+                has_directives: true, has_auto_parents: false, is_standalone: false,
             };
             
             const mock_scope_resolver = {
@@ -2204,7 +2204,7 @@ display \`result'
                     reason: 'after_call_site' as const,
                 }],
                 diagnostics: [],
-                has_directives: true, has_auto_parents: false,
+                has_directives: true, has_auto_parents: false, is_standalone: false,
             };
             
             const mock_scope_resolver = {
@@ -2239,7 +2239,7 @@ display \`result'
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: 'file:///child.do',
                     call_line: 0,
@@ -2310,7 +2310,7 @@ display \`result'
                 }],
                 diagnostics: [],
                 has_directives: true,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
             };
 
             const mock_scope_resolver = {
@@ -2373,7 +2373,7 @@ display \`result'
                 chain: [],
                 out_of_scope_symbols: [],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
                 scan_complete_at_resolve_time: true,
                 diagnostics: [diag],
             };

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -562,6 +562,45 @@ gen x = 1`;
             expect(result.diagnostics.length).toBe(0);
         });
 
+        test('code after a leading block comment ends the header', () => {
+            // `/* c */ gen x = 1` is executable code, so the header stops
+            // there; a marker below it must be inert. Applies to backward
+            // directives too (same header boundary).
+            const content = [
+                '/* comment */ gen x = 1',
+                '// sight: standalone',
+                '// sight: done-by: "parent.do"',
+            ].join('\n');
+            const result = parser.parse(content, 'file:///test.do');
+            expect(result.standalone).toBeUndefined();
+            expect(result.directives.length).toBe(0);
+        });
+
+        test('pure block-comment lines (and trailing line comments) stay in the header', () => {
+            const content = [
+                '/* a pure block comment */',
+                '/* leading */ // trailing line comment',
+                '/* multi',
+                '   line */',
+                '// sight: standalone',
+                'gen x = 1',
+            ].join('\n');
+            const result = parser.parse(content, 'file:///test.do');
+            expect(result.standalone).toBeDefined();
+            expect(result.standalone!.range.start.line).toBe(4);
+        });
+
+        test('a marker inside a multi-line block comment is inert', () => {
+            const content = [
+                '/*',
+                '// sight: standalone',
+                '*/',
+                'gen x = 1',
+            ].join('\n');
+            const result = parser.parse(content, 'file:///test.do');
+            expect(result.standalone).toBeUndefined();
+        });
+
         test('first standalone marker wins when repeated', () => {
             const content = [
                 '// sight: standalone',

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -488,6 +488,92 @@ gen x = 1`;
             expect(result.diagnostics.length).toBe(0);
         });
     });
+
+    describe('Standalone Directive (issue #208)', () => {
+        const parser = new DirectiveParser();
+
+        test('parses sight: standalone and @lsp-standalone, with and without colon', () => {
+            const the_forms = [
+                '// sight: standalone',
+                '// sight: standalone:',
+                '// @lsp-standalone',
+                '// @lsp-standalone:',
+                '* sight: standalone',
+                '* @lsp-standalone',
+            ];
+            for (const my_form of the_forms) {
+                const result = parser.parse(
+                    `${my_form}\ngen x = 1`, 'file:///test.do'
+                );
+                expect(result.standalone).toBeDefined();
+                expect(result.standalone!.range.start.line).toBe(0);
+                expect(result.diagnostics.length).toBe(0);
+            }
+        });
+
+        test('is header-only: not recognized after the first code line', () => {
+            const content = 'gen x = 1\n// sight: standalone\n';
+            const result = parser.parse(content, 'file:///test.do');
+            expect(result.standalone).toBeUndefined();
+        });
+
+        test('is recognized below blank and comment lines in the header', () => {
+            const content = [
+                '// A regular comment',
+                '',
+                '// sight: standalone',
+                'gen x = 1',
+            ].join('\n');
+            const result = parser.parse(content, 'file:///test.do');
+            expect(result.standalone).toBeDefined();
+            expect(result.standalone!.range.start.line).toBe(2);
+        });
+
+        test('flags trailing arguments as malformed and does not set standalone', () => {
+            const content = '// sight: standalone "foo.do"\ngen x = 1';
+            const result = parser.parse(content, 'file:///test.do');
+            expect(result.standalone).toBeUndefined();
+            expect(result.diagnostics.length).toBe(1);
+            expect(result.diagnostics[0].message).toContain('Malformed');
+            expect(result.diagnostics[0].severity).toBe('warning');
+        });
+
+        test('does not match longer words that merely start with standalone', () => {
+            const content = '// sight: standalonex\ngen x = 1';
+            const result = parser.parse(content, 'file:///test.do');
+            expect(result.standalone).toBeUndefined();
+            expect(result.diagnostics.length).toBe(0);
+        });
+
+        test('keeps raw backward directives unfiltered and emits NO parser-level warning', () => {
+            // The "ignored directive" warning is resolver-root-emitted
+            // (ScopeResolver.resolve()), deliberately NOT a parser
+            // diagnostic: parser diagnostics ride ancestor parse results
+            // into descendants' resolutions.
+            const content = [
+                '// sight: standalone',
+                '// sight: done-by: "parent.do"',
+                'gen x = 1',
+            ].join('\n');
+            const result = parser.parse(content, 'file:///test.do');
+            expect(result.standalone).toBeDefined();
+            expect(result.directives.length).toBe(1);
+            expect(result.directives[0].type).toBe('done-by');
+            expect(result.diagnostics.length).toBe(0);
+        });
+
+        test('first standalone marker wins when repeated', () => {
+            const content = [
+                '// sight: standalone',
+                '// @lsp-standalone',
+                'gen x = 1',
+            ].join('\n');
+            const result = parser.parse(content, 'file:///test.do');
+            expect(result.standalone).toBeDefined();
+            expect(result.standalone!.range.start.line).toBe(0);
+            expect(result.diagnostics.length).toBe(0);
+        });
+    });
 });
 
 

--- a/tests/unit/document-store-commit-time-cross-file-effects.test.ts
+++ b/tests/unit/document-store-commit-time-cross-file-effects.test.ts
@@ -182,6 +182,49 @@ describe('DocumentStore commit-time cross-file effects (issue #184)', () => {
         ).toBe(true);
     });
 
+    it('a standalone commit registers no backward edges; removing the marker restores them (issue #208)', async () => {
+        const parent_uri =
+            URI.file('/tmp/sight-208-auto-parent.do').toString();
+        const child_uri =
+            URI.file('/tmp/sight-208-auto-child.do').toString();
+        const content_by_uri = new Map<string, string>([
+            [parent_uri, 'do sight-208-auto-child.do\n'],
+        ]);
+        const { document_store, dependency_graph, scope_resolver } =
+            make_harness(content_by_uri);
+
+        dependency_graph.update_caller(parent_uri, [{
+            type: 'do',
+            raw_path: 'sight-208-auto-child.do',
+            is_static: true,
+            call_site_line: 0,
+            range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 10 },
+            },
+            source: 'command',
+        }]);
+
+        // Committed standalone parse: staged is_standalone reaches
+        // apply_backward_directive_registration → effective directives are
+        // empty despite the auto-discoverable graph parent.
+        await document_store.open(
+            child_uri, '// sight: standalone\ndisplay 1\n', 1
+        );
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(false);
+
+        // Removing the marker on the next committed parse re-registers the
+        // auto edge.
+        await document_store.update(child_uri, [{ text: 'display 1\n' }], 2);
+        expect(
+            scope_resolver.get_backward_directive_children(parent_uri)
+                .has(child_uri)
+        ).toBe(true);
+    });
+
     it('registers auto-discovered parents even when the file has its own working directory (probe skipped)', async () => {
         // A file with its own @lsp-cd never runs the WD probe, so before the
         // fix only the RAW parse-time sync ran and auto-discovered parents

--- a/tests/unit/document-store-commit-time-cross-file-effects.test.ts
+++ b/tests/unit/document-store-commit-time-cross-file-effects.test.ts
@@ -16,6 +16,7 @@ import { DocumentStore } from '../../src/document-store';
 import { DependencyGraph } from '../../src/dependency-graph';
 import { WorkspaceIndexer } from '../../src/indexer';
 import { ScopeResolver } from '../../src/scope-resolver';
+import { StataParser } from '../../src/parser';
 import type { ContentProvider } from '../../src/types';
 import { URI } from 'vscode-uri';
 import { wait_until } from '../wait-until';
@@ -33,6 +34,24 @@ function make_content_provider(
                 : { mtimeMs: 0, size: content.length };
         },
     };
+}
+
+function seed_auto_parent(
+    dependency_graph: DependencyGraph,
+    parent_uri: string,
+    child_raw_path: string
+): void {
+    dependency_graph.update_caller(parent_uri, [{
+        type: 'do',
+        raw_path: child_raw_path,
+        is_static: true,
+        call_site_line: 0,
+        range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 3 + child_raw_path.length },
+        },
+        source: 'command',
+    }]);
 }
 
 function make_harness(content_by_uri: Map<string, string>) {
@@ -224,6 +243,54 @@ describe('DocumentStore commit-time cross-file effects (issue #184)', () => {
                 .has(child_uri)
         ).toBe(true);
     });
+
+    it(
+        'parser-failed commits still recover standalone auto-edge toggles',
+        async () => {
+            const parent_uri =
+                URI.file('/tmp/sight-208-failed-auto-parent.do').toString();
+            const child_raw_path = 'sight-208-failed-auto-child.do';
+            const child_uri =
+                URI.file(`/tmp/${child_raw_path}`).toString();
+            const content_by_uri = new Map<string, string>([
+                [parent_uri, `do ${child_raw_path}\n`],
+            ]);
+            const { document_store, dependency_graph, scope_resolver } =
+                make_harness(content_by_uri);
+            const the_parent_has_child = () =>
+                scope_resolver.get_backward_directive_children(parent_uri)
+                    .has(child_uri);
+
+            seed_auto_parent(dependency_graph, parent_uri, child_raw_path);
+            expect(dependency_graph.get_parents(child_uri)).toHaveLength(1);
+
+            await document_store.open(child_uri, 'display 1\n', 1);
+            expect(the_parent_has_child()).toBe(true);
+
+            const original_parse = StataParser.prototype.parse;
+            StataParser.prototype.parse = (() => {
+                throw new Error('injected parser failure');
+            }) as typeof original_parse;
+
+            try {
+                await document_store.update(
+                    child_uri,
+                    [{ text: '// sight: standalone\ndisplay 1\n' }],
+                    2
+                );
+                expect(the_parent_has_child()).toBe(false);
+
+                await document_store.update(
+                    child_uri,
+                    [{ text: 'display 1\n' }],
+                    3
+                );
+                expect(the_parent_has_child()).toBe(true);
+            } finally {
+                StataParser.prototype.parse = original_parse;
+            }
+        }
+    );
 
     it('registers auto-discovered parents even when the file has its own working directory (probe skipped)', async () => {
         // A file with its own @lsp-cd never runs the WD probe, so before the

--- a/tests/unit/scope-isolation-diagnostics.test.ts
+++ b/tests/unit/scope-isolation-diagnostics.test.ts
@@ -172,7 +172,7 @@ display \`inside_x'
             out_of_scope_symbols: [],
             diagnostics: [],
             has_directives: true,
-            has_auto_parents: false,
+            has_auto_parents: false, is_standalone: false,
         };
         const provider = make_provider();
         const the_diagnostics = await provider.get_diagnostics(
@@ -222,7 +222,7 @@ display \`x'
             out_of_scope_symbols: [],
             diagnostics: [],
             has_directives: false,
-            has_auto_parents: true,
+            has_auto_parents: true, is_standalone: false,
             forward_call_symbols: [
                 {
                     callee_uri: 'file:///a.do',
@@ -287,7 +287,7 @@ display \`x'
             out_of_scope_symbols: [],
             diagnostics: [],
             has_directives: false,
-            has_auto_parents: true,
+            has_auto_parents: true, is_standalone: false,
             forward_call_symbols: [
                 {
                     callee_uri: 'file:///a.do',
@@ -339,7 +339,7 @@ display \`x'
             out_of_scope_symbols: [],
             diagnostics: [],
             has_directives: false,
-            has_auto_parents: true,
+            has_auto_parents: true, is_standalone: false,
             forward_call_symbols: [{
                 callee_uri: 'file:///child.do',
                 call_line: 4,

--- a/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
+++ b/tests/unit/scope-resolver-ancestor-effective-sync.test.ts
@@ -247,7 +247,8 @@ describe('issue #286 — ancestor-level effective backward-directive sync', () =
             .parse(c_content, c_uri).directives;
         await scope_resolver.resolve_inherited_working_directory(
             the_directives,
-            c_uri
+            c_uri,
+            false
         );
         // The explicit walk itself must not register auto edges...
         expect(
@@ -378,9 +379,48 @@ describe('issue #286 — ancestor-level effective backward-directive sync', () =
             .parse(c_content, c_uri).directives;
         await scope_resolver.resolve_inherited_working_directory(
             the_directives,
-            c_uri
+            c_uri,
+            false
         );
 
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+    });
+
+    it('a standalone ancestor registers no auto edges on read (issue #208)', async () => {
+        // A --do--> B (auto edge in the graph), but B's header carries
+        // `sight: standalone`: reading B as an ancestor under 'auto' mode
+        // must NOT synthesize/register the A → B backward edge — the
+        // effective directives for a standalone file are empty.
+        const b_path = create_file('b.do',
+            '// sight: standalone\ndisplay "b on disk"\n');
+        create_file('a.do', 'do b.do\n');
+        const a_uri = to_uri(path.join(temp_dir, 'a.do'));
+        const b_uri = to_uri(b_path);
+        seed_auto_parent(a_uri, 'b.do');
+        expect(dependency_graph.get_parents(b_uri)).toHaveLength(1);
+
+        // Fresh-parse path: C's resolution reads B from disk as ancestor.
+        const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+        await scope_resolver.resolve(
+            c_uri,
+            `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`,
+            { backward_dependencies: 'auto' }
+        );
+        expect(
+            scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
+        ).toBe(false);
+
+        // Cache-hit-upgrade path: a second auto-mode read of B hits the
+        // file cache; upgrade_registration_on_cache_hit must also honor
+        // the standalone flag stamped on the cached entry.
+        const d_uri = to_uri(path.join(temp_dir, 'd.do'));
+        await scope_resolver.resolve(
+            d_uri,
+            `// @lsp-done-by: "${b_path}"\ndisplay "d"\n`,
+            { backward_dependencies: 'auto' }
+        );
         expect(
             scope_resolver.get_backward_directive_children(a_uri).has(b_uri)
         ).toBe(false);

--- a/tests/unit/scope-resolver-inherited-wd-case.test.ts
+++ b/tests/unit/scope-resolver-inherited-wd-case.test.ts
@@ -167,6 +167,7 @@ describe('ScopeResolver inherited WD via case-only backward directive', () => {
             await scope_resolver.resolve_inherited_working_directory(
                 [my_child_directive],
                 child_uri,
+                false,
             );
 
         // Forced-explicit walk ignores the auto grandparent → no inherited WD.

--- a/tests/unit/scope-resolver/visible-symbols.test.ts
+++ b/tests/unit/scope-resolver/visible-symbols.test.ts
@@ -32,7 +32,7 @@ const empty_scope: ResolvedScope = {
     out_of_scope_symbols: [],
     diagnostics: [],
     has_directives: false,
-    has_auto_parents: false,
+    has_auto_parents: false, is_standalone: false,
 };
 
 describe('get_visible_symbols_at', () => {
@@ -169,7 +169,7 @@ describe('get_visible_symbols_at — current-file shadowing window (call_line, c
             out_of_scope_symbols: [],
             diagnostics: [],
             has_directives: false,
-            has_auto_parents: false,
+            has_auto_parents: false, is_standalone: false,
             forward_call_symbols: [site],
         };
     };

--- a/tests/unit/unify-forward-call-feeds.test.ts
+++ b/tests/unit/unify-forward-call-feeds.test.ts
@@ -138,7 +138,7 @@ describe('unify-forward-call-feeds refactoring', () => {
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
                 forward_call_symbols: [{
                     callee_uri: URI.file(callee_path).toString(),
                     call_line: 0,
@@ -229,7 +229,7 @@ describe('unify-forward-call-feeds refactoring', () => {
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
                 forward_call_symbols: [
                     // From @lsp-do directive
                     {
@@ -298,7 +298,7 @@ describe('unify-forward-call-feeds refactoring', () => {
                 out_of_scope_symbols: [],
                 diagnostics: [],
                 has_directives: false,
-                has_auto_parents: false,
+                has_auto_parents: false, is_standalone: false,
                 forward_call_symbols: [
                     // From do command (excludes locals)
                     {


### PR DESCRIPTION
Closes #208.

## What

A header-only, no-argument `sight: standalone` directive (permanent alias `@lsp-standalone`) that resolves a file's diagnostics **without any backward parent inheritance** — auto-discovered parents, explicit backward directives (overridden with a warning per ignored line), and inherited working directory are all cut, while the file's own forward calls keep working.

## Semantics (user-decided during design)

- **Cut-everywhere**: standalone is honored in every resolution role. A standalone mid-chain ancestor contributes its *own* symbols to descendants but never conducts its ancestors' scope (or WD) through.
- **Standalone wins over explicit `done-by`/`run-by`/`included-by`**, with one warning per ignored line, emitted by `resolve()`'s root path only — the warning appears in the standalone file itself, never in files that read it as an ancestor.
- **Inherited WD cut** (own `sight: cd` kept), including `sight/getWorkingDirectory` (Send-to-Stata), the indexer's closed-file WD walk, and a sibling-WD fallback guard in `follow_directives` (an earlier sibling parent's WD no longer leaks into a standalone parent's forward calls; the root's inherited WD from non-standalone siblings is preserved).
- **DependencyGraph edges and find-references' raw-connectivity floor unchanged** — graph edges are facts about callers. The resolver-private backward registration follows *effective* directives, so a standalone file registers zero backward edges.
- **"Consistent" provider strictness**: completion uses Scope-Resolved mode (workspace symbols only as out-of-scope entries); hover/definition/references keep their existing workspace fallbacks — a standalone file behaves exactly like a scope-resolved file with zero parents.
- **No new cache keys**: content-hash keying + `dependent_uris` cascade cover toggling (pinned by tests on both invalidation entry points). Forward-closure memo (#234) caller-independence is preserved — standalone only varies the already-keyed inherited-WD input; the memo gate test gained a standalone-callee case with real backward-cut teeth.
- **Answer to the issue's open design question**: this is the own-diagnostics phase; caller-independent forward-closure caching already shipped as #234, so no caller-side caching change is needed.

## Implementation shape

Threaded through the single `get_effective_backward_directives` chokepoint (required `is_standalone` parameter — no default, so future call sites can't silently ignore it), `ParsedFileResult`/file-cache, `StagedCrossFileEffects` (#184 commit-time application), and the #286 `upgrade_registration_on_cache_hit`/close-resync paths. Standalone files never defer diagnostics during the workspace scan (nothing to wait for). `sight check` honors the directive through the shared pipeline.

Hardening that fell out of review (fixed for the whole directive family, not just standalone):
- The directive-header boundary now ends at a block-comment-leading line with trailing code (`/* c */ gen x = 1`).
- Ancestor parser-level diagnostics get source attribution and URI-identity remap routing (keyed through the real-path chokepoint), so they land on the child's directive line with a `parent.do line N` note instead of at raw parent coordinates — immune to basename collisions and case-only/.do-fallback resolution.
- Parse-failure catch paths recover header facts via the failure-independent `DirectiveParser` (a broken file keeps its explicit directives/standalone marker instead of silently regaining auto-discovery).
- `FileCacheEntry` + `cache_entry_to_parsed_result` single-source the four cache-hit copies (the PR #278 bug class).

## Review gate

Design: 3 adversarial codex rounds before implementation (converged clean). Implementation: 3 subagent passes, then 5 rounds of the two-reviewer gate (adversarial + multi-angle lens) — 17 findings found and fixed in-branch across rounds 1–3, rounds 4 and 5 clean from both reviewers on the final diff.

## Tests

45 new tests: parser unit + property suites (spelling forms, header-only boundary incl. block-comment edges, malformed forms, coexistence with backward directives), integration coverage for auto-parents cut, explicit-override warnings (incl. run-by wording), mid-chain cut, WD cut + sibling regression, both cache-invalidation entry points, registration, #184 commit-time staging, #286 ancestor sync, memo gate, deferral, completion mode, references floor, `sight/getWorkingDirectory`, `sight check` batch behavior, parse-failure recovery, and attribution routing (same-basename and case-only variants via injected fs). Full suite: 7,214 pass, typecheck + eslint clean.

Docs: new "Standalone Files" section in docs/cross-file.md, per-file opt-out cross-reference, de-anticipated forward-closure interaction note, AGENTS.md directive list entry.

https://claude.ai/code/session_01SxxDzwQDAddArrAUJHGLjt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `// sight: standalone` / `// `@lsp-standalone`` (header-only) to opt a file out of inherited parent context while preserving its own local behavior.
  * Standalone-aware completion and reference visibility now behave consistently.
* **Bug Fixes**
  * Corrected standalone working-directory inheritance and closure handling for forward-resolution behavior.
  * Adjusted diagnostics to avoid incorrect deferrals and to attribute/emit standalone-related warnings properly.
  * Fixed cache and cross-file dependency updates when toggling standalone markers.
* **Documentation**
  * Updated cross-file directive documentation for standalone semantics.
* **Tests**
  * Expanded integration/unit/property coverage for standalone behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->