### PR TITLE
Fix #305: parse #delimit ; command varlists without splitting

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -111,7 +111,7 @@ export class StataParser {
     } else if (this.check('WORD') && this.isPrefixCommand(this.peek().value)) {
       // Prefix command - delegate to parseCommand which handles prefix parsing
       node = this.parseCommand();
-    } else if (this.checkWord('program') && this.peekNext()?.value === 'define') {
+    } else if (this.checkWord('program') && this.peekValueAfterWhitespace() === 'define') {
       node = this.parseProgramDefinition();
     } else if (this.checkWord('syntax')) {
       node = this.parseSyntaxCommand();
@@ -336,6 +336,12 @@ export class StataParser {
   private parseProgramDefinition(): ProgramNode {
     const start_token = this.advance(); // consume 'program'
 
+    // In `#delimit ;` mode the lexer emits a WHITESPACE token between `program`
+    // and `define` (elided in `#delimit cr` mode); skip it so the `define`
+    // check succeeds and the program is recognized rather than misparsed as an
+    // ordinary command (issue #305).
+    this.skipWhitespace();
+
     if (!this.checkWord('define')) {
       this.addError('Expected "define" after "program"', this.peek().range);
     } else {
@@ -362,7 +368,24 @@ export class StataParser {
     const was_inside_program = this.inside_program;
     this.inside_program = true;
 
-    while (!this.isAtEnd() && !this.checkWord('end')) {
+    // Collect any leading trivia before re-checking `end`, mirroring
+    // parseBraceBody (issue #301). In `#delimit ;` mode the lexer emits
+    // WHITESPACE tokens — and a comment-only line before `end` is a comment
+    // followed by WHITESPACE — that `#delimit cr` mode elides. Without
+    // consuming that trivia here, parseStatement() would run at the comment,
+    // swallow it plus the following whitespace, and then parse `end` as an
+    // ordinary command, losing the terminator and running the program off to
+    // EOF (issue #305). Carrying the trivia forward via pending_trivia so it
+    // attaches to the statement after the program matches how parseBraceBody
+    // handles a comment before `}`. Inert in cr mode (no WHITESPACE tokens).
+    while (!this.isAtEnd()) {
+      const my_trivia = this.collectTrivia();
+      if (my_trivia.length > 0) {
+        this.pending_trivia.push(...my_trivia);
+      }
+      if (this.checkWord('end') || this.isAtEnd()) {
+        break;
+      }
       const stmt = this.parseStatement();
       if (stmt) {
         body.push(stmt);
@@ -876,35 +899,42 @@ export class StataParser {
 
     // Special handling for frame prefix: frame name: command
     // This handles cases like `capture frame this: that`
-    if (commandName === 'frame' && this.check('WORD')) {
+    // In `#delimit ;` mode the lexer emits a WHITESPACE token between `frame`
+    // and the frame name (elided in `#delimit cr` mode); skip it before the
+    // WORD check so frame-prefix syntax is still recognized (issue #305).
+    // saved_pos is captured before that skip so a non-frame-prefix command
+    // backtracks fully and falls through to parseCommandBody unchanged.
+    if (commandName === 'frame') {
       const saved_pos = this.current;
-      const frame_name_token = this.advance();
-      this.skipTrivia();
-      if (this.check('COLON')) {
-        // This is frame prefix syntax: frame name: command
-        this.advance(); // consume colon
+      this.skipWhitespace();
+      if (this.check('WORD')) {
+        const frame_name_token = this.advance();
+        this.skipTrivia();
+        if (this.check('COLON')) {
+          // This is frame prefix syntax: frame name: command
+          this.advance(); // consume colon
 
-        // Create a prefix node for the frame
-        const frame_prefix: PrefixNode = {
-          type: 'prefix',
-          name: 'frame',
-          fullName: 'frame',
-          frameName: frame_name_token.value,
-          has_colon: true,
-          range: this.makeRange(
-            command_token.range.start,
-            this.previous().range.end
-          ),
-        };
+          // Create a prefix node for the frame
+          const frame_prefix: PrefixNode = {
+            type: 'prefix',
+            name: 'frame',
+            fullName: 'frame',
+            frameName: frame_name_token.value,
+            has_colon: true,
+            range: this.makeRange(
+              command_token.range.start,
+              this.previous().range.end
+            ),
+          };
 
-        // Use shared helper for consistent frame prefix parsing
-        return this.parseFramePrefixedCommand(
-          frame_prefix, prefixes, start_token
-        );
-      } else {
-        // Not frame prefix syntax, backtrack
-        this.current = saved_pos;
+          // Use shared helper for consistent frame prefix parsing
+          return this.parseFramePrefixedCommand(
+            frame_prefix, prefixes, start_token
+          );
+        }
       }
+      // Not frame prefix syntax, backtrack
+      this.current = saved_pos;
     }
 
     // Delegate to parseCommandBody for varlist/expression/qualifier/option parsing
@@ -941,6 +971,11 @@ export class StataParser {
         fullName: prefix_token.value,
         range: prefix_token.range,
       };
+      // In `#delimit ;` mode the lexer emits a WHITESPACE token between the
+      // prefix and its optional colon (elided in `#delimit cr` mode); skip it
+      // before the colon check so `frame m: quietly : cmd` is not split at the
+      // colon, mirroring the main prefix loop (issue #305).
+      this.skipWhitespace();
       // Consume colon after any prefix command
       if (this.check('COLON')) {
         this.advance();
@@ -1006,6 +1041,14 @@ export class StataParser {
     // or 'if' keyword). Use file path coalescing for file commands.
     const varlist: IdentifierNode[] = [];
 
+    // In `#delimit ;` mode the lexer emits a WHITESPACE token between the
+    // command name and its first argument (elided in `#delimit cr` mode).
+    // Skip it so the first argument — including a file path — is recognized
+    // rather than the varlist collection breaking immediately (issue #305).
+    // Whitespace only: a comment here belongs to the following statement's
+    // trivia and must not be discarded.
+    this.skipWhitespace();
+
     // For file commands, try to parse the first argument as a file path
     const is_file_cmd = isFileCommand(command_name);
     const has_file_arg = this.check('WORD') || this.check('NUMBER') ||
@@ -1021,6 +1064,17 @@ export class StataParser {
     // Parse remaining arguments normally (including parenthesized groups)
     while (!this.check('COMMA') && !this.isTrivia() &&
            !this.check('STATEMENT_TERMINATOR') && !this.isAtEnd()) {
+      // In `#delimit ;` mode the lexer emits WHITESPACE tokens between varlist
+      // items that `#delimit cr` mode elides. Skip the interstitial spacing so
+      // each item is collected as its own entry instead of the loop breaking
+      // at the first space (issue #305). Whitespace is the item *separator*, so
+      // skipping it still yields separate entries; it must not merge fragments
+      // that coalesce only when adjacent (wildcards like `var*`), which the
+      // isAdjacentToken()-gated coalescing below still handles correctly.
+      if (this.check('WHITESPACE')) {
+        this.advance();
+        continue;
+      }
       // Stop at 'if' keyword for if-qualifier
       if (this.checkWord('if')) {
         break;
@@ -1106,6 +1160,12 @@ export class StataParser {
             fullName: optionToken.value,
             range: optionToken.range,
           };
+
+          // In `#delimit ;` mode a WHITESPACE token may sit between the option
+          // name and its `(...)` argument (elided in `#delimit cr` mode); skip
+          // it so the argument still attaches to the option rather than the
+          // paren group being misread as a separate option (issue #305).
+          this.skipWhitespace();
 
           // Check for option argument
           if (this.check('LPAREN')) {
@@ -1272,6 +1332,12 @@ export class StataParser {
   ): CommandNode {
     const start_pos = command_token.range.start;
 
+    // In `#delimit ;` mode the lexer emits WHITESPACE tokens around the macro
+    // name, colon, and varlist that `#delimit cr` mode elides. Skip that
+    // spacing before each discrete check so the command is not misparsed
+    // (issue #305).
+    this.skipWhitespace();
+
     // Parse macro name
     if (!this.check('WORD')) {
       this.addError('Expected macro name after unab', this.peek().range);
@@ -1290,6 +1356,8 @@ export class StataParser {
     // This keeps varlists pure (only variable names) while preserving syntax
     let has_colon_before_varlist = false;
 
+    this.skipWhitespace();
+
     // Expect colon
     if (!this.check('COLON')) {
       this.addError(
@@ -1302,6 +1370,7 @@ export class StataParser {
     }
 
     // Parse variable list after colon
+    this.skipWhitespace();
     while ((this.check('WORD') || this.check('MACRO_REF_LOCAL') ||
             this.check('MACRO_REF_GLOBAL') ||
             (this.check('OPERATOR') && (this.peek().value === '*' || this.peek().value === '?'))) &&
@@ -1327,6 +1396,11 @@ export class StataParser {
         name: name,
         range: { start: var_token.range.start, end: end_range },
       });
+
+      // Skip interstitial whitespace before the next varlist item. Placed
+      // after wildcard coalescing so `var*` is still joined via adjacency
+      // (issue #305).
+      this.skipWhitespace();
     }
 
     // Parse options (after comma) - same as regular commands
@@ -1344,6 +1418,11 @@ export class StataParser {
             fullName: option_token.value,
             range: option_token.range,
           };
+
+          // Skip a WHITESPACE token between the option name and its `(...)`
+          // argument in `#delimit ;` mode so the argument still attaches
+          // (issue #305).
+          this.skipWhitespace();
 
           // Check for option argument
           if (this.check('LPAREN')) {
@@ -1389,6 +1468,14 @@ export class StataParser {
 
     while (!this.check('STATEMENT_TERMINATOR') &&
            !this.isAtEnd() && !this.isTrivia()) {
+      // In `#delimit ;` mode the lexer emits WHITESPACE tokens between the
+      // names that `#delimit cr` mode elides; skip that spacing so each name
+      // is collected separately instead of the loop breaking at the first
+      // space (issue #305).
+      if (this.check('WHITESPACE')) {
+        this.advance();
+        continue;
+      }
       const is_varlist_token = this.check('WORD') || this.check('STRING') ||
           this.check('MACRO_REF_LOCAL') || this.check('MACRO_REF_GLOBAL');
       if (is_varlist_token) {
@@ -1424,14 +1511,25 @@ export class StataParser {
     let allows_arbitrary_options = false;
     const seen_option_names = new Set<string>();
 
-    // Collect all tokens until statement terminator or comment
+    // Collect all tokens until statement terminator or comment. In
+    // `#delimit ;` mode the lexer emits interstitial WHITESPACE tokens that
+    // `#delimit cr` mode elides; the index-based spec parsers below assume
+    // cr-mode adjacency (e.g. an option name immediately followed by `(`), so
+    // consume the whitespace but do not collect it. This makes the token array
+    // identical to cr mode and keeps `syntax , opt (string)` parsing the same
+    // in both modes (issue #305). Whitespace is not meaningful within a syntax
+    // spec, so dropping it is safe; comments still stop collection via
+    // isTrivia().
     const syntax_tokens: Token[] = [];
     while (
       !this.check('STATEMENT_TERMINATOR') &&
       !this.isAtEnd() &&
       !this.isTrivia()
     ) {
-      syntax_tokens.push(this.advance());
+      const my_token = this.advance();
+      if (my_token.type !== 'WHITESPACE') {
+        syntax_tokens.push(my_token);
+      }
     }
 
     // Parse the collected tokens
@@ -2314,6 +2412,14 @@ export class StataParser {
    * condition - they just have a frame name followed by brace or colon.
    */
   private parseFrameBlock(): ControlFlowNode | CommandNode | null {
+    // Index of the `frame` token itself. Both non-block fallbacks below
+    // restore to exactly this index so parseCommand re-parses `frame` and its
+    // arguments from the start. A fixed offset (e.g. `saved_position - 1`)
+    // assumed `#delimit cr` adjacency where `frame` immediately precedes the
+    // name; in `#delimit ;` mode a WHITESPACE token sits between them, so the
+    // offset landed on the whitespace and dropped `frame` from the re-parse
+    // (issue #305).
+    const frame_index = this.current;
     const frame_token = this.advance(); // consume 'frame'
     const frame_start_line = frame_token.range.start.line;
 
@@ -2323,7 +2429,7 @@ export class StataParser {
     if (!this.check('WORD')) {
       // Not a frame block/prefix syntax, fall back to command parsing
       // Reset position and return null to let parseCommand handle it
-      this.current--;
+      this.current = frame_index;
       return null;
     }
 
@@ -2331,7 +2437,6 @@ export class StataParser {
 
     // Check if followed by brace (frame block) or colon (frame prefix)
     // We need to look ahead past the frame name
-    const saved_position = this.current;
     this.advance(); // consume frame name
     this.skipTrivia();
 
@@ -2360,7 +2465,7 @@ export class StataParser {
     if (!this.check('LBRACE')) {
       // Not frame block syntax (might be `frame create` or similar)
       // Reset position and return null to let parseCommand handle it
-      this.current = saved_position - 1; // Reset to before 'frame' was consumed
+      this.current = frame_index; // Reset to before 'frame' was consumed
       return null;
     }
 
@@ -2403,6 +2508,12 @@ export class StataParser {
   private parseUnabCommandBody(command_token: Token): CommandNode {
     const start_pos = command_token.range.start;
 
+    // In `#delimit ;` mode the lexer emits WHITESPACE tokens around the macro
+    // name, colon, and varlist that `#delimit cr` mode elides. Skip that
+    // spacing before each discrete check so the command is not misparsed
+    // (issue #305).
+    this.skipWhitespace();
+
     // Parse macro name
     if (!this.check('WORD')) {
       this.addError('Expected macro name after unab', this.peek().range);
@@ -2426,6 +2537,8 @@ export class StataParser {
     // This keeps varlists pure (only variable names) while preserving syntax
     let has_colon_before_varlist = false;
 
+    this.skipWhitespace();
+
     // Expect colon
     if (!this.check('COLON')) {
       this.addError(
@@ -2438,6 +2551,7 @@ export class StataParser {
     }
 
     // Parse variable list after colon
+    this.skipWhitespace();
     while ((this.check('WORD') || this.check('MACRO_REF_LOCAL') ||
             this.check('MACRO_REF_GLOBAL') ||
             (this.check('OPERATOR') && (this.peek().value === '*' || this.peek().value === '?'))) &&
@@ -2463,6 +2577,11 @@ export class StataParser {
         name: name,
         range: { start: var_token.range.start, end: end_range },
       });
+
+      // Skip interstitial whitespace before the next varlist item. Placed
+      // after wildcard coalescing so `var*` is still joined via adjacency
+      // (issue #305).
+      this.skipWhitespace();
     }
 
     // Parse options (after comma)
@@ -2479,6 +2598,10 @@ export class StataParser {
             fullName: option_token.value,
             range: option_token.range,
           };
+          // Skip a WHITESPACE token between the option name and its `(...)`
+          // argument in `#delimit ;` mode so the argument still attaches
+          // (issue #305).
+          this.skipWhitespace();
           if (this.check('LPAREN')) {
             const parsed = this.parse_option_argument_inside_parens();
             option.argument = parsed.argument;
@@ -2783,9 +2906,22 @@ export class StataParser {
     return this.tokens[this.current];
   }
 
-  private peekNext(): Token | undefined {
-    if (this.current + 1 >= this.tokens.length) return undefined;
-    return this.tokens[this.current + 1];
+  /**
+   * Value of the next token after any interstitial WHITESPACE tokens, without
+   * consuming anything. `#delimit ;` mode emits a WHITESPACE token between
+   * tokens that `#delimit cr` mode elides, so a two-token lookahead such as
+   * `program` + `define` needs to skip that spacing (issue #305). Whitespace
+   * only — a comment between the two tokens is not skipped, matching cr mode,
+   * where such a comment is likewise a distinct token that defeats the
+   * adjacency lookahead.
+   */
+  private peekValueAfterWhitespace(): string | undefined {
+    let offset = 1;
+    while (this.current + offset < this.tokens.length &&
+           this.tokens[this.current + offset].type === 'WHITESPACE') {
+      offset++;
+    }
+    return this.tokens[this.current + offset]?.value;
   }
 
   private previous(): Token {
@@ -3042,7 +3178,14 @@ export class StataParser {
       // Stray token and split literal detection - skip if in string context, inside brackets, or if this is a delimiter-only STRING
       // We also skip delimiter-only STRING tokens because they are part of the string literal structure
       // Skip when inside brackets (bracket_depth > 0) because subscript expressions like var[_n-1] are valid
-      if (current_state === 'AFTER_RHS' && token.type !== 'LPAREN' && token.type !== 'RPAREN' && token.type !== 'LBRACKET' && token.type !== 'RBRACKET' && bracket_depth === 0 && !in_string_context && !is_delimiter_only) {
+      // Skip WHITESPACE: in `#delimit ;` mode the lexer preserves interstitial
+      // WHITESPACE tokens (elided in `#delimit cr` mode), which reach this
+      // check in AFTER_RHS state (e.g. the space in `if z > 1 in 1/10`). A
+      // space is never a stray token, so treating it as one produced a false
+      // STRAY_TOKEN_IN_CONDITION on valid semicolon-delimited qualifiers; the
+      // state machine already excludes WHITESPACE from transitions below
+      // (issue #305).
+      if (current_state === 'AFTER_RHS' && token.type !== 'WHITESPACE' && token.type !== 'LPAREN' && token.type !== 'RPAREN' && token.type !== 'LBRACKET' && token.type !== 'RBRACKET' && bracket_depth === 0 && !in_string_context && !is_delimiter_only) {
         // Check for split literal patterns first
         if (prev_token && this.detectSplitLiteral(prev_token, token)) {
           // Split literal diagnostic already emitted by detectSplitLiteral

--- a/tests/unit/analyzer/cd-command-detection.test.ts
+++ b/tests/unit/analyzer/cd-command-detection.test.ts
@@ -79,22 +79,24 @@ describe('Analyzer cd_command detection (issue #252)', () => {
         expect(cd_paths('CD "x"\n')).toEqual([]);
     });
 
-    it('does not record cd under #delimit ; (pre-existing parser limitation)', () => {
-        // KNOWN LIMITATION: under `#delimit ;` the parser does not attach the
-        // path as a varlist argument (`cd "raw";` becomes a `cd` node with no
-        // varlist plus a separate `"raw"` node), so cd is skipped. This affects
-        // do/run/include forward-call detection identically and is out of scope
-        // for #252. Pinned here so the behavior change is explicit if the parser
-        // later gains #delimit ; file-command support.
+    it('records cd under #delimit ; now that the parser attaches the path', () => {
+        // Previously a known limitation: under `#delimit ;` the parser split
+        // the command varlist into separate nodes (`cd "raw";` became a `cd`
+        // node with no varlist plus a stray `"raw"` node), so cd was skipped.
+        // Issue #305 fixed the varlist splitting, so `cd "raw";` now attaches
+        // its path and is recorded — matching `#delimit cr` behavior. The
+        // do/run/include forward-call detection recovers identically.
         const src = `#delimit ;\ncd "raw";\ndo import;\n`;
         const the_lex = my_lexer.tokenize(src);
         const the_parse = my_parser.parse(the_lex.tokens);
         const the_result = my_analyzer.analyze(
             the_parse.ast, 'file:///test.do', undefined, undefined, the_lex.tokens,
         );
-        expect(the_result.cd_commands).toEqual([]);
-        // do/run/include detection is a no-op here too — consistency check.
-        expect(the_result.forward_calls).toEqual([]);
+        expect(the_result.cd_commands).toHaveLength(1);
+        expect(the_result.cd_commands[0]!.raw_path).toBe('raw');
+        // do/run/include detection recovers here too — consistency check.
+        expect(the_result.forward_calls).toHaveLength(1);
+        expect(the_result.forward_calls[0]!.raw_path).toBe('import');
     });
 
     it('records the command range start for ordering', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -976,6 +976,264 @@ end`;
     });
   });
 
+  describe('#delimit ; command varlist (issue #305)', () => {
+    // In `#delimit ;` mode the lexer emits WHITESPACE tokens between varlist
+    // items that `#delimit cr` mode elides. The command-body parser assumed
+    // cr-mode adjacency, so it broke at the first interstitial space, left the
+    // varlist empty, and re-parsed the remaining arguments as fresh statements.
+    // A multi-token command must produce ONE command node with the full
+    // varlist (issue #305).
+    const parse = (source: string) =>
+      parser.parse(lexer.tokenize(source).tokens);
+
+    // Extract the sole command-like node from a parse, tolerant of the
+    // directive nodes that bracket a `#delimit ;` block.
+    type CommandLike = {
+      type: string;
+      name?: string;
+      varlist?: { name: string }[];
+      expression?: string;
+      ifExpression?: string;
+      inExpression?: string;
+      options?: { name: string }[];
+      prefix?: { name: string; has_colon?: boolean }[];
+    };
+    const commands = (source: string): CommandLike[] =>
+      (parse(source).ast.nodes as unknown as CommandLike[]).filter(
+        n => n.type === 'command'
+      );
+    const varlist_names = (c: CommandLike | undefined): string[] =>
+      (c?.varlist ?? []).map(v => v.name);
+
+    // Wrap a command body in a `#delimit ;` block terminated with `;`.
+    const semi = (body: string): string =>
+      `#delimit ;\n${body};\n#delimit cr`;
+
+    test('two-variable command is one node with full varlist', () => {
+      const cmds = commands(semi('regress y x'));
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].name).toBe('regress');
+      expect(varlist_names(cmds[0])).toEqual(['y', 'x']);
+    });
+
+    test('matches #delimit cr parsing of the same command', () => {
+      const cr = commands('regress y x');
+      expect(cr).toHaveLength(1);
+      expect(varlist_names(cr[0])).toEqual(['y', 'x']);
+      // The `#delimit ;` varlist must match the cr-mode varlist exactly.
+      expect(varlist_names(commands(semi('regress y x'))[0])).toEqual(
+        varlist_names(cr[0])
+      );
+    });
+
+    test('three-variable command collects every item', () => {
+      const cmds = commands(semi('summarize a b c'));
+      expect(cmds).toHaveLength(1);
+      expect(varlist_names(cmds[0])).toEqual(['a', 'b', 'c']);
+    });
+
+    test('prefixed command keeps prefix and full varlist in one node', () => {
+      const cmds = commands(semi('quietly regress y x'));
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].name).toBe('regress');
+      expect(cmds[0].prefix?.map(p => p.name)).toEqual(['quietly']);
+      expect(varlist_names(cmds[0])).toEqual(['y', 'x']);
+    });
+
+    test('if/in qualifiers parse after the varlist', () => {
+      const source = semi('regress y x if z > 1 in 1/10');
+      // The space after the comparison must not be flagged as a stray token.
+      expect(parse(source).errors).toHaveLength(0);
+      const cmds = commands(source);
+      expect(cmds).toHaveLength(1);
+      expect(varlist_names(cmds[0])).toEqual(['y', 'x']);
+      expect(cmds[0].ifExpression?.replace(/\s+/g, '')).toBe('z>1');
+      expect(cmds[0].inExpression?.replace(/\s+/g, '')).toBe('1/10');
+    });
+
+    test('qualifier expressions do not emit spurious stray-token errors', () => {
+      // In `#delimit ;` mode the WHITESPACE after a completed comparison
+      // (before `in`, `&`, `,`, or `;`) must not be flagged as a stray token
+      // (issue #305). A genuine stray token is still reported.
+      for (const my_body of [
+        'regress y x if z > 1 in 1/10',
+        'regress y x if z > 1, robust',
+        'regress y x if z > 1',
+        'regress y x if z > 1 & w < 2',
+      ]) {
+        expect(parse(semi(my_body)).errors).toHaveLength(0);
+      }
+      const stray = parse(semi('regress y x if z > 1 2')).errors;
+      expect(stray.some(e => e.code === 'STRAY_TOKEN_IN_CONDITION')).toBe(true);
+    });
+
+    test('options parse after the varlist and comma', () => {
+      const cmds = commands(semi('regress y x, robust cluster(id)'));
+      expect(cmds).toHaveLength(1);
+      expect(varlist_names(cmds[0])).toEqual(['y', 'x']);
+      expect(cmds[0].options?.map(o => o.name)).toEqual(['robust', 'cluster']);
+    });
+
+    test('assignment expression parses after the varlist', () => {
+      const cmds = commands(semi('gen z = x + y'));
+      expect(cmds).toHaveLength(1);
+      expect(varlist_names(cmds[0])).toEqual(['z']);
+      expect(cmds[0].expression?.replace(/\s+/g, '')).toBe('x+y');
+    });
+
+    test('adjacent wildcards coalesce but remain separate items', () => {
+      const cmds = commands(semi('summarize pop* gdp*'));
+      expect(cmds).toHaveLength(1);
+      expect(varlist_names(cmds[0])).toEqual(['pop*', 'gdp*']);
+    });
+
+    test('file-command path with a dot stays a single argument', () => {
+      const cmds = commands(semi('do myfile.do'));
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].name).toBe('do');
+      expect(varlist_names(cmds[0])).toEqual(['myfile.do']);
+    });
+
+    test('args command collects every name', () => {
+      const cmds = commands(semi('args a b c'));
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].name).toBe('args');
+      expect(varlist_names(cmds[0])).toEqual(['a', 'b', 'c']);
+    });
+
+    test('unab command collects macro name and varlist', () => {
+      const cmds = commands(semi('unab vars : pop*'));
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].name).toBe('unab');
+      expect(varlist_names(cmds[0])).toEqual(['vars', 'pop*']);
+    });
+
+    test('frame-prefixed command parses in #delimit ; mode', () => {
+      const cmds = commands(semi('frame mine: regress y x'));
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].name).toBe('regress');
+      expect(cmds[0].prefix?.some(p => p.name === 'frame')).toBe(true);
+      expect(varlist_names(cmds[0])).toEqual(['y', 'x']);
+    });
+
+    test('non-prefix frame subcommand parses as one frame command', () => {
+      // `frame create x;` is a plain `frame` command (subcommand `create`,
+      // arg `x`), not the `frame name:` prefix or `frame name { }` block.
+      // parseFrameBlock must backtrack to the `frame` token — not to the
+      // interstitial WHITESPACE — so parseCommand re-parses it whole (#305).
+      const source = semi('frame create x');
+      const result = parse(source);
+      expect(result.errors).toHaveLength(0);
+      const cmds = commands(source);
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].name).toBe('frame');
+      expect(varlist_names(cmds[0])).toEqual(['create', 'x']);
+    });
+
+    test('frame subcommand matches #delimit cr parsing', () => {
+      const cr = commands('frame change default');
+      expect(cr).toHaveLength(1);
+      expect(cr[0].name).toBe('frame');
+      expect(varlist_names(commands(semi('frame change default'))[0])).toEqual(
+        varlist_names(cr[0])
+      );
+    });
+
+    test('frame block parses without errors in #delimit ; mode', () => {
+      const source = '#delimit ;\nframe mine {;\n  gen x = 1;\n};\n#delimit cr';
+      const result = parse(source);
+      expect(result.errors).toHaveLength(0);
+      expect(result.ast.nodes.some(n => n.type === 'frame')).toBe(true);
+    });
+
+    test('option argument attaches with a space before its paren', () => {
+      // `cluster (id)` — a WHITESPACE token sits between the option name and
+      // its `(...)` in `#delimit ;` mode; the argument must still attach
+      // rather than the paren group being read as a separate option (#305).
+      const cmds = commands(semi('regress y x, cluster (id)'));
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].options?.map(o => o.name)).toEqual(['cluster']);
+      // Matches `#delimit cr` parsing of the same command text.
+      const cr = commands('regress y x, cluster (id)');
+      expect(cmds[0].options?.map(o => o.name)).toEqual(
+        cr[0].options?.map(o => o.name)
+      );
+    });
+
+    test('program define is recognized in #delimit ; mode', () => {
+      // `program` and `define` are separated by a WHITESPACE token in
+      // #delimit ; mode; the lookahead and the define check must tolerate it
+      // so the program is recognized (not misparsed as an ordinary command
+      // that runs off to EOF), and the body must terminate at `end` (#305).
+      const source =
+        '#delimit ;\nprogram define p;\n  display 1;\nend;\n#delimit cr';
+      const result = parse(source);
+      expect(result.errors).toHaveLength(0);
+      const prog = result.ast.nodes.find(n => n.type === 'program');
+      expect(prog).toBeDefined();
+      if (prog && prog.type === 'program') {
+        expect(prog.name).toBe('p');
+        expect(prog.body).toHaveLength(1);
+      }
+      // No stray top-level command named `program` or `end`.
+      const cmd_names = (result.ast.nodes as unknown as CommandLike[])
+        .filter(n => n.type === 'command')
+        .map(n => n.name);
+      expect(cmd_names).not.toContain('program');
+      expect(cmd_names).not.toContain('end');
+    });
+
+    test('program with a comment before end closes and keeps following code', () => {
+      // A comment-only line before `end` must not swallow `end` and the
+      // statements after the program. The body loop collects the comment as
+      // trivia and re-checks `end`, mirroring parseBraceBody (#305).
+      const source =
+        '#delimit ;\nprogram define p;\n  display 1;\n  // note\nend;\n' +
+        'display 2;\n#delimit cr';
+      const result = parse(source);
+      expect(result.errors).toHaveLength(0);
+      const prog = result.ast.nodes.find(n => n.type === 'program');
+      expect(prog && prog.type === 'program' && prog.body).toHaveLength(1);
+      // `display 2` survives as a top-level command after the program.
+      const cmds = commands(source);
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].name).toBe('display');
+    });
+
+    test('syntax option argument attaches across a space before its paren', () => {
+      // `opt (string)` — the WHITESPACE before `(` must not detach the
+      // argument type, matching #delimit cr parsing (#305).
+      const source =
+        '#delimit ;\nprogram define p;\n  syntax , opt (string);\nend;\n#delimit cr';
+      const result = parse(source);
+      expect(result.errors).toHaveLength(0);
+      const prog = result.ast.nodes.find(n => n.type === 'program');
+      const the_syntax = prog && prog.type === 'program'
+        ? prog.body?.find(n => n.type === 'syntax')
+        : undefined;
+      expect(the_syntax).toBeDefined();
+      if (the_syntax && the_syntax.type === 'syntax') {
+        expect(the_syntax.signature.options).toHaveLength(1);
+        expect(the_syntax.signature.options[0].name).toBe('opt');
+        expect(the_syntax.signature.options[0].argumentType).toBe('string');
+      }
+    });
+
+    test('nested prefix colon inside a frame prefix parses in #delimit ; mode', () => {
+      // `frame mine: quietly : cmd` — the WHITESPACE before the inner colon
+      // must not split the statement (#305).
+      const source = semi('frame mine: quietly : regress y x');
+      const result = parse(source);
+      expect(result.errors).toHaveLength(0);
+      const cmds = commands(source);
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].name).toBe('regress');
+      expect(cmds[0].prefix?.map(p => p.name)).toEqual(['frame', 'quietly']);
+      expect(cmds[0].prefix?.every(p => p.has_colon)).toBe(true);
+      expect(varlist_names(cmds[0])).toEqual(['y', 'x']);
+    });
+  });
+
   describe('macro reference command parsing', () => {
     test('should parse local macro at start of statement', () => {
       const source = '`custom_cmd\' "arg1" "arg2"';


### PR DESCRIPTION
## Summary

Fixes #305. In `#delimit ;` mode the lexer emits `WHITESPACE` tokens between
tokens that `#delimit cr` mode elides. The command/varlist parser assumed
cr-mode adjacency, so it broke at the first interstitial space, left the varlist
empty, and re-parsed the remaining arguments as fresh statements — e.g.
`regress y x;` became three `command` nodes (empty `regress`, then `y`, then
`x`) instead of one command with `varlist: ["y", "x"]`. This corrupted the AST
for essentially every multi-token command in a `#delimit ;` file, degrading all
AST-backed features (diagnostics, symbols, hover, completion, go-to-definition,
find-references, formatting).

Same root-cause class as #301 (the `#delimit ;` whitespace-adjacency mismatch),
but on the command/varlist surface rather than brace blocks.

## Approach

All fixes use whitespace-only skips (reusing #301's `skipWhitespace()`, which
preserves comments) and are **provably inert in `#delimit cr` mode**, which
emits no `WHITESPACE` tokens — so cr-mode parsing is untouched. The
whitespace-adjacency defect turned out to be much broader than the varlist; each
fix was verified at cr-vs-`;` structural parity.

Fixes in `src/parser/index.ts`:

- **Command varlist loop** — skip interstitial `WHITESPACE` between items
  (wildcard coalescing still gated on `isAdjacentToken`); skip the space before
  the first argument so file-command paths (`do myfile.do;`) are recognized.
- **`args` and `unab`** — macro name, colon, varlist, and options.
- **Option arguments** across a space before `(` (`cluster (id)`) — all three
  option loops.
- **Frame-name prefix** (`frame m: cmd`) and **`parseFrameBlock`** — replaced the
  fixed `saved_position - 1` backtrack (which landed on the whitespace and
  dropped the `frame` token) with restoration to the `frame` index, so
  non-prefix frame subcommands (`frame create x;`) parse as one command.
- **Nested prefix colons** inside a frame prefix (`frame m: quietly : cmd`).
- **Qualifier stray-token diagnostic** — suppress the false
  `STRAY_TOKEN_IN_CONDITION` on the space after a completed comparison
  (`if z > 1 in 1/10`); genuine stray tokens are still reported.
- **`program define`** — whitespace-tolerant `define` lookahead and check, and a
  body loop that terminates at `end`, including a comment-only line before `end`
  (handled via parseBraceBody-style trivia collection).
- **`syntax` spec parsing** — consume but do not collect `WHITESPACE`, so the
  index-based spec parsers see a cr-identical token array
  (`syntax , opt (string)` attaches its argument type as in cr mode).

A test in `cd-command-detection.test.ts` that pinned the pre-existing limitation
now asserts the recovered behavior: `cd "raw";` and `do import;` under
`#delimit ;` are detected again (the #252 working-directory / forward-call path).

## Tests

Adds a `#delimit ; command varlist (issue #305)` regression block (21 tests)
covering varlists (2+ vars, wildcards, file paths, macros), prefixed commands,
if/in qualifiers (asserting no spurious errors), options and option arguments,
assignment expressions, `args`/`unab`, frame prefix/subcommand/block, nested
frame prefix colons, `program define` with a comment before `end`, and `syntax`
option-argument attachment. Each asserts cr-mode parity.

- `bun run test` (typecheck + full suite): passing (0 failures).
- `bun run lint`: clean.

## Deferred (out of scope)

Tracked in #306: reconstructed **expression / if-in qualifier /
parenthesized-group STRINGS** keep their interstitial spaces in `#delimit ;`
mode whereas `#delimit cr` has none (`x + y` vs `x+y`) — the AST **structure is
identical**, only the internal spacing of those string fields differs. #306 also
notes a pre-existing `#delimit cr` file-command coalescing quirk (`merge 1:1 id
using data` collapses to a single token in cr mode).

https://claude.ai/code/session_01N1XfzmR354HE7zNLa3bhxY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing in `#delimit ;` mode so commands with spacing between keywords, varlists, prefixes, and options are recognized correctly.
  * Fixed handling for commands like `program`, `frame`, `unab`, `args`, `syntax`, `regress`, and `summarize` so they are no longer split or misread when separators include whitespace.
  * Corrected command detection so entries like `cd "raw";` and forward-call cases are recorded consistently.
  * Reduced false stray-token warnings in semicolon-delimited statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->