### PR TITLE
Fix #301: parse valid #delimit ; brace blocks without spurious errors

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -728,6 +728,14 @@ export class StataParser {
         range: prefix_token.range,
       };
 
+      // In `#delimit ;` mode the lexer emits WHITESPACE tokens between the
+      // prefix and what follows it — an optional colon, a chained prefix, or a
+      // `{ ... }` block (elided in `#delimit cr` mode). Skip that spacing
+      // before each of those checks so the prefix is not misparsed and its
+      // block is recognized rather than treated as a stray open brace (issue
+      // #301). Whitespace only — a comment here must not be discarded.
+      this.skipWhitespace();
+
       // Handle 'by' prefix with variable list
       if (prefix_token.value === 'by') {
         if (this.check('COLON')) {
@@ -742,6 +750,7 @@ export class StataParser {
       if (this.check('COLON')) {
         this.advance();
         prefix.has_colon = true;
+        this.skipWhitespace();
       }
 
       prefixes.push(prefix);
@@ -805,12 +814,7 @@ export class StataParser {
       this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
       const body: StataNode[] = [];
-      while (!this.check('RBRACE') && !this.isAtEnd()) {
-        const stmt = this.parseStatement();
-        if (stmt) {
-          body.push(stmt);
-        }
-      }
+      body.push(...this.parseBraceBody());
       if (this.check('RBRACE')) {
         const rbrace_index = this.current;
         const rbrace_token = this.advance(); // consume }
@@ -1963,12 +1967,7 @@ export class StataParser {
       const has_condition_before = lbrace_token.range.start.line === condition_start_line;
       this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
-      while (!this.check('RBRACE') && !this.isAtEnd()) {
-        const stmt = this.parseStatement();
-        if (stmt) {
-          body.push(stmt);
-        }
-      }
+      body.push(...this.parseBraceBody());
 
       if (this.check('RBRACE')) {
         const rbrace_index = this.current;
@@ -1991,6 +1990,13 @@ export class StataParser {
 
   private parseElseStatement(): ControlFlowNode {
     const elseToken = this.advance(); // consume 'else'
+
+    // In `#delimit ;` mode the lexer emits a WHITESPACE token between `else`
+    // and what follows (elided in `#delimit cr` mode), so skip that spacing
+    // before the `else if` / brace checks. Without this an `else {` on its own
+    // line is misparsed as a single-statement else whose statement is a stray
+    // `{` (issue #301). Whitespace only — a comment here must not be discarded.
+    this.skipWhitespace();
 
     // Check for 'if' (else if)
     if (this.checkWord('if')) {
@@ -2015,12 +2021,7 @@ export class StataParser {
       const has_condition_before = lbrace_token.range.start.line === elseToken.range.start.line;
       this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
-      while (!this.check('RBRACE') && !this.isAtEnd()) {
-        const stmt = this.parseStatement();
-        if (stmt) {
-          body.push(stmt);
-        }
-      }
+      body.push(...this.parseBraceBody());
 
       if (this.check('RBRACE')) {
         const rbrace_index = this.current;
@@ -2067,10 +2068,16 @@ export class StataParser {
     let loopVar = '';
     let loopSpec = '';
 
-    // Parse loop variable
+    // Parse loop variable. In `#delimit ;` mode the lexer emits WHITESPACE
+    // tokens between the keyword, the loop variable, and the spec keyword
+    // (they are elided in `#delimit cr` mode), so skip that spacing before
+    // each discrete token check (issue #301). Whitespace only — a comment here
+    // must not be discarded.
+    this.skipWhitespace();
     if (this.check('WORD')) {
       loopVar = this.advance().value;
     }
+    this.skipWhitespace();
 
     // Parse loop specification
     // For forvalues: next token is '=' (OPERATOR)
@@ -2156,12 +2163,7 @@ export class StataParser {
       const has_condition_before = lbrace_token.range.start.line === loop_start_line;
       this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
-      while (!this.check('RBRACE') && !this.isAtEnd()) {
-        const stmt = this.parseStatement();
-        if (stmt) {
-          body.push(stmt);
-        }
-      }
+      body.push(...this.parseBraceBody());
 
       if (this.check('RBRACE')) {
         const rbrace_index = this.current;
@@ -2244,12 +2246,7 @@ export class StataParser {
       const has_condition_before = lbrace_token.range.start.line === while_start_line;
       this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
-      while (!this.check('RBRACE') && !this.isAtEnd()) {
-        const stmt = this.parseStatement();
-        if (stmt) {
-          body.push(stmt);
-        }
-      }
+      body.push(...this.parseBraceBody());
 
       if (this.check('RBRACE')) {
         const rbrace_index = this.current;
@@ -2379,13 +2376,7 @@ export class StataParser {
     this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
     // Parse body
-    const body: StataNode[] = [];
-    while (!this.check('RBRACE') && !this.isAtEnd()) {
-      const stmt = this.parseStatement();
-      if (stmt) {
-        body.push(stmt);
-      }
-    }
+    const body: StataNode[] = this.parseBraceBody();
 
     if (this.check('RBRACE')) {
       const rbrace_index = this.current;
@@ -2573,6 +2564,58 @@ export class StataParser {
     while (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK') || this.check('CONTINUATION') || this.check('WHITESPACE')) {
       this.advance();
     }
+  }
+
+  /**
+   * Skip only WHITESPACE tokens, leaving comments and continuations in place.
+   *
+   * `#delimit ;` mode emits a WHITESPACE token between adjacent tokens that
+   * `#delimit cr` mode elides (e.g. between a loop keyword and its variable,
+   * `else` and its brace, or a prefix and its block). Structural checks that
+   * only need to tolerate that interstitial spacing use this rather than
+   * skipTrivia(), which would silently discard comment trivia at those
+   * positions — dropping user comments from the formatter output (issue #301).
+   */
+  private skipWhitespace(): void {
+    while (this.check('WHITESPACE')) {
+      this.advance();
+    }
+  }
+
+  /**
+   * Parse the statements of a brace-delimited block body, stopping at the
+   * matching `}` (left unconsumed for the caller to validate) or EOF.
+   *
+   * In `#delimit ;` mode a raw newline before `}` is emitted as a WHITESPACE
+   * token (elided in `#delimit cr` mode), so the closing brace can be preceded
+   * by trivia. This loop consumes that leading trivia — carrying comments
+   * forward via pending_trivia exactly as parseStatement would — and then
+   * checks for `}` itself, so the closing brace is never handed to
+   * parseStatement, which would misreport it as an orphan (issue #301).
+   *
+   * A comment sitting between the last body statement and the closing brace is
+   * left in pending_trivia so it attaches to the statement after the block —
+   * identical to how the parser already handles that comment in `#delimit cr`
+   * mode. (Folding it into the last body node's trailing trivia instead makes
+   * the AST pretty-printer emit it inline on the preceding statement's line,
+   * corrupting output; repositioning block-ending comments is out of scope.)
+   */
+  private parseBraceBody(): StataNode[] {
+    const body: StataNode[] = [];
+    while (!this.isAtEnd()) {
+      const my_trivia = this.collectTrivia();
+      if (my_trivia.length > 0) {
+        this.pending_trivia.push(...my_trivia);
+      }
+      if (this.check('RBRACE') || this.isAtEnd()) {
+        break;
+      }
+      const stmt = this.parseStatement();
+      if (stmt) {
+        body.push(stmt);
+      }
+    }
+    return body;
   }
 
   // Skip trivia within a macro definition statement, bridging `///`

--- a/src/providers/indentation-diagnostics.ts
+++ b/src/providers/indentation-diagnostics.ts
@@ -760,12 +760,6 @@ export class IndentationDiagnosticAnalyzer {
    * `document.diagnostics` and `document.ast` are produced by the same parse
    * pass, so the two are consistent and the taint toggles together with the
    * diagnostics in a single publish — no transient flicker in healthy regions.
-   *
-   * Known limitation (issue #301): the parser emits a spurious
-   * ORPHAN_CLOSE_BRACE on valid `#delimit ;` brace blocks, so those blocks are
-   * tainted and their genuine indentation issues go unreported until that
-   * parser bug is fixed. This is the conservative side of the trade-off (a
-   * miss, not a false positive).
    */
   private compute_structural_taint(document: DocumentState): Set<number> {
     const tainted_lines = new Set<number>();

--- a/tests/integration/indentation-missing-symmetric.test.ts
+++ b/tests/integration/indentation-missing-symmetric.test.ts
@@ -77,13 +77,21 @@ describe('symmetric AST-depth indentation diagnostics (issue #300)', () => {
     expect(unnecessary_lines(source)).toEqual([]);
   });
 
-  test('suppresses MISSING inside a block corrupted by a structural error', () => {
-    // `#delimit ;` with braces: the error-recovering parser misparents the
-    // trailing `#delimit cr` into the unterminated `if` block, giving that
-    // column-0 line a bogus expected depth. The AST-depth check must not flag
-    // it (the formatter can't fix it either). Verified via the structural
-    // taint gate: the malformed `if` block is tainted, so no false positive.
-    const source = '#delimit ;\nif 1 {;\n    display 1;\n};\n#delimit cr';
+  test('flags an under-indented #delimit ; brace body (issue #301)', () => {
+    // Before #301 was fixed, valid `#delimit ;` brace blocks emitted a
+    // spurious ORPHAN_CLOSE_BRACE, so the structural taint gate suppressed all
+    // AST-depth indentation checks inside them. Now the block parses cleanly,
+    // so a genuinely under-indented body line must be flagged.
+    const source =
+      '#delimit ;\nforvalues i=1/3 {;\ndisplay 1;\n};\n#delimit cr';
+    // Line 2 (`display 1;` at column 0) has expected depth 1 but actual 0.
+    expect(missing_lines(source)).toEqual([2]);
+    expect(unnecessary_lines(source)).toEqual([]);
+  });
+
+  test('does not flag a correctly indented #delimit ; brace body (issue #301)', () => {
+    const source =
+      '#delimit ;\nforvalues i=1/3 {;\n    display 1;\n};\n#delimit cr';
     expect(missing_lines(source)).toEqual([]);
     expect(unnecessary_lines(source)).toEqual([]);
   });

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -802,6 +802,180 @@ end`;
     });
   });
 
+  describe('#delimit ; brace blocks (issue #301)', () => {
+    // In `#delimit ;` mode the lexer emits WHITESPACE tokens between tokens
+    // (in `#delimit cr` mode they are elided). A valid brace block must parse
+    // without spurious ORPHAN_CLOSE_BRACE / SYNTAX_ERROR on its closing brace.
+    const parse = (source: string) =>
+      parser.parse(lexer.tokenize(source).tokens);
+
+    const structural_error_codes = new Set([
+      'ORPHAN_CLOSE_BRACE',
+      'OPEN_BRACE_ALONE',
+      'SYNTAX_ERROR',
+    ]);
+    const structural_errors = (source: string) =>
+      parse(source).errors.filter(
+        e => e.code && structural_error_codes.has(e.code)
+      );
+
+    // Trailing-trivia contents of a node, tolerant of union members that do
+    // not carry trivia.
+    // Recursively collect the contents of every leading/trailing trivia node
+    // in the tree, tolerant of union members that do not carry trivia.
+    type MaybeTriviaNode = {
+      leadingTrivia?: { content: string }[];
+      trailingTrivia?: { content: string }[];
+      body?: MaybeTriviaNode[];
+    };
+    const collect_all_trivia = (nodes: readonly unknown[]): string[] => {
+      const contents: string[] = [];
+      const walk = (the_nodes: MaybeTriviaNode[]): void => {
+        for (const my_node of the_nodes) {
+          for (const t of my_node.leadingTrivia ?? []) contents.push(t.content);
+          for (const t of my_node.trailingTrivia ?? []) contents.push(t.content);
+          if (my_node.body) walk(my_node.body);
+        }
+      };
+      walk(nodes as unknown as MaybeTriviaNode[]);
+      return contents;
+    };
+    const all_comment_contents = (source: string): string =>
+      collect_all_trivia(parse(source).ast.nodes).join('');
+
+    test('forvalues block parses without structural errors', () => {
+      const source =
+        '#delimit ;\nforvalues i=1/3 {;\n    display 1;\n};\n#delimit cr';
+      const result = parse(source);
+      expect(structural_errors(source)).toHaveLength(0);
+      const loop = result.ast.nodes.find(n => n.type === 'forvalues');
+      expect(loop).toBeDefined();
+      if (loop && loop.type === 'forvalues') {
+        expect(loop.loopVar).toBe('i');
+        expect(loop.body).toHaveLength(1);
+      }
+    });
+
+    test('foreach block parses without structural errors', () => {
+      const source =
+        '#delimit ;\nforeach x in a b {;\n    display 1;\n};\n#delimit cr';
+      const result = parse(source);
+      expect(structural_errors(source)).toHaveLength(0);
+      const loop = result.ast.nodes.find(n => n.type === 'foreach');
+      expect(loop).toBeDefined();
+      if (loop && loop.type === 'foreach') {
+        expect(loop.loopVar).toBe('x');
+        expect(loop.body).toHaveLength(1);
+      }
+    });
+
+    test('if block parses without structural errors', () => {
+      const source =
+        '#delimit ;\nif 1 {;\n    display 1;\n};\n#delimit cr';
+      expect(structural_errors(source)).toHaveLength(0);
+    });
+
+    test('while block parses without structural errors', () => {
+      const source =
+        '#delimit ;\nwhile 1 {;\n    display 1;\n};\n#delimit cr';
+      expect(structural_errors(source)).toHaveLength(0);
+    });
+
+    test('nested blocks parse without structural errors', () => {
+      const source =
+        '#delimit ;\nforvalues i=1/3 {;\n    if 1 {;\n' +
+        '        display 1;\n    };\n};\n#delimit cr';
+      expect(structural_errors(source)).toHaveLength(0);
+    });
+
+    test('forvalues with spaces around = parses', () => {
+      const source =
+        '#delimit ;\nforvalues i = 1/3 {;\n    display 1;\n};\n#delimit cr';
+      const result = parse(source);
+      expect(structural_errors(source)).toHaveLength(0);
+      const loop = result.ast.nodes.find(n => n.type === 'forvalues');
+      expect(loop && loop.type === 'forvalues' && loop.loopVar).toBe('i');
+    });
+
+    test('else block parses without structural errors', () => {
+      const source =
+        '#delimit ;\nif 1 {;\n    display 1;\n};\nelse {;\n' +
+        '    display 2;\n};\n#delimit cr';
+      const result = parse(source);
+      expect(structural_errors(source)).toHaveLength(0);
+      expect(result.ast.nodes.some(n => n.type === 'else')).toBe(true);
+    });
+
+    test('prefix brace block parses without structural errors', () => {
+      const source =
+        '#delimit ;\nquietly {;\n    display 1;\n};\n#delimit cr';
+      expect(structural_errors(source)).toHaveLength(0);
+    });
+
+    test('chained prefix brace block parses without structural errors', () => {
+      const source =
+        '#delimit ;\nquietly capture {;\n    display 1;\n};\n#delimit cr';
+      expect(structural_errors(source)).toHaveLength(0);
+    });
+
+    test('prefix-colon brace block with space before colon parses', () => {
+      // `quietly : {` — whitespace before the colon is a WHITESPACE token in
+      // `#delimit ;` mode; the colon must still be consumed and the block
+      // recognized (issue #301).
+      const source =
+        '#delimit ;\nquietly : {;\n    display 1;\n};\n#delimit cr';
+      const result = parse(source);
+      expect(structural_errors(source)).toHaveLength(0);
+      const cmd = result.ast.nodes.find(n => n.type === 'command');
+      expect(cmd && cmd.type === 'command' && cmd.prefix?.[0]?.has_colon).toBe(true);
+    });
+
+    test('chained prefix-colon brace block with spaces parses', () => {
+      const source =
+        '#delimit ;\nquietly capture : {;\n    display 1;\n};\n#delimit cr';
+      expect(structural_errors(source)).toHaveLength(0);
+    });
+
+    test('genuine orphan close brace is still reported', () => {
+      const source = '#delimit ;\ndisplay 1;\n};\n#delimit cr';
+      const codes = parse(source).errors.map(e => e.code);
+      expect(codes).toContain('ORPHAN_CLOSE_BRACE');
+    });
+
+    test('comment before } is preserved and not corrupted', () => {
+      // A comment on its own line just before the closing brace must survive in
+      // the AST (it must never be dropped). Its attachment point matches the
+      // pre-existing `#delimit cr` behavior; this fix does not reposition it.
+      const source =
+        '#delimit ;\nforvalues i=1/3 {;\n    display 1;\n' +
+        '    * inner;\n};\ndisplay 2;\n#delimit cr';
+      const result = parse(source);
+      const loop = result.ast.nodes.find(n => n.type === 'forvalues');
+      expect(loop && loop.type === 'forvalues' && loop.body).toHaveLength(1);
+      expect(collect_all_trivia(result.ast.nodes).join('')).toContain('* inner');
+    });
+
+    // The whitespace-only skips added for #301 must not discard comments that
+    // sit at an adjacency point (between a keyword/prefix and what follows).
+    // These positions are unusual, but a comment there must survive in the AST
+    // so the formatter never deletes it.
+    test('comment between loop keyword and variable is not dropped', () => {
+      expect(all_comment_contents('forvalues /* c */ i=1/3 {\n    display 1\n}'))
+        .toContain('/* c */');
+    });
+
+    test('comment between else and its brace is not dropped', () => {
+      const source =
+        'if 1 {\n    display 1\n}\nelse /* c */ {\n    display 2\n}';
+      expect(all_comment_contents(source)).toContain('/* c */');
+    });
+
+    test('comment between prefix and its block is not dropped', () => {
+      expect(all_comment_contents('quietly /* c */ {\n    display 1\n}'))
+        .toContain('/* c */');
+    });
+  });
+
   describe('macro reference command parsing', () => {
     test('should parse local macro at start of statement', () => {
       const source = '`custom_cmd\' "arg1" "arg2"';


### PR DESCRIPTION
## Summary

Fixes #301. In `#delimit ;` mode the lexer emits `WHITESPACE` tokens between
tokens that `#delimit cr` mode elides. The control-flow parsers assumed cr-mode
adjacency, so **valid** brace blocks emitted spurious `ORPHAN_CLOSE_BRACE`,
`OPEN_BRACE_ALONE`, or `SYNTAX_ERROR`:

- the brace-body loops (`while (!check('RBRACE'))`) saw the `WHITESPACE` before
  `}` and handed the `}` to `parseStatement`, which reported it as an orphan; and
- the discrete keyword / loop-variable / spec / prefix-colon checks failed on
  the interstitial whitespace, cascading into further structural errors.

This was a user-visible false diagnostic on valid code, and it also created an
indentation blind spot: the #300 AST-depth indentation checks are suppressed
inside any block containing a structural error, so genuine `MISSING_INDENTATION`
/ `UNNECESSARY_INDENTATION` inside valid `#delimit ;` blocks went unreported.

## Changes

`src/parser/index.ts`
- Add a shared `parseBraceBody()` that collects pre-`}` trivia and checks
  `RBRACE` itself, so a legitimate close brace is never handed to
  `parseStatement`. Replaces the six identical brace-body loops (prefix block,
  `if`, `else`, loop, `while`, `frame`).
- Add a whitespace-only `skipWhitespace()` used at adjacency points
  (`parseLoopStatement` loop var/spec, `parseElseStatement`, and the
  `parseCommand` prefix loop, including before and after the optional prefix
  colon). Whitespace only — **not** `skipTrivia()` — so comments at those
  positions are preserved rather than discarded from formatter output.

`src/providers/indentation-diagnostics.ts`
- Remove the now-stale #301 limitation note. Valid `#delimit ;` blocks are no
  longer tainted, so genuine indentation issues inside them are reported again.

## Tests

- 19 new parser tests (`tests/unit/parser.test.ts`): every brace form
  (`forvalues`/`foreach`/`if`/`while`/`else`/prefix/chained-prefix), nesting,
  spaces around `=`, prefix-colon blocks with a space before `:`, comment
  preservation at adjacency points, and a guard that genuine orphan braces are
  still reported.
- 2 new indentation tests (`tests/integration/indentation-missing-symmetric.test.ts`):
  the lifted blind spot now flags an under-indented `#delimit ;` body and leaves
  a correctly-indented one clean. (Replaces a test that was built around the
  #301 bug.)
- Full suite green (7266 pass, 0 fail); lint + typecheck clean.

## Review

Codex adversarial review reached two consecutive clean rounds. An earlier round
caught a real in-scope bug (a prefix-colon block with a space before the colon),
now fixed and covered by a test.

## Out of scope (deferred)

Two **pre-existing** behaviors (verified identical on `main`), confirmed
cleanly separable by independent design scopings, are left for a follow-up:

1. **Block-ending comment placement** — a comment on its own line before `}`
   attaches to the statement after the block, matching pre-existing `#delimit cr`
   behavior. Repositioning it inside the block requires a new `blockEndingTrivia`
   AST field plus AST pretty-printer and source-preserving formatter support
   (medium change, broad formatter-test churn). Folding the comment into the
   last body node's `trailingTrivia` was tried and reverted because it corrupts
   AST-formatter output (renders the comment inline on the preceding line).
2. **`#delimit ;` varlist splitting** — e.g. `regress y x;` parses `y` and `x`
   as separate command nodes. This affects all commands (with or without a
   prefix) and is unrelated to brace blocks.

https://claude.ai/code/session_01N1XfzmR354HE7zNLa3bhxY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of brace-based control flow so comments and whitespace are handled correctly in `#delimit ;` mode.
  * Fixed `else`, loop, `if`, `while`, `frame`, and prefix-style blocks to avoid false structural brace errors and preserve nearby comments.

* **Tests**
  * Added coverage for `#delimit ;` brace blocks, including nested cases, spacing variations, and genuine orphan closing braces.
  * Expanded diagnostics checks to verify indentation warnings behave correctly in symmetric cases.

* **Documentation**
  * Removed an outdated limitation note from parser diagnostics comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->