### PR TITLE
[codex] Support nobreak call prefix

### DIFF
--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -824,7 +824,7 @@ export class DirectiveParser {
      * - Quoted paths: do "child.do", include "path/child.do"
      * - Unquoted paths: do child.do, run child
      * - With/without .do suffix (case-insensitive for file extension)
-     * - Prefix commands: quietly do child.do, cap include child.do, nobreak do child.do
+     * - Prefix commands: quietly do child.do, nobreak do child.do, version 18.0: do child.do
      * - @lsp-do, @lsp-run, @lsp-include directives in comments
      *
      * Case-sensitivity:
@@ -1014,7 +1014,7 @@ export class DirectiveParser {
      * - Quoted paths: do "child.do", include "path/child.do"
      * - Unquoted paths: do child.do, run child
      * - With/without .do suffix (case-insensitive for file extension)
-     * - Prefix commands: quietly do child.do, cap include child.do, nobreak do child.do
+     * - Prefix commands: quietly do child.do, nobreak do child.do, version 18.0: do child.do
      * - @lsp-do, @lsp-run, @lsp-include directives in comments
      *
      * Case-sensitivity:

--- a/src/directive-parser/index.ts
+++ b/src/directive-parser/index.ts
@@ -824,7 +824,7 @@ export class DirectiveParser {
      * - Quoted paths: do "child.do", include "path/child.do"
      * - Unquoted paths: do child.do, run child
      * - With/without .do suffix (case-insensitive for file extension)
-     * - Prefix commands: quietly do child.do, cap include child.do, noi run child.do
+     * - Prefix commands: quietly do child.do, cap include child.do, nobreak do child.do
      * - @lsp-do, @lsp-run, @lsp-include directives in comments
      *
      * Case-sensitivity:
@@ -1014,7 +1014,7 @@ export class DirectiveParser {
      * - Quoted paths: do "child.do", include "path/child.do"
      * - Unquoted paths: do child.do, run child
      * - With/without .do suffix (case-insensitive for file extension)
-     * - Prefix commands: quietly do child.do, cap include child.do, noi run child.do
+     * - Prefix commands: quietly do child.do, cap include child.do, nobreak do child.do
      * - @lsp-do, @lsp-run, @lsp-include directives in comments
      *
      * Case-sensitivity:

--- a/src/utils/stata-call-patterns.ts
+++ b/src/utils/stata-call-patterns.ts
@@ -9,14 +9,15 @@
 
 // Stata prefix commands that can legally precede `do`, `run`, or `include`.
 // Keywords must be lowercase (Stata is case-sensitive). Written so that every
-// whitespace run is consumed by exactly one `\s+` when this fragment is wrapped
-// in `(?:(?:<prefix>)\s+)*`, avoiding nested-quantifier ReDoS (CodeQL js/redos).
+// whitespace is consumed by a single non-nested quantifier at each syntactic
+// boundary when this fragment is wrapped in `(?:(?:<prefix>)\s+)*`, avoiding
+// nested-quantifier ReDoS (CodeQL js/redos).
 //
 // Intentionally excluded: `timer` is a standalone command in Stata
 // (`timer on 1`, `timer off 1`, `timer clear`, `timer list`), not a prefix
 // command — `timer do "x.do"` is not legal syntax.
 export const CALL_PREFIX_ALTERNATIVES =
-    /qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|nobreak|version\s+\d+(?:\.\d+)?/.source;
+    /qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|nobreak|version\s+\d+(?:\.\d+)?\s*:/.source;
 
 /**
  * Mode for {@link build_do_include_pattern}:

--- a/src/utils/stata-call-patterns.ts
+++ b/src/utils/stata-call-patterns.ts
@@ -16,7 +16,7 @@
 // (`timer on 1`, `timer off 1`, `timer clear`, `timer list`), not a prefix
 // command — `timer do "x.do"` is not legal syntax.
 export const CALL_PREFIX_ALTERNATIVES =
-    /qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|version\s+\d+(?:\.\d+)?/.source;
+    /qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|nobreak|version\s+\d+(?:\.\d+)?/.source;
 
 /**
  * Mode for {@link build_do_include_pattern}:

--- a/src/utils/stata-call-patterns.ts
+++ b/src/utils/stata-call-patterns.ts
@@ -8,16 +8,17 @@
  */
 
 // Stata prefix commands that can legally precede `do`, `run`, or `include`.
-// Keywords must be lowercase (Stata is case-sensitive). Written so that every
-// whitespace is consumed by a single non-nested quantifier at each syntactic
-// boundary when this fragment is wrapped in `(?:(?:<prefix>)\s+)*`, avoiding
-// nested-quantifier ReDoS (CodeQL js/redos).
+// Keywords must be lowercase (Stata is case-sensitive). Simple prefixes require
+// whitespace after the prefix; `version #:` can be adjacent to the next command.
 //
 // Intentionally excluded: `timer` is a standalone command in Stata
 // (`timer on 1`, `timer off 1`, `timer clear`, `timer list`), not a prefix
 // command — `timer do "x.do"` is not legal syntax.
 export const CALL_PREFIX_ALTERNATIVES =
-    /qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|nobreak|version\s+\d+(?:\.\d+)?\s*:/.source;
+    /qui(?:etly)?|cap(?:ture)?|noi(?:sily)?|nobreak/.source;
+
+const CALL_PREFIX_WITH_SEPARATOR =
+    `(?:(?:${CALL_PREFIX_ALTERNATIVES})\\s+|version\\s+\\d+(?:\\.\\d+)?\\s*:\\s*)`;
 
 /**
  * Mode for {@link build_do_include_pattern}:
@@ -41,6 +42,6 @@ const PATH_CAPTURE_SUFFIX = '(?:"([^"]+)"|([^\\s,]+))';
 export function build_do_include_pattern(mode: DoIncludePatternMode): RegExp {
     const path_suffix = mode === 'capture' ? PATH_CAPTURE_SUFFIX : '';
     return new RegExp(
-        `^\\s*(?:(?:${CALL_PREFIX_ALTERNATIVES})\\s+)*\\s*(do|include|run)\\s+${path_suffix}`,
+        `^\\s*(?:${CALL_PREFIX_WITH_SEPARATOR})*(do|include|run)\\s+${path_suffix}`,
     );
 }

--- a/tests/unit/directive-parser-classify-call-line.test.ts
+++ b/tests/unit/directive-parser-classify-call-line.test.ts
@@ -29,7 +29,10 @@ describe('DirectiveParser.classify_call_line', () => {
         expect(parser.classify_call_line('nobreak do "x.do"')).toBe('do');
         expect(parser.classify_call_line('nobreak include x.do')).toBe('include');
         expect(parser.classify_call_line('nobreak run "x.do"')).toBe('run');
+        expect(parser.classify_call_line('nobreak capture do "x.do"')).toBe('do');
+        expect(parser.classify_call_line('quietly nobreak do "x.do"')).toBe('do');
         expect(parser.classify_call_line('version 18.0: do "x.do"')).toBe('do');
+        expect(parser.classify_call_line('version 18.0:do "x.do"')).toBe('do');
         expect(parser.classify_call_line('version 18.0 : include x.do')).toBe('include');
     });
 

--- a/tests/unit/directive-parser-classify-call-line.test.ts
+++ b/tests/unit/directive-parser-classify-call-line.test.ts
@@ -26,6 +26,9 @@ describe('DirectiveParser.classify_call_line', () => {
         expect(parser.classify_call_line('qui do "x.do"')).toBe('do');
         expect(parser.classify_call_line('cap include x.do')).toBe('include');
         expect(parser.classify_call_line('noisily run "x.do"')).toBe('run');
+        expect(parser.classify_call_line('nobreak do "x.do"')).toBe('do');
+        expect(parser.classify_call_line('nobreak include x.do')).toBe('include');
+        expect(parser.classify_call_line('nobreak run "x.do"')).toBe('run');
     });
 
     test('rejects a pathless do command', () => {

--- a/tests/unit/directive-parser-classify-call-line.test.ts
+++ b/tests/unit/directive-parser-classify-call-line.test.ts
@@ -29,11 +29,17 @@ describe('DirectiveParser.classify_call_line', () => {
         expect(parser.classify_call_line('nobreak do "x.do"')).toBe('do');
         expect(parser.classify_call_line('nobreak include x.do')).toBe('include');
         expect(parser.classify_call_line('nobreak run "x.do"')).toBe('run');
+        expect(parser.classify_call_line('version 18.0: do "x.do"')).toBe('do');
+        expect(parser.classify_call_line('version 18.0 : include x.do')).toBe('include');
     });
 
     test('rejects a pathless do command', () => {
         expect(parser.classify_call_line('do ')).toBeUndefined();
         expect(parser.classify_call_line('do')).toBeUndefined();
+    });
+
+    test('rejects invalid no-colon version prefix commands', () => {
+        expect(parser.classify_call_line('version 18.0 do "x.do"')).toBeUndefined();
     });
 
     test('accepts a real path with a trailing comment', () => {

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -676,6 +676,15 @@ global after 2
         expect(result).toBe(1);
     });
 
+    test('infer_call_site_for_file should match lowercase with nobreak prefix', () => {
+        const parent_content = `global setup 1
+nobreak do "child.do"
+global after 2
+`;
+        const result = parser.infer_call_site_for_file(parent_content, 'child.do');
+        expect(result).toBe(1);
+    });
+
     test('infer_call_site_for_file should NOT treat bare timer as a prefix', () => {
         const parent_content = `global setup 1
 timer do "child.do"

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -685,6 +685,24 @@ global after 2
         expect(result).toBe(1);
     });
 
+    test('infer_call_site_for_file should match lowercase with version colon prefix', () => {
+        const parent_content = `global setup 1
+version 18.0: do "child.do"
+global after 2
+`;
+        const result = parser.infer_call_site_for_file(parent_content, 'child.do');
+        expect(result).toBe(1);
+    });
+
+    test('infer_call_site_for_file should NOT match invalid no-colon version prefix', () => {
+        const parent_content = `global setup 1
+version 18.0 do "child.do"
+global after 2
+`;
+        const result = parser.infer_call_site_for_file(parent_content, 'child.do');
+        expect(result).toBeUndefined();
+    });
+
     test('infer_call_site_for_file should NOT treat bare timer as a prefix', () => {
         const parent_content = `global setup 1
 timer do "child.do"

--- a/tests/unit/directive-parser.test.ts
+++ b/tests/unit/directive-parser.test.ts
@@ -694,6 +694,24 @@ global after 2
         expect(result).toBe(1);
     });
 
+    test('infer_call_site_for_file should match version prefix with no post-colon space', () => {
+        const parent_content = `global setup 1
+version 18.0:do "child.do"
+global after 2
+`;
+        const result = parser.infer_call_site_for_file(parent_content, 'child.do');
+        expect(result).toBe(1);
+    });
+
+    test('infer_call_site_for_file should match chained nobreak prefix orderings', () => {
+        const parent_content = `global setup 1
+nobreak capture do "child.do"
+global after 2
+`;
+        const result = parser.infer_call_site_for_file(parent_content, 'child.do');
+        expect(result).toBe(1);
+    });
+
     test('infer_call_site_for_file should NOT match invalid no-colon version prefix', () => {
         const parent_content = `global setup 1
 version 18.0 do "child.do"


### PR DESCRIPTION
## Summary
- Add `nobreak` to the shared Stata call-prefix pattern for `do`, `run`, and `include` detection.
- Align `version` prefix handling with real Stata syntax: accept `version 18.0: do ...`, `version 18.0 : do ...`, and `version 18.0:do ...`; reject invalid `version 18.0 do ...`.
- Cover both call-site inference and single-line call classification, including chained prefix orderings.
- Keep `timer` excluded because it is a standalone Stata command, not a legal prefix.

Closes #143.

## Stata verification
I ran temporary batch do-files through the installed `stata` CLI to confirm accepted and rejected forms. Real Stata accepted bare `do`/`run`/`include`, `quietly`/`qui`, `capture`/`cap`, `noisily`/`noi`, `nobreak`, chained `capture nobreak` / `nobreak capture`, and colon-form `version` prefixes with or without spaces around the colon. It rejected uppercase `Nobreak`, prefix-like `nobreaking`, abbreviated `nobr`/`nobre`/`nobrea`, `timer`, and no-colon `version 18.0 do ...`.

## Review notes
A Claude review found no blocking correctness issues. It raised low-severity gaps around possible `nobreak` abbreviations, reversed prefix ordering, and `version 18.0:do` with no post-colon space. I checked those against Stata; abbreviations are invalid, reversed prefix ordering is valid, and `version 18.0:do` is valid. This PR now includes coverage/fixes for those valid forms.

## ReDoS note
`nobreak` is a literal alternation with no internal whitespace matcher. The regex builder models prefixes with their separators so ordinary prefixes require whitespace while `version #:` can be adjacent to the following command.

## Testing
- `stata -b do /private/tmp/sight-stata-prefix-check-292-20260704/prefix-check.do`
- `stata -b do /private/tmp/sight-stata-prefix-check-292-20260704/version-spacing.do`
- `stata -b do /private/tmp/sight-stata-prefix-check-292-20260704/claude-followup.do`
- `bun test tests/unit/directive-parser.test.ts`
- `bun test tests/unit/directive-parser-classify-call-line.test.ts`
- `bun run test`
- `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of Stata `do`, `run`, and `include` calls with additional prefix-command formats, including `nobreak` and `version 18.0:` variants.
  * Fixed handling of spacing around the `version ...:` prefix so valid call sites are detected more reliably.
  * Invalid prefix formats without the required colon are still rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->