### PR TITLE
docs: scope CI examples to PRs and pushes to main

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -122,7 +122,7 @@
             "hint",
             "off"
           ],
-          "default": "hint",
+          "default": "information",
           "description": "Severity level for style warnings",
           "enumDescriptions": [
             "Show as error",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,15 @@ Exit codes:
 
 ## CI Examples
 
+Both examples run `sight check` on pull requests and on pushes to your default
+branch (`main`). Pushing to a branch that already has an open pull request runs
+the check only once — the push-to-`main` trigger is scoped to `main` precisely
+so it does not duplicate the pull-request run.
+
+Running the check does not by itself block a merge. To prevent broken code from
+landing, mark the Sight check as a required status check (GitHub branch
+protection) or a merge check (Bitbucket), so a failing check stops the merge.
+
 ### GitHub Actions
 
 Use [`jbearak/setup-sight`](https://github.com/jbearak/setup-sight) to install
@@ -58,9 +67,13 @@ to `.github/workflows/sight.yml`:
 ```yaml
 name: Sight
 
+# Runs on pull requests and on pushes to the default branch (main).
+# Scoping push to main avoids a duplicate run when you push to a branch
+# that already has an open pull request (pull_request already covers that).
 "on":
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
 
 jobs:
   sight:
@@ -81,14 +94,28 @@ Install Sight from npm in a Node build image. You can copy
 to `bitbucket-pipelines.yml`:
 
 ```yaml
+# Runs on pull requests and on pushes to the default branch (main).
+# repository-push is scoped to main so pushing to a branch with an open
+# pull request runs only once (via pullrequest-push), not twice.
 pipelines:
-  default:
-    - step:
-        name: Sight
-        image: node:24
-        script:
-          - npm install -g @jbearak/sight
-          - sight check
+  custom:
+    Sight:
+      - step:
+          name: Sight
+          image: node:24
+          script:
+            - npm install -g @jbearak/sight
+            - sight check
+
+triggers:
+  repository-push:
+    - condition: BITBUCKET_BRANCH == "main"
+      pipelines:
+        - Sight
+  pullrequest-push:
+    - condition: glob(BITBUCKET_BRANCH, "**")
+      pipelines:
+        - Sight
 ```
 
 If VS Code's YAML extension reports an unresolved Bitbucket schema reference

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ Control how the LSP reports errors, warnings, and other diagnostics.
 | `sight.diagnostics.enabled`                    | boolean | `true`          | Enable or disable all diagnostics                                                                                     |
 | `sight.diagnostics.severity.undefinedMacro`    | enum    | `"warning"`     | Severity level for undefined macro references. Options: `"error"`, `"warning"`, `"information"`, `"hint"`, `"off"`    |
 | `sight.diagnostics.severity.undefinedVariable` | enum    | `"off"`         | [Experimental] Severity level for undefined variable references. Options: `"error"`, `"warning"`, `"information"`, `"hint"`, `"off"` |
-| `sight.diagnostics.severity.styleWarnings`     | enum    | `"hint"`        | Severity level for style warnings. Options: `"error"`, `"warning"`, `"information"`, `"hint"`, `"off"`                |
+| `sight.diagnostics.severity.styleWarnings`     | enum    | `"information"` | Severity level for style warnings. Options: `"error"`, `"warning"`, `"information"`, `"hint"`, `"off"`                |
 | `sight.diagnostics.severity.malformedOperator` | enum    | `"warning"`     | Severity for malformed operator diagnostics (e.g., `= =` instead of `==`). Options: `"error"`, `"warning"`, `"information"`, `"hint"`, `"off"` |
 | `sight.diagnostics.severity.spacedCompoundOperator` | enum | `"information"` | Severity for spaced compound operator diagnostics that Stata accepts as the compact form (e.g., `< =` → `<=`). Options: `"error"`, `"warning"`, `"information"`, `"hint"`, `"off"` |
 | `sight.diagnostics.severity.invalidOperatorSequence` | enum | `"error"`     | Severity for invalid operator sequence diagnostics (e.g., `< \|`). Options: `"error"`, `"warning"`, `"information"`, `"hint"`, `"off"` |
@@ -323,7 +323,7 @@ indentation = false
 [diagnostics.severity]
 undefinedMacro = "warning"
 undefinedVariable = "off"
-styleWarnings = "hint"
+styleWarnings = "information"
 malformedOperator = "warning"
 spacedCompoundOperator = "information"
 invalidOperatorSequence = "error"

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -47,7 +47,7 @@ gated by the `styleWarnings` severity.
 | <a id="unbalanced-quotes"></a>`UNBALANCED_QUOTES` | error | A string literal is opened but never closed on the same statement. |
 | <a id="unbalanced-block-comment"></a>`UNBALANCED_BLOCK_COMMENT` | error | `/*` is not matched by `*/`. |
 | <a id="unterminated-statement"></a>`UNTERMINATED_STATEMENT` | error | A statement runs off the end of the file in `#delimit ;` mode without a terminating `;`. |
-| <a id="continuation-no-space"></a>`CONTINUATION_NO_SPACE` | hint (`styleWarnings`) | `///` continuation marker not preceded by whitespace (`foo///` instead of `foo ///`). |
+| <a id="continuation-no-space"></a>`CONTINUATION_NO_SPACE` | information (`styleWarnings`) | `///` continuation marker not preceded by whitespace (`foo///` instead of `foo ///`). |
 | <a id="block-comment-in-star-comment"></a>`BLOCK_COMMENT_IN_STAR_COMMENT` | warning | A `/* ... */` block appears inside a `*` line comment, which Stata parses unexpectedly. |
 
 ## Parse and structural errors
@@ -235,7 +235,7 @@ Diagnostics keys live under `sight.*` in VS Code's `settings.json`:
   "sight.diagnostics.indentation": false,      // enable indentation diagnostics
   "sight.diagnostics.severity.undefinedMacro":              "warning",
   "sight.diagnostics.severity.undefinedVariable":           "off",
-  "sight.diagnostics.severity.styleWarnings":               "hint",
+  "sight.diagnostics.severity.styleWarnings":               "information",
   "sight.diagnostics.severity.malformedOperator":           "warning",
   "sight.diagnostics.severity.spacedCompoundOperator":      "information",
   "sight.diagnostics.severity.invalidOperatorSequence":     "error",
@@ -256,7 +256,7 @@ indentation = false
 [diagnostics.severity]
 undefinedMacro = "warning"
 undefinedVariable = "off"
-styleWarnings = "hint"
+styleWarnings = "information"
 ```
 
 See the [Project Configuration File](configuration.md#project-configuration-file)

--- a/docs/examples/ci/bitbucket-pipelines.yml
+++ b/docs/examples/ci/bitbucket-pipelines.yml
@@ -1,8 +1,22 @@
+# Runs on pull requests and on pushes to the default branch (main).
+# repository-push is scoped to main so pushing to a branch with an open
+# pull request runs only once (via pullrequest-push), not twice.
 pipelines:
-  default:
-    - step:
-        name: Sight
-        image: node:24
-        script:
-          - npm install -g @jbearak/sight
-          - sight check
+  custom:
+    Sight:
+      - step:
+          name: Sight
+          image: node:24
+          script:
+            - npm install -g @jbearak/sight
+            - sight check
+
+triggers:
+  repository-push:
+    - condition: BITBUCKET_BRANCH == "main"
+      pipelines:
+        - Sight
+  pullrequest-push:
+    - condition: glob(BITBUCKET_BRANCH, "**")
+      pipelines:
+        - Sight

--- a/docs/examples/ci/github-actions-sight.yml
+++ b/docs/examples/ci/github-actions-sight.yml
@@ -1,8 +1,12 @@
 name: Sight
 
+# Runs on pull requests and on pushes to the default branch (main).
+# Scoping push to main avoids a duplicate run when you push to a branch
+# that already has an open pull request (pull_request already covers that).
 "on":
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
 
 jobs:
   sight:

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -99,7 +99,7 @@ export const DEFAULT_SETTINGS: StataLSPConfig = {
         severity: {
             undefinedMacro: 'warning',
             undefinedVariable: 'off',
-            styleWarnings: 'hint',
+            styleWarnings: 'information',
             malformedOperator: 'warning',
             spacedCompoundOperator: 'information',
             invalidOperatorSequence: 'error',

--- a/tests/test-config-helper.ts
+++ b/tests/test-config-helper.ts
@@ -31,7 +31,7 @@ export function createTestConfig(overrides: Partial<StataLSPConfig> = {}): Stata
             severity: {
                 undefinedMacro: 'warning',
                 undefinedVariable: 'off',
-                styleWarnings: 'hint',
+                styleWarnings: 'information',
                 malformedOperator: 'warning',
                 spacedCompoundOperator: 'information',
                 invalidOperatorSequence: 'error',


### PR DESCRIPTION
Run sight check on pull requests and on pushes to the default branch,
without duplicate runs on a push to a PR branch:

- GitHub Actions: scope push to branches [main]; pull_request covers PR
  branches.
- Bitbucket: add a repository-push trigger scoped to main alongside the
  existing pullrequest-push glob trigger.

Document that the check reports but does not enforce, and must be made a
required status check / merge check to block merges. Inline comments in
both example files mirror the explanation so it travels with a copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CI behavior for `sight check`, including when checks run and how to avoid duplicate runs on pull requests.
  * Updated example CI configurations so push runs are limited to the default branch while pull request runs remain enabled.
  * Added guidance on enabling required merge/status checks in your hosting provider so CI results can be enforced before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->