### PR TITLE
Add a post-compute diagnostics publish gate (#293)

### DIFF
--- a/src/providers/diagnostics-publish-gate.ts
+++ b/src/providers/diagnostics-publish-gate.ts
@@ -1,0 +1,49 @@
+/**
+ * Gate diagnostics publication by document version, while allowing counted
+ * same-version force republishes for dependency-triggered recomputation.
+ */
+export class DiagnosticsPublishGate {
+    private last_published: Map<string, number> = new Map();
+    private force_budget: Map<string, number> = new Map();
+
+    would_publish(uri: string, version: number): boolean {
+        const last_version = this.last_published.get(uri);
+        if (last_version === undefined || version > last_version) {
+            return true;
+        }
+
+        const budget = this.force_budget.get(uri) ?? 0;
+        return version === last_version && budget > 0;
+    }
+
+    try_consume_publish(uri: string, version: number): boolean {
+        const last_version = this.last_published.get(uri);
+        if (last_version === undefined || version > last_version) {
+            this.last_published.set(uri, version);
+            this.force_budget.delete(uri);
+            return true;
+        }
+
+        const budget = this.force_budget.get(uri) ?? 0;
+        if (version === last_version && budget > 0) {
+            if (budget === 1) {
+                this.force_budget.delete(uri);
+            } else {
+                this.force_budget.set(uri, budget - 1);
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    mark_force_republish(uri: string): void {
+        const budget = this.force_budget.get(uri) ?? 0;
+        this.force_budget.set(uri, budget + 1);
+    }
+
+    forget(uri: string): void {
+        this.last_published.delete(uri);
+        this.force_budget.delete(uri);
+    }
+}

--- a/src/providers/diagnostics-publish-gate.ts
+++ b/src/providers/diagnostics-publish-gate.ts
@@ -1,36 +1,46 @@
 /**
- * Gate diagnostics publication by document version, while allowing counted
- * same-version force republishes for dependency-triggered recomputation.
+ * Gate diagnostics publication by document version and per-URI force epoch.
  */
 export class DiagnosticsPublishGate {
-    private last_published: Map<string, number> = new Map();
-    private force_budget: Map<string, number> = new Map();
+    private last_published_version: Map<string, number> = new Map();
+    private last_published_epoch: Map<string, number> = new Map();
+    private current_epoch: Map<string, number> = new Map();
 
-    would_publish(uri: string, version: number): boolean {
-        const last_version = this.last_published.get(uri);
-        if (last_version === undefined || version > last_version) {
-            return true;
-        }
-
-        const budget = this.force_budget.get(uri) ?? 0;
-        return version === last_version && budget > 0;
+    get_current_epoch(uri: string): number {
+        return this.current_epoch.get(uri) ?? 0;
     }
 
-    try_consume_publish(uri: string, version: number): boolean {
-        const last_version = this.last_published.get(uri);
-        if (last_version === undefined || version > last_version) {
-            this.last_published.set(uri, version);
-            this.force_budget.delete(uri);
+    would_publish(uri: string, version: number, epoch: number): boolean {
+        const my_last_version = this.last_published_version.get(uri);
+        if (my_last_version === undefined || version > my_last_version) {
             return true;
         }
 
-        const budget = this.force_budget.get(uri) ?? 0;
-        if (version === last_version && budget > 0) {
-            if (budget === 1) {
-                this.force_budget.delete(uri);
-            } else {
-                this.force_budget.set(uri, budget - 1);
-            }
+        if (version < my_last_version) {
+            return false;
+        }
+
+        const my_current_epoch = this.current_epoch.get(uri) ?? 0;
+        const my_last_epoch = this.last_published_epoch.get(uri) ?? 0;
+        return epoch === my_current_epoch && epoch > my_last_epoch;
+    }
+
+    try_consume_publish(uri: string, version: number, epoch: number): boolean {
+        const my_last_version = this.last_published_version.get(uri);
+        if (my_last_version === undefined || version > my_last_version) {
+            this.last_published_version.set(uri, version);
+            this.last_published_epoch.set(uri, epoch);
+            return true;
+        }
+
+        if (version < my_last_version) {
+            return false;
+        }
+
+        const my_current_epoch = this.current_epoch.get(uri) ?? 0;
+        const my_last_epoch = this.last_published_epoch.get(uri) ?? 0;
+        if (epoch === my_current_epoch && epoch > my_last_epoch) {
+            this.last_published_epoch.set(uri, epoch);
             return true;
         }
 
@@ -38,12 +48,12 @@ export class DiagnosticsPublishGate {
     }
 
     mark_force_republish(uri: string): void {
-        const budget = this.force_budget.get(uri) ?? 0;
-        this.force_budget.set(uri, budget + 1);
+        this.current_epoch.set(uri, (this.current_epoch.get(uri) ?? 0) + 1);
     }
 
     forget(uri: string): void {
-        this.last_published.delete(uri);
-        this.force_budget.delete(uri);
+        this.last_published_version.delete(uri);
+        this.last_published_epoch.delete(uri);
+        this.current_epoch.delete(uri);
     }
 }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -45,6 +45,7 @@ import { OperatorSequenceAnalyzer } from './operator-sequence-diagnostics';
 import { MixedLogicalOperatorAnalyzer } from './mixed-logical-diagnostics';
 import { ChainedComparisonAnalyzer } from './chained-comparison-diagnostics';
 import { LiteralMacroAdjacencyAnalyzer } from './literal-macro-adjacency-diagnostics';
+import { DiagnosticsPublishGate } from './diagnostics-publish-gate';
 type SemanticDiagnostic = {
     message: string;
     range: Range;
@@ -165,8 +166,7 @@ export class DiagnosticsProvider {
     private literal_macro_adjacency_analyzer = new LiteralMacroAdjacencyAnalyzer();
     private dependency_graph?: import('../dependency-graph').DependencyGraph;
 
-    // Track published versions to prevent stale diagnostics
-    private published_versions: Map<string, number> = new Map();
+    private publish_gate = new DiagnosticsPublishGate();
 
     // Cache filtered diagnostics by (uri, version, config_hash)
     private filtered_cache: Map<string, Map<string, Diagnostic[]>> = new Map();
@@ -211,14 +211,11 @@ export class DiagnosticsProvider {
     }
 
     /**
-     * Clear the published version for a document.
-     * This forces the next publish_diagnostics call to actually publish,
-     * even if the document version hasn't changed.
+     * Mark a document for forced same-version republish.
      * Used when dependencies change and diagnostics need to be recomputed.
      */
-    clear_published_version(uri: string): void {
-        this.published_versions.delete(uri);
-        // Also clear the filtered cache for this URI
+    mark_force_republish(uri: string): void {
+        this.publish_gate.mark_force_republish(uri);
         this.filtered_cache.delete(uri);
     }
 
@@ -240,35 +237,46 @@ export class DiagnosticsProvider {
         scope_resolver?: ScopeResolver,
         cancellation_token?: CancellationToken
     ): Promise<{ diagnostics: Diagnostic[]; pending: boolean }> {
-        // Version gating: only publish if this is the latest version
-        const current_published = this.published_versions.get(document.uri);
-        if (current_published !== undefined && current_published >= document.version) {
-            // Stale request, skip
+        if (!this.publish_gate.would_publish(document.uri, document.version)) {
             return { diagnostics: [], pending: false };
         }
 
         // Check if diagnostics are enabled
         if (!config?.diagnostics?.enabled) {
-            // Clear diagnostics and return
+            if (!this.publish_gate.try_consume_publish(
+                document.uri,
+                document.version
+            )) {
+                return { diagnostics: [], pending: false };
+            }
             this.clear_diagnostics(document.uri);
-            this.published_versions.set(document.uri, document.version);
             return { diagnostics: [], pending: false };
         }
 
         // Check if debounce is pending for this document
-        const is_pending = this.debounce_manager?.is_pending(document.uri) ?? false;
+        const is_pending =
+            this.debounce_manager?.is_pending(document.uri) ?? false;
 
         // Collect all diagnostics (reuse cached results from DocumentStore)
-        const the_diagnostics = await this.get_diagnostics(document, config, workspace_symbols, scope_resolver, cancellation_token);
+        const the_diagnostics = await this.get_diagnostics(
+            document,
+            config,
+            workspace_symbols,
+            scope_resolver,
+            cancellation_token
+        );
 
-        // Publish diagnostics
+        if (!this.publish_gate.try_consume_publish(
+            document.uri,
+            document.version
+        )) {
+            return { diagnostics: [], pending: is_pending };
+        }
+
         this.connection.sendDiagnostics({
             uri: document.uri,
             diagnostics: the_diagnostics,
         });
-
-        // Update published version
-        this.published_versions.set(document.uri, document.version);
         
         return { diagnostics: the_diagnostics, pending: is_pending };
     }
@@ -841,7 +849,7 @@ export class DiagnosticsProvider {
      * Remove tracking for a closed document.
      */
     on_document_closed(uri: string): void {
-        this.published_versions.delete(uri);
+        this.publish_gate.forget(uri);
         this.clear_cache_for_document(uri);
         this.clear_diagnostics(uri);
     }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -237,7 +237,13 @@ export class DiagnosticsProvider {
         scope_resolver?: ScopeResolver,
         cancellation_token?: CancellationToken
     ): Promise<{ diagnostics: Diagnostic[]; pending: boolean }> {
-        if (!this.publish_gate.would_publish(document.uri, document.version)) {
+        const my_epoch = this.publish_gate.get_current_epoch(document.uri);
+
+        if (!this.publish_gate.would_publish(
+            document.uri,
+            document.version,
+            my_epoch
+        )) {
             return { diagnostics: [], pending: false };
         }
 
@@ -245,7 +251,8 @@ export class DiagnosticsProvider {
         if (!config?.diagnostics?.enabled) {
             if (!this.publish_gate.try_consume_publish(
                 document.uri,
-                document.version
+                document.version,
+                my_epoch
             )) {
                 return { diagnostics: [], pending: false };
             }
@@ -268,7 +275,8 @@ export class DiagnosticsProvider {
 
         if (!this.publish_gate.try_consume_publish(
             document.uri,
-            document.version
+            document.version,
+            my_epoch
         )) {
             return { diagnostics: [], pending: is_pending };
         }
@@ -293,6 +301,8 @@ export class DiagnosticsProvider {
         scope_resolver?: ScopeResolver,
         cancellation_token?: CancellationToken
     ): Promise<Diagnostic[]> {
+        const cache_epoch_at_start =
+            this.publish_gate.get_current_epoch(document.uri);
         // Generate config hash for cache key
         const config_hash = this.compute_config_hash(config);
         
@@ -725,13 +735,21 @@ export class DiagnosticsProvider {
             }
         }
 
-        // Cache the filtered diagnostics
-        let cache_for_uri = this.filtered_cache.get(document.uri);
-        if (!cache_for_uri) {
-            cache_for_uri = new Map();
-            this.filtered_cache.set(document.uri, cache_for_uri);
+        // Cache the filtered diagnostics if no force epoch advanced mid-run.
+        if (
+            this.publish_gate.get_current_epoch(document.uri) ===
+            cache_epoch_at_start
+        ) {
+            let cache_for_uri = this.filtered_cache.get(document.uri);
+            if (!cache_for_uri) {
+                cache_for_uri = new Map();
+                this.filtered_cache.set(document.uri, cache_for_uri);
+            }
+            cache_for_uri.set(
+                `${document.version}:${config_hash}`,
+                the_diagnostics
+            );
         }
-        cache_for_uri.set(`${document.version}:${config_hash}`, the_diagnostics);
 
         return the_diagnostics;
     }

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -531,10 +531,10 @@ export async function create_server(options: ServerOptions): Promise<void> {
 
             const callee_doc = documents.get(my_callee_uri);
             if (callee_doc) {
-                // Clear the published version so diagnostics will be republished
-                // even though the callee document's version hasn't changed
+                // Mark a forced republish so diagnostics update even though
+                // the callee document's version hasn't changed.
                 if (diagnostics_provider) {
-                    diagnostics_provider.clear_published_version(my_callee_uri);
+                    diagnostics_provider.mark_force_republish(my_callee_uri);
                 }
 
                 // Route through debounce instead of setTimeout (Req 3.1, 3.2)
@@ -663,10 +663,10 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 connection.console.log(`[caller-revalidation] Checking ${my_caller_uri}: doc=${caller_doc ? 'found' : 'not found'}`);
             }
             if (caller_doc) {
-                // Clear the published version so diagnostics will be republished
-                // even though the caller document's version hasn't changed
+                // Mark a forced republish so diagnostics update even though
+                // the caller document's version hasn't changed.
                 if (diagnostics_provider) {
-                    diagnostics_provider.clear_published_version(my_caller_uri);
+                    diagnostics_provider.mark_force_republish(my_caller_uri);
                 }
 
                 // Route through debounce instead of setTimeout (Req 3.1, 3.2)
@@ -736,7 +736,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
             if (!my_doc) {
                 continue;
             }
-            diagnostics_provider?.clear_published_version(
+            diagnostics_provider?.mark_force_republish(
                 my_callee_uri
             );
             void validate_text_document(my_doc, 0);
@@ -744,13 +744,13 @@ export async function create_server(options: ServerOptions): Promise<void> {
     }
 
     /**
-     * Clear published diagnostics and re-trigger validation for all
+     * Force diagnostics republish and re-trigger validation for all
      * currently open documents. Called after workspace state changes.
      */
     function revalidate_all_open_docs(): void {
         for (const my_doc of documents.all()) {
             if (diagnostics_provider) {
-                diagnostics_provider.clear_published_version(my_doc.uri);
+                diagnostics_provider.mark_force_republish(my_doc.uri);
             }
             void validate_text_document(my_doc, 0);
         }
@@ -1458,7 +1458,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
             // No indexing-affecting change: keep the index intact,
             // reconfigure providers, and revalidate open documents
             // immediately against the live index. revalidate_all_open_docs
-            // clears each document's published version and re-validates.
+            // marks each document for forced republish and re-validates.
             configure_completion_provider(settings);
             workspace_indexer?.configure(settings);
             revalidate_all_open_docs();

--- a/tests/integration/cmd-hover-peek-flicker.test.ts
+++ b/tests/integration/cmd-hover-peek-flicker.test.ts
@@ -163,7 +163,7 @@ describe('Cmd-hover peek lifecycle flicker (parent open then close)', () => {
     });
 
     async function child_diagnostics() {
-        provider.clear_published_version(child_uri);
+        provider.mark_force_republish(child_uri);
         return provider.get_diagnostics(
             store.get(child_uri) as never,
             build_config(),

--- a/tests/integration/cross-file-close-flicker.test.ts
+++ b/tests/integration/cross-file-close-flicker.test.ts
@@ -155,7 +155,7 @@ describe('cross-file diagnostic flicker on parent close', () => {
     });
 
     async function child_diagnostics() {
-        provider.clear_published_version(child_uri);
+        provider.mark_force_republish(child_uri);
         return provider.get_diagnostics(
             store.get(child_uri) as never,
             build_config(),

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -549,6 +549,84 @@ describe('DiagnosticsProvider', () => {
                 expect(sent_after_a_resumes.length).toBe(1);
             }
         );
+
+        it(
+            'should drop a forced same-version republish superseded ' +
+                'by a version advance',
+            async () => {
+                const document_v1 = create_document_state(
+                    'display `undefined\'\n',
+                    1
+                );
+                const document_v2 = create_document_state('gen y = 2\n', 2);
+                const original_get_diagnostics = provider.get_diagnostics.bind(
+                    provider
+                );
+                let resolve_a: (() => void) | undefined;
+                let resolve_a_started: (() => void) | undefined;
+                let my_delayed_a = false;
+                const a_started = new Promise<void>(resolve => {
+                    resolve_a_started = resolve;
+                });
+                const a_delay = new Promise<void>(resolve => {
+                    resolve_a = resolve;
+                });
+
+                // Publish v1 so a same-version force is meaningful.
+                await provider.publish_diagnostics(document_v1, DEFAULT_CONFIG);
+                mock_connection.clear_sent_diagnostics();
+
+                provider.get_diagnostics = async (
+                    my_document: DocumentState,
+                    the_config: StataLSPConfig,
+                    the_workspace_symbols?: SymbolTable,
+                    the_scope_resolver?: ScopeResolver,
+                    the_cancellation_token?: CancellationToken
+                ): Promise<Diagnostic[]> => {
+                    const the_diagnostics = await original_get_diagnostics(
+                        my_document,
+                        the_config,
+                        the_workspace_symbols,
+                        the_scope_resolver,
+                        the_cancellation_token
+                    );
+
+                    if (!my_delayed_a && my_document.version === 1) {
+                        my_delayed_a = true;
+                        resolve_a_started?.();
+                        await a_delay;
+                    }
+
+                    return the_diagnostics;
+                };
+
+                // Forced same-version republish A captures epoch at v1 and
+                // stalls mid-compute.
+                provider.mark_force_republish(document_v1.uri);
+                const publish_a = provider.publish_diagnostics(
+                    document_v1,
+                    DEFAULT_CONFIG
+                );
+                await a_started;
+
+                // The document advances to v2 and publishes to completion
+                // while A is still in flight.
+                await provider.publish_diagnostics(document_v2, DEFAULT_CONFIG);
+
+                const sent_after_v2 = mock_connection.get_sent_diagnostics();
+                expect(sent_after_v2.length).toBe(1);
+                expect(resolve_a).toBeDefined();
+
+                // A resumes: its captured v1 is now older than the published
+                // v2, so it must be dropped (version dominates the epoch).
+                resolve_a?.();
+                await publish_a;
+
+                const sent_after_a_resumes =
+                    mock_connection.get_sent_diagnostics();
+                expect(sent_after_a_resumes.length).toBe(1);
+            }
+        );
     });
 
     describe('clear_diagnostics', () => {

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -3,7 +3,10 @@ import {
     create_real_document_state,
 } from '../test-context-helper';
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
-import { DiagnosticsProvider } from '../../src/providers/diagnostics';
+import {
+    DiagnosticsConnection,
+    DiagnosticsProvider,
+} from '../../src/providers/diagnostics';
 import { DocumentState } from '../../src/document-store';
 import {
     CrossFileCaseMismatchSeverity,
@@ -28,19 +31,39 @@ import { ScopeResolver } from '../../src/scope-resolver';
  * ResolvedScope. Used to exercise forward-call symbol filtering and
  * directive-diagnostic emission without standing up a full resolver.
  */
-function make_stub_scope_resolver(resolved_scope: ResolvedScope): ScopeResolver {
+function make_stub_scope_resolver(
+    resolved_scope: ResolvedScope
+): ScopeResolver {
     const the_stub = new ScopeResolver();
-    (the_stub as any).resolve = async () => resolved_scope;
+    the_stub.resolve = async () => resolved_scope;
     return the_stub;
 }
 
-// Mock connection for testing
-function create_mock_connection() {
-    const sent_diagnostics: { uri: string; diagnostics: any[] }[] = [];
+function create_empty_resolved_scope(): ResolvedScope {
     return {
-        sendDiagnostics: mock((params: { uri: string; diagnostics: any[] }) => {
-            sent_diagnostics.push(params);
-        }),
+        chain: [],
+        symbols: create_empty_symbol_table(),
+        out_of_scope_symbols: [],
+        diagnostics: [],
+        has_directives: false,
+        has_auto_parents: false,
+        is_standalone: false,
+        scan_complete_at_resolve_time: true,
+    };
+}
+
+// Mock connection for testing
+function create_mock_connection(): DiagnosticsConnection & {
+    get_sent_diagnostics(): { uri: string; diagnostics: Diagnostic[] }[];
+    clear_sent_diagnostics(): void;
+} {
+    const sent_diagnostics: { uri: string; diagnostics: Diagnostic[] }[] = [];
+    return {
+        sendDiagnostics: mock(
+            (params: { uri: string; diagnostics: Diagnostic[] }) => {
+                sent_diagnostics.push(params);
+            }
+        ),
         get_sent_diagnostics: () => sent_diagnostics,
         clear_sent_diagnostics: () => { sent_diagnostics.length = 0; },
     };
@@ -139,7 +162,7 @@ describe('DiagnosticsProvider', () => {
 
     beforeEach(() => {
         mock_connection = create_mock_connection();
-        provider = new DiagnosticsProvider(mock_connection as any);
+        provider = new DiagnosticsProvider(mock_connection);
     });
 
     describe('get_diagnostics', () => {
@@ -281,6 +304,59 @@ describe('DiagnosticsProvider', () => {
             // Diagnostics are still computed, but publish_diagnostics would clear them
             expect(the_diagnostics.length).toBeGreaterThan(0);
         });
+
+        it('should not cache diagnostics if force epoch advances', async () => {
+            const document = create_document_state(
+                'display `undefined\'\n',
+                1
+            );
+            const delayed_scope_resolver = new ScopeResolver();
+            let my_resolve_count = 0;
+            let resolve_first: (() => void) | undefined;
+            let resolve_first_started: (() => void) | undefined;
+            const first_started = new Promise<void>(resolve => {
+                resolve_first_started = resolve;
+            });
+            const first_delay = new Promise<void>(resolve => {
+                resolve_first = resolve;
+            });
+
+            delayed_scope_resolver.resolve =
+                async (): Promise<ResolvedScope> => {
+                    my_resolve_count++;
+                    if (my_resolve_count === 1) {
+                        resolve_first_started?.();
+                        await first_delay;
+                    }
+                    return create_empty_resolved_scope();
+                };
+
+            const first_diagnostics_promise = provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                delayed_scope_resolver
+            );
+            await first_started;
+
+            provider.mark_force_republish(document.uri);
+            expect(resolve_first).toBeDefined();
+            resolve_first?.();
+
+            const first_diagnostics = await first_diagnostics_promise;
+            expect(my_resolve_count).toBe(1);
+
+            const second_diagnostics = await provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                delayed_scope_resolver
+            );
+
+            expect(my_resolve_count).toBe(2);
+            expect(second_diagnostics).not.toBe(first_diagnostics);
+            expect(second_diagnostics).toEqual(first_diagnostics);
+        });
     });
 
     describe('publish_diagnostics', () => {
@@ -385,7 +461,7 @@ describe('DiagnosticsProvider', () => {
             expect(sent_after_v1_resumes[0].diagnostics).toEqual([]);
         });
 
-        it('should count same-version force republishes', async () => {
+        it('should publish once for one same-version force epoch', async () => {
             const document = create_document_state('gen x = 1\n', 1);
 
             await provider.publish_diagnostics(document, DEFAULT_CONFIG);
@@ -403,6 +479,76 @@ describe('DiagnosticsProvider', () => {
             const sent_without_mark = mock_connection.get_sent_diagnostics();
             expect(sent_without_mark.length).toBe(0);
         });
+
+        it(
+            'should drop older same-version work after newer force work',
+            async () => {
+                const document = create_document_state(
+                    'display `undefined\'\n',
+                    1
+                );
+                const original_get_diagnostics = provider.get_diagnostics.bind(
+                    provider
+                );
+                let resolve_a: (() => void) | undefined;
+                let resolve_a_started: (() => void) | undefined;
+                let my_delayed_a = false;
+                const a_started = new Promise<void>(resolve => {
+                    resolve_a_started = resolve;
+                });
+                const a_delay = new Promise<void>(resolve => {
+                    resolve_a = resolve;
+                });
+
+                await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+                mock_connection.clear_sent_diagnostics();
+
+                provider.get_diagnostics = async (
+                    my_document: DocumentState,
+                    the_config: StataLSPConfig,
+                    the_workspace_symbols?: SymbolTable,
+                    the_scope_resolver?: ScopeResolver,
+                    the_cancellation_token?: CancellationToken
+                ): Promise<Diagnostic[]> => {
+                    const the_diagnostics = await original_get_diagnostics(
+                        my_document,
+                        the_config,
+                        the_workspace_symbols,
+                        the_scope_resolver,
+                        the_cancellation_token
+                    );
+
+                    if (!my_delayed_a && my_document.version === 1) {
+                        my_delayed_a = true;
+                        resolve_a_started?.();
+                        await a_delay;
+                    }
+
+                    return the_diagnostics;
+                };
+
+                provider.mark_force_republish(document.uri);
+                const publish_a = provider.publish_diagnostics(
+                    document,
+                    DEFAULT_CONFIG
+                );
+                await a_started;
+
+                provider.mark_force_republish(document.uri);
+                await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+
+                const sent_after_b = mock_connection.get_sent_diagnostics();
+                expect(sent_after_b.length).toBe(1);
+                expect(resolve_a).toBeDefined();
+
+                resolve_a?.();
+                await publish_a;
+
+                const sent_after_a_resumes =
+                    mock_connection.get_sent_diagnostics();
+                expect(sent_after_a_resumes.length).toBe(1);
+            }
+        );
     });
 
     describe('clear_diagnostics', () => {

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -5,8 +5,20 @@ import {
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { DiagnosticsProvider } from '../../src/providers/diagnostics';
 import { DocumentState } from '../../src/document-store';
-import { StataLSPConfig, StataDiagnosticCode, LexerErrorCode, ParseErrorCode, ResolvedScope, CrossFileCaseMismatchSeverity } from '../../src/types';
-import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import {
+    CrossFileCaseMismatchSeverity,
+    LexerErrorCode,
+    ParseErrorCode,
+    ResolvedScope,
+    StataDiagnosticCode,
+    StataLSPConfig,
+    SymbolTable,
+} from '../../src/types';
+import {
+    CancellationToken,
+    Diagnostic,
+    DiagnosticSeverity,
+} from 'vscode-languageserver';
 import { ContextTracker } from '../../src/context-tracker';
 import { create_empty_symbol_table } from '../../src/analyzer';
 import { ScopeResolver } from '../../src/scope-resolver';
@@ -311,6 +323,85 @@ describe('DiagnosticsProvider', () => {
             
             const sent = mock_connection.get_sent_diagnostics();
             expect(sent.length).toBe(0);
+        });
+
+        it('should drop a stale publish that resumes after a newer version', async () => {
+            const document_v1 = create_document_state(
+                'display `undefined\'\n',
+                1
+            );
+            const document_v2 = create_document_state('gen y = 2\n', 2);
+            const original_get_diagnostics = provider.get_diagnostics.bind(
+                provider
+            );
+            let resolve_v1: (() => void) | undefined;
+            let resolve_v1_started: (() => void) | undefined;
+            const v1_started = new Promise<void>(resolve => {
+                resolve_v1_started = resolve;
+            });
+            const v1_delay = new Promise<void>(resolve => {
+                resolve_v1 = resolve;
+            });
+
+            provider.get_diagnostics = async (
+                my_document: DocumentState,
+                the_config: StataLSPConfig,
+                the_workspace_symbols?: SymbolTable,
+                the_scope_resolver?: ScopeResolver,
+                the_cancellation_token?: CancellationToken
+            ): Promise<Diagnostic[]> => {
+                if (my_document.version === 1) {
+                    resolve_v1_started?.();
+                    await v1_delay;
+                }
+
+                return original_get_diagnostics(
+                    my_document,
+                    the_config,
+                    the_workspace_symbols,
+                    the_scope_resolver,
+                    the_cancellation_token
+                );
+            };
+
+            const publish_v1 = provider.publish_diagnostics(
+                document_v1,
+                DEFAULT_CONFIG
+            );
+            await v1_started;
+
+            await provider.publish_diagnostics(document_v2, DEFAULT_CONFIG);
+            const sent_after_v2 = mock_connection.get_sent_diagnostics();
+            expect(sent_after_v2.length).toBe(1);
+            expect(sent_after_v2[0].diagnostics).toEqual([]);
+
+            expect(resolve_v1).toBeDefined();
+            resolve_v1?.();
+            await publish_v1;
+
+            const sent_after_v1_resumes =
+                mock_connection.get_sent_diagnostics();
+            expect(sent_after_v1_resumes.length).toBe(1);
+            expect(sent_after_v1_resumes[0].diagnostics).toEqual([]);
+        });
+
+        it('should count same-version force republishes', async () => {
+            const document = create_document_state('gen x = 1\n', 1);
+
+            await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+            mock_connection.clear_sent_diagnostics();
+
+            provider.mark_force_republish(document.uri);
+            await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+
+            const sent_after_mark = mock_connection.get_sent_diagnostics();
+            expect(sent_after_mark.length).toBe(1);
+            mock_connection.clear_sent_diagnostics();
+
+            await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+
+            const sent_without_mark = mock_connection.get_sent_diagnostics();
+            expect(sent_without_mark.length).toBe(0);
         });
     });
 

--- a/tests/unit/diagnostics-publish-gate.test.ts
+++ b/tests/unit/diagnostics-publish-gate.test.ts
@@ -6,78 +6,138 @@ import {
 describe('DiagnosticsPublishGate', () => {
     const uri = 'file:///test.do';
 
-    it('should advance monotonically for newer versions', () => {
+    it('should allow first publishes and strictly newer versions', () => {
         const gate = new DiagnosticsPublishGate();
+        const my_epoch_0 = gate.get_current_epoch(uri);
 
-        expect(gate.would_publish(uri, 1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1)).toBe(true);
-        expect(gate.would_publish(uri, 2)).toBe(true);
-        expect(gate.try_consume_publish(uri, 2)).toBe(true);
+        expect(my_epoch_0).toBe(0);
+        expect(gate.would_publish(uri, 1, my_epoch_0)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
+
+        expect(gate.would_publish(uri, 2, my_epoch_0)).toBe(true);
+        expect(gate.try_consume_publish(uri, 2, my_epoch_0)).toBe(true);
     });
 
     it('should deny stale versions', () => {
         const gate = new DiagnosticsPublishGate();
+        const my_epoch_0 = gate.get_current_epoch(uri);
 
-        expect(gate.try_consume_publish(uri, 2)).toBe(true);
-        expect(gate.would_publish(uri, 1)).toBe(false);
-        expect(gate.try_consume_publish(uri, 1)).toBe(false);
+        expect(gate.try_consume_publish(uri, 2, my_epoch_0)).toBe(true);
+        expect(gate.would_publish(uri, 1, my_epoch_0)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(false);
     });
 
-    it('should deny same-version publishes when force budget is zero', () => {
+    it('should allow only the current unconsumed same-version epoch', () => {
         const gate = new DiagnosticsPublishGate();
+        const my_epoch_0 = gate.get_current_epoch(uri);
 
-        expect(gate.try_consume_publish(uri, 1)).toBe(true);
-        expect(gate.would_publish(uri, 1)).toBe(false);
-        expect(gate.try_consume_publish(uri, 1)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
+        expect(gate.would_publish(uri, 1, my_epoch_0)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(false);
+
+        gate.mark_force_republish(uri);
+        const my_epoch_1 = gate.get_current_epoch(uri);
+
+        expect(gate.would_publish(uri, 1, my_epoch_1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_1)).toBe(true);
+        expect(gate.would_publish(uri, 1, my_epoch_1)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_1)).toBe(false);
     });
 
-    it('should count same-version force-republish budget exactly', () => {
+    it('should deny stale and non-current same-version epochs', () => {
         const gate = new DiagnosticsPublishGate();
+        const my_epoch_0 = gate.get_current_epoch(uri);
 
-        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
         gate.mark_force_republish(uri);
+        const my_epoch_1 = gate.get_current_epoch(uri);
         gate.mark_force_republish(uri);
-        gate.mark_force_republish(uri);
+        const my_epoch_2 = gate.get_current_epoch(uri);
 
-        expect(gate.try_consume_publish(uri, 1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1)).toBe(false);
+        expect(gate.would_publish(uri, 1, my_epoch_0)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(false);
+        expect(gate.would_publish(uri, 1, my_epoch_1)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_1)).toBe(false);
+        expect(gate.would_publish(uri, 1, my_epoch_2 + 1)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_2 + 1)).toBe(false);
+
+        expect(gate.would_publish(uri, 1, my_epoch_2)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_2)).toBe(true);
     });
 
-    it('should reset force budget when the version advances', () => {
+    it('should not mutate state when checking would_publish', () => {
         const gate = new DiagnosticsPublishGate();
+        const my_epoch_0 = gate.get_current_epoch(uri);
 
-        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
         gate.mark_force_republish(uri);
-        gate.mark_force_republish(uri);
+        const my_epoch_1 = gate.get_current_epoch(uri);
 
-        expect(gate.try_consume_publish(uri, 2)).toBe(true);
-        expect(gate.would_publish(uri, 2)).toBe(false);
-        expect(gate.try_consume_publish(uri, 2)).toBe(false);
+        expect(gate.would_publish(uri, 1, my_epoch_1)).toBe(true);
+        expect(gate.would_publish(uri, 1, my_epoch_1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_1)).toBe(false);
     });
 
-    it('should forget published state and force budget', () => {
+    it('should bump force epochs and enable same-version consumes', () => {
         const gate = new DiagnosticsPublishGate();
+        const my_epoch_0 = gate.get_current_epoch(uri);
 
-        expect(gate.try_consume_publish(uri, 3)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
         gate.mark_force_republish(uri);
+        const my_epoch_1 = gate.get_current_epoch(uri);
+        gate.mark_force_republish(uri);
+        const my_epoch_2 = gate.get_current_epoch(uri);
+
+        expect(my_epoch_1).toBe(my_epoch_0 + 1);
+        expect(my_epoch_2).toBe(my_epoch_1 + 1);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_2)).toBe(true);
+    });
+
+    it('should forget all per-uri state', () => {
+        const gate = new DiagnosticsPublishGate();
+        const my_epoch_0 = gate.get_current_epoch(uri);
+
+        expect(gate.try_consume_publish(uri, 3, my_epoch_0)).toBe(true);
+        gate.mark_force_republish(uri);
+        expect(gate.get_current_epoch(uri)).toBe(1);
+
         gate.forget(uri);
 
-        expect(gate.would_publish(uri, 1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1)).toBe(false);
+        expect(gate.get_current_epoch(uri)).toBe(0);
+        expect(gate.would_publish(uri, 1, 0)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, 0)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, 0)).toBe(false);
     });
 
-    it('should not consume budget when peeking with would_publish', () => {
+    it('should deny older same-version work after newer work consumes', () => {
         const gate = new DiagnosticsPublishGate();
+        const my_epoch_0 = gate.get_current_epoch(uri);
 
-        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
         gate.mark_force_republish(uri);
+        const my_epoch_a = gate.get_current_epoch(uri);
+        gate.mark_force_republish(uri);
+        const my_epoch_b = gate.get_current_epoch(uri);
 
-        expect(gate.would_publish(uri, 1)).toBe(true);
-        expect(gate.would_publish(uri, 1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_b)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_a)).toBe(false);
+    });
+
+    it('should allow newer same-version work after older work consumes', () => {
+        const gate = new DiagnosticsPublishGate();
+        const my_epoch_0 = gate.get_current_epoch(uri);
+
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
+        gate.mark_force_republish(uri);
+        const my_epoch_a = gate.get_current_epoch(uri);
+
+        expect(gate.try_consume_publish(uri, 1, my_epoch_a)).toBe(true);
+
+        gate.mark_force_republish(uri);
+        const my_epoch_b = gate.get_current_epoch(uri);
+
+        expect(gate.try_consume_publish(uri, 1, my_epoch_b)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_a)).toBe(false);
     });
 });

--- a/tests/unit/diagnostics-publish-gate.test.ts
+++ b/tests/unit/diagnostics-publish-gate.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    DiagnosticsPublishGate,
+} from '../../src/providers/diagnostics-publish-gate';
+
+describe('DiagnosticsPublishGate', () => {
+    const uri = 'file:///test.do';
+
+    it('should advance monotonically for newer versions', () => {
+        const gate = new DiagnosticsPublishGate();
+
+        expect(gate.would_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        expect(gate.would_publish(uri, 2)).toBe(true);
+        expect(gate.try_consume_publish(uri, 2)).toBe(true);
+    });
+
+    it('should deny stale versions', () => {
+        const gate = new DiagnosticsPublishGate();
+
+        expect(gate.try_consume_publish(uri, 2)).toBe(true);
+        expect(gate.would_publish(uri, 1)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1)).toBe(false);
+    });
+
+    it('should deny same-version publishes when force budget is zero', () => {
+        const gate = new DiagnosticsPublishGate();
+
+        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        expect(gate.would_publish(uri, 1)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1)).toBe(false);
+    });
+
+    it('should count same-version force-republish budget exactly', () => {
+        const gate = new DiagnosticsPublishGate();
+
+        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        gate.mark_force_republish(uri);
+        gate.mark_force_republish(uri);
+        gate.mark_force_republish(uri);
+
+        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1)).toBe(false);
+    });
+
+    it('should reset force budget when the version advances', () => {
+        const gate = new DiagnosticsPublishGate();
+
+        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        gate.mark_force_republish(uri);
+        gate.mark_force_republish(uri);
+
+        expect(gate.try_consume_publish(uri, 2)).toBe(true);
+        expect(gate.would_publish(uri, 2)).toBe(false);
+        expect(gate.try_consume_publish(uri, 2)).toBe(false);
+    });
+
+    it('should forget published state and force budget', () => {
+        const gate = new DiagnosticsPublishGate();
+
+        expect(gate.try_consume_publish(uri, 3)).toBe(true);
+        gate.mark_force_republish(uri);
+        gate.forget(uri);
+
+        expect(gate.would_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1)).toBe(false);
+    });
+
+    it('should not consume budget when peeking with would_publish', () => {
+        const gate = new DiagnosticsPublishGate();
+
+        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        gate.mark_force_republish(uri);
+
+        expect(gate.would_publish(uri, 1)).toBe(true);
+        expect(gate.would_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1)).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #293.

## Problem

`DiagnosticsProvider.publish_diagnostics` checked the version guard **before**
awaiting diagnostic computation, then sent afterward. Because the only yield
point is `await get_diagnostics(...)`, a stale version-N computation could resume
after a newer version N+1 published and overwrite it with stale diagnostics.
Separately, `clear_published_version(uri)` (used for dependency-triggered
same-version republishes) deleted the tracking entry, so multiple republishes
collapsed silently.

## Fix

A **publish gate** (`DiagnosticsPublishGate`) combining document-version
monotonicity with a per-URI monotonic **force epoch**:

- `publish_diagnostics` captures `get_current_epoch(uri)` **synchronously** at
  its first line, uses it for the cheap non-consuming preflight, and consumes
  the gate **synchronously immediately before `sendDiagnostics`** (no `await`
  between consume and send). If a newer version/epoch published during the
  await, the stale result is dropped without sending.
- `mark_force_republish(uri)` (replaces `clear_published_version`) bumps the
  URI's epoch and still clears the filtered cache. A same-version publish is
  admitted only when its captured epoch equals the current epoch **and** exceeds
  the last-published epoch — so the newest-triggered work wins and older
  in-flight work is denied.
- `get_diagnostics` **fences its `filtered_cache` write** on the same epoch: a
  computation whose epoch was bumped mid-run neither publishes nor repopulates
  the cache, so it can't serve a stale result to a later reader.

## Why the epoch (not a counted budget)

The first implementation used a counted force-republish budget. Review found
that same-URI same-version validations can genuinely overlap — the debounce
layer only serializes across versions (`execute_parse` skips only when
`version < current`) and `max_concurrent_parses` defaults to 2. With a counted
budget this allowed three same-version races: (1) an older in-flight republish
overwriting a newer one, (2) a stale in-flight computation refilling the cache
after a force mark cleared it, and (3) budget leaking under debounce
coalescing. The monotonic-epoch design closes all three; version always
dominates the epoch, so an older document version is never published after a
newer one.

## Tests

- `tests/unit/diagnostics-publish-gate.test.ts` — full epoch contract (monotonic
  advance, stale-version denial, same-version epoch admission/denial,
  would_publish is non-mutating, forget resets state, newest-wins ordering).
- `tests/unit/diagnostics-provider.test.ts` — regressions: stale publish that
  resumes after a newer version is dropped; one force epoch → one same-version
  publish (no leak); older same-version work dropped after newer force work;
  cache write skipped when the epoch advances mid-run; a forced same-version
  republish superseded by a version advance is dropped.

Local gates: `bun run typecheck` clean, `bun test` 7251 pass / 0 fail,
`bun run lint` clean.

## Review

Reviewed with Codex (task-mode) and independent Claude subagents over three
rounds. Round 1 surfaced the three same-version races above (addressed by the
epoch redesign). Rounds 2 and 3 returned clean on the production code from both
reviewers; the only remaining round-3 note was about the discriminating power of
one added guard test (its scenario entangles version-dominance with the epoch
check — both correctly drop the stale work — and the epoch-reread invariant is
pinned by a sibling test).

## Deferrals (out of scope, non-blocking)

- If a force-triggered re-validate is dropped by debounce backpressure
  (`parse_queue` full), the in-flight publish is epoch-denied and no republish
  runs until the next edit — a transient stale display. This exposure is
  **pre-existing** (the old `clear_published_version` path had it too) and
  unchanged by this PR.
- Two historical planning documents still mention the removed
  `clear_published_version` name in prose
  (`.kiro/specs/lsp-architectural-fixes/design.md`,
  `docs/superpowers/plans/2026-06-21-sight-toml-config.md`). Not live code; left
  as point-in-time records.

https://claude.ai/code/session_01Y4P3JWN6QaBAJ56F8SingA
