### PR TITLE
Fix #306: normalize lexer whitespace emission across delimiter modes

### DIFF
--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -1031,6 +1031,12 @@ export class SemanticAnalyzer {
         }
     }
 
+    private semantic_varlist(node: CommandNode): IdentifierNode[] {
+        return (node.varlist ?? []).filter(
+            (item) => item.recovery_only !== true
+        );
+    }
+
     /**
      * Extract static c_local macro names from program body.
      * Only extracts names that are literal identifiers (not macro expansions).
@@ -1039,8 +1045,9 @@ export class SemanticAnalyzer {
         const c_locals: string[] = [];
         for (const node of nodes) {
             if (node.type === 'command') {
-                if (node.fullName === 'c_local' && node.varlist && node.varlist.length > 0) {
-                    const name = node.varlist[0].name;
+                const varlist = this.semantic_varlist(node);
+                if (node.fullName === 'c_local' && varlist.length > 0) {
+                    const name = varlist[0].name;
                     // Only include valid literal identifiers (exclude macro refs like `name')
                     if (is_valid_identifier(name)) {
                         c_locals.push(name);
@@ -1090,9 +1097,10 @@ export class SemanticAnalyzer {
         
         for (const node of nodes) {
             if (node.type === 'command') {
+                const varlist = this.semantic_varlist(node);
                 // Check for c_local `local' pattern (case-sensitive)
-                if (node.fullName === 'c_local' && node.varlist && node.varlist.length > 0) {
-                    const macro_name = node.varlist[0].name;
+                if (node.fullName === 'c_local' && varlist.length > 0) {
+                    const macro_name = varlist[0].name;
                     // Check if it's a macro reference pattern (starts with backtick)
                     if (macro_name.startsWith('`') && macro_name.endsWith("'")) {
                         const inner_name = macro_name.slice(1, -1);
@@ -1104,8 +1112,8 @@ export class SemanticAnalyzer {
                     }
                 }
                 // Check for global `global' pattern (case-sensitive)
-                else if (node.fullName === 'global' && node.varlist && node.varlist.length > 0) {
-                    const macro_name = node.varlist[0].name;
+                else if (node.fullName === 'global' && varlist.length > 0) {
+                    const macro_name = varlist[0].name;
                     // Check if it's a macro reference pattern (starts with backtick)
                     if (macro_name.startsWith('`') && macro_name.endsWith("'")) {
                         const inner_name = macro_name.slice(1, -1);
@@ -1483,14 +1491,15 @@ export class SemanticAnalyzer {
     private extract_command_path(
         node: CommandNode
     ): { raw_path: string; has_macro: boolean } | null {
-        if (!node.varlist || node.varlist.length === 0) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length === 0) {
             return null;
         }
 
         let raw_path = '';
         let has_macro = false;
 
-        const first_item = node.varlist[0];
+        const first_item = varlist[0];
         const first_name = first_item.name;
 
         // Check if this is a complete quoted string (starts and ends with same quote)
@@ -1509,8 +1518,8 @@ export class SemanticAnalyzer {
             raw_path = first_name;
             has_macro = raw_path.includes('`') || raw_path.includes('$');
 
-            for (let i = 1; i < node.varlist.length; i++) {
-                const item_name = node.varlist[i].name;
+            for (let i = 1; i < varlist.length; i++) {
+                const item_name = varlist[i].name;
                 raw_path += item_name;
 
                 // Check for macro references in this item
@@ -1755,21 +1764,22 @@ export class SemanticAnalyzer {
         symbols: SymbolTable,
         node_index: number
     ): void {
-        if (!node.varlist || node.varlist.length === 0) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length === 0) {
             return;
         }
 
-        const scalar_name = node.varlist[0].name;
+        const scalar_name = varlist[0].name;
         this.add_or_append_definition(
             symbols.scalars,
             scalar_name,
             node_index,
-            node.varlist[0].range,
+            varlist[0].range,
             () => ({
                 name: scalar_name,
-                location: { uri: this.uri, range: node.varlist![0].range },
+                location: { uri: this.uri, range: varlist[0].range },
                 sourceUri: this.uri,
-                definition_line: node.varlist![0].range.start.line,
+                definition_line: varlist[0].range.start.line,
             })
         );
     }
@@ -1785,12 +1795,13 @@ export class SemanticAnalyzer {
         symbols: SymbolTable,
         node_index: number
     ): void {
-        if (!node.varlist || node.varlist.length === 0) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length === 0) {
             return;
         }
 
-        const first = node.varlist[0]?.name;
-        const second = node.varlist[1]?.name;
+        const first = varlist[0]?.name;
+        const second = varlist[1]?.name;
 
         const matrix_name = (first && first === 'define')
             ? second
@@ -1801,9 +1812,9 @@ export class SemanticAnalyzer {
         }
 
         // If 'define' is present, prefer the name token's range.
-        const name_range = (first && first === 'define' && node.varlist[1])
-            ? node.varlist[1].range
-            : node.varlist[0].range;
+        const name_range = (first && first === 'define' && varlist[1])
+            ? varlist[1].range
+            : varlist[0].range;
 
         this.add_or_append_definition(
             symbols.matrices,
@@ -1828,22 +1839,23 @@ export class SemanticAnalyzer {
     // Pushes diagnostics to this.current_diagnostics; only call from within an
     // analyze() cycle (e.g., process_command → extract_gen_variable / extract_egen_variable).
     private pick_new_variable(node: CommandNode): IdentifierNode | undefined {
-        if (!node.varlist || node.varlist.length === 0) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length === 0) {
             return undefined;
         }
-        if (is_stata_storage_type(node.varlist[0].name)) {
-            if (node.varlist.length > 1) {
-                return node.varlist[1];
+        if (is_stata_storage_type(varlist[0].name)) {
+            if (varlist.length > 1) {
+                return varlist[1];
             }
             this.current_diagnostics.push({
-                message: `Missing variable name after storage type \`${node.varlist[0].name}'`,
-                range: node.varlist[0].range,
+                message: `Missing variable name after storage type \`${varlist[0].name}'`,
+                range: varlist[0].range,
                 code: StataDiagnosticCode.MISSING_VARIABLE_NAME,
                 severity: 'error',
             });
             return undefined;
         }
-        return node.varlist[0];
+        return varlist[0];
     }
 
     /**
@@ -1897,11 +1909,12 @@ export class SemanticAnalyzer {
      * Syntax: input varlist
      */
     private extract_input_variables(node: CommandNode, symbols: SymbolTable): void {
-        if (!node.varlist) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length === 0) {
             return;
         }
 
-        for (const var_node of node.varlist) {
+        for (const var_node of varlist) {
             // Skip macro references - they are not actual variable definitions
             if (this.is_macro_reference(var_node.name)) {
                 continue;
@@ -1974,7 +1987,8 @@ export class SemanticAnalyzer {
      * as they cannot be statically resolved.
      */
     private extract_rename_variables(node: CommandNode, symbols: SymbolTable): void {
-        if (!node.varlist || node.varlist.length < 2) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length < 2) {
             return;
         }
 
@@ -1984,16 +1998,16 @@ export class SemanticAnalyzer {
         //
         // This also guards cases like: rename old new?  ("?" may become a separate WORD token)
         if (
-            node.varlist.length !== 2 &&
-            !(node.varlist[0].name.startsWith('(') && node.varlist[1].name.startsWith('('))
+            varlist.length !== 2 &&
+            !(varlist[0].name.startsWith('(') && varlist[1].name.startsWith('('))
         ) {
             return;
         }
 
         // Check for grouped syntax: (old1 old2) (new1 new2)
         // Parser captures parenthesized groups as single varlist items with parens
-        const first_item = node.varlist[0].name;
-        const second_item = node.varlist[1].name;
+        const first_item = varlist[0].name;
+        const second_item = varlist[1].name;
 
         if (first_item.startsWith('(') && second_item.startsWith('(')) {
             // If either group contains wildcards, treat as pattern-based rename
@@ -2001,7 +2015,7 @@ export class SemanticAnalyzer {
                 return;
             }
             // Grouped syntax - extract names from second group
-            this.extract_grouped_rename_variables(second_item, node.varlist[1].range, symbols);
+            this.extract_grouped_rename_variables(second_item, varlist[1].range, symbols);
             return;
         }
 
@@ -2015,13 +2029,13 @@ export class SemanticAnalyzer {
         // (and similarly for *new). The parser currently drops the wildcard token from
         // varlist, so we must consult the token stream to avoid false registration.
         if (
-            this.has_adjacent_wildcard_token(node.varlist[0].range) ||
-            this.has_adjacent_wildcard_token(node.varlist[1].range)
+            this.has_adjacent_wildcard_token(varlist[0].range) ||
+            this.has_adjacent_wildcard_token(varlist[1].range)
         ) {
             return;
         }
 
-        const new_var = node.varlist[1];
+        const new_var = varlist[1];
 
         // Skip macro references - they are not actual variable definitions
         if (this.is_macro_reference(new_var.name)) {
@@ -2097,11 +2111,12 @@ export class SemanticAnalyzer {
      * then register the second varlist item as the variable.
      */
     private extract_confirm_variable(node: CommandNode, symbols: SymbolTable): void {
-        if (!node.varlist || node.varlist.length < 2) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length < 2) {
             return;
         }
 
-        const first_item = node.varlist[0].name.toLowerCase();
+        const first_item = varlist[0].name.toLowerCase();
 
         // Check if this is a "confirm variable" or "confirm var" command
         if (first_item !== 'variable' && first_item !== 'var') {
@@ -2109,7 +2124,7 @@ export class SemanticAnalyzer {
         }
 
         // The second item is the variable name
-        const var_node = node.varlist[1];
+        const var_node = varlist[1];
 
         // Skip macro references - they are not actual variable definitions
         if (this.is_macro_reference(var_node.name)) {
@@ -2137,11 +2152,12 @@ export class SemanticAnalyzer {
         current_scope: ScopeInfo,
         node_index: number
     ): void {
-        if (!node.varlist) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length === 0) {
             return;
         }
 
-        for (const var_node of node.varlist) {
+        for (const var_node of varlist) {
             this.register_local_macro(
                 current_scope,
                 symbols,
@@ -2174,8 +2190,9 @@ export class SemanticAnalyzer {
     ): void {
         // For unab command, the first argument is the macro name
         // The syntax is: unab macname : varlist
-        if (node.varlist && node.varlist.length > 0) {
-            const macro_node = node.varlist[0];
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length > 0) {
+            const macro_node = varlist[0];
             const macro_name = macro_node.name;
             this.register_local_macro(
                 current_scope,
@@ -2211,8 +2228,9 @@ export class SemanticAnalyzer {
     ): void {
         // For args command, each argument in the varlist becomes a local macro
         // The syntax is: args name1 name2 name3 ...
-        if (node.varlist && node.varlist.length > 0) {
-            for (const my_var_node of node.varlist) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length > 0) {
+            for (const my_var_node of varlist) {
                 const macro_name = my_var_node.name;
                 // Use definition_index: 0 and definition_line: 0 because args
                 // macros represent parameters passed into the program/file.
@@ -2259,14 +2277,15 @@ export class SemanticAnalyzer {
         // The syntax is: gettoken macname1 [macname2] : macname3 [, options]
         // - If varlist has 1 element: single output macro (macname1)
         // - If varlist has 2 elements: two output macros (macname1, macname2)
-        if (!node.varlist || node.varlist.length === 0) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length === 0) {
             return;
         }
 
         // Extract up to 2 macro names from the varlist (before the colon)
-        const max_macros = Math.min(node.varlist.length, 2);
+        const max_macros = Math.min(varlist.length, 2);
         for (let i = 0; i < max_macros; i++) {
-            const my_var_node = node.varlist[i];
+            const my_var_node = varlist[i];
             const macro_name = my_var_node.name;
 
             // Skip invalid identifiers (e.g., macro references like `name')
@@ -2312,16 +2331,17 @@ export class SemanticAnalyzer {
         node_index: number
     ): void {
         // Require at least 3 varlist items: subcommand, handle, macroname
-        if (!node.varlist || node.varlist.length < 3) {
+        const varlist = this.semantic_varlist(node);
+        if (varlist.length < 3) {
             return;
         }
 
         // Only "read" subcommand creates a local macro (exact match)
-        if (node.varlist[0].name !== 'read') {
+        if (varlist[0].name !== 'read') {
             return;
         }
 
-        const macro_node = node.varlist[2];
+        const macro_node = varlist[2];
         const macro_name = macro_node.name;
 
         if (!is_valid_identifier(macro_name)) {
@@ -2506,7 +2526,7 @@ export class SemanticAnalyzer {
         if (node.fullName !== 'macro' && node.fullName !== 'mac') {
             return { names: [], unknown: false };
         }
-        const the_args = node.varlist ?? [];
+        const the_args = this.semantic_varlist(node);
         // First varlist item is the `drop` subcommand (allow abbreviations).
         if (the_args.length < 2 || !/^dr(o(p)?)?$/.test(the_args[0].name)) {
             return { names: [], unknown: false };
@@ -2550,19 +2570,21 @@ export class SemanticAnalyzer {
             cmd_name === 'tempvar' || cmd_name === 'tempfile'
             || cmd_name === 'tempname' || cmd_name === 'args'
         ) {
-            for (const my_var of node.varlist ?? []) push_literal(my_var.name);
+            for (const my_var of this.semantic_varlist(node)) push_literal(my_var.name);
         } else if (cmd_name === 'unab') {
-            push_literal(node.varlist?.[0]?.name);
+            push_literal(this.semantic_varlist(node)[0]?.name);
         } else if (cmd_name === 'gettoken' || cmd_name === 'gettok') {
-            const max_macros = Math.min(node.varlist?.length ?? 0, 2);
+            const varlist = this.semantic_varlist(node);
+            const max_macros = Math.min(varlist.length, 2);
             for (let i = 0; i < max_macros; i++) {
-                push_literal(node.varlist![i].name);
+                push_literal(varlist[i].name);
             }
         } else if (cmd_name === 'file' || cmd_name === 'fil' || cmd_name === 'fi') {
             // `file read handle macroname` — only the "read" subcommand creates
             // a macro, stored in varlist[2] (see extract_file_read_macro).
-            if ((node.varlist?.length ?? 0) >= 3 && node.varlist![0].name === 'read') {
-                push_literal(node.varlist![2].name);
+            const varlist = this.semantic_varlist(node);
+            if (varlist.length >= 3 && varlist[0].name === 'read') {
+                push_literal(varlist[2].name);
             }
         }
         return names;
@@ -3367,26 +3389,24 @@ export class SemanticAnalyzer {
         }
 
         // Check varlist for undefined variables
-        if (node.varlist) {
-            for (const var_node of node.varlist) {
-                const is_defined = this.is_variable_defined(
-                    var_node.name,
-                    symbols,
-                    var_node.range.start.line
-                );
+        for (const var_node of this.semantic_varlist(node)) {
+            const is_defined = this.is_variable_defined(
+                var_node.name,
+                symbols,
+                var_node.range.start.line
+            );
 
-                if (!is_defined) {
-                    diagnostics.push({
-                        message: format_undefined_variable_message(
-                            var_node.name
-                        ),
-                        range: var_node.range,
-                        code: StataDiagnosticCode.UNDEFINED_VARIABLE,
-                        severity: 'information',
-                        symbol_name: var_node.name,
-                        reference_kind: 'variable',
-                    });
-                }
+            if (!is_defined) {
+                diagnostics.push({
+                    message: format_undefined_variable_message(
+                        var_node.name
+                    ),
+                    range: var_node.range,
+                    code: StataDiagnosticCode.UNDEFINED_VARIABLE,
+                    severity: 'information',
+                    symbol_name: var_node.name,
+                    reference_kind: 'variable',
+                });
             }
         }
     }

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -2047,8 +2047,14 @@ export class SemanticAnalyzer {
         group_range: Range,
         symbols: SymbolTable
     ): void {
-        // Remove parentheses and split by whitespace
-        const inner = group_content.slice(1, -1).trim();
+        // Remove the source-authored wrapper. During parser recovery an
+        // unclosed group keeps the missing close paren out of `name`, so only
+        // strip a trailing close when one is actually present.
+        const inner = (
+            group_content.endsWith(')')
+                ? group_content.slice(1, -1)
+                : group_content.slice(1)
+        ).trim();
         const the_names = inner.split(/\s+/).filter(n => n.length > 0);
 
         for (const my_name of the_names) {

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -770,9 +770,7 @@ export class SemanticAnalyzer {
             if (token.range.start.line !== line) {
                 break;
             }
-            if (token.type !== 'WHITESPACE') {
-                return false;
-            }
+            return false;
         }
 
         return true;
@@ -4697,9 +4695,9 @@ export class SemanticAnalyzer {
         // with no intervening hard break. A hard break is a real (non-`///`)
         // STATEMENT_TERMINATOR or a `;` separator (under `#delimit ;`); once
         // one is seen the body is on a later line, so a blank or comment-only
-        // continued line cannot keep the opener on the logical line. Under
-        // `#delimit ;` a physical newline lexes as WHITESPACE (no terminator
-        // token), so the physical-line comparison is what detects that break.
+        // continued line cannot keep the opener on the logical line. A
+        // physical-line change without a terminator is also a break unless it
+        // was crossed by `///`.
         let opener_idx = mata_index + 1;
         let crossed_continuation = false;
         let saw_hard_break = false;

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -770,6 +770,9 @@ export class SemanticAnalyzer {
             if (token.range.start.line !== line) {
                 break;
             }
+            if (token.type === 'WHITESPACE') {
+                continue;
+            }
             return false;
         }
 

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -2464,6 +2464,9 @@ export class SemanticAnalyzer {
             this.get_program_macro_creating_options(node.fullName, symbols);
         if (!builtin_cmd && !program_options) return false;
         for (const my_option of node.options) {
+            if (my_option.argument_unclosed) {
+                continue;
+            }
             let matches = false;
             if (builtin_cmd) {
                 for (const opt of builtin_cmd.local_options) {
@@ -2607,6 +2610,9 @@ export class SemanticAnalyzer {
             argument_range?: Range;
         }> = [];
         for (const option of node.options) {
+            if (option.argument_unclosed) {
+                continue;
+            }
             const parse_result = parse_option_argument(option.argument);
             if (!parse_result.is_literal || !parse_result.identifier) {
                 continue;

--- a/src/analyzer/loop-expander/name-expander.ts
+++ b/src/analyzer/loop-expander/name-expander.ts
@@ -2,9 +2,8 @@
  * Extract a constructed macro-name template from a `local`/`global` statement's
  * tokens, and expand it across loop iterator bindings.
  *
- * Name extraction uses **source-range adjacency**, not whitespace tokens,
- * because the lexer emits no WHITESPACE tokens in the default `cr` delimiter
- * mode (src/lexer/index.ts) — a space manifests as a gap between token ranges.
+ * Name extraction uses **source-range adjacency**, not whitespace tokens; a
+ * space manifests as a gap between token ranges.
  */
 import { SymbolTable, Token } from '../../types';
 import { is_valid_identifier } from '../option-argument-parser';
@@ -113,13 +112,6 @@ function parse_macro_def_head(statement_tokens: Token[]): MacroDefHead | null {
     const run: Token[] = [];
     while (i < statement_tokens.length) {
         const my_tok = statement_tokens[i];
-        // `#delimit ;` mode emits WHITESPACE tokens; skip them. The range
-        // adjacency check still detects the gap they occupy, so a space-
-        // separated trailing value is not joined to the name.
-        if (my_tok.type === 'WHITESPACE') {
-            i++;
-            continue;
-        }
         if (!NAME_TOKEN_TYPES.has(my_tok.type)) break;
         if (run.length > 0 && !tokens_adjacent(run[run.length - 1], my_tok)) break;
         run.push(my_tok);

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -393,16 +393,7 @@ export class StataLexer {
         this.advance();
       }
 
-      // In semicolon mode, whitespace is trivia - return it
-      // In cr mode, skip whitespace entirely
-      if (this.state.delimiterMode === 'semicolon') {
-        return {
-          type: 'WHITESPACE',
-          value: this.source.substring(this.position_to_offset(startLine, startColumn), this.position),
-          range: this.makeRange(startLine, startColumn, this.line, this.column),
-        };
-      }
-      return null; // Skip whitespace in cr mode
+      return null;
     }
 
     // Handle newlines (significant in cr mode)
@@ -413,14 +404,8 @@ export class StataLexer {
           value: '\n',
           range: this.makeRange(startLine, startColumn, this.line, this.column),
         };
-      } else {
-        // In semicolon mode, newlines are whitespace
-        return {
-          type: 'WHITESPACE',
-          value: '\n',
-          range: this.makeRange(startLine, startColumn, this.line, this.column),
-        };
       }
+      return null;
     }
 
     // Handle semicolons (significant in semicolon mode)

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1215,9 +1215,6 @@ export class StataParser {
             if (parsed.argument_unclosed) {
               option.argument_unclosed = true;
             }
-            if (parsed.argument_trailing_trivia) {
-              option.argument_trailing_trivia = parsed.argument_trailing_trivia;
-            }
           }
 
           options.push(option);
@@ -1252,7 +1249,6 @@ export class StataParser {
     argument: string;
     argument_range?: Range;
     argument_unclosed?: true;
-    argument_trailing_trivia?: string;
   } {
     this.advance(); // consume (
     // Collect argument tokens and reconstruct spacing from their ranges via
@@ -1262,7 +1258,6 @@ export class StataParser {
     const arg_tokens: Token[] = [];
     const preceded_by_continuation: boolean[] = [];
     const continuation = new ContinuationTracker();
-    let pending_trailing_trivia: Token[] = [];
     let paren_depth = 1;
     while (!this.isAtEnd() && paren_depth > 0) {
       if (this.check('STATEMENT_TERMINATOR')) {
@@ -1272,12 +1267,11 @@ export class StataParser {
         const cont_token = this.peek();
         if (this.skipContinuation()) {
           continuation.note_continuation(cont_token);
-          pending_trailing_trivia = [];
           continue;
         }
       }
       if (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK')) {
-        pending_trailing_trivia.push(this.advance());
+        this.advance();
         continue;
       }
       const t = this.advance();
@@ -1290,13 +1284,9 @@ export class StataParser {
         }
       }
       arg_tokens.push(t);
-      pending_trailing_trivia = [];
       preceded_by_continuation.push(continuation.collect(t));
     }
     const argument_unclosed = paren_depth > 0 ? true : undefined;
-    const argument_trailing_trivia = argument_unclosed && pending_trailing_trivia.length > 0
-      ? pending_trailing_trivia.map(token => token.value).join(' ')
-      : undefined;
     const argument = this.reconstruct_value_tokens(
       arg_tokens,
       preceded_by_continuation
@@ -1304,7 +1294,7 @@ export class StataParser {
     const argument_range = arg_tokens.length > 0
       ? { start: arg_tokens[0].range.start, end: arg_tokens[arg_tokens.length - 1].range.end }
       : undefined;
-    return { argument, argument_range, argument_unclosed, argument_trailing_trivia };
+    return { argument, argument_range, argument_unclosed };
   }
 
   /**
@@ -1524,9 +1514,6 @@ export class StataParser {
             option.argument_range = parsed.argument_range;
             if (parsed.argument_unclosed) {
               option.argument_unclosed = true;
-            }
-            if (parsed.argument_trailing_trivia) {
-              option.argument_trailing_trivia = parsed.argument_trailing_trivia;
             }
           }
 
@@ -2677,9 +2664,6 @@ export class StataParser {
             option.argument_range = parsed.argument_range;
             if (parsed.argument_unclosed) {
               option.argument_unclosed = true;
-            }
-            if (parsed.argument_trailing_trivia) {
-              option.argument_trailing_trivia = parsed.argument_trailing_trivia;
             }
           }
           options.push(option);

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1417,9 +1417,17 @@ export class StataParser {
       this.advance(); // consume closing paren
     }
 
-    // Return null for empty/whitespace-only content
+    // Empty balanced groups are not useful varlist items. Empty unclosed
+    // groups still contain authored source text: keep the opener so AST-mode
+    // formatting does not delete user input while they are mid-statement.
     if (!paren_content.trim()) {
-      return null;
+      if (closed_group) {
+        return null;
+      }
+      return {
+        name: '(',
+        range: this.makeRange(paren_start.range.start, paren_end_pos),
+      };
     }
 
     // If recovery stopped at a statement terminator or EOF, preserve only the

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -36,10 +36,10 @@ const PREFIX_COMMANDS = new Set(['by', 'bysort', 'quietly', 'qui', 'capture', 'c
  * i.e. every physical line between them ended with `///`.
  *
  * `///` continues ONLY the immediately-following line, so a token pushed
- * further down by a raw newline (a blank line in `#delimit ;` mode, or a `///`
- * that does not extend the chain contiguously) is NOT a continuation join and
- * must separate. This prevents value-token fusion such as `a///\n\nb` -> `ab`
- * or `a///\n\n///\nb` -> `ab` (issue #306). The boolean flag it produces feeds
+ * further down by a raw newline or by a `///` that does not extend the chain
+ * contiguously is NOT a continuation join and must separate. This prevents
+ * value-token fusion such as `a///\n\nb` -> `ab` or
+ * `a///\n\n///\nb` -> `ab` (issue #306). The boolean flag it produces feeds
  * `reconstruct_value_tokens`, which applies the column-0-join rule only when
  * the flag is true.
  */
@@ -184,7 +184,8 @@ export class StataParser {
     } else if (this.check('WORD') && this.isPrefixCommand(this.peek().value)) {
       // Prefix command - delegate to parseCommand which handles prefix parsing
       node = this.parseCommand();
-    } else if (this.checkWord('program') && this.peekValueAfterWhitespace() === 'define') {
+    } else if (this.checkWord('program') &&
+        this.tokens[this.current + 1]?.value === 'define') {
       node = this.parseProgramDefinition();
     } else if (this.checkWord('syntax')) {
       node = this.parseSyntaxCommand();
@@ -422,12 +423,6 @@ export class StataParser {
   private parseProgramDefinition(): ProgramNode {
     const start_token = this.advance(); // consume 'program'
 
-    // In `#delimit ;` mode the lexer emits a WHITESPACE token between `program`
-    // and `define` (elided in `#delimit cr` mode); skip it so the `define`
-    // check succeeds and the program is recognized rather than misparsed as an
-    // ordinary command (issue #305).
-    this.skipWhitespace();
-
     if (!this.checkWord('define')) {
       this.addError('Expected "define" after "program"', this.peek().range);
     } else {
@@ -455,15 +450,9 @@ export class StataParser {
     this.inside_program = true;
 
     // Collect any leading trivia before re-checking `end`, mirroring
-    // parseBraceBody (issue #301). In `#delimit ;` mode the lexer emits
-    // WHITESPACE tokens — and a comment-only line before `end` is a comment
-    // followed by WHITESPACE — that `#delimit cr` mode elides. Without
-    // consuming that trivia here, parseStatement() would run at the comment,
-    // swallow it plus the following whitespace, and then parse `end` as an
-    // ordinary command, losing the terminator and running the program off to
-    // EOF (issue #305). Carrying the trivia forward via pending_trivia so it
-    // attaches to the statement after the program matches how parseBraceBody
-    // handles a comment before `}`. Inert in cr mode (no WHITESPACE tokens).
+    // parseBraceBody (issue #301). Carrying the trivia forward via
+    // pending_trivia so it attaches to the statement after the program matches
+    // how parseBraceBody handles a comment before `}`.
     while (!this.isAtEnd()) {
       const my_trivia = this.collectTrivia();
       if (my_trivia.length > 0) {
@@ -627,19 +616,6 @@ export class StataParser {
 
       const token = this.advance();
 
-      // In `#delimit ;` mode the lexer emits WHITESPACE tokens whose value is
-      // the raw run of spaces/newlines. Skip them: reconstruct_value_tokens
-      // re-inserts a single space from inter-token gaps, so keeping them would
-      // embed literal whitespace (and `\n`) into the stored macro value.
-      // Leave continuation_line untouched: a `///` continuation's indentation
-      // may surface as a WHITESPACE token before the next real token, and the
-      // continuation still applies to that token (unless extra raw newlines
-      // push it off the immediately-following line — see
-      // token_follows_continuation).
-      if (token.type === 'WHITESPACE') {
-        continue;
-      }
-
       // Track parenthesis depth for error checking
       if (token.type === 'LPAREN') {
         paren_depth++;
@@ -699,14 +675,12 @@ export class StataParser {
     const function_name = this.advance().value;
     this.skipMacroDefinitionTrivia();
 
-    // Collect function arguments. `arg_tokens` keeps every token (including
-    // WHITESPACE) for macro-reference extraction, while `value_tokens` holds
-    // only the non-whitespace tokens used to reconstruct the arg string.
-    // Reconstructing from token ranges via reconstruct_value_tokens keeps the
-    // two delimiter modes identical (a single space per gap) and never invents
-    // artificial boundaries (adjacent tokens like `0Ea` stay joined), unlike
-    // appending raw WHITESPACE token values which embeds literal spaces and
-    // newlines in `#delimit ;` mode (issue #306).
+    // Collect function arguments. `arg_tokens` keeps every token for
+    // macro-reference extraction, while `value_tokens` holds the tokens used
+    // to reconstruct the arg string from source ranges. Range reconstruction
+    // keeps the two delimiter modes identical (a single space per gap) and
+    // never invents artificial boundaries (adjacent tokens like `0Ea` stay
+    // joined).
     const arg_tokens: Token[] = [];
     const value_tokens: Token[] = [];
     const preceded_by_continuation: boolean[] = [];
@@ -729,12 +703,10 @@ export class StataParser {
 
       const token = this.advance();
       arg_tokens.push(token);
-      if (token.type !== 'WHITESPACE') {
-        value_tokens.push(token);
-        preceded_by_continuation.push(
-          continuation.collect(token)
-        );
-      }
+      value_tokens.push(token);
+      preceded_by_continuation.push(
+        continuation.collect(token)
+      );
     }
 
     // Reconstruct args with mode-independent single-space spacing.
@@ -864,14 +836,6 @@ export class StataParser {
         range: prefix_token.range,
       };
 
-      // In `#delimit ;` mode the lexer emits WHITESPACE tokens between the
-      // prefix and what follows it — an optional colon, a chained prefix, or a
-      // `{ ... }` block (elided in `#delimit cr` mode). Skip that spacing
-      // before each of those checks so the prefix is not misparsed and its
-      // block is recognized rather than treated as a stray open brace (issue
-      // #301). Whitespace only — a comment here must not be discarded.
-      this.skipWhitespace();
-
       // Handle 'by' prefix with variable list
       if (prefix_token.value === 'by') {
         if (this.check('COLON')) {
@@ -886,7 +850,6 @@ export class StataParser {
       if (this.check('COLON')) {
         this.advance();
         prefix.has_colon = true;
-        this.skipWhitespace();
       }
 
       prefixes.push(prefix);
@@ -1011,15 +974,9 @@ export class StataParser {
     }
 
     // Special handling for frame prefix: frame name: command
-    // This handles cases like `capture frame this: that`
-    // In `#delimit ;` mode the lexer emits a WHITESPACE token between `frame`
-    // and the frame name (elided in `#delimit cr` mode); skip it before the
-    // WORD check so frame-prefix syntax is still recognized (issue #305).
-    // saved_pos is captured before that skip so a non-frame-prefix command
-    // backtracks fully and falls through to parseCommandBody unchanged.
+    // This handles cases like `capture frame this: that`.
     if (commandName === 'frame') {
       const saved_pos = this.current;
-      this.skipWhitespace();
       if (this.check('WORD')) {
         const frame_name_token = this.advance();
         this.skipTrivia();
@@ -1084,11 +1041,6 @@ export class StataParser {
         fullName: prefix_token.value,
         range: prefix_token.range,
       };
-      // In `#delimit ;` mode the lexer emits a WHITESPACE token between the
-      // prefix and its optional colon (elided in `#delimit cr` mode); skip it
-      // before the colon check so `frame m: quietly : cmd` is not split at the
-      // colon, mirroring the main prefix loop (issue #305).
-      this.skipWhitespace();
       // Consume colon after any prefix command
       if (this.check('COLON')) {
         this.advance();
@@ -1154,14 +1106,6 @@ export class StataParser {
     // or 'if' keyword). Use file path coalescing for file commands.
     const varlist: IdentifierNode[] = [];
 
-    // In `#delimit ;` mode the lexer emits a WHITESPACE token between the
-    // command name and its first argument (elided in `#delimit cr` mode).
-    // Skip it so the first argument — including a file path — is recognized
-    // rather than the varlist collection breaking immediately (issue #305).
-    // Whitespace only: a comment here belongs to the following statement's
-    // trivia and must not be discarded.
-    this.skipWhitespace();
-
     // For file commands, try to parse the first argument as a file path
     const is_file_cmd = isFileCommand(command_name);
     const has_file_arg = this.check('WORD') || this.check('NUMBER') ||
@@ -1177,17 +1121,6 @@ export class StataParser {
     // Parse remaining arguments normally (including parenthesized groups)
     while (!this.check('COMMA') && !this.isTrivia() &&
            !this.check('STATEMENT_TERMINATOR') && !this.isAtEnd()) {
-      // In `#delimit ;` mode the lexer emits WHITESPACE tokens between varlist
-      // items that `#delimit cr` mode elides. Skip the interstitial spacing so
-      // each item is collected as its own entry instead of the loop breaking
-      // at the first space (issue #305). Whitespace is the item *separator*, so
-      // skipping it still yields separate entries; it must not merge fragments
-      // that coalesce only when adjacent (wildcards like `var*`), which the
-      // isAdjacentToken()-gated coalescing below still handles correctly.
-      if (this.check('WHITESPACE')) {
-        this.advance();
-        continue;
-      }
       // Stop at 'if' keyword for if-qualifier
       if (this.checkWord('if')) {
         break;
@@ -1274,12 +1207,6 @@ export class StataParser {
             range: optionToken.range,
           };
 
-          // In `#delimit ;` mode a WHITESPACE token may sit between the option
-          // name and its `(...)` argument (elided in `#delimit cr` mode); skip
-          // it so the argument still attaches to the option rather than the
-          // paren group being misread as a separate option (issue #305).
-          this.skipWhitespace();
-
           // Check for option argument
           if (this.check('LPAREN')) {
             const parsed = this.parse_option_argument_inside_parens();
@@ -1315,12 +1242,10 @@ export class StataParser {
    */
   private parse_option_argument_inside_parens(): { argument: string; argument_range?: Range } {
     this.advance(); // consume (
-    // Collect the non-whitespace argument tokens and reconstruct spacing from
-    // their ranges via reconstruct_value_tokens, so `#delimit ;` and
-    // `#delimit cr` produce the identical single-space form and multi-token
-    // arguments are never fused — e.g. `absorb(firm year)` stays `firm year`,
-    // not `firmyear` (issue #306). Appending raw token values would also embed
-    // literal WHITESPACE and `///` continuation markers into the argument.
+    // Collect argument tokens and reconstruct spacing from their ranges via
+    // reconstruct_value_tokens, so delimiter modes produce the identical
+    // single-space form and multi-token arguments are never fused — e.g.
+    // `absorb(firm year)` stays `firm year`, not `firmyear` (issue #306).
     const arg_tokens: Token[] = [];
     const preceded_by_continuation: boolean[] = [];
     const continuation = new ContinuationTracker();
@@ -1333,9 +1258,6 @@ export class StataParser {
         }
       }
       const t = this.advance();
-      if (t.type === 'WHITESPACE') {
-        continue;
-      }
       arg_tokens.push(t);
       preceded_by_continuation.push(continuation.collect(t));
     }
@@ -1379,20 +1301,16 @@ export class StataParser {
 
     while (!this.isAtEnd()) {
       // Stop at whitespace, comma, terminator, or trivia
-      if (this.check('WHITESPACE') ||
-          this.check('COMMA') ||
+      if (this.check('COMMA') ||
           this.check('STATEMENT_TERMINATOR') ||
           this.isTrivia()) {
         break;
       }
 
-      // Stop at a source gap. In `#delimit cr` mode the lexer emits no
-      // WHITESPACE tokens, so coalescing every non-trivia token would merge a
+      // Stop at a source gap. Coalescing every non-trivia token would merge a
       // file command's entire argument list into one path (e.g.
       // `merge 1:1 id using data` -> `1:1idusingdata`). Only coalesce tokens
-      // physically adjacent to the previous one; a gap ends the path. In
-      // `#delimit ;` mode the WHITESPACE break above already separates
-      // arguments, so this adjacency guard is inert there (issue #306).
+      // physically adjacent to the previous one; a gap ends the path.
       if (!this.isAdjacentToken(prev_token, this.peek())) {
         break;
       }
@@ -1422,9 +1340,9 @@ export class StataParser {
     const paren_start = this.advance(); // consume (
     // Collect the inner tokens (everything up to, but not including, the
     // matching outer close paren) and reconstruct spacing from their ranges via
-    // reconstruct_value_tokens, so `#delimit ;` and `#delimit cr` produce the
-    // identical single-space form — e.g. `(a b)` stays `(a b)` and `(1/3 = 1)`
-    // is `(1/3 = 1)` in both modes (issue #306). WHITESPACE only marks a gap.
+    // reconstruct_value_tokens, so delimiter modes produce the identical
+    // single-space form — e.g. `(a b)` stays `(a b)` and `(1/3 = 1)` is
+    // `(1/3 = 1)` in both modes (issue #306).
     const inner_tokens: Token[] = [];
     const preceded_by_continuation: boolean[] = [];
     const continuation = new ContinuationTracker();
@@ -1438,10 +1356,6 @@ export class StataParser {
     };
 
     while (!this.isAtEnd() && paren_depth > 0) {
-      if (this.check('WHITESPACE')) {
-        this.advance();
-        continue;
-      }
       if (this.check('CONTINUATION')) {
         const cont_token = this.peek();
         if (this.skipContinuation()) {
@@ -1496,12 +1410,6 @@ export class StataParser {
   ): CommandNode {
     const start_pos = command_token.range.start;
 
-    // In `#delimit ;` mode the lexer emits WHITESPACE tokens around the macro
-    // name, colon, and varlist that `#delimit cr` mode elides. Skip that
-    // spacing before each discrete check so the command is not misparsed
-    // (issue #305).
-    this.skipWhitespace();
-
     // Parse macro name
     if (!this.check('WORD')) {
       this.addError('Expected macro name after unab', this.peek().range);
@@ -1520,8 +1428,6 @@ export class StataParser {
     // This keeps varlists pure (only variable names) while preserving syntax
     let has_colon_before_varlist = false;
 
-    this.skipWhitespace();
-
     // Expect colon
     if (!this.check('COLON')) {
       this.addError(
@@ -1534,7 +1440,6 @@ export class StataParser {
     }
 
     // Parse variable list after colon
-    this.skipWhitespace();
     while ((this.check('WORD') || this.check('MACRO_REF_LOCAL') ||
             this.check('MACRO_REF_GLOBAL') ||
             (this.check('OPERATOR') && (this.peek().value === '*' || this.peek().value === '?'))) &&
@@ -1561,10 +1466,6 @@ export class StataParser {
         range: { start: var_token.range.start, end: end_range },
       });
 
-      // Skip interstitial whitespace before the next varlist item. Placed
-      // after wildcard coalescing so `var*` is still joined via adjacency
-      // (issue #305).
-      this.skipWhitespace();
     }
 
     // Parse options (after comma) - same as regular commands
@@ -1582,11 +1483,6 @@ export class StataParser {
             fullName: option_token.value,
             range: option_token.range,
           };
-
-          // Skip a WHITESPACE token between the option name and its `(...)`
-          // argument in `#delimit ;` mode so the argument still attaches
-          // (issue #305).
-          this.skipWhitespace();
 
           // Check for option argument
           if (this.check('LPAREN')) {
@@ -1632,14 +1528,6 @@ export class StataParser {
 
     while (!this.check('STATEMENT_TERMINATOR') &&
            !this.isAtEnd() && !this.isTrivia()) {
-      // In `#delimit ;` mode the lexer emits WHITESPACE tokens between the
-      // names that `#delimit cr` mode elides; skip that spacing so each name
-      // is collected separately instead of the loop breaking at the first
-      // space (issue #305).
-      if (this.check('WHITESPACE')) {
-        this.advance();
-        continue;
-      }
       const is_varlist_token = this.check('WORD') || this.check('STRING') ||
           this.check('MACRO_REF_LOCAL') || this.check('MACRO_REF_GLOBAL');
       if (is_varlist_token) {
@@ -1675,15 +1563,9 @@ export class StataParser {
     let allows_arbitrary_options = false;
     const seen_option_names = new Set<string>();
 
-    // Collect all tokens until statement terminator or comment. In
-    // `#delimit ;` mode the lexer emits interstitial WHITESPACE tokens that
-    // `#delimit cr` mode elides; the index-based spec parsers below assume
-    // cr-mode adjacency (e.g. an option name immediately followed by `(`), so
-    // consume the whitespace but do not collect it. This makes the token array
-    // identical to cr mode and keeps `syntax , opt (string)` parsing the same
-    // in both modes (issue #305). Whitespace is not meaningful within a syntax
-    // spec, so dropping it is safe; comments still stop collection via
-    // isTrivia().
+    // Collect all tokens until statement terminator or comment. The
+    // index-based spec parsers below operate on the lexer token stream
+    // directly; comments still stop collection.
     const syntax_tokens: Token[] = [];
     while (
       !this.check('STATEMENT_TERMINATOR') &&
@@ -1700,9 +1582,7 @@ export class StataParser {
         break;
       }
       const my_token = this.advance();
-      if (my_token.type !== 'WHITESPACE') {
-        syntax_tokens.push(my_token);
-      }
+      syntax_tokens.push(my_token);
     }
 
     // Parse the collected tokens
@@ -2013,12 +1893,6 @@ export class StataParser {
               let j = i + 2;
               while (j < type_tokens.length && default_paren_depth > 0) {
                 const my_token = type_tokens[j];
-                // syntax_tokens has WHITESPACE/CONTINUATION already stripped, so
-                // spacing comes purely from token ranges via the helper.
-                if (my_token.type === 'WHITESPACE') {
-                  j++;
-                  continue;
-                }
                 if (my_token.type === 'LPAREN') {
                   default_paren_depth++;
                 } else if (my_token.type === 'RPAREN') {
@@ -2232,11 +2106,8 @@ export class StataParser {
         }
       }
 
-      // Skip whitespace tokens but collect all others
-      if (token.type !== 'WHITESPACE') {
-        condition_tokens.push(token);
-        preceded_by_continuation.push(continuation.collect(token));
-      }
+      condition_tokens.push(token);
+      preceded_by_continuation.push(continuation.collect(token));
     }
 
     // Reconstruct condition with mode-independent single-space spacing.
@@ -2288,13 +2159,6 @@ export class StataParser {
 
   private parseElseStatement(): ControlFlowNode {
     const elseToken = this.advance(); // consume 'else'
-
-    // In `#delimit ;` mode the lexer emits a WHITESPACE token between `else`
-    // and what follows (elided in `#delimit cr` mode), so skip that spacing
-    // before the `else if` / brace checks. Without this an `else {` on its own
-    // line is misparsed as a single-statement else whose statement is a stray
-    // `{` (issue #301). Whitespace only — a comment here must not be discarded.
-    this.skipWhitespace();
 
     // Check for 'if' (else if)
     if (this.checkWord('if')) {
@@ -2366,16 +2230,10 @@ export class StataParser {
     let loopVar = '';
     let loopSpec = '';
 
-    // Parse loop variable. In `#delimit ;` mode the lexer emits WHITESPACE
-    // tokens between the keyword, the loop variable, and the spec keyword
-    // (they are elided in `#delimit cr` mode), so skip that spacing before
-    // each discrete token check (issue #301). Whitespace only — a comment here
-    // must not be discarded.
-    this.skipWhitespace();
+    // Parse loop variable.
     if (this.check('WORD')) {
       loopVar = this.advance().value;
     }
-    this.skipWhitespace();
 
     // Parse loop specification
     // For forvalues: next token is '=' (OPERATOR)
@@ -2415,9 +2273,6 @@ export class StataParser {
         const token = this.advance();
         if (token.type === 'CONTINUATION') {
           continuation.note_continuation(token);
-          continue;
-        }
-        if (token.type === 'WHITESPACE') {
           continue;
         }
         spec_tokens.push(token);
@@ -2501,11 +2356,8 @@ export class StataParser {
         }
       }
 
-      // Skip whitespace tokens but collect all others
-      if (token.type !== 'WHITESPACE') {
-        condition_tokens.push(token);
-        preceded_by_continuation.push(continuation.collect(token));
-      }
+      condition_tokens.push(token);
+      preceded_by_continuation.push(continuation.collect(token));
     }
 
     // Reconstruct condition with mode-independent single-space spacing.
@@ -2572,9 +2424,7 @@ export class StataParser {
     // Collect all tokens until statement terminator
     while (!this.check('STATEMENT_TERMINATOR') && !this.isAtEnd()) {
       const token = this.advance();
-      if (token.type !== 'WHITESPACE') {
-        statement_tokens.push(token);
-      }
+      statement_tokens.push(token);
     }
 
     // Reconstruct the string with original spacing
@@ -2604,11 +2454,7 @@ export class StataParser {
   private parseFrameBlock(): ControlFlowNode | CommandNode | null {
     // Index of the `frame` token itself. Both non-block fallbacks below
     // restore to exactly this index so parseCommand re-parses `frame` and its
-    // arguments from the start. A fixed offset (e.g. `saved_position - 1`)
-    // assumed `#delimit cr` adjacency where `frame` immediately precedes the
-    // name; in `#delimit ;` mode a WHITESPACE token sits between them, so the
-    // offset landed on the whitespace and dropped `frame` from the re-parse
-    // (issue #305).
+    // arguments from the start.
     const frame_index = this.current;
     const frame_token = this.advance(); // consume 'frame'
     const frame_start_line = frame_token.range.start.line;
@@ -2698,12 +2544,6 @@ export class StataParser {
   private parseUnabCommandBody(command_token: Token): CommandNode {
     const start_pos = command_token.range.start;
 
-    // In `#delimit ;` mode the lexer emits WHITESPACE tokens around the macro
-    // name, colon, and varlist that `#delimit cr` mode elides. Skip that
-    // spacing before each discrete check so the command is not misparsed
-    // (issue #305).
-    this.skipWhitespace();
-
     // Parse macro name
     if (!this.check('WORD')) {
       this.addError('Expected macro name after unab', this.peek().range);
@@ -2727,8 +2567,6 @@ export class StataParser {
     // This keeps varlists pure (only variable names) while preserving syntax
     let has_colon_before_varlist = false;
 
-    this.skipWhitespace();
-
     // Expect colon
     if (!this.check('COLON')) {
       this.addError(
@@ -2741,7 +2579,6 @@ export class StataParser {
     }
 
     // Parse variable list after colon
-    this.skipWhitespace();
     while ((this.check('WORD') || this.check('MACRO_REF_LOCAL') ||
             this.check('MACRO_REF_GLOBAL') ||
             (this.check('OPERATOR') && (this.peek().value === '*' || this.peek().value === '?'))) &&
@@ -2768,10 +2605,6 @@ export class StataParser {
         range: { start: var_token.range.start, end: end_range },
       });
 
-      // Skip interstitial whitespace before the next varlist item. Placed
-      // after wildcard coalescing so `var*` is still joined via adjacency
-      // (issue #305).
-      this.skipWhitespace();
     }
 
     // Parse options (after comma)
@@ -2788,10 +2621,6 @@ export class StataParser {
             fullName: option_token.value,
             range: option_token.range,
           };
-          // Skip a WHITESPACE token between the option name and its `(...)`
-          // argument in `#delimit ;` mode so the argument still attaches
-          // (issue #305).
-          this.skipWhitespace();
           if (this.check('LPAREN')) {
             const parsed = this.parse_option_argument_inside_parens();
             option.argument = parsed.argument;
@@ -2841,7 +2670,7 @@ export class StataParser {
   private collectTrivia(): TriviaNode[] {
     const trivia: TriviaNode[] = [];
 
-    while (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK') || this.check('CONTINUATION') || this.check('WHITESPACE')) {
+    while (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK') || this.check('CONTINUATION')) {
       const token = this.advance();
 
       if (token.type === 'COMMENT_LINE') {
@@ -2867,7 +2696,6 @@ export class StataParser {
           range: token.range,
         });
       }
-      // Skip whitespace tokens (don't add to trivia)
     }
 
     return trivia;
@@ -2880,31 +2708,13 @@ export class StataParser {
   }
 
   /**
-   * Skip only WHITESPACE tokens, leaving comments and continuations in place.
-   *
-   * `#delimit ;` mode emits a WHITESPACE token between adjacent tokens that
-   * `#delimit cr` mode elides (e.g. between a loop keyword and its variable,
-   * `else` and its brace, or a prefix and its block). Structural checks that
-   * only need to tolerate that interstitial spacing use this rather than
-   * skipTrivia(), which would silently discard comment trivia at those
-   * positions — dropping user comments from the formatter output (issue #301).
-   */
-  private skipWhitespace(): void {
-    while (this.check('WHITESPACE')) {
-      this.advance();
-    }
-  }
-
-  /**
    * Parse the statements of a brace-delimited block body, stopping at the
    * matching `}` (left unconsumed for the caller to validate) or EOF.
    *
-   * In `#delimit ;` mode a raw newline before `}` is emitted as a WHITESPACE
-   * token (elided in `#delimit cr` mode), so the closing brace can be preceded
-   * by trivia. This loop consumes that leading trivia — carrying comments
-   * forward via pending_trivia exactly as parseStatement would — and then
-   * checks for `}` itself, so the closing brace is never handed to
-   * parseStatement, which would misreport it as an orphan (issue #301).
+   * This loop consumes leading trivia — carrying comments forward via
+   * pending_trivia exactly as parseStatement would — and then checks for `}`
+   * itself, so the closing brace is never handed to parseStatement, which
+   * would misreport it as an orphan (issue #301).
    *
    * A comment sitting between the last body statement and the closing brace is
    * left in pending_trivia so it attaches to the statement after the block —
@@ -2949,7 +2759,7 @@ export class StataParser {
         continue;
       }
 
-      if (this.check('WHITESPACE') || this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK')) {
+      if (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK')) {
         this.advance();
         continue;
       }
@@ -2979,8 +2789,7 @@ export class StataParser {
         }
         continue;
       }
-      if (token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK' ||
-          token.type === 'WHITESPACE') {
+      if (token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK') {
         offset++;
         continue;
       }
@@ -3096,24 +2905,6 @@ export class StataParser {
     return this.tokens[this.current];
   }
 
-  /**
-   * Value of the next token after any interstitial WHITESPACE tokens, without
-   * consuming anything. `#delimit ;` mode emits a WHITESPACE token between
-   * tokens that `#delimit cr` mode elides, so a two-token lookahead such as
-   * `program` + `define` needs to skip that spacing (issue #305). Whitespace
-   * only — a comment between the two tokens is not skipped, matching cr mode,
-   * where such a comment is likewise a distinct token that defeats the
-   * adjacency lookahead.
-   */
-  private peekValueAfterWhitespace(): string | undefined {
-    let offset = 1;
-    while (this.current + offset < this.tokens.length &&
-           this.tokens[this.current + offset].type === 'WHITESPACE') {
-      offset++;
-    }
-    return this.tokens[this.current + offset]?.value;
-  }
-
   private previous(): Token {
     return this.tokens[this.current - 1];
   }
@@ -3141,9 +2932,8 @@ export class StataParser {
    */
   parseExpression(): string {
     // Collect the surviving tokens and reconstruct spacing from their ranges,
-    // so `#delimit ;` (which emits WHITESPACE tokens) and `#delimit cr` (which
-    // does not) produce the identical, source-faithful single-space form
-    // (issue #306). WHITESPACE contributes only a gap, never a character.
+    // so delimiter modes produce the identical, source-faithful single-space
+    // form (issue #306).
     const the_tokens: Token[] = [];
     const preceded_by_continuation: boolean[] = [];
     const continuation = new ContinuationTracker();
@@ -3188,13 +2978,10 @@ export class StataParser {
       }
 
       this.advance();
-      // WHITESPACE only marks a gap for range-based spacing; do not collect it.
-      if (token.type !== 'WHITESPACE') {
-        the_tokens.push(token);
-        preceded_by_continuation.push(
-          continuation.collect(token)
-        );
-      }
+      the_tokens.push(token);
+      preceded_by_continuation.push(
+        continuation.collect(token)
+      );
     }
 
     const expression = this.reconstruct_value_tokens(
@@ -3300,7 +3087,7 @@ export class StataParser {
     // Track state at each paren depth level
     const state_stack: ExpressionState[] = ['INITIAL'];
 
-    // Track previous non-whitespace token for split literal detection
+    // Track previous significant token for split literal detection
     let prev_token: Token | null = null;
 
     // Track string context for embedded macro handling
@@ -3389,14 +3176,7 @@ export class StataParser {
       // Stray token and split literal detection - skip if in string context, inside brackets, or if this is a delimiter-only STRING
       // We also skip delimiter-only STRING tokens because they are part of the string literal structure
       // Skip when inside brackets (bracket_depth > 0) because subscript expressions like var[_n-1] are valid
-      // Skip WHITESPACE: in `#delimit ;` mode the lexer preserves interstitial
-      // WHITESPACE tokens (elided in `#delimit cr` mode), which reach this
-      // check in AFTER_RHS state (e.g. the space in `if z > 1 in 1/10`). A
-      // space is never a stray token, so treating it as one produced a false
-      // STRAY_TOKEN_IN_CONDITION on valid semicolon-delimited qualifiers; the
-      // state machine already excludes WHITESPACE from transitions below
-      // (issue #305).
-      if (current_state === 'AFTER_RHS' && token.type !== 'WHITESPACE' && token.type !== 'LPAREN' && token.type !== 'RPAREN' && token.type !== 'LBRACKET' && token.type !== 'RBRACKET' && bracket_depth === 0 && !in_string_context && !is_delimiter_only) {
+      if (current_state === 'AFTER_RHS' && token.type !== 'LPAREN' && token.type !== 'RPAREN' && token.type !== 'LBRACKET' && token.type !== 'RBRACKET' && bracket_depth === 0 && !in_string_context && !is_delimiter_only) {
         // Check for split literal patterns first
         if (prev_token && this.detectSplitLiteral(prev_token, token)) {
           // Split literal diagnostic already emitted by detectSplitLiteral
@@ -3410,10 +3190,10 @@ export class StataParser {
         }
       }
 
-      // State transitions based on token type (skip whitespace)
+      // State transitions based on token type.
       // Also skip state transitions when inside brackets - bracket content is a subscript
       // expression that doesn't affect the outer expression state
-      if (token.type !== 'WHITESPACE' && token.type !== 'LPAREN' && token.type !== 'RPAREN' && bracket_depth === 0) {
+      if (token.type !== 'LPAREN' && token.type !== 'RPAREN' && bracket_depth === 0) {
         const current_state_for_transition = state_stack[state_stack.length - 1];
 
         if (token.type === 'OPERATOR') {
@@ -3460,13 +3240,10 @@ export class StataParser {
       }
 
       this.advance();
-      // WHITESPACE only marks a gap for range-based spacing; do not collect it.
-      if (token.type !== 'WHITESPACE') {
-        the_tokens.push(token);
-        preceded_by_continuation.push(
-          continuation.collect(token)
-        );
-      }
+      the_tokens.push(token);
+      preceded_by_continuation.push(
+        continuation.collect(token)
+      );
     }
 
     // Check for unbalanced parentheses
@@ -3581,7 +3358,7 @@ export class StataParser {
   /**
    * Check if there are non-trivia tokens after the given position on the same line.
    * Returns the first non-trivia token if found, null otherwise.
-   * Skips WHITESPACE, COMMENT_LINE, COMMENT_BLOCK, CONTINUATION tokens.
+   * Skips COMMENT_LINE, COMMENT_BLOCK, CONTINUATION tokens.
    * A `///` continuation joins the next physical line, so "same
    * line" means the same logical line.
    */
@@ -3594,14 +3371,13 @@ export class StataParser {
    * and return its first and last non-trivia tokens, or null when the
    * line has no code before a real terminator or EOF. A `///`
    * continuation joins the next physical line into the same logical
-   * line. Skips WHITESPACE, COMMENT_LINE, COMMENT_BLOCK, CONTINUATION.
+   * line. Skips COMMENT_LINE, COMMENT_BLOCK, CONTINUATION.
    */
   scan_code_on_same_line(
     start_pos: number,
     line: number
   ): { first_token: Token; last_token: Token } | null {
     const trivia_types: TokenType[] = [
-      'WHITESPACE',
       'COMMENT_LINE',
       'COMMENT_BLOCK',
       'CONTINUATION',
@@ -3660,13 +3436,12 @@ export class StataParser {
   /**
    * Check if there are non-trivia tokens before the given position on the same line.
    * Returns the last non-trivia token if found, null otherwise.
-   * Skips WHITESPACE, COMMENT_LINE, COMMENT_BLOCK, CONTINUATION tokens.
+   * Skips COMMENT_LINE, COMMENT_BLOCK, CONTINUATION tokens.
    * A `///` continuation joins the next physical line, so "same
    * line" means the same logical line.
    */
   find_code_before_on_same_line(end_pos: number, line: number): Token | null {
     const trivia_types: TokenType[] = [
-      'WHITESPACE',
       'COMMENT_LINE',
       'COMMENT_BLOCK',
       'CONTINUATION',
@@ -3828,7 +3603,7 @@ export class StataParser {
    * `reconstructTokensWithSpacing`, exact widths and indentation are collapsed,
    * so values read cleanly.
    *
-   * @param tokens - value tokens in order (WHITESPACE/CONTINUATION removed)
+   * @param tokens - value tokens in order (CONTINUATION removed)
    * @param preceded_by_continuation - parallel array; entry `i` is true when
    *   `tokens[i]` was reached by crossing a `///` continuation
    */

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -369,13 +369,26 @@ export class StataParser {
         // Add the token value
         content += my_token.value;
 
-        // Add space between tokens if there's a gap and not the last token
+        // Add source gap between tokens if there is one. In `#delimit ;`
+        // mode, inline embedded content can cross physical lines without an
+        // interposed WHITESPACE token; preserve that line boundary so `//`
+        // comments do not swallow the next physical line.
         if (i < content_tokens.length - 1) {
           const next_token = content_tokens[i + 1];
-          const gap = next_token.range.start.character - my_token.range.end.character;
-          if (gap > 0) {
-            // Add the appropriate number of spaces
-            content += ' '.repeat(gap);
+          if (next_token.range.start.line === my_token.range.end.line) {
+            const gap =
+              next_token.range.start.character -
+              my_token.range.end.character;
+            if (gap > 0) {
+              content += ' '.repeat(gap);
+            }
+          } else if (next_token.range.start.line > my_token.range.end.line) {
+            const line_gap =
+              next_token.range.start.line - my_token.range.end.line;
+            content += '\n'.repeat(line_gap);
+            if (next_token.range.start.character > 0) {
+              content += ' '.repeat(next_token.range.start.character);
+            }
           }
         }
       }
@@ -3877,13 +3890,12 @@ export class StataParser {
           if (gap > 0) {
             the_parts.push(' '.repeat(gap));
           }
-        } else {
-          // Different lines - preserve original spacing by using the token's column position
-          const spaces_from_line_start = my_token.range.start.character;
-          if (spaces_from_line_start > 0) {
-            the_parts.push(' '.repeat(spaces_from_line_start));
-          } else {
-            the_parts.push(' ');
+        } else if (my_token.range.start.line > prev_token.range.end.line) {
+          const line_gap =
+            my_token.range.start.line - prev_token.range.end.line;
+          the_parts.push('\n'.repeat(line_gap));
+          if (my_token.range.start.character > 0) {
+            the_parts.push(' '.repeat(my_token.range.start.character));
           }
         }
       }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1212,6 +1212,9 @@ export class StataParser {
             const parsed = this.parse_option_argument_inside_parens();
             option.argument = parsed.argument;
             option.argument_range = parsed.argument_range;
+            if (parsed.argument_unclosed) {
+              option.argument_unclosed = true;
+            }
           }
 
           options.push(option);
@@ -1238,9 +1241,15 @@ export class StataParser {
   /**
    * Parse option argument inside parentheses.
    * Assumes LPAREN is next token. Consumes through RPAREN.
-   * Returns argument string and argument_range (span of non-whitespace tokens).
+   * Returns argument string, argument_range (span of non-whitespace tokens),
+   * and argument_unclosed when recovery stopped before consuming the outer
+   * closing paren.
    */
-  private parse_option_argument_inside_parens(): { argument: string; argument_range?: Range } {
+  private parse_option_argument_inside_parens(): {
+    argument: string;
+    argument_range?: Range;
+    argument_unclosed?: true;
+  } {
     this.advance(); // consume (
     // Collect argument tokens and reconstruct spacing from their ranges via
     // reconstruct_value_tokens, so delimiter modes produce the identical
@@ -1275,11 +1284,17 @@ export class StataParser {
       arg_tokens.push(t);
       preceded_by_continuation.push(continuation.collect(t));
     }
+    const argument_unclosed = paren_depth > 0 ? true : undefined;
     if (
       stopped_at_terminator &&
       paren_depth === 1 &&
       arg_tokens[arg_tokens.length - 1]?.type === 'RPAREN'
     ) {
+      // Recovery-only trim: a trailing inner `)` often belongs to the final
+      // nested call (`vce(seed(123)`) rather than to the option itself. Removing
+      // it keeps the recovered argument tidy, but this does NOT count as a
+      // closed outer option paren; downstream semantic effects must still see
+      // argument_unclosed.
       arg_tokens.pop();
       preceded_by_continuation.pop();
     }
@@ -1290,7 +1305,7 @@ export class StataParser {
     const argument_range = arg_tokens.length > 0
       ? { start: arg_tokens[0].range.start, end: arg_tokens[arg_tokens.length - 1].range.end }
       : undefined;
-    return { argument, argument_range };
+    return { argument, argument_range, argument_unclosed };
   }
 
   /**
@@ -1508,6 +1523,9 @@ export class StataParser {
             const parsed = this.parse_option_argument_inside_parens();
             option.argument = parsed.argument;
             option.argument_range = parsed.argument_range;
+            if (parsed.argument_unclosed) {
+              option.argument_unclosed = true;
+            }
           }
 
           options.push(option);
@@ -2655,6 +2673,9 @@ export class StataParser {
             const parsed = this.parse_option_argument_inside_parens();
             option.argument = parsed.argument;
             option.argument_range = parsed.argument_range;
+            if (parsed.argument_unclosed) {
+              option.argument_unclosed = true;
+            }
           }
           options.push(option);
         } else {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1250,7 +1250,12 @@ export class StataParser {
     const preceded_by_continuation: boolean[] = [];
     const continuation = new ContinuationTracker();
     let paren_depth = 1;
+    let stopped_at_terminator = false;
     while (!this.isAtEnd() && paren_depth > 0) {
+      if (this.check('STATEMENT_TERMINATOR')) {
+        stopped_at_terminator = true;
+        break;
+      }
       if (this.check('CONTINUATION')) {
         const cont_token = this.peek();
         if (this.skipContinuation()) {
@@ -1269,6 +1274,14 @@ export class StataParser {
       }
       arg_tokens.push(t);
       preceded_by_continuation.push(continuation.collect(t));
+    }
+    if (
+      stopped_at_terminator &&
+      paren_depth === 1 &&
+      arg_tokens[arg_tokens.length - 1]?.type === 'RPAREN'
+    ) {
+      arg_tokens.pop();
+      preceded_by_continuation.pop();
     }
     const argument = this.reconstruct_value_tokens(
       arg_tokens,

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1215,6 +1215,9 @@ export class StataParser {
             if (parsed.argument_unclosed) {
               option.argument_unclosed = true;
             }
+            if (parsed.argument_trailing_trivia) {
+              option.argument_trailing_trivia = parsed.argument_trailing_trivia;
+            }
           }
 
           options.push(option);
@@ -1249,6 +1252,7 @@ export class StataParser {
     argument: string;
     argument_range?: Range;
     argument_unclosed?: true;
+    argument_trailing_trivia?: string;
   } {
     this.advance(); // consume (
     // Collect argument tokens and reconstruct spacing from their ranges via
@@ -1258,8 +1262,8 @@ export class StataParser {
     const arg_tokens: Token[] = [];
     const preceded_by_continuation: boolean[] = [];
     const continuation = new ContinuationTracker();
+    let pending_trailing_trivia: Token[] = [];
     let paren_depth = 1;
-    let option_closes_after_comments: boolean | undefined;
     while (!this.isAtEnd() && paren_depth > 0) {
       if (this.check('STATEMENT_TERMINATOR')) {
         break;
@@ -1268,21 +1272,13 @@ export class StataParser {
         const cont_token = this.peek();
         if (this.skipContinuation()) {
           continuation.note_continuation(cont_token);
+          pending_trailing_trivia = [];
           continue;
         }
       }
       if (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK')) {
-        // One forward scan is enough for all comments in this option argument:
-        // once an outer close is known to exist before the effective statement
-        // end, every later comment we reach is still on the same path toward
-        // that close. If no close exists, recovery breaks immediately here.
-        option_closes_after_comments ??=
-          this.has_matching_option_close_before_statement(paren_depth);
-        if (option_closes_after_comments) {
-          this.advance();
-          continue;
-        }
-        break;
+        pending_trailing_trivia.push(this.advance());
+        continue;
       }
       const t = this.advance();
       if (t.type === 'LPAREN') {
@@ -1294,9 +1290,13 @@ export class StataParser {
         }
       }
       arg_tokens.push(t);
+      pending_trailing_trivia = [];
       preceded_by_continuation.push(continuation.collect(t));
     }
     const argument_unclosed = paren_depth > 0 ? true : undefined;
+    const argument_trailing_trivia = argument_unclosed && pending_trailing_trivia.length > 0
+      ? pending_trailing_trivia.map(token => token.value).join(' ')
+      : undefined;
     const argument = this.reconstruct_value_tokens(
       arg_tokens,
       preceded_by_continuation
@@ -1304,53 +1304,7 @@ export class StataParser {
     const argument_range = arg_tokens.length > 0
       ? { start: arg_tokens[0].range.start, end: arg_tokens[arg_tokens.length - 1].range.end }
       : undefined;
-    return { argument, argument_range, argument_unclosed };
-  }
-
-  /**
-   * Look ahead from a comment inside an option argument to determine whether
-   * the already-open option parenthesis is closed before the statement ends.
-   * Comments are trivia for the argument string, but a close paren after trivia
-   * still means the option is semantically closed.
-   */
-  private has_matching_option_close_before_statement(paren_depth: number):
-    boolean {
-    let scan_depth = paren_depth;
-    let index = this.current;
-    while (index < this.tokens.length && scan_depth > 0) {
-      const token = this.tokens[index];
-      if (token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK') {
-        index++;
-        continue;
-      }
-      if (token.type === 'CONTINUATION') {
-        const next_token = this.tokens[index + 1];
-        index += 1;
-        if (
-          next_token !== undefined &&
-          is_swallowed_continuation_terminator(next_token, true)
-        ) {
-          index += 1;
-        }
-        continue;
-      }
-      if (token.type === 'STATEMENT_TERMINATOR') {
-        return false;
-      }
-      if (token.type === 'LPAREN') {
-        scan_depth++;
-      } else if (token.type === 'RPAREN') {
-        scan_depth--;
-        if (scan_depth === 0) {
-          return true;
-        }
-      }
-      // STRING tokens are ignored here on purpose: the lexer keeps any parens
-      // inside a string literal inside the STRING token value rather than
-      // emitting LPAREN/RPAREN tokens, so they cannot affect option depth.
-      index++;
-    }
-    return false;
+    return { argument, argument_range, argument_unclosed, argument_trailing_trivia };
   }
 
   /**
@@ -1570,6 +1524,9 @@ export class StataParser {
             option.argument_range = parsed.argument_range;
             if (parsed.argument_unclosed) {
               option.argument_unclosed = true;
+            }
+            if (parsed.argument_trailing_trivia) {
+              option.argument_trailing_trivia = parsed.argument_trailing_trivia;
             }
           }
 
@@ -2720,6 +2677,9 @@ export class StataParser {
             option.argument_range = parsed.argument_range;
             if (parsed.argument_unclosed) {
               option.argument_unclosed = true;
+            }
+            if (parsed.argument_trailing_trivia) {
+              option.argument_trailing_trivia = parsed.argument_trailing_trivia;
             }
           }
           options.push(option);

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1259,6 +1259,7 @@ export class StataParser {
     const preceded_by_continuation: boolean[] = [];
     const continuation = new ContinuationTracker();
     let paren_depth = 1;
+    let option_closes_after_comments: boolean | undefined;
     while (!this.isAtEnd() && paren_depth > 0) {
       if (this.check('STATEMENT_TERMINATOR')) {
         break;
@@ -1271,7 +1272,13 @@ export class StataParser {
         }
       }
       if (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK')) {
-        if (this.has_matching_option_close_before_statement(paren_depth)) {
+        // One forward scan is enough for all comments in this option argument:
+        // once an outer close is known to exist before the effective statement
+        // end, every later comment we reach is still on the same path toward
+        // that close. If no close exists, recovery breaks immediately here.
+        option_closes_after_comments ??=
+          this.has_matching_option_close_before_statement(paren_depth);
+        if (option_closes_after_comments) {
           this.advance();
           continue;
         }
@@ -1312,6 +1319,21 @@ export class StataParser {
     let index = this.current;
     while (index < this.tokens.length && scan_depth > 0) {
       const token = this.tokens[index];
+      if (token.type === 'COMMENT_LINE' || token.type === 'COMMENT_BLOCK') {
+        index++;
+        continue;
+      }
+      if (token.type === 'CONTINUATION') {
+        const next_token = this.tokens[index + 1];
+        index += 1;
+        if (
+          next_token !== undefined &&
+          is_swallowed_continuation_terminator(next_token, true)
+        ) {
+          index += 1;
+        }
+        continue;
+      }
       if (token.type === 'STATEMENT_TERMINATOR') {
         return false;
       }
@@ -1323,6 +1345,9 @@ export class StataParser {
           return true;
         }
       }
+      // STRING tokens are ignored here on purpose: the lexer keeps any parens
+      // inside a string literal inside the STRING token value rather than
+      // emitting LPAREN/RPAREN tokens, so they cannot affect option depth.
       index++;
     }
     return false;

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1379,6 +1379,9 @@ export class StataParser {
     };
 
     while (!this.isAtEnd() && paren_depth > 0) {
+      if (this.check('STATEMENT_TERMINATOR')) {
+        break;
+      }
       if (this.check('CONTINUATION')) {
         const cont_token = this.peek();
         if (this.skipContinuation()) {
@@ -2983,6 +2986,10 @@ export class StataParser {
     while (!this.isAtEnd()) {
       const token = this.peek();
 
+      if (token.type === 'STATEMENT_TERMINATOR') {
+        break;
+      }
+
       // Handle continuation tokens - skip them and continue parsing
       if (this.skipContinuation()) {
         continuation.note_continuation(token);
@@ -3001,9 +3008,10 @@ export class StataParser {
         }
       }
 
-      // Stop at top-level comma, statement terminator, or qualifier keywords
+      // Stop at top-level comma or qualifier keywords. A statement terminator
+      // is always a hard stop and is handled before depth accounting above.
       if (paren_depth === 0) {
-        if (token.type === 'COMMA' || token.type === 'STATEMENT_TERMINATOR') {
+        if (token.type === 'COMMA') {
           break;
         }
         // Stop at qualifier keywords
@@ -3138,6 +3146,10 @@ export class StataParser {
     while (!this.isAtEnd()) {
       const token = this.peek();
 
+      if (token.type === 'STATEMENT_TERMINATOR') {
+        break;
+      }
+
       // Track parenthesis depth
       if (token.type === 'LPAREN') {
         paren_depth++;
@@ -3182,9 +3194,11 @@ export class StataParser {
         continue;
       }
 
-      // Stop at top-level terminators (only when not inside brackets)
+      // Stop at top-level separators (only when not inside brackets). A
+      // statement terminator is always a hard stop and is handled before depth
+      // accounting above.
       if (paren_depth === 0 && bracket_depth === 0) {
-        if (token.type === 'STATEMENT_TERMINATOR' || token.type === 'COMMA') {
+        if (token.type === 'COMMA') {
           break;
         }
         // Stop at 'in' keyword (only for if-qualifiers)

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1408,11 +1408,12 @@ export class StataParser {
       inner_tokens,
       preceded_by_continuation
     );
-    const paren_end_pos = this.check('RPAREN')
+    const closed_group = paren_depth === 0 && this.check('RPAREN');
+    const paren_end_pos = closed_group
         ? this.peek().range.end
         : this.previous().range.end;
 
-    if (this.check('RPAREN')) {
+    if (closed_group) {
       this.advance(); // consume closing paren
     }
 
@@ -1421,8 +1422,16 @@ export class StataParser {
       return null;
     }
 
+    // If recovery stopped at a statement terminator or EOF, preserve only the
+    // text the user wrote. We intentionally do not emit an unbalanced-paren
+    // diagnostic here: like unclosed option arguments, this is usually an
+    // editor mid-typing state and warning on each keystroke is noisy.
+    const group_name = closed_group
+      ? `(${paren_content})`
+      : `(${paren_content}`;
+
     return {
-      name: `(${paren_content})`,
+      name: group_name,
       range: this.makeRange(paren_start.range.start, paren_end_pos),
     };
   }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1567,6 +1567,8 @@ export class StataParser {
     // index-based spec parsers below operate on the lexer token stream
     // directly; comments still stop collection.
     const syntax_tokens: Token[] = [];
+    const preceded_by_continuation: boolean[] = [];
+    const continuation = new ContinuationTracker();
     while (
       !this.check('STATEMENT_TERMINATOR') &&
       !this.isAtEnd()
@@ -1575,14 +1577,19 @@ export class StataParser {
       // syntax declaration (`syntax varlist, ///` newline `opt(string)`) is
       // collected whole rather than truncated at the first continuation
       // (issue #306). A comment still stops collection.
-      if (this.skipContinuation()) {
-        continue;
+      if (this.check('CONTINUATION')) {
+        const cont_token = this.peek();
+        if (this.skipContinuation()) {
+          continuation.note_continuation(cont_token);
+          continue;
+        }
       }
       if (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK')) {
         break;
       }
       const my_token = this.advance();
       syntax_tokens.push(my_token);
+      preceded_by_continuation.push(continuation.collect(my_token));
     }
 
     // Parse the collected tokens
@@ -1623,7 +1630,8 @@ export class StataParser {
           // This is a required option marker, let parse_option_spec handle it
           const opt_result = this.parse_option_spec(
             syntax_tokens,
-            token_idx
+            token_idx,
+            preceded_by_continuation
           );
           if (opt_result) {
             // Track option names for duplicate detection
@@ -1646,7 +1654,8 @@ export class StataParser {
       // Try to parse an option
       const opt_result = this.parse_option_spec(
         syntax_tokens,
-        token_idx
+        token_idx,
+        preceded_by_continuation
       );
       if (opt_result) {
         // Track option names for duplicate detection
@@ -1791,7 +1800,8 @@ export class StataParser {
 
   private parse_option_spec(
     tokens: Token[],
-    start_idx: number
+    start_idx: number,
+    preceded_by_continuation: boolean[] = []
   ): { spec: OptionSpec; next_idx: number } | null {
     if (start_idx >= tokens.length) {
       return null;
@@ -1838,6 +1848,7 @@ export class StataParser {
 
       // Collect tokens until closing paren
       const type_tokens: Token[] = [];
+      const type_flags: boolean[] = [];
       let paren_depth = 1;
       while (current_idx < tokens.length && paren_depth > 0) {
         const my_token = tokens[current_idx];
@@ -1850,6 +1861,7 @@ export class StataParser {
           }
         }
         type_tokens.push(my_token);
+        type_flags.push(preceded_by_continuation[current_idx] ?? false);
         current_idx++;
       }
 
@@ -1888,7 +1900,6 @@ export class StataParser {
               // absent here.
               const default_tokens: Token[] = [];
               const default_flags: boolean[] = [];
-              const default_continuation = new ContinuationTracker();
               let default_paren_depth = 1;
               let j = i + 2;
               while (j < type_tokens.length && default_paren_depth > 0) {
@@ -1902,7 +1913,7 @@ export class StataParser {
                   }
                 }
                 default_tokens.push(my_token);
-                default_flags.push(default_continuation.collect(my_token));
+                default_flags.push(type_flags[j] ?? false);
                 j++;
               }
               default_value = this.reconstruct_value_tokens(

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -28,6 +28,79 @@ import { is_swallowed_continuation_terminator } from '../utils/continuation';
 
 const PREFIX_COMMANDS = new Set(['by', 'bysort', 'quietly', 'qui', 'capture', 'cap', 'noisily', 'noi']);
 
+/**
+ * Tracks `///` line-continuation state while a caller collects the tokens of a
+ * reconstructed value (expression, if/in qualifier, parenthesized group, macro
+ * value, or loop spec). It answers, per collected token, whether that token was
+ * reached by an UNBROKEN continuation chain from the previous collected token —
+ * i.e. every physical line between them ended with `///`.
+ *
+ * `///` continues ONLY the immediately-following line, so a token pushed
+ * further down by a raw newline (a blank line in `#delimit ;` mode, or a `///`
+ * that does not extend the chain contiguously) is NOT a continuation join and
+ * must separate. This prevents value-token fusion such as `a///\n\nb` -> `ab`
+ * or `a///\n\n///\nb` -> `ab` (issue #306). The boolean flag it produces feeds
+ * `reconstruct_value_tokens`, which applies the column-0-join rule only when
+ * the flag is true.
+ */
+class ContinuationTracker {
+  // The line that must end with `///` to extend the chain by one line. Advances
+  // as contiguous continuations are noted; a gap leaves it behind the next
+  // collected token, which then reads as a raw-newline separator.
+  private required_line = -1;
+  private prev_collected_line: number | null = null;
+  private prev_collected_end: { line: number; character: number } | null = null;
+  // False once the chain contains real whitespace that must separate (a
+  // same-line gap before the first `///`, e.g. `a ///`); a "clean" chain is a
+  // pure column-0 join like `a///`.
+  private chain_clean = true;
+
+  /** Record a `///` continuation token (used for its own line and column). */
+  note_continuation(continuation_token: Token): void {
+    const cont_line = continuation_token.range.start.line;
+    if (cont_line !== this.required_line) {
+      // Not a contiguous extension; collect()'s line check separates the token.
+      return;
+    }
+    // Whitespace immediately before a contiguous `///` is real content that
+    // must separate, so the chain is no longer a clean column-0 join (issue
+    // #306). For the FIRST `///` (on the previous collected token's line) that
+    // is a same-line gap after that token, e.g. `a ///`. For a `///` on its own
+    // continuation line, any leading indentation is that whitespace, e.g. the
+    // `    ` before the second `///` in `a///` / `    ///` / `b`.
+    const cont_col = continuation_token.range.start.character;
+    const is_first_on_prev_line =
+      this.prev_collected_end !== null &&
+      this.required_line === this.prev_collected_line &&
+      cont_line === this.prev_collected_end.line;
+    const has_leading_gap = is_first_on_prev_line
+      ? cont_col > (this.prev_collected_end as { character: number }).character
+      : cont_col > 0;
+    if (has_leading_gap) {
+      this.chain_clean = false;
+    }
+    this.required_line += 1;
+  }
+
+  /**
+   * Register a collected token; returns whether it directly follows an unbroken,
+   * gap-free `///` chain from the previous collected token (a column-0 join).
+   */
+  collect(token: Token): boolean {
+    const token_line = token.range.start.line;
+    const follows_continuation =
+      this.prev_collected_line !== null &&
+      token_line > this.prev_collected_line &&
+      token_line === this.required_line &&
+      this.chain_clean;
+    this.prev_collected_line = token_line;
+    this.prev_collected_end = token.range.end;
+    this.required_line = token_line;
+    this.chain_clean = true;
+    return follows_continuation;
+  }
+}
+
 export class StataParser {
   private tokens: Token[] = [];
   private current: number = 0;
@@ -521,13 +594,16 @@ export class StataParser {
     // with no space; a raw `#delimit ;` newline is ordinary whitespace and
     // always separates. See reconstruct_value_tokens.
     const preceded_by_continuation: boolean[] = [];
-    let continuation_pending = false;
+    const continuation = new ContinuationTracker();
 
     while (!this.check('STATEMENT_TERMINATOR') && !this.isAtEnd()) {
       // Handle continuation tokens - skip them and continue parsing
-      if (this.skipContinuation()) {
-        continuation_pending = true;
-        continue;
+      if (this.check('CONTINUATION')) {
+        const cont_token = this.peek();
+        if (this.skipContinuation()) {
+          continuation.note_continuation(cont_token);
+          continue;
+        }
       }
 
       // Stop at comments (but not continuations - handled above)
@@ -542,9 +618,11 @@ export class StataParser {
       // the raw run of spaces/newlines. Skip them: reconstruct_value_tokens
       // re-inserts a single space from inter-token gaps, so keeping them would
       // embed literal whitespace (and `\n`) into the stored macro value.
-      // Leave continuation_pending untouched: a `///` continuation's
-      // indentation may surface as a WHITESPACE token before the next real
-      // token, and the continuation status still applies to that token.
+      // Leave continuation_line untouched: a `///` continuation's indentation
+      // may surface as a WHITESPACE token before the next real token, and the
+      // continuation still applies to that token (unless extra raw newlines
+      // push it off the immediately-following line — see
+      // token_follows_continuation).
       if (token.type === 'WHITESPACE') {
         continue;
       }
@@ -562,8 +640,9 @@ export class StataParser {
       }
 
       value_tokens.push(token);
-      preceded_by_continuation.push(continuation_pending);
-      continuation_pending = false;
+      preceded_by_continuation.push(
+        continuation.collect(token)
+      );
     }
 
     // Reconstruct with single-space separation from token ranges. The lexer
@@ -607,15 +686,27 @@ export class StataParser {
     const function_name = this.advance().value;
     this.skipMacroDefinitionTrivia();
 
-    // Collect function arguments.
-    // IMPORTANT: Preserve the original token stream verbatim to avoid introducing
-    // artificial token boundaries (e.g., turning "0Ea" into "0E a").
+    // Collect function arguments. `arg_tokens` keeps every token (including
+    // WHITESPACE) for macro-reference extraction, while `value_tokens` holds
+    // only the non-whitespace tokens used to reconstruct the arg string.
+    // Reconstructing from token ranges via reconstruct_value_tokens keeps the
+    // two delimiter modes identical (a single space per gap) and never invents
+    // artificial boundaries (adjacent tokens like `0Ea` stay joined), unlike
+    // appending raw WHITESPACE token values which embeds literal spaces and
+    // newlines in `#delimit ;` mode (issue #306).
     const arg_tokens: Token[] = [];
+    const value_tokens: Token[] = [];
+    const preceded_by_continuation: boolean[] = [];
+    const continuation = new ContinuationTracker();
     while (!this.check('STATEMENT_TERMINATOR') && !this.isAtEnd()) {
       // Bridge `///` continuations onto the next physical line, matching the
       // standard `= ...` value path.
-      if (this.skipContinuation()) {
-        continue;
+      if (this.check('CONTINUATION')) {
+        const cont_token = this.peek();
+        if (this.skipContinuation()) {
+          continuation.note_continuation(cont_token);
+          continue;
+        }
       }
 
       // Stop at comments (continuations are handled above).
@@ -625,10 +716,19 @@ export class StataParser {
 
       const token = this.advance();
       arg_tokens.push(token);
+      if (token.type !== 'WHITESPACE') {
+        value_tokens.push(token);
+        preceded_by_continuation.push(
+          continuation.collect(token)
+        );
+      }
     }
 
-    // Reconstruct args with original spacing preserved
-    const args_trimmed = this.reconstructTokensWithSpacing(arg_tokens).trim();
+    // Reconstruct args with mode-independent single-space spacing.
+    const args_trimmed = this.reconstruct_value_tokens(
+      value_tokens,
+      preceded_by_continuation
+    ).trim();
     const extended_function = {
       name: function_name,
       args: args_trimmed,
@@ -1202,19 +1302,39 @@ export class StataParser {
    */
   private parse_option_argument_inside_parens(): { argument: string; argument_range?: Range } {
     this.advance(); // consume (
-    let argument = '';
+    // Collect the non-whitespace argument tokens and reconstruct spacing from
+    // their ranges via reconstruct_value_tokens, so `#delimit ;` and
+    // `#delimit cr` produce the identical single-space form and multi-token
+    // arguments are never fused — e.g. `absorb(firm year)` stays `firm year`,
+    // not `firmyear` (issue #306). Appending raw token values would also embed
+    // literal WHITESPACE and `///` continuation markers into the argument.
     const arg_tokens: Token[] = [];
+    const preceded_by_continuation: boolean[] = [];
+    const continuation = new ContinuationTracker();
     while (!this.check('RPAREN') && !this.isAtEnd()) {
+      if (this.check('CONTINUATION')) {
+        const cont_token = this.peek();
+        if (this.skipContinuation()) {
+          continuation.note_continuation(cont_token);
+          continue;
+        }
+      }
       const t = this.advance();
+      if (t.type === 'WHITESPACE') {
+        continue;
+      }
       arg_tokens.push(t);
-      argument += t.value;
+      preceded_by_continuation.push(continuation.collect(t));
     }
     if (this.check('RPAREN')) {
       this.advance(); // consume )
     }
-    const non_ws = arg_tokens.filter(t => t.type !== 'WHITESPACE');
-    const argument_range = non_ws.length > 0
-      ? { start: non_ws[0].range.start, end: non_ws[non_ws.length - 1].range.end }
+    const argument = this.reconstruct_value_tokens(
+      arg_tokens,
+      preceded_by_continuation
+    );
+    const argument_range = arg_tokens.length > 0
+      ? { start: arg_tokens[0].range.start, end: arg_tokens[arg_tokens.length - 1].range.end }
       : undefined;
     return { argument, argument_range };
   }
@@ -1238,10 +1358,11 @@ export class StataParser {
       return null;
     }
 
-    // Coalesce all tokens until whitespace, comma, terminator, or trivia
+    // Coalesce adjacent tokens until whitespace, comma, terminator, or trivia
     const start_token = this.advance();
     let path = start_token.value;
     let end_range = start_token.range.end;
+    let prev_token = start_token;
 
     while (!this.isAtEnd()) {
       // Stop at whitespace, comma, terminator, or trivia
@@ -1252,10 +1373,22 @@ export class StataParser {
         break;
       }
 
+      // Stop at a source gap. In `#delimit cr` mode the lexer emits no
+      // WHITESPACE tokens, so coalescing every non-trivia token would merge a
+      // file command's entire argument list into one path (e.g.
+      // `merge 1:1 id using data` -> `1:1idusingdata`). Only coalesce tokens
+      // physically adjacent to the previous one; a gap ends the path. In
+      // `#delimit ;` mode the WHITESPACE break above already separates
+      // arguments, so this adjacency guard is inert there (issue #306).
+      if (!this.isAdjacentToken(prev_token, this.peek())) {
+        break;
+      }
+
       // Consume any other token as part of the path
       const token = this.advance();
       path += token.value;
       end_range = token.range.end;
+      prev_token = token;
     }
 
     return {
@@ -1274,36 +1407,54 @@ export class StataParser {
    */
   private parseParenthesizedGroup(): IdentifierNode | null {
     const paren_start = this.advance(); // consume (
-    const paren_parts: string[] = [];
+    // Collect the inner tokens (everything up to, but not including, the
+    // matching outer close paren) and reconstruct spacing from their ranges via
+    // reconstruct_value_tokens, so `#delimit ;` and `#delimit cr` produce the
+    // identical single-space form — e.g. `(a b)` stays `(a b)` and `(1/3 = 1)`
+    // is `(1/3 = 1)` in both modes (issue #306). WHITESPACE only marks a gap.
+    const inner_tokens: Token[] = [];
+    const preceded_by_continuation: boolean[] = [];
+    const continuation = new ContinuationTracker();
     let paren_depth = 1;
-    let last_was_word = false;
+
+    const collect = (my_token: Token): void => {
+      inner_tokens.push(my_token);
+      preceded_by_continuation.push(
+        continuation.collect(my_token)
+      );
+    };
 
     while (!this.isAtEnd() && paren_depth > 0) {
+      if (this.check('WHITESPACE')) {
+        this.advance();
+        continue;
+      }
+      if (this.check('CONTINUATION')) {
+        const cont_token = this.peek();
+        if (this.skipContinuation()) {
+          continuation.note_continuation(cont_token);
+          continue;
+        }
+      }
       if (this.check('LPAREN')) {
         paren_depth++;
-        paren_parts.push(this.advance().value);
-        last_was_word = false;
+        collect(this.advance());
       } else if (this.check('RPAREN')) {
         paren_depth--;
+        // Collect nested close parens; the matching outer close is the wrapper
+        // and is excluded from the reconstructed content.
         if (paren_depth > 0) {
-          paren_parts.push(this.advance().value);
+          collect(this.advance());
         }
-        last_was_word = false;
       } else {
-        const current_is_word = this.check('WORD') ||
-            this.check('NUMBER') ||
-            this.check('MACRO_REF_LOCAL') ||
-            this.check('MACRO_REF_GLOBAL');
-        // Add space between consecutive word-like tokens
-        if (last_was_word && current_is_word) {
-          paren_parts.push(' ');
-        }
-        paren_parts.push(this.advance().value);
-        last_was_word = current_is_word;
+        collect(this.advance());
       }
     }
 
-    const paren_content = paren_parts.join('');
+    const paren_content = this.reconstruct_value_tokens(
+      inner_tokens,
+      preceded_by_continuation
+    );
     const paren_end_pos = this.check('RPAREN')
         ? this.peek().range.end
         : this.previous().range.end;
@@ -1523,9 +1674,18 @@ export class StataParser {
     const syntax_tokens: Token[] = [];
     while (
       !this.check('STATEMENT_TERMINATOR') &&
-      !this.isAtEnd() &&
-      !this.isTrivia()
+      !this.isAtEnd()
     ) {
+      // Bridge `///` continuations onto the next physical line so a multi-line
+      // syntax declaration (`syntax varlist, ///` newline `opt(string)`) is
+      // collected whole rather than truncated at the first continuation
+      // (issue #306). A comment still stops collection.
+      if (this.skipContinuation()) {
+        continue;
+      }
+      if (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK')) {
+        break;
+      }
       const my_token = this.advance();
       if (my_token.type !== 'WHITESPACE') {
         syntax_tokens.push(my_token);
@@ -1827,26 +1987,41 @@ export class StataParser {
                 type_tokens[i].value === 'default' &&
                 i + 1 < type_tokens.length &&
                 type_tokens[i + 1].type === 'LPAREN') {
-              // Found default(, collect tokens until closing paren
-              let default_str = '';
+              // Found default(, collect tokens until closing paren and
+              // reconstruct spacing from token ranges via the shared helper, so
+              // a multi-token default like `default(a b)` stays `a b` instead
+              // of fusing to `ab` (issue #306). Range-based reconstruction
+              // yields a single space per gap even though whitespace tokens are
+              // absent here.
+              const default_tokens: Token[] = [];
+              const default_flags: boolean[] = [];
+              const default_continuation = new ContinuationTracker();
               let default_paren_depth = 1;
               let j = i + 2;
               while (j < type_tokens.length && default_paren_depth > 0) {
                 const my_token = type_tokens[j];
+                // syntax_tokens has WHITESPACE/CONTINUATION already stripped, so
+                // spacing comes purely from token ranges via the helper.
+                if (my_token.type === 'WHITESPACE') {
+                  j++;
+                  continue;
+                }
                 if (my_token.type === 'LPAREN') {
                   default_paren_depth++;
-                  default_str += my_token.value;
                 } else if (my_token.type === 'RPAREN') {
                   default_paren_depth--;
-                  if (default_paren_depth > 0) {
-                    default_str += my_token.value;
+                  if (default_paren_depth === 0) {
+                    break;
                   }
-                } else {
-                  default_str += my_token.value;
                 }
+                default_tokens.push(my_token);
+                default_flags.push(default_continuation.collect(my_token));
                 j++;
               }
-              default_value = default_str.trim();
+              default_value = this.reconstruct_value_tokens(
+                default_tokens,
+                default_flags
+              ).trim();
               break;
             }
           }
@@ -2007,15 +2182,23 @@ export class StataParser {
   private parseIfStatement(): ControlFlowNode {
     const ifToken = this.advance(); // consume 'if'
 
-    // Parse condition - collect tokens until { and reconstruct with original spacing
+    // Parse condition - collect tokens until { and reconstruct spacing from
+    // token ranges, so both delimiter modes agree and `///` continuations use
+    // the same join semantics as expressions/qualifiers (issue #306).
     const condition_tokens: Token[] = [];
+    const preceded_by_continuation: boolean[] = [];
+    const continuation = new ContinuationTracker();
     const condition_start_line = ifToken.range.start.line;
     let paren_depth = 0;
 
     while (!this.check('LBRACE') && !this.isAtEnd()) {
       // Handle continuation tokens - skip them and continue parsing
-      if (this.skipContinuation()) {
-        continue;
+      if (this.check('CONTINUATION')) {
+        const cont_token = this.peek();
+        if (this.skipContinuation()) {
+          continuation.note_continuation(cont_token);
+          continue;
+        }
       }
 
       // Stop at statement terminator
@@ -2039,11 +2222,15 @@ export class StataParser {
       // Skip whitespace tokens but collect all others
       if (token.type !== 'WHITESPACE') {
         condition_tokens.push(token);
+        preceded_by_continuation.push(continuation.collect(token));
       }
     }
 
-    // Reconstruct condition with original spacing preserved
-    const condition = this.reconstructTokensWithSpacing(condition_tokens).trim();
+    // Reconstruct condition with mode-independent single-space spacing.
+    const condition = this.reconstruct_value_tokens(
+      condition_tokens,
+      preceded_by_continuation
+    ).trim();
 
     // Check for unbalanced parentheses and empty condition
     if (paren_depth > 0) {
@@ -2186,13 +2373,14 @@ export class StataParser {
 
     if (is_forvalues_spec || is_foreach_spec) {
       const specType = this.advance().value;
-      let loop_spec_body = '';
-      let prev_spec_token: Token | null = null;
-      // True when the next real token was reached by crossing a `///`
-      // continuation (vs an ordinary newline). A `///` join keeps only the
-      // continuation line's indentation, so an unindented item joins with no
-      // space; a raw `#delimit ;` newline is whitespace and always separates.
-      let continuation_pending = false;
+      // Collect the spec tokens and reconstruct spacing from their ranges via
+      // reconstruct_value_tokens, so `#delimit ;` and `#delimit cr` yield the
+      // identical single-space form and value items are never fused (issue
+      // #306). A `///` continuation changes how a line break is spaced, so its
+      // line is recorded on the shared ContinuationTracker.
+      const spec_tokens: Token[] = [];
+      const preceded_by_continuation: boolean[] = [];
+      const continuation = new ContinuationTracker();
 
       // Collect specification until {
       while (!this.check('LBRACE') && !this.isAtEnd()) {
@@ -2212,42 +2400,20 @@ export class StataParser {
           break;
         }
         const token = this.advance();
-        // Spacing is derived from token ranges, not from WHITESPACE/CONTINUATION
-        // token values. A `///` continuation, however, changes how a line break
-        // is spaced, so remember that we crossed one.
         if (token.type === 'CONTINUATION') {
-          continuation_pending = true;
+          continuation.note_continuation(token);
           continue;
         }
         if (token.type === 'WHITESPACE') {
           continue;
         }
-        if (prev_spec_token !== null) {
-          const same_line = prev_spec_token.range.end.line === token.range.start.line;
-          let needs_separator: boolean;
-          if (same_line) {
-            // Same-line gap: separate only when there is whitespace between.
-            // Truly adjacent fragments (e.g. `a`m'`) join into one list item.
-            needs_separator =
-              token.range.start.character - prev_spec_token.range.end.character > 0;
-          } else if (continuation_pending) {
-            // `///`-continued item: Stata removes the newline and keeps only
-            // indentation, so an unindented continuation joins (`a///`\n`b` ⇒
-            // `ab`) and an indented one separates.
-            needs_separator = token.range.start.character > 0;
-          } else {
-            // Raw newline (`#delimit ;` mode): ordinary whitespace separator.
-            needs_separator = true;
-          }
-          if (needs_separator) {
-            loop_spec_body += ' ';
-          }
-        }
-        loop_spec_body += token.value;
-        prev_spec_token = token;
-        continuation_pending = false;
+        spec_tokens.push(token);
+        preceded_by_continuation.push(
+          continuation.collect(token)
+        );
       }
-      loopSpec = specType + ' ' + loop_spec_body.trim();
+      loopSpec = specType + ' ' +
+        this.reconstruct_value_tokens(spec_tokens, preceded_by_continuation).trim();
     }
 
     // Parse body
@@ -2287,14 +2453,21 @@ export class StataParser {
     const whileToken = this.advance(); // consume 'while'
     const while_start_line = whileToken.range.start.line;
 
-    // Parse condition - collect tokens until { and reconstruct with original spacing
+    // Parse condition - collect tokens until { and reconstruct spacing from
+    // token ranges, matching the expression/qualifier path (issue #306).
     const condition_tokens: Token[] = [];
+    const preceded_by_continuation: boolean[] = [];
+    const continuation = new ContinuationTracker();
     let paren_depth = 0;
 
     while (!this.check('LBRACE') && !this.isAtEnd()) {
       // Handle continuation tokens - skip them and continue parsing
-      if (this.skipContinuation()) {
-        continue;
+      if (this.check('CONTINUATION')) {
+        const cont_token = this.peek();
+        if (this.skipContinuation()) {
+          continuation.note_continuation(cont_token);
+          continue;
+        }
       }
 
       // Stop at statement terminator
@@ -2318,11 +2491,15 @@ export class StataParser {
       // Skip whitespace tokens but collect all others
       if (token.type !== 'WHITESPACE') {
         condition_tokens.push(token);
+        preceded_by_continuation.push(continuation.collect(token));
       }
     }
 
-    // Reconstruct condition with original spacing preserved
-    const condition = this.reconstructTokensWithSpacing(condition_tokens).trim();
+    // Reconstruct condition with mode-independent single-space spacing.
+    const condition = this.reconstruct_value_tokens(
+      condition_tokens,
+      preceded_by_continuation
+    ).trim();
 
     // Check for unbalanced parentheses and empty condition
     if (paren_depth > 0) {
@@ -2950,7 +3127,13 @@ export class StataParser {
    * Returns the expression as a trimmed string.
    */
   parseExpression(): string {
-    let expression = '';
+    // Collect the surviving tokens and reconstruct spacing from their ranges,
+    // so `#delimit ;` (which emits WHITESPACE tokens) and `#delimit cr` (which
+    // does not) produce the identical, source-faithful single-space form
+    // (issue #306). WHITESPACE contributes only a gap, never a character.
+    const the_tokens: Token[] = [];
+    const preceded_by_continuation: boolean[] = [];
+    const continuation = new ContinuationTracker();
     let paren_depth = 0;
     const start_pos = this.current;
 
@@ -2959,6 +3142,7 @@ export class StataParser {
 
       // Handle continuation tokens - skip them and continue parsing
       if (this.skipContinuation()) {
+        continuation.note_continuation(token);
         continue;
       }
 
@@ -2990,13 +3174,20 @@ export class StataParser {
         break;
       }
 
-      const tokenValue = this.advance().value;
-      if (token.type === 'WHITESPACE') {
-        expression += ' '; // Normalize whitespace to single space
-      } else {
-        expression += tokenValue;
+      this.advance();
+      // WHITESPACE only marks a gap for range-based spacing; do not collect it.
+      if (token.type !== 'WHITESPACE') {
+        the_tokens.push(token);
+        preceded_by_continuation.push(
+          continuation.collect(token)
+        );
       }
     }
+
+    const expression = this.reconstruct_value_tokens(
+      the_tokens,
+      preceded_by_continuation
+    );
 
     // Check for unbalanced parentheses (unclosed opening parentheses)
     if (paren_depth > 0) {
@@ -3078,7 +3269,13 @@ export class StataParser {
     stop_at_in: boolean,
     check_empty: boolean
   ): string {
-    let expression = '';
+    // Collect the surviving tokens and reconstruct spacing from their ranges,
+    // so `#delimit ;` and `#delimit cr` yield the identical single-space form
+    // (issue #306). The stray-token state machine below is unchanged; only the
+    // string it builds is collected here instead of appended inline.
+    const the_tokens: Token[] = [];
+    const preceded_by_continuation: boolean[] = [];
+    const continuation = new ContinuationTracker();
     let paren_depth = 0;
     let bracket_depth = 0;  // Track subscript bracket depth
     const start_token = this.peek();
@@ -3141,6 +3338,7 @@ export class StataParser {
 
       // Handle continuation tokens - skip them and continue parsing
       if (this.skipContinuation()) {
+        continuation.note_continuation(token);
         continue;
       }
 
@@ -3248,11 +3446,13 @@ export class StataParser {
         prev_token = token;
       }
 
-      const tokenValue = this.advance().value;
-      if (token.type === 'WHITESPACE') {
-        expression += ' ';
-      } else {
-        expression += tokenValue;
+      this.advance();
+      // WHITESPACE only marks a gap for range-based spacing; do not collect it.
+      if (token.type !== 'WHITESPACE') {
+        the_tokens.push(token);
+        preceded_by_continuation.push(
+          continuation.collect(token)
+        );
       }
     }
 
@@ -3261,7 +3461,10 @@ export class StataParser {
       this.addError(`Unbalanced parentheses in ${qualifier_type} qualifier: missing closing parenthesis`, start_token.range, ParseErrorCode.UNBALANCED_PARENTHESES);
     }
 
-    const trimmed_expression = expression.trim();
+    const trimmed_expression = this.reconstruct_value_tokens(
+      the_tokens,
+      preceded_by_continuation
+    ).trim();
 
     // Check for empty expression (only for if-qualifiers)
     if (check_empty && trimmed_expression === '') {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1259,10 +1259,8 @@ export class StataParser {
     const preceded_by_continuation: boolean[] = [];
     const continuation = new ContinuationTracker();
     let paren_depth = 1;
-    let stopped_at_terminator = false;
     while (!this.isAtEnd() && paren_depth > 0) {
       if (this.check('STATEMENT_TERMINATOR')) {
-        stopped_at_terminator = true;
         break;
       }
       if (this.check('CONTINUATION')) {
@@ -1285,19 +1283,6 @@ export class StataParser {
       preceded_by_continuation.push(continuation.collect(t));
     }
     const argument_unclosed = paren_depth > 0 ? true : undefined;
-    if (
-      stopped_at_terminator &&
-      paren_depth === 1 &&
-      arg_tokens[arg_tokens.length - 1]?.type === 'RPAREN'
-    ) {
-      // Recovery-only trim: a trailing inner `)` often belongs to the final
-      // nested call (`vce(seed(123)`) rather than to the option itself. Removing
-      // it keeps the recovered argument tidy, but this does NOT count as a
-      // closed outer option paren; downstream semantic effects must still see
-      // argument_unclosed.
-      arg_tokens.pop();
-      preceded_by_continuation.pop();
-    }
     const argument = this.reconstruct_value_tokens(
       arg_tokens,
       preceded_by_continuation

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1426,6 +1426,7 @@ export class StataParser {
       }
       return {
         name: '(',
+        recovery_only: true,
         range: this.makeRange(paren_start.range.start, paren_end_pos),
       };
     }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1249,7 +1249,8 @@ export class StataParser {
     const arg_tokens: Token[] = [];
     const preceded_by_continuation: boolean[] = [];
     const continuation = new ContinuationTracker();
-    while (!this.check('RPAREN') && !this.isAtEnd()) {
+    let paren_depth = 1;
+    while (!this.isAtEnd() && paren_depth > 0) {
       if (this.check('CONTINUATION')) {
         const cont_token = this.peek();
         if (this.skipContinuation()) {
@@ -1258,11 +1259,16 @@ export class StataParser {
         }
       }
       const t = this.advance();
+      if (t.type === 'LPAREN') {
+        paren_depth++;
+      } else if (t.type === 'RPAREN') {
+        paren_depth--;
+        if (paren_depth === 0) {
+          break;
+        }
+      }
       arg_tokens.push(t);
       preceded_by_continuation.push(continuation.collect(t));
-    }
-    if (this.check('RPAREN')) {
-      this.advance(); // consume )
     }
     const argument = this.reconstruct_value_tokens(
       arg_tokens,

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1270,6 +1270,13 @@ export class StataParser {
           continue;
         }
       }
+      if (this.check('COMMENT_LINE') || this.check('COMMENT_BLOCK')) {
+        if (this.has_matching_option_close_before_statement(paren_depth)) {
+          this.advance();
+          continue;
+        }
+        break;
+      }
       const t = this.advance();
       if (t.type === 'LPAREN') {
         paren_depth++;
@@ -1291,6 +1298,34 @@ export class StataParser {
       ? { start: arg_tokens[0].range.start, end: arg_tokens[arg_tokens.length - 1].range.end }
       : undefined;
     return { argument, argument_range, argument_unclosed };
+  }
+
+  /**
+   * Look ahead from a comment inside an option argument to determine whether
+   * the already-open option parenthesis is closed before the statement ends.
+   * Comments are trivia for the argument string, but a close paren after trivia
+   * still means the option is semantically closed.
+   */
+  private has_matching_option_close_before_statement(paren_depth: number):
+    boolean {
+    let scan_depth = paren_depth;
+    let index = this.current;
+    while (index < this.tokens.length && scan_depth > 0) {
+      const token = this.tokens[index];
+      if (token.type === 'STATEMENT_TERMINATOR') {
+        return false;
+      }
+      if (token.type === 'LPAREN') {
+        scan_depth++;
+      } else if (token.type === 'RPAREN') {
+        scan_depth--;
+        if (scan_depth === 0) {
+          return true;
+        }
+      }
+      index++;
+    }
+    return false;
   }
 
   /**

--- a/src/pretty-printer/index.ts
+++ b/src/pretty-printer/index.ts
@@ -316,7 +316,11 @@ export class PrettyPrinter {
 
         if (option.argument !== undefined) {
             const close_paren = option.argument_unclosed ? '' : ')';
-            result += `(${format_expression_spacing(option.argument)}${close_paren}`;
+            const argument = format_expression_spacing(option.argument);
+            const trailing_trivia = option.argument_trailing_trivia
+                ? `${argument.length > 0 ? ' ' : ''}${option.argument_trailing_trivia}`
+                : '';
+            result += `(${argument}${trailing_trivia}${close_paren}`;
         }
 
         return result;

--- a/src/pretty-printer/index.ts
+++ b/src/pretty-printer/index.ts
@@ -317,10 +317,7 @@ export class PrettyPrinter {
         if (option.argument !== undefined) {
             const close_paren = option.argument_unclosed ? '' : ')';
             const argument = format_expression_spacing(option.argument);
-            const trailing_trivia = option.argument_trailing_trivia
-                ? `${argument.length > 0 ? ' ' : ''}${option.argument_trailing_trivia}`
-                : '';
-            result += `(${argument}${trailing_trivia}${close_paren}`;
+            result += `(${argument}${close_paren}`;
         }
 
         return result;

--- a/src/pretty-printer/index.ts
+++ b/src/pretty-printer/index.ts
@@ -315,7 +315,8 @@ export class PrettyPrinter {
         let result = option.name;
 
         if (option.argument !== undefined) {
-            result += `(${format_expression_spacing(option.argument)})`;
+            const close_paren = option.argument_unclosed ? '' : ')';
+            result += `(${format_expression_spacing(option.argument)}${close_paren}`;
         }
 
         return result;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -246,6 +246,7 @@ export interface OptionNode {
   argument?: string;
   argument_range?: Range;
   argument_unclosed?: true;
+  argument_trailing_trivia?: string;
   range: Range;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -245,6 +245,7 @@ export interface OptionNode {
   fullName: string;
   argument?: string;
   argument_range?: Range;
+  argument_unclosed?: true;
   range: Range;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -251,6 +251,7 @@ export interface OptionNode {
 
 export interface IdentifierNode {
   name: string;
+  recovery_only?: true;
   range: Range;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -246,7 +246,6 @@ export interface OptionNode {
   argument?: string;
   argument_range?: Range;
   argument_unclosed?: true;
-  argument_trailing_trivia?: string;
   range: Range;
 }
 

--- a/src/utils/continuation.ts
+++ b/src/utils/continuation.ts
@@ -5,10 +5,8 @@ import { Token } from '../types';
  * preceding `///` continuation — trivia, not a real statement end.
  *
  * Only a newline terminator qualifies: `///` consumes exactly the line
- * break that follows it. Under `#delimit cr` that line break lexes as a
- * STATEMENT_TERMINATOR with value '\n'; under `#delimit ;` it lexes as
- * WHITESPACE, so any STATEMENT_TERMINATOR seen mid-continuation there
- * is a literal `;` — always a real statement end.
+ * break that follows it. A `;` terminator under `#delimit ;` is always a real
+ * statement end.
  *
  * Shared by every token scan that applies this rule, so it cannot
  * drift between them. Callers either track an in-continuation flag

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -21,6 +21,7 @@ const LEADING_TRIVIA_TYPES: ReadonlySet<string> = new Set([
     'COMMENT_LINE',
     'COMMENT_BLOCK',
     'CONTINUATION',
+    'WHITESPACE',
     'STATEMENT_TERMINATOR',
     'DELIMIT_DIRECTIVE',
 ]);

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -11,14 +11,13 @@ export interface LineSpan {
 
 /**
  * Token types skipped while searching for the first token of the "next
- * statement" after a directive comment: surrounding whitespace, other
- * comments, a `///` continuation and the newline it swallows, blank
- * statement terminators, and a `#delimit` mode switch — so an
+ * statement" after a directive comment: surrounding comments, a `///`
+ * continuation and the newline it swallows, blank statement terminators, and a
+ * `#delimit` mode switch — so an
  * `@lsp-ignore-next` immediately followed by `#delimit ;` targets the
  * first real statement under the new mode, not the mode-switch line.
  */
 const LEADING_TRIVIA_TYPES: ReadonlySet<string> = new Set([
-    'WHITESPACE',
     'COMMENT_LINE',
     'COMMENT_BLOCK',
     'CONTINUATION',
@@ -45,7 +44,6 @@ const BODY_OPENER_TYPES: ReadonlySet<string> = new Set([
  * src/providers/diagnostic-token-stream.ts).
  */
 const CONTINUATION_NEUTRAL_TYPES: ReadonlySet<string> = new Set([
-    'WHITESPACE',
     'COMMENT_LINE',
     'COMMENT_BLOCK',
 ]);

--- a/tests/property/delimiter-mode-equivalence.prop.test.ts
+++ b/tests/property/delimiter-mode-equivalence.prop.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Property test: `#delimit cr` and `#delimit ;` must parse to equivalent ASTs.
+ *
+ * Feature: delimiter-mode reconstruction parity (issue #306)
+ *
+ * The root cause of the #306 bug class is that the lexer emits WHITESPACE
+ * tokens in `#delimit ;` mode that `#delimit cr` mode elides. Many parser
+ * methods reconstruct string-valued AST fields (expressions, if/in qualifiers,
+ * parenthesized groups, option arguments, loop specs, macro values, conditions)
+ * from the token stream, and any that depend on WHITESPACE-token presence
+ * diverge between the two modes for identical source.
+ *
+ * This property encodes the invariant the fix must uphold: for the same command
+ * text, parsing it in `#delimit cr` mode and in `#delimit ;` mode must produce
+ * the same AST (ignoring source ranges and the `#delimit` directive nodes that
+ * bracket the semicolon-mode wrapper) and the same set of diagnostics. It is the
+ * executable oracle for the whole class — a single generated counter-example
+ * catches any reconstruction site that still diverges by delimiter mode.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import * as fc from 'fast-check';
+import { StataParser } from '../../src/parser';
+import { StataLexer } from '../../src/lexer';
+import { StataNode } from '../../src/types';
+
+function parse(source: string) {
+  const lexer = new StataLexer();
+  const parser = new StataParser();
+  return parser.parse(lexer.tokenize(source).tokens);
+}
+
+// Nodes present only because of the semicolon-mode wrapper; excluded from the
+// cross-mode comparison.
+const WRAPPER_TYPES = new Set(['directive', 'comment']);
+
+function content_nodes(nodes: StataNode[]): StataNode[] {
+  return nodes.filter(n => !WRAPPER_TYPES.has(n.type));
+}
+
+// Canonicalize nodes for comparison: sort keys and drop every position-bearing
+// field (`range`, `argument_range`) — those legitimately differ because the
+// semicolon-mode wrapper shifts the command onto a later line. What must match
+// across modes is the structural + string content, which is what #306 governs.
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonical);
+  }
+  if (value !== null && typeof value === 'object') {
+    const the_result: Record<string, unknown> = {};
+    for (const my_key of Object.keys(value as Record<string, unknown>).sort()) {
+      if (my_key === 'range' || my_key === 'argument_range') {
+        continue;
+      }
+      the_result[my_key] = canonical((value as Record<string, unknown>)[my_key]);
+    }
+    return the_result;
+  }
+  return value;
+}
+
+function error_codes(result: ReturnType<StataParser['parse']>): string[] {
+  return result.errors.map(e => String(e.code)).sort();
+}
+
+// Spacing variants injected between tokens: none, one, or several spaces/tabs.
+// Where whitespace is optional (around operators, commas, parens) all three are
+// valid; where a separator is required (between a command and its varlist) we
+// use `sep` to keep at least one space.
+const gap = fc.constantFrom('', ' ', '  ', '\t');
+const sep = fc.constantFrom(' ', '  ', ' \t ');
+
+const identifier = fc.constantFrom('a', 'b', 'x', 'y', 'z', 'foo', 'bar', 'v1', 'v2');
+const number = fc.constantFrom('0', '1', '2', '10', '3.14');
+const binop = fc.constantFrom('+', '-', '*', '/', '==', '!=', '>', '<', '>=', '&', '|');
+const term = fc.oneof(identifier, number);
+
+// `term (op term){0,2}`, e.g. `a`, `a + b`, `x*2 > y`.
+const expression = fc
+  .tuple(
+    term,
+    fc.array(fc.tuple(gap, binop, gap, term), { maxLength: 2 })
+  )
+  .map(([head, rest]) =>
+    head + rest.map(([g1, op, g2, t]) => `${g1}${op}${g2}${t}`).join('')
+  );
+
+// A function call like `inrange(a, 1, 10)` with varied spacing.
+const func_call = fc
+  .tuple(
+    fc.constantFrom('inrange', 'cond', 'max', 'group'),
+    fc.array(fc.tuple(gap, term), { minLength: 1, maxLength: 3 }),
+    gap
+  )
+  .map(([fn, args, trailing]) => {
+    const inner = args.map(([, t]) => t).join(', ');
+    return `${fn}(${trailing}${inner}${trailing})`;
+  });
+
+const assignment_command = fc
+  .tuple(
+    fc.constantFrom('gen', 'generate', 'egen', 'replace'),
+    sep,
+    identifier,
+    gap,
+    gap,
+    fc.oneof(expression, func_call)
+  )
+  .map(([cmd, s1, v, g1, g2, rhs]) => `${cmd}${s1}${v}${g1}=${g2}${rhs}`);
+
+const if_command = fc
+  .tuple(
+    fc.constantFrom('keep', 'drop', 'list', 'summarize'),
+    sep,
+    fc.array(identifier, { minLength: 1, maxLength: 3 }),
+    sep,
+    fc.oneof(expression, func_call)
+  )
+  .map(([cmd, s1, vars, s2, cond]) => `${cmd}${s1}${vars.join(' ')} if${s2}${cond}`);
+
+const option_command = fc
+  .tuple(
+    sep,
+    fc.array(identifier, { minLength: 1, maxLength: 2 }),
+    gap,
+    fc.constantFrom('absorb', 'cluster', 'by'),
+    gap,
+    fc.array(identifier, { minLength: 1, maxLength: 3 }),
+    gap
+  )
+  .map(([s1, vars, g1, opt, g2, args, g3]) =>
+    `reg${s1}${vars.join(' ')},${g1}${opt}(${g2}${args.join(' ')}${g3})`
+  );
+
+const paren_group_command = fc
+  .tuple(sep, identifier, sep, gap, number, gap, gap, number, gap)
+  .map(([s1, v, s2, g1, lo, g2, g3, hi, g4]) =>
+    `recode${s1}${v}${s2}(${g1}${lo}/${g2}${hi}${g3}=${g4}${hi})`
+  );
+
+const macro_command = fc
+  .tuple(fc.constantFrom('local', 'global'), sep, identifier, gap, gap, expression)
+  .map(([scope, s1, name, g1, g2, val]) => `${scope}${s1}${name}${g1}=${g2}${val}`);
+
+const command_source = fc.oneof(
+  assignment_command,
+  if_command,
+  option_command,
+  paren_group_command,
+  macro_command
+);
+
+describe('delimiter-mode reconstruction parity (issue #306)', () => {
+  it('parses identically in #delimit cr and #delimit ; modes', () => {
+    fc.assert(
+      fc.property(command_source, body => {
+        const cr = parse(body);
+        const semi = parse(`#delimit ;\n${body};\n#delimit cr`);
+
+        // Same diagnostics (by code) regardless of delimiter mode.
+        expect(error_codes(semi)).toEqual(error_codes(cr));
+
+        // Same command AST, ignoring ranges and the #delimit wrapper nodes.
+        const cr_nodes = canonical(content_nodes(cr.ast.nodes));
+        const semi_nodes = canonical(content_nodes(semi.ast.nodes));
+        expect(JSON.stringify(semi_nodes)).toBe(JSON.stringify(cr_nodes));
+      }),
+      { numRuns: 2000 }
+    );
+  });
+});

--- a/tests/property/delimiter-mode-equivalence.prop.test.ts
+++ b/tests/property/delimiter-mode-equivalence.prop.test.ts
@@ -82,6 +82,23 @@ const identifier = fc.constantFrom('a', 'b', 'x', 'y', 'z', 'foo', 'bar', 'v1', 
 const number = fc.constantFrom('0', '1', '2', '10', '3.14');
 const binop = fc.constantFrom('+', '-', '*', '/', '==', '!=', '>', '<', '>=', '&', '|');
 const term = fc.oneof(identifier, number);
+type RenderedFuncArg = [string, string];
+
+function render_func_call(
+  fn: string,
+  args: RenderedFuncArg[],
+  trailing: string
+): string {
+  const first = args[0];
+  const rest = args.slice(1);
+  const inner = first === undefined
+    ? ''
+    : [
+        first[1],
+        ...rest.map(([comma_gap, t]) => `${comma_gap},${comma_gap}${t}`),
+      ].join('');
+  return `${fn}(${trailing}${inner}${trailing})`;
+}
 
 // `term (op term){0,2}`, e.g. `a`, `a + b`, `x*2 > y`.
 const expression = fc
@@ -100,10 +117,7 @@ const func_call = fc
     fc.array(fc.tuple(gap, term), { minLength: 1, maxLength: 3 }),
     gap
   )
-  .map(([fn, args, trailing]) => {
-    const inner = args.map(([, t]) => t).join(', ');
-    return `${fn}(${trailing}${inner}${trailing})`;
-  });
+  .map(([fn, args, trailing]) => render_func_call(fn, args, trailing));
 
 const assignment_command = fc
   .tuple(
@@ -491,6 +505,16 @@ const structured_source_pair = fc.oneof(
 // well-defined pair of equivalent embedded programs.
 
 describe('delimiter-mode reconstruction parity (issue #306)', () => {
+  it('function-call generator renders drawn comma gaps', () => {
+    expect(render_func_call('max', [['', 'a'], ['', 'b']], '')).toBe('max(a,b)');
+    expect(render_func_call('max', [['', 'a'], ['  ', 'b']], '')).toBe(
+      'max(a  ,  b)'
+    );
+    expect(render_func_call('max', [['', 'a'], ['\t', 'b']], '')).toBe(
+      'max(a\t,\tb)'
+    );
+  });
+
   it('parses identically in #delimit cr and #delimit ; modes', () => {
     fc.assert(
       fc.property(command_source, body => {

--- a/tests/property/delimiter-mode-equivalence.prop.test.ts
+++ b/tests/property/delimiter-mode-equivalence.prop.test.ts
@@ -39,9 +39,10 @@ function content_nodes(nodes: StataNode[]): StataNode[] {
 }
 
 // Canonicalize nodes for comparison: sort keys and drop every position-bearing
-// field (`range`, `argument_range`) — those legitimately differ because the
-// semicolon-mode wrapper shifts the command onto a later line. What must match
-// across modes is the structural + string content, which is what #306 governs.
+// field (`range`, `argument_range`, `syntaxRanges`) — those legitimately differ
+// because the semicolon-mode wrapper shifts the command onto a later line. What
+// must match across modes is the structural + string content, which is what
+// #306 governs.
 function canonical(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(canonical);
@@ -49,7 +50,11 @@ function canonical(value: unknown): unknown {
   if (value !== null && typeof value === 'object') {
     const the_result: Record<string, unknown> = {};
     for (const my_key of Object.keys(value as Record<string, unknown>).sort()) {
-      if (my_key === 'range' || my_key === 'argument_range') {
+      if (
+        my_key === 'range' ||
+        my_key === 'argument_range' ||
+        my_key === 'syntaxRanges'
+      ) {
         continue;
       }
       the_result[my_key] = canonical((value as Record<string, unknown>)[my_key]);
@@ -150,6 +155,254 @@ const command_source = fc.oneof(
   macro_command
 );
 
+type DelimiterMode = 'cr' | 'semicolon';
+
+type Statement =
+  | { kind: 'simple'; body: string }
+  | { kind: 'simple_pair'; cr_body: string; semi_body: string }
+  | { kind: 'brace_block'; header: string; body: Statement[] }
+  | {
+      kind: 'if_else';
+      condition: string;
+      if_body: Statement[];
+      else_body: Statement[];
+    }
+  | { kind: 'program'; name: string; syntax: string; body: Statement[] };
+
+interface SourcePair {
+  label: string;
+  cr: string;
+  semi: string;
+}
+
+function terminator(mode: DelimiterMode): string {
+  return mode === 'semicolon' ? ';' : '';
+}
+
+function indent(source: string): string {
+  return source
+    .split('\n')
+    .map(line => line.length > 0 ? `  ${line}` : line)
+    .join('\n');
+}
+
+function render_statement_list(
+  statements: Statement[],
+  mode: DelimiterMode
+): string {
+  return statements.map(statement => render_statement(statement, mode)).join('\n');
+}
+
+function render_statement(statement: Statement, mode: DelimiterMode): string {
+  switch (statement.kind) {
+    case 'simple':
+      return `${statement.body}${terminator(mode)}`;
+    case 'simple_pair': {
+      const body = mode === 'semicolon' ? statement.semi_body : statement.cr_body;
+      return `${body}${terminator(mode)}`;
+    }
+    case 'brace_block': {
+      const opener = mode === 'semicolon'
+        ? `${statement.header} {;`
+        : `${statement.header} {`;
+      const closer = mode === 'semicolon' ? '};' : '}';
+      return [
+        opener,
+        indent(render_statement_list(statement.body, mode)),
+        closer,
+      ].join('\n');
+    }
+    case 'if_else': {
+      const if_opener = mode === 'semicolon'
+        ? `if ${statement.condition} {;`
+        : `if ${statement.condition} {`;
+      const else_opener = mode === 'semicolon' ? 'else {;' : 'else {';
+      const closer = mode === 'semicolon' ? '};' : '}';
+      return [
+        if_opener,
+        indent(render_statement_list(statement.if_body, mode)),
+        closer,
+        else_opener,
+        indent(render_statement_list(statement.else_body, mode)),
+        closer,
+      ].join('\n');
+    }
+    case 'program': {
+      return [
+        `program define ${statement.name}${terminator(mode)}`,
+        indent(`${statement.syntax}${terminator(mode)}`),
+        indent(render_statement_list(statement.body, mode)),
+        `end${terminator(mode)}`,
+      ].join('\n');
+    }
+  }
+}
+
+function render_source_pair(label: string, statements: Statement[]): SourcePair {
+  return {
+    label,
+    cr: render_statement_list(statements, 'cr'),
+    semi: `#delimit ;\n${render_statement_list(statements, 'semicolon')}`,
+  };
+}
+
+const simple_statement_body = fc.oneof(
+  command_source,
+  fc.constantFrom(
+    'by id: gen x = 1',
+    'bysort id: gen x = 1',
+    'quietly: gen x = 1',
+    'quietly : replace y = x[_n-1]',
+    'frame create analysis',
+    'frame change default',
+    'gen lag_x = x[_n-1]',
+    'gen s = "plain string"',
+    'gen t = "value `foo\'"',
+    'local quoted = "value `foo\'"',
+    'local compound = `"hello `foo\'"\'',
+    'local n : word count a b c',
+    'local joined = a///\nb',
+    'local indented = a///\n    b',
+    'local spaced = a ///\nb',
+    'gen continued = a///\nb',
+    'gen continued_spaced = a ///\nb'
+  )
+);
+
+const gratuitous_newline_statement = fc.constantFrom<Statement>(
+  {
+    kind: 'simple_pair',
+    cr_body: 'gen z = x + y',
+    semi_body: 'gen z = x\n  + y',
+  },
+  {
+    kind: 'simple_pair',
+    cr_body: 'reg y x, absorb(firm year)',
+    semi_body: 'reg y\n  x, absorb(firm\nyear)',
+  },
+  {
+    kind: 'simple_pair',
+    cr_body: 'local n : word count a b c',
+    semi_body: 'local n : word\n  count a\n  b c',
+  },
+  {
+    kind: 'simple_pair',
+    cr_body: 'bysort id: gen x = 1',
+    semi_body: 'bysort id:\n  gen x = 1',
+  },
+  {
+    kind: 'simple_pair',
+    cr_body: 'keep if x > 0',
+    semi_body: 'keep if x\n  > 0',
+  }
+);
+
+const block_body_statement = fc.oneof(
+  fc.constant<Statement>({ kind: 'simple', body: 'display "inside"' }),
+  fc.constant<Statement>({ kind: 'simple', body: 'gen y = x[_n-1]' }),
+  fc.constant<Statement>({ kind: 'simple', body: 'local n : word count a b c' }),
+  fc.constant<Statement>({ kind: 'simple', body: 'quietly: replace y = x + 1' })
+);
+
+const loop_statement = fc
+  .tuple(
+    fc.constantFrom('foreach i in a b c', 'forvalues i = 1/3'),
+    fc.array(block_body_statement, { minLength: 1, maxLength: 3 })
+  )
+  .map(([header, body]): Statement => ({ kind: 'brace_block', header, body }));
+
+const while_statement = fc
+  .tuple(
+    fc.constantFrom('x > 0', 'a///\nb', 'a ///\nb'),
+    fc.array(block_body_statement, { minLength: 1, maxLength: 2 })
+  )
+  .map(([condition, body]): Statement => ({
+    kind: 'brace_block',
+    header: `while ${condition}`,
+    body,
+  }));
+
+const if_else_statement = fc
+  .tuple(
+    fc.constantFrom('x > 0', 'x[_n-1] != 0', 'a///\nb', 'a ///\nb'),
+    fc.array(block_body_statement, { minLength: 1, maxLength: 2 }),
+    fc.array(block_body_statement, { minLength: 1, maxLength: 2 })
+  )
+  .map(([condition, if_body, else_body]): Statement => ({
+    kind: 'if_else',
+    condition,
+    if_body,
+    else_body,
+  }));
+
+const frame_block_statement = fc
+  .array(block_body_statement, { minLength: 1, maxLength: 3 })
+  .map((body): Statement => ({
+    kind: 'brace_block',
+    header: 'frame analysis',
+    body,
+  }));
+
+const nested_block_statement = fc.constant<Statement>({
+  kind: 'brace_block',
+  header: 'forvalues i = 1/3',
+  body: [
+    {
+      kind: 'if_else',
+      condition: 'x[_n-1] > 0',
+      if_body: [{ kind: 'simple', body: 'display "positive"' }],
+      else_body: [{ kind: 'simple', body: 'display `"not positive"\'' }],
+    },
+  ],
+});
+
+const program_statement = fc
+  .tuple(
+    fc.constantFrom('p', 'build_vars', 'summarize_sample'),
+    fc.constantFrom(
+      'syntax varlist, opt (string default(a b)) cluster(varname)',
+      'syntax , flag(integer) label (string default(`"hello `foo\'"\'))'
+    ),
+    fc.array(block_body_statement, { minLength: 1, maxLength: 3 })
+  )
+  .map(([name, syntax, body]): Statement => ({
+    kind: 'program',
+    name,
+    syntax,
+    body,
+  }));
+
+const top_level_simple_statement = simple_statement_body.map(
+  (body): Statement => ({ kind: 'simple', body })
+);
+
+const structured_statement = fc.oneof(
+  top_level_simple_statement,
+  gratuitous_newline_statement,
+  loop_statement,
+  while_statement,
+  if_else_statement,
+  frame_block_statement,
+  nested_block_statement,
+  program_statement
+);
+
+const structured_source_pair = fc.oneof(
+  structured_statement.map(statement =>
+    render_source_pair(statement.kind, [statement])
+  ),
+  fc
+    .array(structured_statement, { minLength: 2, maxLength: 4 })
+    .map(statements => render_source_pair('statement_list', statements))
+);
+
+// Embedded Mata/Python shapes are intentionally not part of this oracle. The
+// embedded lexer path preserves embedded whitespace, but newlines are still
+// delimiter-sensitive tokens (`STATEMENT_TERMINATOR` in cr mode and WHITESPACE
+// in semicolon mode). A cross-mode render would therefore compare Stata
+// delimiter mechanics inside a non-Stata body rather than a semantically
+// well-defined pair of equivalent embedded programs.
+
 describe('delimiter-mode reconstruction parity (issue #306)', () => {
   it('parses identically in #delimit cr and #delimit ; modes', () => {
     fc.assert(
@@ -166,6 +419,24 @@ describe('delimiter-mode reconstruction parity (issue #306)', () => {
         expect(JSON.stringify(semi_nodes)).toBe(JSON.stringify(cr_nodes));
       }),
       { numRuns: 2000 }
+    );
+  });
+
+  it('parses generated structured sources identically in both delimiter modes', () => {
+    fc.assert(
+      fc.property(structured_source_pair, pair => {
+        const cr = parse(pair.cr);
+        const semi = parse(pair.semi);
+
+        // Same diagnostics (by code) regardless of delimiter mode.
+        expect(error_codes(semi)).toEqual(error_codes(cr));
+
+        // Same command AST, ignoring ranges and the #delimit wrapper node.
+        const cr_nodes = canonical(content_nodes(cr.ast.nodes));
+        const semi_nodes = canonical(content_nodes(semi.ast.nodes));
+        expect(JSON.stringify(semi_nodes)).toBe(JSON.stringify(cr_nodes));
+      }),
+      { numRuns: 800 }
     );
   });
 });

--- a/tests/property/delimiter-mode-equivalence.prop.test.ts
+++ b/tests/property/delimiter-mode-equivalence.prop.test.ts
@@ -32,6 +32,9 @@ function parse(source: string) {
 
 // Nodes present only because of the semicolon-mode wrapper; excluded from the
 // cross-mode comparison.
+// The `comment` wrapper currently covers only generated `#delimit` artifacts.
+// If this generator starts emitting real source comments, narrow this filter to
+// directive-line ranges so genuine comment AST differences remain visible.
 const WRAPPER_TYPES = new Set(['directive', 'comment']);
 
 function content_nodes(nodes: StataNode[]): StataNode[] {
@@ -160,10 +163,13 @@ type DelimiterMode = 'cr' | 'semicolon';
 type Statement =
   | { kind: 'simple'; body: string }
   | { kind: 'simple_pair'; cr_body: string; semi_body: string }
-  | { kind: 'brace_block'; header: string; body: Statement[] }
+  | { kind: 'brace_block'; header: string; open_gap: string; body: Statement[] }
   | {
       kind: 'if_else';
+      keyword_sep: string;
       condition: string;
+      open_gap: string;
+      else_gap: string;
       if_body: Statement[];
       else_body: Statement[];
     }
@@ -203,8 +209,8 @@ function render_statement(statement: Statement, mode: DelimiterMode): string {
     }
     case 'brace_block': {
       const opener = mode === 'semicolon'
-        ? `${statement.header} {;`
-        : `${statement.header} {`;
+        ? `${statement.header}${statement.open_gap}{;`
+        : `${statement.header}${statement.open_gap}{`;
       const closer = mode === 'semicolon' ? '};' : '}';
       return [
         opener,
@@ -214,9 +220,11 @@ function render_statement(statement: Statement, mode: DelimiterMode): string {
     }
     case 'if_else': {
       const if_opener = mode === 'semicolon'
-        ? `if ${statement.condition} {;`
-        : `if ${statement.condition} {`;
-      const else_opener = mode === 'semicolon' ? 'else {;' : 'else {';
+        ? `if${statement.keyword_sep}${statement.condition}${statement.open_gap}{;`
+        : `if${statement.keyword_sep}${statement.condition}${statement.open_gap}{`;
+      const else_opener = mode === 'semicolon'
+        ? `else${statement.else_gap}{;`
+        : `else${statement.else_gap}{`;
       const closer = mode === 'semicolon' ? '};' : '}';
       return [
         if_opener,
@@ -248,11 +256,16 @@ function render_source_pair(label: string, statements: Statement[]): SourcePair 
 
 const simple_statement_body = fc.oneof(
   command_source,
+  fc
+    .tuple(sep, identifier, gap, gap, gap, expression)
+    .map(([s1, byvar, g1, g2, g3, rhs]) => `by${s1}${byvar}${g1}:${g2}gen x${g3}=${g3}${rhs}`),
+  fc
+    .tuple(sep, identifier, gap, gap, gap, expression)
+    .map(([s1, byvar, g1, g2, g3, rhs]) => `bysort${s1}${byvar}${g1}:${g2}gen x${g3}=${g3}${rhs}`),
+  fc
+    .tuple(gap, gap, sep, gap, gap, expression)
+    .map(([g1, g2, s1, g3, g4, rhs]) => `quietly${g1}:${g2}replace${s1}y${g3}=${g4}${rhs}`),
   fc.constantFrom(
-    'by id: gen x = 1',
-    'bysort id: gen x = 1',
-    'quietly: gen x = 1',
-    'quietly : replace y = x[_n-1]',
     'frame create analysis',
     'frame change default',
     'gen lag_x = x[_n-1]',
@@ -301,68 +314,142 @@ const block_body_statement = fc.oneof(
   fc.constant<Statement>({ kind: 'simple', body: 'display "inside"' }),
   fc.constant<Statement>({ kind: 'simple', body: 'gen y = x[_n-1]' }),
   fc.constant<Statement>({ kind: 'simple', body: 'local n : word count a b c' }),
-  fc.constant<Statement>({ kind: 'simple', body: 'quietly: replace y = x + 1' })
+  fc
+    .tuple(gap, gap, sep, gap, gap)
+    .map(([g1, g2, s1, g3, g4]): Statement => ({
+      kind: 'simple',
+      body: `quietly${g1}:${g2}replace${s1}y${g3}=${g4}x + 1`,
+    }))
 );
 
 const loop_statement = fc
   .tuple(
-    fc.constantFrom('foreach i in a b c', 'forvalues i = 1/3'),
+    fc.oneof(
+      fc
+        .tuple(sep, sep, sep, sep, sep)
+        .map(([s1, s2, s3, s4, s5]) => `foreach${s1}i${s2}in${s3}a${s4}b${s5}c`),
+      fc
+        .tuple(sep, gap, gap, gap, gap)
+        .map(([s1, g1, g2, g3, g4]) => `forvalues${s1}i${g1}=${g2}1${g3}/${g4}3`)
+    ),
+    sep,
     fc.array(block_body_statement, { minLength: 1, maxLength: 3 })
   )
-  .map(([header, body]): Statement => ({ kind: 'brace_block', header, body }));
-
-const while_statement = fc
-  .tuple(
-    fc.constantFrom('x > 0', 'a///\nb', 'a ///\nb'),
-    fc.array(block_body_statement, { minLength: 1, maxLength: 2 })
-  )
-  .map(([condition, body]): Statement => ({
+  .map(([header, open_gap, body]): Statement => ({
     kind: 'brace_block',
-    header: `while ${condition}`,
+    header,
+    open_gap,
     body,
   }));
 
+const while_condition = fc.oneof(
+  fc.tuple(identifier, gap, binop, gap, term).map(([left, g1, op, g2, right]) =>
+    `${left}${g1}${op}${g2}${right}`
+  ),
+  fc.constantFrom('a///\nb', 'a ///\nb')
+);
+
+const while_statement = fc
+  .tuple(
+    sep,
+    while_condition,
+    sep,
+    fc.array(block_body_statement, { minLength: 1, maxLength: 2 })
+  )
+  .map(([s1, condition, open_gap, body]): Statement => ({
+    kind: 'brace_block',
+    header: `while${s1}${condition}`,
+    open_gap,
+    body,
+  }));
+
+const if_condition = fc.oneof(
+  fc.tuple(identifier, gap, binop, gap, term).map(([left, g1, op, g2, right]) =>
+    `${left}${g1}${op}${g2}${right}`
+  ),
+  fc.tuple(identifier, gap, gap, gap, binop, gap, term).map(([name, g1, g2, g3, op, g4, right]) =>
+    `${name}[${g1}_n${g2}-${g3}1]${g4}${op}${g4}${right}`
+  ),
+  fc.constantFrom('a///\nb', 'a ///\nb')
+);
+
 const if_else_statement = fc
   .tuple(
-    fc.constantFrom('x > 0', 'x[_n-1] != 0', 'a///\nb', 'a ///\nb'),
+    sep,
+    if_condition,
+    sep,
+    sep,
     fc.array(block_body_statement, { minLength: 1, maxLength: 2 }),
     fc.array(block_body_statement, { minLength: 1, maxLength: 2 })
   )
-  .map(([condition, if_body, else_body]): Statement => ({
+  .map(([keyword_sep, condition, open_gap, else_gap, if_body, else_body]): Statement => ({
     kind: 'if_else',
+    keyword_sep,
     condition,
+    open_gap,
+    else_gap,
     if_body,
     else_body,
   }));
 
 const frame_block_statement = fc
-  .array(block_body_statement, { minLength: 1, maxLength: 3 })
-  .map((body): Statement => ({
+  .tuple(
+    sep,
+    sep,
+    fc.array(block_body_statement, { minLength: 1, maxLength: 3 })
+  )
+  .map(([s1, open_gap, body]): Statement => ({
     kind: 'brace_block',
-    header: 'frame analysis',
+    header: `frame${s1}analysis`,
+    open_gap,
     body,
   }));
 
-const nested_block_statement = fc.constant<Statement>({
-  kind: 'brace_block',
-  header: 'forvalues i = 1/3',
-  body: [
-    {
-      kind: 'if_else',
-      condition: 'x[_n-1] > 0',
-      if_body: [{ kind: 'simple', body: 'display "positive"' }],
-      else_body: [{ kind: 'simple', body: 'display `"not positive"\'' }],
-    },
-  ],
-});
+const nested_block_statement = fc
+  .tuple(
+    sep,
+    gap,
+    gap,
+    gap,
+    gap,
+    sep,
+    sep,
+    if_condition
+  )
+  .map(([for_sep, eq_left, eq_right, slash_left, slash_right, outer_open, inner_open, condition]): Statement => ({
+    kind: 'brace_block',
+    header: `forvalues${for_sep}i${eq_left}=${eq_right}1${slash_left}/${slash_right}3`,
+    open_gap: outer_open,
+    body: [
+      {
+        kind: 'if_else',
+        keyword_sep: ' ',
+        condition,
+        open_gap: inner_open,
+        else_gap: ' ',
+        if_body: [{ kind: 'simple', body: 'display "positive"' }],
+        else_body: [{ kind: 'simple', body: 'display `"not positive"\'' }],
+      },
+    ],
+  }));
+
+const syntax_declaration = fc.oneof(
+  fc
+    .tuple(sep, sep, gap, gap, gap, gap, sep, gap, gap, gap)
+    .map(([s1, s2, opt_open, opt_inner, default_open, default_inner, value_sep, default_close, opt_close, cluster_open]) =>
+      `syntax${s1}varlist,${s2}opt${opt_open}(${opt_inner}string default${default_open}(${default_inner}a${value_sep}b${default_close})${opt_close}) cluster${cluster_open}(varname)`
+    ),
+  fc
+    .tuple(sep, sep, gap, gap, gap, gap, gap, gap)
+    .map(([s1, s2, label_open, label_inner, default_open, default_inner, default_close, label_close]) =>
+      `syntax${s1},${s2}flag(integer) label${label_open}(${label_inner}string default${default_open}(${default_inner}\`"hello \`foo'"'${default_close})${label_close})`
+    )
+);
 
 const program_statement = fc
   .tuple(
     fc.constantFrom('p', 'build_vars', 'summarize_sample'),
-    fc.constantFrom(
-      'syntax varlist, opt (string default(a b)) cluster(varname)',
-      'syntax , flag(integer) label (string default(`"hello `foo\'"\'))'
-    ),
+    syntax_declaration,
     fc.array(block_body_statement, { minLength: 1, maxLength: 3 })
   )
   .map(([name, syntax, body]): Statement => ({

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -220,6 +220,19 @@ display \`result'
             expect(result.symbols.globalMacros.has('G')).toBe(true);
             expect(result.diagnostics.find(
                 d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                d.message.includes('G')
+            )).toBeUndefined();
+        });
+
+        it('should register a closed levelsof global() option with inline comment', () => {
+            const result = analyze(
+                'levelsof rep78, global(G /* c */)\ndisplay $G',
+                { undefined_macro_enabled: true }
+            );
+
+            expect(result.symbols.globalMacros.has('G')).toBe(true);
+            expect(result.diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
                     d.message.includes('G')
             )).toBeUndefined();
         });

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -469,6 +469,14 @@ display \`result'
             expect(result.symbols.variables.get('new2')?.source).toBe('rename');
         });
 
+        it('should preserve final variable in unclosed grouped rename command', () => {
+            const result = analyze('rename (old1 old2) (new1 new2');
+
+            expect(result.symbols.variables.has('new1')).toBe(true);
+            expect(result.symbols.variables.has('new2')).toBe(true);
+            expect(result.symbols.variables.has('new')).toBe(false);
+        });
+
         it('should NOT register local macro references as variables in confirm variable', () => {
             const result = analyze('capture confirm variable `my_var\'');
             

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -160,6 +160,70 @@ display \`result'
             )).toBeUndefined();
         });
 
+        it('should not register an unclosed levelsof global() option in cr mode', () => {
+            const source = 'levelsof rep78, global(G\ndisplay $G';
+            const { tokens } = lexer.tokenize(source);
+            const { ast } = parser.parse(tokens);
+            const commands = ast.nodes
+                .filter(n => n.type === 'command')
+                .map(n => n.name);
+
+            expect(commands).toEqual(['levelsof', 'display']);
+
+            const result = analyzer.analyze(
+                ast,
+                'test://file.do',
+                undefined,
+                { undefined_macro_enabled: true },
+                tokens
+            );
+
+            expect(result.symbols.globalMacros.has('G')).toBe(false);
+            expect(result.diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('G')
+            )).toBeDefined();
+        });
+
+        it('should not register an unclosed levelsof local() option in cr mode', () => {
+            const result = analyze(
+                'levelsof rep78, local(L\ndisplay `L\'',
+                { undefined_macro_enabled: true }
+            );
+
+            expect(result.symbols.localMacros.has('L')).toBe(false);
+            expect(result.diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('L')
+            )).toBeDefined();
+        });
+
+        it('should not register an unclosed levelsof global() option in semicolon mode', () => {
+            const result = analyze(
+                '#delimit ;\nlevelsof rep78, global(G;\ndisplay $G;\n#delimit cr',
+                { undefined_macro_enabled: true }
+            );
+
+            expect(result.symbols.globalMacros.has('G')).toBe(false);
+            expect(result.diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('G')
+            )).toBeDefined();
+        });
+
+        it('should still register a closed levelsof global() option', () => {
+            const result = analyze(
+                'levelsof rep78, global(G)\ndisplay $G',
+                { undefined_macro_enabled: true }
+            );
+
+            expect(result.symbols.globalMacros.has('G')).toBe(true);
+            expect(result.diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('G')
+            )).toBeUndefined();
+        });
+
         it('should fall back to command range when option argument_range is undefined', () => {
             // Per spec requirements 3.3 and 4.3: definition location should use
             // option argument span, and if unavailable fall back to command span

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -237,6 +237,31 @@ display \`result'
             )).toBeUndefined();
         });
 
+        it('should register a closed levelsof global() option across comment continuation', () => {
+            const source = 'levelsof rep78, global(G /* c */ ///\n)\ndisplay $G';
+            const { tokens } = lexer.tokenize(source);
+            const { ast } = parser.parse(tokens);
+            const commands = ast.nodes
+                .filter(n => n.type === 'command')
+                .map(n => n.name);
+
+            expect(commands).toEqual(['levelsof', 'display']);
+
+            const result = analyzer.analyze(
+                ast,
+                'test://file.do',
+                undefined,
+                { undefined_macro_enabled: true },
+                tokens
+            );
+
+            expect(result.symbols.globalMacros.has('G')).toBe(true);
+            expect(result.diagnostics.find(
+                d => d.code === StataDiagnosticCode.UNDEFINED_MACRO &&
+                    d.message.includes('G')
+            )).toBeUndefined();
+        });
+
         it('should fall back to command range when option argument_range is undefined', () => {
             // Per spec requirements 3.3 and 4.3: definition location should use
             // option argument span, and if unavailable fall back to command span

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -477,6 +477,12 @@ display \`result'
             expect(result.symbols.variables.has('new')).toBe(false);
         });
 
+        it('should ignore bare open paren in unclosed grouped rename command', () => {
+            const result = analyze('rename (old1 old2) (');
+
+            expect(result.symbols.variables.size).toBe(0);
+        });
+
         it('should NOT register local macro references as variables in confirm variable', () => {
             const result = analyze('capture confirm variable `my_var\'');
             

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { SemanticAnalyzer, create_empty_symbol_table, merge_symbol_tables } from '../../src/analyzer';
 import { StataLexer } from '../../src/lexer';
 import { StataParser } from '../../src/parser';
-import { StataDiagnosticCode, SymbolTable } from '../../src/types';
+import { StataDiagnosticCode, SymbolTable, Token } from '../../src/types';
 
 describe('SemanticAnalyzer', () => {
     const lexer = new StataLexer();
@@ -580,6 +580,30 @@ display \`undefined_macro'
                 d => d.code === StataDiagnosticCode.UNDEFINED_MACRO
             );
             expect(undefined_diags.length).toBe(0);
+        });
+
+        it('classifies indented embedded-block comment lines as standalone', () => {
+            const { tokens } = lexer.tokenize(
+                'mata:\n    // @lsp-ignore\n    x = 1\nend'
+            );
+            const comment_index = tokens.findIndex(
+                token => token.type === 'COMMENT_LINE' &&
+                    token.value.includes('@lsp-ignore')
+            );
+            expect(comment_index).toBeGreaterThanOrEqual(0);
+
+            const analyzer_with_private = analyzer as unknown as {
+                is_standalone_comment_token(
+                    token_stream: Token[],
+                    comment_token_index: number
+                ): boolean;
+            };
+            expect(
+                analyzer_with_private.is_standalone_comment_token(
+                    tokens,
+                    comment_index
+                )
+            ).toBe(true);
         });
 
         it('should suppress diagnostics with canonical sight ignore directives', () => {

--- a/tests/unit/expression-keyword-disambiguation.test.ts
+++ b/tests/unit/expression-keyword-disambiguation.test.ts
@@ -24,7 +24,7 @@ describe('Expression Keyword Disambiguation', () => {
       
       if (node.type === 'command') {
         expect(node.name).toBe('count');
-        expect(node.ifExpression).toBe('program=="x"');
+        expect(node.ifExpression).toBe('program == "x"');
       }
     });
 
@@ -41,7 +41,7 @@ describe('Expression Keyword Disambiguation', () => {
       
       if (node.type === 'command') {
         expect(node.name).toBe('drop');
-        expect(node.ifExpression).toBe('_merge==1&program=="dhs"');
+        expect(node.ifExpression).toBe('_merge == 1 & program == "dhs"');
       }
     });
 
@@ -58,7 +58,7 @@ describe('Expression Keyword Disambiguation', () => {
       
       if (node.type === 'command') {
         expect(node.name).toBe('keep');
-        expect(node.ifExpression).toBe('program!="missing"');
+        expect(node.ifExpression).toBe('program != "missing"');
       }
     });
 
@@ -77,7 +77,7 @@ describe('Expression Keyword Disambiguation', () => {
         expect(node.name).toBe('replace');
         expect(node.varlist?.[0].name).toBe('value');
         expect(node.expression).toBe('0');
-        expect(node.ifExpression).toBe('program=="test"');
+        expect(node.ifExpression).toBe('program == "test"');
       }
     });
   });
@@ -191,7 +191,7 @@ describe('Expression Keyword Disambiguation', () => {
       
       if (node.type === 'command') {
         expect(node.name).toBe('generate');
-        expect(node.expression).toBe('program+while+foreach');
+        expect(node.expression).toBe('program + while + foreach');
       }
     });
 
@@ -208,7 +208,7 @@ describe('Expression Keyword Disambiguation', () => {
       
       if (node.type === 'command') {
         expect(node.name).toBe('generate');
-        expect(node.expression).toBe('max(program,while,foreach)');
+        expect(node.expression).toBe('max(program, while, foreach)');
       }
     });
 
@@ -225,7 +225,7 @@ describe('Expression Keyword Disambiguation', () => {
       
       if (node.type === 'command') {
         expect(node.name).toBe('generate');
-        expect(node.expression).toBe('(program+while)*foreach');
+        expect(node.expression).toBe('(program + while) * foreach');
       }
     });
   });

--- a/tests/unit/formatter.test.ts
+++ b/tests/unit/formatter.test.ts
@@ -74,6 +74,28 @@ function command_option_summary(
     };
 }
 
+function command_varlist_summary(
+    source: string,
+    lexer: StataLexer,
+    parser: StataParser
+): {
+    command_names: string[];
+    varlist_names: string[][];
+} {
+    const my_ast = parser.parse(lexer.tokenize(source).tokens).ast;
+    const the_commands = my_ast.nodes.filter(n => n.type === 'command') as {
+        name: string;
+        varlist?: { name: string }[];
+    }[];
+
+    return {
+        command_names: the_commands.map(c => c.name),
+        varlist_names: the_commands.map(c =>
+            (c.varlist ?? []).map(v => v.name)
+        ),
+    };
+}
+
 function expect_format_round_trip_stable(
     source: string,
     mode: FormatterMode,
@@ -178,6 +200,59 @@ display 1`;
 display 1
 `;
       expect(my_formatted).toBe(my_expected);
+    });
+
+    for_each_formatter_mode('should not synthesize close paren for unclosed varlist group', (mode) => {
+      const the_cases = [
+        {
+          source: `rename (old1 old2
+display 1`,
+          ast_expected: `rename (old1 old2
+display 1
+`,
+        },
+        {
+          source: `#delimit ;
+rename (old1 old2;
+display 1;
+#delimit cr`,
+          ast_expected: `#delimit ;;
+rename (old1 old2;
+display 1;
+#delimit cr
+`,
+        },
+      ];
+      const config = create_formatter_config(mode);
+      const mode_formatter = new CodeFormatter();
+
+      for (const my_case of the_cases) {
+        const my_formatted = format_document(
+          my_case.source,
+          lexer,
+          parser,
+          mode_formatter,
+          config
+        );
+        const my_expected = mode === 'source-preserving'
+          ? my_case.source
+          : my_case.ast_expected;
+
+        expect(my_formatted).toBe(my_expected);
+        expect(my_formatted).not.toContain('(old1 old2)');
+
+        const my_formatted_again = format_document(
+          my_formatted,
+          lexer,
+          parser,
+          mode_formatter,
+          config
+        );
+        expect(my_formatted_again).toBe(my_formatted);
+        expect(command_varlist_summary(my_formatted, lexer, parser)).toEqual(
+          command_varlist_summary(my_case.source, lexer, parser)
+        );
+      }
     });
 
     for_each_formatter_mode('should not delete inner option close paren during recovery', (mode) => {

--- a/tests/unit/formatter.test.ts
+++ b/tests/unit/formatter.test.ts
@@ -143,6 +143,85 @@ display 1
       expect(my_formatted_again).toBe(my_formatted);
     });
 
+    for_each_formatter_mode('should not format line comment as option argument text', (mode) => {
+      const my_source = `reg y x, vce(seed(123) // note
+display 1`;
+      const config = create_formatter_config(mode);
+      const mode_formatter = new CodeFormatter();
+      const my_formatted = format_document(my_source, lexer, parser, mode_formatter, config);
+
+      const my_expected = mode === 'source-preserving'
+        ? my_source
+        : `reg y x, vce(seed(123) // note
+display 1
+`;
+      expect(my_formatted).toBe(my_expected);
+      expect(my_formatted).not.toContain('/ / note');
+
+      const my_formatted_again = format_document(
+        my_formatted,
+        lexer,
+        parser,
+        mode_formatter,
+        config
+      );
+      expect(my_formatted_again).toBe(my_formatted);
+    });
+
+    for_each_formatter_mode('should not format block comment as option argument text', (mode) => {
+      const my_source = `reg y x, vce(seed(123) /* note */
+display 1`;
+      const config = create_formatter_config(mode);
+      const mode_formatter = new CodeFormatter();
+      const my_formatted = format_document(my_source, lexer, parser, mode_formatter, config);
+
+      const my_expected = mode === 'source-preserving'
+        ? my_source
+        : `reg y x, vce(seed(123) /* note */
+display 1
+`;
+      expect(my_formatted).toBe(my_expected);
+      expect(my_formatted).not.toContain('/ * note * /');
+
+      const my_formatted_again = format_document(
+        my_formatted,
+        lexer,
+        parser,
+        mode_formatter,
+        config
+      );
+      expect(my_formatted_again).toBe(my_formatted);
+    });
+
+    for_each_formatter_mode('should recover semicolon option argument before block comment', (mode) => {
+      const my_source = `#delimit ;
+reg y x, vce(seed(123) /* note */;
+display 1;
+#delimit cr`;
+      const config = create_formatter_config(mode);
+      const mode_formatter = new CodeFormatter();
+      const my_formatted = format_document(my_source, lexer, parser, mode_formatter, config);
+
+      const my_expected = mode === 'source-preserving'
+        ? my_source
+        : `#delimit ;;
+reg y x, vce(seed(123) /* note */;
+display 1;
+#delimit cr
+`;
+      expect(my_formatted).toBe(my_expected);
+      expect(my_formatted).not.toContain('/ * note * /');
+
+      const my_formatted_again = format_document(
+        my_formatted,
+        lexer,
+        parser,
+        mode_formatter,
+        config
+      );
+      expect(my_formatted_again).toBe(my_formatted);
+    });
+
     for_each_formatter_mode('should preserve unclosed option argument before continuation EOF', (mode) => {
       const my_source = 'reg y x, vce(seed(123) ///';
       const config = create_formatter_config(mode);

--- a/tests/unit/formatter.test.ts
+++ b/tests/unit/formatter.test.ts
@@ -91,6 +91,45 @@ summarize age`;
       expect(my_formatted).toContain('age');
       expect(my_formatted).toContain('robust');
     });
+
+    for_each_formatter_mode('should preserve unclosed option argument at EOF', (mode) => {
+      const my_source = 'reg y x, vce(seed(123)';
+      const config = create_formatter_config(mode);
+      const mode_formatter = new CodeFormatter();
+      const my_formatted = format_document(my_source, lexer, parser, mode_formatter, config);
+
+      const my_expected = mode === 'source-preserving'
+        ? my_source
+        : 'reg y x, vce(seed(123)\n';
+      expect(my_formatted).toBe(my_expected);
+    });
+
+    for_each_formatter_mode('should preserve unclosed option argument before newline terminator', (mode) => {
+      const my_source = `reg y x, vce(seed(123)
+display 1`;
+      const config = create_formatter_config(mode);
+      const mode_formatter = new CodeFormatter();
+      const my_formatted = format_document(my_source, lexer, parser, mode_formatter, config);
+
+      const my_expected = mode === 'source-preserving'
+        ? my_source
+        : `reg y x, vce(seed(123
+display 1
+`;
+      expect(my_formatted).toBe(my_expected);
+    });
+
+    for_each_formatter_mode('should preserve unclosed option argument before continuation EOF', (mode) => {
+      const my_source = 'reg y x, vce(seed(123) ///';
+      const config = create_formatter_config(mode);
+      const mode_formatter = new CodeFormatter();
+      const my_formatted = format_document(my_source, lexer, parser, mode_formatter, config);
+
+      const my_expected = mode === 'source-preserving'
+        ? my_source
+        : 'reg y x, vce(seed(123)\n';
+      expect(my_formatted).toBe(my_expected);
+    });
   });
 
   describe('embedded content preservation', () => {

--- a/tests/unit/formatter.test.ts
+++ b/tests/unit/formatter.test.ts
@@ -113,10 +113,34 @@ display 1`;
 
       const my_expected = mode === 'source-preserving'
         ? my_source
-        : `reg y x, vce(seed(123
+        : `reg y x, vce(seed(123)
 display 1
 `;
       expect(my_formatted).toBe(my_expected);
+    });
+
+    for_each_formatter_mode('should not delete inner option close paren during recovery', (mode) => {
+      const my_source = `reg y x, vce(seed(123)
+display 1`;
+      const config = create_formatter_config(mode);
+      const mode_formatter = new CodeFormatter();
+      const my_formatted = format_document(my_source, lexer, parser, mode_formatter, config);
+
+      const my_expected = mode === 'source-preserving'
+        ? my_source
+        : `reg y x, vce(seed(123)
+display 1
+`;
+      expect(my_formatted).toBe(my_expected);
+
+      const my_formatted_again = format_document(
+        my_formatted,
+        lexer,
+        parser,
+        mode_formatter,
+        config
+      );
+      expect(my_formatted_again).toBe(my_formatted);
     });
 
     for_each_formatter_mode('should preserve unclosed option argument before continuation EOF', (mode) => {

--- a/tests/unit/formatter.test.ts
+++ b/tests/unit/formatter.test.ts
@@ -46,6 +46,67 @@ function format_document(source: string, lexer: StataLexer, parser: StataParser,
     return format_shared_document(source, lexer, parser, formatter, options, config);
 }
 
+function command_option_summary(
+    source: string,
+    lexer: StataLexer,
+    parser: StataParser
+): {
+    command_names: string[];
+    option_argument?: string;
+    option_unclosed?: true;
+} {
+    const my_ast = parser.parse(lexer.tokenize(source).tokens).ast;
+    const the_commands = my_ast.nodes.filter(n => n.type === 'command') as {
+        name: string;
+        options?: {
+            name: string;
+            argument?: string;
+            argument_unclosed?: true;
+        }[];
+    }[];
+    const my_reg = the_commands.find(c => c.name === 'reg');
+    const my_option = my_reg?.options?.find(o => o.name === 'vce');
+
+    return {
+        command_names: the_commands.map(c => c.name),
+        option_argument: my_option?.argument,
+        option_unclosed: my_option?.argument_unclosed,
+    };
+}
+
+function expect_format_round_trip_stable(
+    source: string,
+    mode: FormatterMode,
+    lexer: StataLexer,
+    parser: StataParser
+): void {
+    const config = create_formatter_config(mode);
+    const mode_formatter = new CodeFormatter();
+    const my_formatted = format_document(
+        source,
+        lexer,
+        parser,
+        mode_formatter,
+        config
+    );
+    const my_formatted_again = format_document(
+        my_formatted,
+        lexer,
+        parser,
+        mode_formatter,
+        config
+    );
+
+    expect(my_formatted_again).toBe(my_formatted);
+    if (mode === 'source-preserving') {
+        expect(my_formatted).toBe(source);
+    }
+
+    expect(command_option_summary(my_formatted, lexer, parser)).toEqual(
+        command_option_summary(source, lexer, parser)
+    );
+}
+
 describe('CodeFormatter with embedded language support', () => {
   let formatter: CodeFormatter;
   let parser: StataParser;
@@ -152,7 +213,7 @@ display 1`;
 
       const my_expected = mode === 'source-preserving'
         ? my_source
-        : `reg y x, vce(seed(123) // note
+        : `reg y x, vce(seed(123)
 display 1
 `;
       expect(my_formatted).toBe(my_expected);
@@ -177,7 +238,7 @@ display 1`;
 
       const my_expected = mode === 'source-preserving'
         ? my_source
-        : `reg y x, vce(seed(123) /* note */
+        : `reg y x, vce(seed(123)
 display 1
 `;
       expect(my_formatted).toBe(my_expected);
@@ -205,7 +266,7 @@ display 1;
       const my_expected = mode === 'source-preserving'
         ? my_source
         : `#delimit ;;
-reg y x, vce(seed(123) /* note */;
+reg y x, vce(seed(123);
 display 1;
 #delimit cr
 `;
@@ -220,6 +281,34 @@ display 1;
         config
       );
       expect(my_formatted_again).toBe(my_formatted);
+    });
+
+    for_each_formatter_mode('should round-trip cr-mode line comment after unclosed option', (mode) => {
+      const my_source = `reg y x, vce(seed(123) // note
+display 1`;
+
+      expect_format_round_trip_stable(my_source, mode, lexer, parser);
+    });
+
+    for_each_formatter_mode('should round-trip semicolon line comment after unclosed option', (mode) => {
+      const my_source = `#delimit ;
+reg y x, vce(seed(123) // note
+;
+display 1;
+#delimit cr`;
+
+      expect_format_round_trip_stable(my_source, mode, lexer, parser);
+    });
+
+    for_each_formatter_mode('should round-trip multiple semicolon comments after unclosed option', (mode) => {
+      const my_source = `#delimit ;
+reg y x, vce(seed(123) // one
+/* two */ // three
+;
+display 1;
+#delimit cr`;
+
+      expect_format_round_trip_stable(my_source, mode, lexer, parser);
     });
 
     for_each_formatter_mode('should preserve unclosed option argument before continuation EOF', (mode) => {

--- a/tests/unit/formatter.test.ts
+++ b/tests/unit/formatter.test.ts
@@ -207,6 +207,20 @@ summarize z`;
       expect(my_formatted).toContain('summarize z');
     });
 
+    for_each_formatter_mode('should not move semicolon-mode inline mata code into a line comment', (mode) => {
+      const my_source = `#delimit ;
+mata: real // note
+scalar x;
+#delimit cr`;
+      const config = create_formatter_config(mode);
+      const mode_formatter = new CodeFormatter(config);
+      const my_formatted = format_document(my_source, lexer, parser, mode_formatter, config);
+
+      expect(my_formatted).toContain(`real // note
+scalar x`);
+      expect(my_formatted).not.toContain('real // notescalar x');
+    });
+
     test('should preserve nested embedded blocks', () => {
       const my_source = `mata
       matrix A = (1, 2)

--- a/tests/unit/formatter.test.ts
+++ b/tests/unit/formatter.test.ts
@@ -212,12 +212,30 @@ display 1
 `,
         },
         {
+          source: `rename (
+display 1`,
+          ast_expected: `rename (
+display 1
+`,
+        },
+        {
           source: `#delimit ;
 rename (old1 old2;
 display 1;
 #delimit cr`,
           ast_expected: `#delimit ;;
 rename (old1 old2;
+display 1;
+#delimit cr
+`,
+        },
+        {
+          source: `#delimit ;
+rename (;
+display 1;
+#delimit cr`,
+          ast_expected: `#delimit ;;
+rename (;
 display 1;
 #delimit cr
 `,

--- a/tests/unit/lexer.test.ts
+++ b/tests/unit/lexer.test.ts
@@ -1,4 +1,23 @@
 import { StataLexer } from '../../src/lexer';
+import { LanguageContext, LexerResult } from '../../src/types';
+
+function tokenizeWithMode(source: string, delimiterMode: 'cr' | 'semicolon'): LexerResult {
+  const lexer = new StataLexer();
+  return lexer.tokenize(source, {
+    delimiterMode,
+    line: 0,
+    column: 0,
+    language_context: LanguageContext.STATA,
+    context_stack: [LanguageContext.STATA],
+  });
+}
+
+function comparableTokenShapes(result: LexerResult): Array<{ type: string; value: string }> {
+  return result.tokens.map(token => ({
+    type: token.type,
+    value: token.type === 'STATEMENT_TERMINATOR' ? '<terminator>' : token.value,
+  }));
+}
 
 describe('StataLexer', () => {
   let lexer: StataLexer;
@@ -38,6 +57,53 @@ describe('StataLexer', () => {
       // Find the semicolon token
       const semicolonToken = result.tokens.find(t => t.value === ';' && t.type === 'STATEMENT_TERMINATOR');
       expect(semicolonToken).toBeDefined();
+    });
+
+    test('should skip Stata whitespace in semicolon mode', () => {
+      const source = 'generate\tage = 25\r\n  replace\tage = 26;\n';
+      const result = tokenizeWithMode(source, 'semicolon');
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.tokens.some(t => t.type === 'WHITESPACE')).toBe(false);
+      expect(result.tokens.filter(t => t.type === 'STATEMENT_TERMINATOR').map(t => t.value)).toEqual([';']);
+      expect(result.tokens.map(t => t.value)).toEqual([
+        'generate',
+        'age',
+        '=',
+        '25',
+        'replace',
+        'age',
+        '=',
+        '26',
+        ';',
+        '',
+      ]);
+    });
+
+    test('should make cr and semicolon Stata streams differ only by terminator spelling', () => {
+      const cr_result = tokenizeWithMode('generate\tage = 25\n', 'cr');
+      const semicolon_result = tokenizeWithMode('generate\tage = 25;', 'semicolon');
+
+      expect(cr_result.errors).toHaveLength(0);
+      expect(semicolon_result.errors).toHaveLength(0);
+      expect(comparableTokenShapes(semicolon_result)).toEqual(comparableTokenShapes(cr_result));
+    });
+
+    test('should preserve exact-width embedded whitespace in both delimiter modes', () => {
+      const sources = ['mata\nx  \t= 1\nend', 'python\nx  \t= 1\nend'];
+
+      for (const source of sources) {
+        for (const mode of ['cr', 'semicolon'] as const) {
+          const result = tokenizeWithMode(source, mode);
+          const whitespace_values = result.tokens
+            .filter(t => t.type === 'WHITESPACE')
+            .map(t => t.value);
+
+          expect(result.errors).toHaveLength(0);
+          expect(whitespace_values).toContain('  \t');
+          expect(whitespace_values).toContain(' ');
+        }
+      }
     });
 
     test('should tokenize local macro reference', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1367,6 +1367,12 @@ end`;
       (parse(source).ast.nodes as unknown as CommandLike[]).find(
         n => n.type === 'command'
       );
+    const command_names = (source: string): string[] =>
+      (parse(source).ast.nodes as unknown as CommandLike[])
+        .filter(n => n.type === 'command')
+        .map(n => n.name ?? '');
+    const varlist_names = (source: string): string[] =>
+      command(source)?.varlist?.map(v => v.name) ?? [];
     const semi = (body: string): string =>
       `#delimit ;\n${body};\n#delimit cr`;
 
@@ -1434,6 +1440,59 @@ end`;
       expect((semi_cmd?.varlist ?? []).map(v => v.name)).toEqual(
         (cr?.varlist ?? []).map(v => v.name)
       );
+    });
+
+    test('unterminated cr-mode parenthesized group does not swallow following statements', () => {
+      const source = 'rename (old1 old2\ndisplay 1\ndisplay 2';
+
+      expect(command_names(source)).toEqual(['rename', 'display', 'display']);
+      expect(varlist_names(source)).toEqual(['(old1 old2)']);
+    });
+
+    test('unterminated semicolon-mode parenthesized group does not consume the terminator', () => {
+      const source =
+        '#delimit ;\nrename (old1 old2;\ndisplay 1;\n#delimit cr';
+
+      expect(command_names(source)).toEqual(['rename', 'display']);
+      expect(varlist_names(source)).toEqual(['(old1 old2)']);
+    });
+
+    test('unterminated assignment expression does not swallow following statements', () => {
+      const source = 'gen z = (x\ndisplay 1\ndisplay 2';
+
+      expect(command_names(source)).toEqual(['gen', 'display', 'display']);
+      expect(command(source)?.expression).toBe('(x');
+    });
+
+    test('unterminated semicolon-mode assignment expression does not consume the terminator', () => {
+      const source = '#delimit ;\ngen z = (x;\ndisplay 1;\n#delimit cr';
+
+      expect(command_names(source)).toEqual(['gen', 'display']);
+      expect(command(source)?.expression).toBe('(x');
+    });
+
+    test('unterminated if qualifier does not swallow following statements', () => {
+      const source = 'keep if (x > 0\ndisplay 1\ndisplay 2';
+
+      expect(command_names(source)).toEqual(['keep', 'display', 'display']);
+      expect(command(source)?.ifExpression).toBe('(x > 0');
+    });
+
+    test('balanced rename parenthesized groups stay intact', () => {
+      expect(varlist_names('rename (old1 old2) (new1 new2)')).toEqual([
+        '(old1 old2)',
+        '(new1 new2)',
+      ]);
+    });
+
+    test('cr-mode slash continuation inside parenthesized group stays in the group', () => {
+      const source = 'rename (old1 ///\nold2) (new1 new2)';
+
+      expect(command_names(source)).toEqual(['rename']);
+      expect(varlist_names(source)).toEqual([
+        '(old1 old2)',
+        '(new1 new2)',
+      ]);
     });
 
     test('AST formatter emits valid Stata for value-separator whitespace', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1620,6 +1620,10 @@ end`;
     };
     const semi = (body: string): string =>
       `#delimit ;\n${body};\n#delimit cr`;
+    const command_names = (source: string): string[] =>
+      parse(source).ast.nodes
+        .filter(n => n.type === 'command')
+        .map(n => (n as { name: string }).name);
 
     test('multi-token option argument matches across modes', () => {
       expect(option_arg('reg y x, absorb(firm year)', 'absorb')).toBe(
@@ -1648,6 +1652,20 @@ end`;
       }
     });
 
+    test('unterminated nested option argument recovers at cr-mode statement terminator', () => {
+      const source = 'reg y x, vce(seed(123)\ndisplay 1\ndisplay 2';
+
+      expect(command_names(source)).toEqual(['reg', 'display', 'display']);
+      expect(option_arg(source, 'vce')).toBe('seed(123');
+    });
+
+    test('unterminated nested option argument recovers at semicolon-mode statement terminator', () => {
+      const source = '#delimit ;\nreg y x, vce(seed(123);\ndisplay 1;\n#delimit cr';
+
+      expect(command_names(source)).toEqual(['reg', 'display']);
+      expect(option_arg(source, 'vce')).toBe('seed(123');
+    });
+
     test('two-level nested option arguments are preserved', () => {
       expect(option_arg('reg y x, absorb(f(a) g(b))', 'absorb')).toBe(
         'f(a) g(b)'
@@ -1655,6 +1673,20 @@ end`;
       expect(option_arg(semi('reg y x, absorb(f(a) g(b))'), 'absorb')).toBe(
         'f(a) g(b)'
       );
+    });
+
+    test('cr-mode option argument continues across slash continuation', () => {
+      const source = 'reg y x, vce(seed(123) ///\nrep(300))';
+
+      expect(command_names(source)).toEqual(['reg']);
+      expect(option_arg(source, 'vce')).toBe('seed(123) rep(300)');
+    });
+
+    test('cr-mode raw newline inside option argument ends the statement', () => {
+      const source = 'reg y x, vce(a\nb)';
+
+      expect(command_names(source)).toEqual(['reg', 'b']);
+      expect(option_arg(source, 'vce')).toBe('a');
     });
 
     test('nested option argument range spans the full argument content', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,5 +1,6 @@
 import { StataParser } from '../../src/parser';
 import { StataLexer } from '../../src/lexer';
+import { PrettyPrinter } from '../../src/pretty-printer';
 
 describe('StataParser', () => {
   let parser: StataParser;
@@ -45,7 +46,7 @@ describe('StataParser', () => {
         expect(node.name).toBe('generate');
         expect(node.varlist).toHaveLength(1);
         expect(node.varlist?.[0].name).toBe('newvar');
-        expect(node.expression).toBe('oldvar+1*2');
+        expect(node.expression).toBe('oldvar + 1 * 2');
       }
     });
 
@@ -65,7 +66,7 @@ describe('StataParser', () => {
         expect(node.varlist).toHaveLength(2);
         expect(node.varlist?.[0].name).toBe('var1');
         expect(node.varlist?.[1].name).toBe('var2');
-        expect(node.ifExpression).toBe('age>30');
+        expect(node.ifExpression).toBe('age > 30');
         expect(node.inExpression).toBeUndefined();
       }
     });
@@ -106,7 +107,7 @@ describe('StataParser', () => {
         expect(node.varlist).toHaveLength(2);
         expect(node.varlist?.[0].name).toBe('var1');
         expect(node.varlist?.[1].name).toBe('var2');
-        expect(node.ifExpression).toBe('age>30');
+        expect(node.ifExpression).toBe('age > 30');
         expect(node.inExpression).toBe('1/10');
       }
     });
@@ -126,8 +127,8 @@ describe('StataParser', () => {
         expect(node.name).toBe('generate');
         expect(node.varlist).toHaveLength(1);
         expect(node.varlist?.[0].name).toBe('newvar');
-        expect(node.expression).toBe('oldvar*2');
-        expect(node.ifExpression).toBe('condition==1');
+        expect(node.expression).toBe('oldvar * 2');
+        expect(node.ifExpression).toBe('condition == 1');
         expect(node.inExpression).toBeUndefined();
       }
     });
@@ -147,7 +148,7 @@ describe('StataParser', () => {
         expect(node.name).toBe('list');
         expect(node.varlist).toHaveLength(1);
         expect(node.varlist?.[0].name).toBe('var');
-        expect(node.ifExpression).toBe('(age>30&gender=="male")');
+        expect(node.ifExpression).toBe('(age > 30 & gender == "male")');
       }
     });
 
@@ -1234,6 +1235,368 @@ end`;
     });
   });
 
+  describe('#delimit ; reconstructed-string spacing parity (issue #306)', () => {
+    // In `#delimit ;` mode the lexer emits WHITESPACE tokens that `#delimit cr`
+    // mode elides, so the reconstructed expression / if-in qualifier /
+    // parenthesized-group strings gained internal spaces in `;` mode that were
+    // absent in `cr` mode. The AST structure was already identical; only the
+    // internal spacing diverged. We reconstruct spacing from token ranges (via
+    // reconstruct_value_tokens) in BOTH modes, so each yields the identical,
+    // source-faithful single-space form (issue #306, Option 3). This also fixes
+    // the latent `cr`-mode defect where value-separator whitespace was lost
+    // (e.g. `group(a b)` became `group(ab)`), which the pretty-printer could
+    // not recover once two value tokens had been fused into one identifier.
+    const parse = (source: string) =>
+      parser.parse(lexer.tokenize(source).tokens);
+    type CommandLike = {
+      type: string;
+      name?: string;
+      varlist?: { name: string }[];
+      expression?: string;
+      ifExpression?: string;
+      inExpression?: string;
+    };
+    const command = (source: string): CommandLike | undefined =>
+      (parse(source).ast.nodes as unknown as CommandLike[]).find(
+        n => n.type === 'command'
+      );
+    const semi = (body: string): string =>
+      `#delimit ;\n${body};\n#delimit cr`;
+
+    // For each body, the `;`-mode reconstruction must equal the `cr`-mode one
+    // (a single space per source gap), and neither mode may emit a diagnostic.
+    const cases: { body: string; expr?: string; if_?: string; in_?: string;
+                   vl?: string[] }[] = [
+      { body: 'gen z = x + y', expr: 'x + y', vl: ['z'] },
+      { body: 'gen z = x+y', expr: 'x+y', vl: ['z'] },
+      { body: 'gen z = (x + y) * 2', expr: '(x + y) * 2', vl: ['z'] },
+      // Value-separator whitespace must survive so the argument list is not
+      // fused into one identifier (the pre-existing cr-mode defect).
+      { body: 'egen g = group(a b)', expr: 'group(a b)', vl: ['g'] },
+      { body: 'replace z = x * 2 if y > 0', expr: 'x * 2', if_: 'y > 0',
+        vl: ['z'] },
+      { body: 'keep if inrange(age, 18, 65)', if_: 'inrange(age, 18, 65)' },
+      { body: 'keep in 1 / 10', in_: '1 / 10' },
+      { body: 'recode x (1/3 = 1) (4/6 = 2)',
+        vl: ['x', '(1/3 = 1)', '(4/6 = 2)'] },
+    ];
+
+    for (const my_case of cases) {
+      test(`"${my_case.body}" matches cr spacing and is error-free`, () => {
+        const cr = parse(my_case.body);
+        const semi_result = parse(semi(my_case.body));
+        expect(cr.errors).toHaveLength(0);
+        expect(semi_result.errors).toHaveLength(0);
+
+        const cr_cmd = command(my_case.body);
+        const semi_cmd = command(semi(my_case.body));
+        expect(cr_cmd).toBeDefined();
+        expect(semi_cmd).toBeDefined();
+
+        // Parity: every reconstructed field agrees across modes.
+        expect(semi_cmd?.expression).toBe(cr_cmd?.expression);
+        expect(semi_cmd?.ifExpression).toBe(cr_cmd?.ifExpression);
+        expect(semi_cmd?.inExpression).toBe(cr_cmd?.inExpression);
+        expect((semi_cmd?.varlist ?? []).map(v => v.name)).toEqual(
+          (cr_cmd?.varlist ?? []).map(v => v.name)
+        );
+
+        // And the agreed form is the source-faithful single-space one.
+        if (my_case.expr !== undefined) {
+          expect(semi_cmd?.expression).toBe(my_case.expr);
+        }
+        if (my_case.if_ !== undefined) {
+          expect(semi_cmd?.ifExpression).toBe(my_case.if_);
+        }
+        if (my_case.in_ !== undefined) {
+          expect(semi_cmd?.inExpression).toBe(my_case.in_);
+        }
+        if (my_case.vl !== undefined) {
+          expect((semi_cmd?.varlist ?? []).map(v => v.name)).toEqual(my_case.vl);
+        }
+      });
+    }
+
+    test('multi-word parenthesized group keeps its word separators', () => {
+      // Range-based reconstruction must keep the value separator: `(a b)` is
+      // `(a b)` in both modes, never `(ab)`. Whitespace around operators is
+      // normalized to a single space rather than dropped.
+      const cr = command('mycmd (a b)');
+      const semi_cmd = command(semi('mycmd (a b)'));
+      expect((cr?.varlist ?? []).map(v => v.name)).toContain('(a b)');
+      expect((semi_cmd?.varlist ?? []).map(v => v.name)).toEqual(
+        (cr?.varlist ?? []).map(v => v.name)
+      );
+    });
+
+    test('AST formatter emits valid Stata for value-separator whitespace', () => {
+      // Regression: reconstructing the assignment RHS without value-separator
+      // whitespace produced `group(ab)` — a different, broken expression the
+      // pretty-printer could not repair. Both modes must round-trip through the
+      // AST formatter with `group(a b)` intact (issue #306).
+      const printer = new PrettyPrinter();
+      const format = (source: string): string =>
+        printer.print(parse(source).ast);
+      expect(format('egen g = group(a b)')).toContain('group(a b)');
+      expect(format(semi('egen g = group(a b)'))).toContain('group(a b)');
+      expect(format('egen g = group(a b)')).not.toContain('group(ab)');
+    });
+
+    test('/// continuation joins only the immediately-following line', () => {
+      // `///` continues one line: a column-0 token on the next line joins with
+      // no space, an indented token keeps one space, and consecutive `///`
+      // lines still join. A blank line after `///` is an ordinary newline and
+      // must separate — it must NOT fuse the tokens into one identifier
+      // (issue #306; matches the documented macro-value convention).
+      const expr = (body: string): string | undefined =>
+        command(semi(body))?.expression;
+      expect(expr('gen z = a///\nb')).toBe('ab');
+      expect(expr('gen z = a///\n    b')).toBe('a b');
+      expect(expr('gen z = a///\n///\nb')).toBe('ab');
+      expect(expr('gen z = a///\n\nb')).toBe('a b');
+      // A same-line space before `///` is real whitespace and must separate,
+      // even when the continued token starts at column 0.
+      expect(expr('gen z = a ///\nb')).toBe('a b');
+      // A raw newline before a later `///` breaks the chain: the tokens must
+      // not fuse just because the second `///` sits next to the final token.
+      expect(expr('gen z = a///\n\n///\nb')).toBe('a b');
+      // Diagnostic-free in every case.
+      for (const my_body of [
+        'gen z = a///\nb',
+        'gen z = a///\n\nb',
+        'gen z = a///\n    b',
+        'gen z = a///\n\n///\nb',
+      ]) {
+        expect(parse(semi(my_body)).errors).toHaveLength(0);
+      }
+    });
+  });
+
+  describe('#delimit cr file-command argument coalescing (issue #306)', () => {
+    // In `#delimit cr` mode the lexer emits no WHITESPACE tokens, so a file
+    // command's first-argument path coalesced every following token into one
+    // string (`merge 1:1 id using data` -> `["1:1idusingdata"]`), whereas
+    // `#delimit ;` mode kept the arguments separate. parseFilePathArgument now
+    // stops coalescing at a source gap, so both modes agree (issue #306).
+    const parse = (source: string) =>
+      parser.parse(lexer.tokenize(source).tokens);
+    type CommandLike = { type: string; name?: string; varlist?: { name: string }[] };
+    const commands = (source: string): CommandLike[] =>
+      (parse(source).ast.nodes as unknown as CommandLike[]).filter(
+        n => n.type === 'command'
+      );
+    const varlist_names = (c: CommandLike | undefined): string[] =>
+      (c?.varlist ?? []).map(v => v.name);
+    const semi = (body: string): string =>
+      `#delimit ;\n${body};\n#delimit cr`;
+
+    test('merge arguments stay separate in #delimit cr mode', () => {
+      const cr = commands('merge 1:1 id using data');
+      expect(cr).toHaveLength(1);
+      expect(cr[0].name).toBe('merge');
+      expect(varlist_names(cr[0])).toEqual(['1:1', 'id', 'using', 'data']);
+      expect(parse('merge 1:1 id using data').errors).toHaveLength(0);
+    });
+
+    test('merge parses identically in #delimit cr and #delimit ; modes', () => {
+      const cr = commands('merge 1:1 id using data');
+      const semi_cmds = commands(semi('merge 1:1 id using data'));
+      expect(semi_cmds).toHaveLength(1);
+      expect(varlist_names(cr[0])).toEqual(varlist_names(semi_cmds[0]));
+    });
+
+    test('m:1 merge with a using path matches across modes', () => {
+      const cr = commands('merge m:1 statefip year using acs');
+      const semi_cmds = commands(semi('merge m:1 statefip year using acs'));
+      expect(cr).toHaveLength(1);
+      expect(semi_cmds).toHaveLength(1);
+      expect(varlist_names(cr[0])).toEqual(varlist_names(semi_cmds[0]));
+      expect(varlist_names(cr[0])[0]).toBe('m:1');
+    });
+
+    test('unquoted file paths still coalesce as one argument in cr mode', () => {
+      // Adjacent tokens (no source gap) remain a single path: the adjacency
+      // guard must not fragment `use data/sub.dir/file.dta` or `do myfile.do`.
+      expect(varlist_names(commands('do myfile.do')[0])).toEqual(['myfile.do']);
+      expect(varlist_names(commands('use data/sub.dir/file.dta')[0])).toEqual([
+        'data/sub.dir/file.dta',
+      ]);
+    });
+  });
+
+  describe('#delimit ; loop-spec spacing parity (issue #306)', () => {
+    // The foreach/forvalues loop spec is reconstructed from tokens too, so it
+    // must agree across delimiter modes and never fuse list items — otherwise
+    // the loop expander sees one iterator value (`x_ab`) instead of two
+    // (`x_a`, `x_b`) (issue #306).
+    const parse = (source: string) =>
+      parser.parse(lexer.tokenize(source).tokens);
+    const loop_spec = (source: string): string | undefined => {
+      const my_node = parse(source).ast.nodes.find(
+        n => n.type === 'foreach' || n.type === 'forvalues'
+      ) as { loopSpec?: string } | undefined;
+      return my_node?.loopSpec;
+    };
+    const semi_loop = (spec_line: string): string =>
+      `#delimit ;\n${spec_line} {;\n  display 1;\n};\n#delimit cr`;
+
+    test('foreach in-list matches across modes', () => {
+      const cr = loop_spec('foreach i in a b c {\n  display 1\n}');
+      expect(cr).toBe('in a b c');
+      expect(loop_spec(semi_loop('foreach i in a b c'))).toBe(cr);
+    });
+
+    test('forvalues spec matches across modes', () => {
+      const cr = loop_spec('forvalues i = 1/10 {\n  display 1\n}');
+      expect(cr).toBe('= 1/10');
+      expect(loop_spec(semi_loop('forvalues i = 1/10'))).toBe(cr);
+    });
+
+    test('/// continuation in a foreach list joins only the next line', () => {
+      // Column-0 join, then a blank line that must separate rather than fuse.
+      expect(loop_spec(semi_loop('foreach i in a///\nb'))).toBe('in ab');
+      expect(loop_spec(semi_loop('foreach i in a///\n\nb'))).toBe('in a b');
+    });
+  });
+
+  describe('if/while condition spacing parity (issue #306)', () => {
+    // if/while conditions are reconstructed from tokens too. They were already
+    // mode-invariant, but used a different spacing path; routing them through
+    // the shared reconstruct_value_tokens gives consistent single-space spacing
+    // and correct `///` join semantics (issue #306).
+    const parse = (source: string) =>
+      parser.parse(lexer.tokenize(source).tokens);
+    const condition = (source: string): string | undefined => {
+      const my_node = parse(source).ast.nodes.find(
+        n => n.type === 'if' || n.type === 'while'
+      ) as { condition?: string } | undefined;
+      return my_node?.condition;
+    };
+
+    test('condition spacing agrees across delimiter modes', () => {
+      const cr = condition('if x > 0 & y < 1 {\n  display 1\n}');
+      expect(cr).toBe('x > 0 & y < 1');
+      const semi = condition(
+        '#delimit ;\nif x > 0 & y < 1 {;\n  display 1;\n};\n#delimit cr'
+      );
+      expect(semi).toBe(cr);
+    });
+
+    test('/// continuation in a condition joins only the next line', () => {
+      // Column-0 join matches Stata (`if a///` then `b` executes `if ab`); a
+      // space before `///` separates.
+      expect(condition('if a///\nb {\n  display 1\n}')).toBe('ab');
+      expect(condition('if a ///\nb {\n  display 1\n}')).toBe('a b');
+      expect(condition('while a///\nb {\n  display 1\n}')).toBe('ab');
+    });
+  });
+
+  describe('#delimit ; option-argument spacing parity (issue #306)', () => {
+    // An option's parenthesized argument is reconstructed from tokens too, so a
+    // multi-token argument must agree across delimiter modes and never fuse —
+    // `absorb(firm year)` is `firm year`, not `firmyear` (issue #306).
+    const parse = (source: string) =>
+      parser.parse(lexer.tokenize(source).tokens);
+    const option_arg = (source: string, name: string): string | undefined => {
+      const my_cmd = parse(source).ast.nodes.find(n => n.type === 'command') as
+        { options?: { name: string; argument?: string }[] } | undefined;
+      return my_cmd?.options?.find(o => o.name === name)?.argument;
+    };
+    const semi = (body: string): string =>
+      `#delimit ;\n${body};\n#delimit cr`;
+
+    test('multi-token option argument matches across modes', () => {
+      expect(option_arg('reg y x, absorb(firm year)', 'absorb')).toBe(
+        'firm year'
+      );
+      expect(option_arg(semi('reg y x, absorb(firm year)'), 'absorb')).toBe(
+        'firm year'
+      );
+      expect(parse('reg y x, absorb(firm year)').errors).toHaveLength(0);
+    });
+
+    test('adjacent option-argument tokens stay joined in both modes', () => {
+      expect(option_arg('reg y x, cluster(id)', 'cluster')).toBe('id');
+      expect(option_arg(semi('reg y x, cluster(id)'), 'cluster')).toBe('id');
+    });
+  });
+
+  describe('#delimit ; extended-macro argument parity (issue #306)', () => {
+    // Extended macro functions (`local n : word count a b c`) reconstruct their
+    // argument string from tokens too, so it must agree across delimiter modes
+    // and normalize spacing to a single space per gap (issue #306).
+    const parse = (source: string) =>
+      parser.parse(lexer.tokenize(source).tokens);
+    const ext_args = (source: string): string | undefined => {
+      const my_node = parse(source).ast.nodes.find(
+        n => n.type === 'macro_def'
+      ) as { extendedFunction?: { args?: string } } | undefined;
+      return my_node?.extendedFunction?.args;
+    };
+    const semi = (body: string): string =>
+      `#delimit ;\n${body};\n#delimit cr`;
+
+    test('multi-token extended-macro args match across modes', () => {
+      expect(ext_args('local n : word count a b c')).toBe('count a b c');
+      expect(ext_args(semi('local n : word count a b c'))).toBe('count a b c');
+    });
+
+    test('/// continuation in extended-macro args joins only the next line', () => {
+      expect(ext_args('local x : display a///\nb')).toBe('ab');
+      expect(ext_args(semi('local x : display a///\n\nb'))).toBe('a b');
+    });
+  });
+
+  describe('syntax option default() value spacing (issue #306)', () => {
+    // A `syntax` option's default() value is reconstructed from tokens too; a
+    // multi-token default must keep its separator (`default(a b)` -> `a b`, not
+    // `ab`) so hover/completion default text is correct (issue #306).
+    const parse = (source: string) =>
+      parser.parse(lexer.tokenize(source).tokens);
+    const default_value = (source: string): string | undefined => {
+      const my_prog = parse(source).ast.nodes.find(n => n.type === 'program') as
+        { body?: { type: string; signature?: { options?: { name: string;
+          defaultValue?: string }[] } }[] } | undefined;
+      const my_syntax = my_prog?.body?.find(n => n.type === 'syntax');
+      return my_syntax?.signature?.options?.[0]?.defaultValue;
+    };
+
+    test('multi-token default keeps its separator and agrees across modes', () => {
+      const src = 'program define q\n  syntax , opt(string default(a b))\nend';
+      const semi_src =
+        '#delimit ;\nprogram define q;\n  syntax , opt(string default(a b));\n' +
+        'end;\n#delimit cr';
+      expect(default_value(src)).toBe('a b');
+      expect(default_value(semi_src)).toBe('a b');
+    });
+
+    test('single-token and nested defaults are preserved', () => {
+      expect(
+        default_value('program define q\n  syntax , opt(string default(foo))\nend')
+      ).toBe('foo');
+      expect(
+        default_value('program define q\n  syntax , opt(string default(f(x)))\nend')
+      ).toBe('f(x)');
+    });
+
+    test('syntax declaration spanning /// continuations is collected whole', () => {
+      // A `///` used to truncate the syntax declaration at the first
+      // continuation (isTrivia included CONTINUATION); it must now be bridged
+      // so every option on continued lines is captured (issue #306).
+      const my_prog = parse(
+        'program define q\n  syntax varlist, ///\n  Robust ///\n' +
+        '  Cluster(varname)\nend'
+      ).ast.nodes.find(n => n.type === 'program') as
+        { body?: { type: string; signature?: { options?: { name: string }[] } }[] }
+        | undefined;
+      const my_syntax = my_prog?.body?.find(n => n.type === 'syntax');
+      expect(my_syntax?.signature?.options?.map(o => o.name)).toEqual([
+        'Robust',
+        'Cluster',
+      ]);
+    });
+  });
+
   describe('macro reference command parsing', () => {
     test('should parse local macro at start of statement', () => {
       const source = '`custom_cmd\' "arg1" "arg2"';
@@ -1335,7 +1698,7 @@ else {
         expect(node.name).toBe('`cmd\'');
         expect(node.varlist).toHaveLength(1);
         expect(node.varlist?.[0].name).toBe('var1');
-        expect(node.ifExpression).toBe('x>0');
+        expect(node.ifExpression).toBe('x > 0');
       }
     });
 

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1666,6 +1666,17 @@ end`;
       const my_syntax = my_prog?.body?.find(n => n.type === 'syntax');
       return my_syntax?.signature?.options?.[0]?.defaultValue;
     };
+    const cr_program = (syntax_line: string): string =>
+      `program define q\n  ${syntax_line}\nend`;
+    const semi_program = (syntax_line: string): string =>
+      `#delimit ;\nprogram define q;\n  ${syntax_line};\nend;\n#delimit cr`;
+    const expect_default_in_both_modes = (
+      syntax_line: string,
+      expected: string
+    ) => {
+      expect(default_value(cr_program(syntax_line))).toBe(expected);
+      expect(default_value(semi_program(syntax_line))).toBe(expected);
+    };
 
     test('multi-token default keeps its separator and agrees across modes', () => {
       const src = 'program define q\n  syntax , opt(string default(a b))\nend';
@@ -1683,6 +1694,34 @@ end`;
       expect(
         default_value('program define q\n  syntax , opt(string default(f(x)))\nend')
       ).toBe('f(x)');
+    });
+
+    test('default column-0 continuation joins without a separator in both modes', () => {
+      expect_default_in_both_modes(
+        'syntax , opt(string default(a///\nb))',
+        'ab'
+      );
+    });
+
+    test('default continuation with space before slashes keeps a separator in both modes', () => {
+      expect_default_in_both_modes(
+        'syntax , opt(string default(a ///\nb))',
+        'a b'
+      );
+    });
+
+    test('default indented continuation-only line keeps a separator in both modes', () => {
+      expect_default_in_both_modes(
+        'syntax , opt(string default(a///\n    ///\nb))',
+        'a b'
+      );
+    });
+
+    test('plain multi-token default keeps a separator in both modes', () => {
+      expect_default_in_both_modes(
+        'syntax , opt(string default(a b))',
+        'a b'
+      );
     });
 
     test('syntax declaration spanning /// continuations is collected whole', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1608,6 +1608,16 @@ end`;
         { options?: { name: string; argument?: string }[] } | undefined;
       return my_cmd?.options?.find(o => o.name === name)?.argument;
     };
+    const command_options = (source: string): { name: string; argument?: string;
+      argument_range?: { start: { line: number; character: number };
+        end: { line: number; character: number } } }[] => {
+      const my_cmd = parse(source).ast.nodes.find(n => n.type === 'command') as
+        { options?: { name: string; argument?: string; argument_range?: {
+          start: { line: number; character: number };
+          end: { line: number; character: number };
+        } }[] } | undefined;
+      return my_cmd?.options ?? [];
+    };
     const semi = (body: string): string =>
       `#delimit ;\n${body};\n#delimit cr`;
 
@@ -1624,6 +1634,50 @@ end`;
     test('adjacent option-argument tokens stay joined in both modes', () => {
       expect(option_arg('reg y x, cluster(id)', 'cluster')).toBe('id');
       expect(option_arg(semi('reg y x, cluster(id)'), 'cluster')).toBe('id');
+    });
+
+    test('nested option arguments are not truncated in either delimiter mode', () => {
+      for (const source of [
+        'reg y x, vce(bootstrap, nodots seed(123) rep(300))',
+        semi('reg y x, vce(bootstrap, nodots seed(123) rep(300))'),
+      ]) {
+        const options = command_options(source);
+        expect(options.map(o => o.name)).toEqual(['vce']);
+        expect(options.find(o => o.name === 'rep')).toBeUndefined();
+        expect(options[0].argument).toBe('bootstrap, nodots seed(123) rep(300)');
+      }
+    });
+
+    test('two-level nested option arguments are preserved', () => {
+      expect(option_arg('reg y x, absorb(f(a) g(b))', 'absorb')).toBe(
+        'f(a) g(b)'
+      );
+      expect(option_arg(semi('reg y x, absorb(f(a) g(b))'), 'absorb')).toBe(
+        'f(a) g(b)'
+      );
+    });
+
+    test('nested option argument range spans the full argument content', () => {
+      const options = command_options(
+        'reg y x, vce(bootstrap, nodots seed(123) rep(300))'
+      );
+      expect(options[0].argument_range?.end.character).toBe(
+        'reg y x, vce(bootstrap, nodots seed(123) rep(300)'.length
+      );
+    });
+
+    test('unbalanced nested option argument does not crash', () => {
+      expect(() => parse('reg y x, cluster(seed(1')).not.toThrow();
+      const result = parse('reg y x, cluster(seed(1');
+      expect(result.ast.nodes.find(n => n.type === 'command')).toBeDefined();
+    });
+
+    test('AST formatter preserves nested option arguments', () => {
+      const printer = new PrettyPrinter();
+      const format = (source: string): string =>
+        printer.print(parse(source).ast);
+      expect(format('reg y x, vce(bootstrap, nodots seed(123) rep(300))'))
+        .toContain('vce(bootstrap, nodots seed(123) rep(300))');
     });
   });
 

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1657,7 +1657,7 @@ end`;
       const source = 'reg y x, vce(seed(123)\ndisplay 1\ndisplay 2';
 
       expect(command_names(source)).toEqual(['reg', 'display', 'display']);
-      expect(option_arg(source, 'vce')).toBe('seed(123');
+      expect(option_arg(source, 'vce')).toBe('seed(123)');
     });
 
     test('unterminated option argument is marked on the option node', () => {
@@ -1674,7 +1674,7 @@ end`;
       const source = '#delimit ;\nreg y x, vce(seed(123);\ndisplay 1;\n#delimit cr';
 
       expect(command_names(source)).toEqual(['reg', 'display']);
-      expect(option_arg(source, 'vce')).toBe('seed(123');
+      expect(option_arg(source, 'vce')).toBe('seed(123)');
     });
 
     test('two-level nested option arguments are preserved', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,6 +1,7 @@
 import { StataParser } from '../../src/parser';
 import { StataLexer } from '../../src/lexer';
 import { PrettyPrinter } from '../../src/pretty-printer';
+import { SemanticAnalyzer } from '../../src/analyzer';
 
 describe('StataParser', () => {
   let parser: StataParser;
@@ -1626,6 +1627,18 @@ end`;
         .filter(n => n.type === 'command')
         .map(n => (n as { name: string }).name);
     const parse_errors = (source: string) => parse(source).errors;
+    const forward_calls = (source: string) => {
+      const lex_result = lexer.tokenize(source);
+      const parse_result = parser.parse(lex_result.tokens);
+      const analyzer = new SemanticAnalyzer();
+      return analyzer.analyze(
+        parse_result.ast,
+        'file:///test.do',
+        undefined,
+        undefined,
+        lex_result.tokens
+      ).forward_calls;
+    };
 
     test('multi-token option argument matches across modes', () => {
       expect(option_arg('reg y x, absorb(firm year)', 'absorb')).toBe(
@@ -1729,7 +1742,7 @@ end`;
       const source = 'reg y x, vce(a /* c */ ///\nb\ndisplay 1';
       const options = command_options(source);
 
-      expect(options.find(o => o.name === 'vce')?.argument).toBe('a');
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a b');
       expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBe(true);
     });
 
@@ -1737,8 +1750,38 @@ end`;
       const source = 'reg y x, vce(a ///\n/* c */ b\ndisplay 1';
       const options = command_options(source);
 
-      expect(options.find(o => o.name === 'vce')?.argument).toBe('a');
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a b');
       expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBe(true);
+    });
+
+    test('cr-mode comment before continued unclosed option does not expose do as top-level command', () => {
+      const source = 'reg y x, vce(a /* c */ ///\ndo child.do\ndisplay 1';
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg', 'display']);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a do child.do');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBe(true);
+      expect(forward_calls(source)).toHaveLength(0);
+    });
+
+    test('semicolon-mode comment before unclosed option does not expose do as top-level command', () => {
+      const source = '#delimit ;\nreg y x, vce(a // c\ndo child.do ;\ndisplay 1;';
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg', 'display']);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a do child.do');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBe(true);
+      expect(forward_calls(source)).toHaveLength(0);
+    });
+
+    test('top-level do after terminated option statement still emits forward call', () => {
+      const source = 'reg y x, vce(a)\ndo child.do\ndisplay 1';
+      const calls = forward_calls(source);
+
+      expect(command_names(source)).toEqual(['reg', 'do', 'display']);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].type).toBe('do');
+      expect(calls[0].raw_path).toBe('child.do');
     });
 
     test('many comments inside one closed option argument parse without quadratic blowup', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1358,7 +1358,7 @@ end`;
     type CommandLike = {
       type: string;
       name?: string;
-      varlist?: { name: string }[];
+      varlist?: { name: string; recovery_only?: true }[];
       expression?: string;
       ifExpression?: string;
       inExpression?: string;
@@ -1373,6 +1373,8 @@ end`;
         .map(n => n.name ?? '');
     const varlist_names = (source: string): string[] =>
       command(source)?.varlist?.map(v => v.name) ?? [];
+    const varlist_items = (source: string): Array<{ name: string; recovery_only?: true }> =>
+      command(source)?.varlist ?? [];
     const semi = (body: string): string =>
       `#delimit ;\n${body};\n#delimit cr`;
 
@@ -1454,6 +1456,30 @@ end`;
 
       expect(command_names(source)).toEqual(['rename', 'display']);
       expect(varlist_names(source)).toEqual(['(']);
+    });
+
+    test('unterminated empty parenthesized group is marked recovery-only', () => {
+      expect(varlist_items('rename (\ndisplay 1')).toEqual([
+        expect.objectContaining({ name: '(', recovery_only: true }),
+      ]);
+      expect(varlist_items('#delimit ;\nrename (;\ndisplay 1;')).toEqual([
+        expect.objectContaining({ name: '(', recovery_only: true }),
+      ]);
+    });
+
+    test('non-empty unclosed and balanced parenthesized groups are not recovery-only', () => {
+      expect(varlist_items('rename (old1 old2\ndisplay 1')).toEqual([
+        expect.objectContaining({ name: '(old1 old2' }),
+      ]);
+      expect(varlist_items('rename (old1 old2\ndisplay 1')[0].recovery_only).toBeUndefined();
+
+      expect(varlist_items('rename (old1 old2) (new1 new2)')).toEqual([
+        expect.objectContaining({ name: '(old1 old2)' }),
+        expect.objectContaining({ name: '(new1 new2)' }),
+      ]);
+      expect(varlist_items('rename (old1 old2) (new1 new2)').some(
+        item => item.recovery_only
+      )).toBe(false);
     });
 
     test('unterminated semicolon-mode parenthesized group does not consume the terminator', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1446,7 +1446,7 @@ end`;
       const source = 'rename (old1 old2\ndisplay 1\ndisplay 2';
 
       expect(command_names(source)).toEqual(['rename', 'display', 'display']);
-      expect(varlist_names(source)).toEqual(['(old1 old2)']);
+      expect(varlist_names(source)).toEqual(['(old1 old2']);
     });
 
     test('unterminated semicolon-mode parenthesized group does not consume the terminator', () => {
@@ -1454,7 +1454,7 @@ end`;
         '#delimit ;\nrename (old1 old2;\ndisplay 1;\n#delimit cr';
 
       expect(command_names(source)).toEqual(['rename', 'display']);
-      expect(varlist_names(source)).toEqual(['(old1 old2)']);
+      expect(varlist_names(source)).toEqual(['(old1 old2']);
     });
 
     test('unterminated assignment expression does not swallow following statements', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1689,6 +1689,70 @@ end`;
       expect(closed.find(o => o.name === 'global')?.argument_unclosed).toBeUndefined();
     });
 
+    test('cr-mode option comment before slash continuation keeps option closed', () => {
+      const source = 'reg y x, vce(a /* c */ ///\nb)';
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg']);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a b');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBeUndefined();
+    });
+
+    test('semicolon-mode option comment before physical newline keeps option closed', () => {
+      const source = semi('reg y x, vce(a /* c */\nb)');
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg']);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a b');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBeUndefined();
+    });
+
+    test('continuation between option comment and close paren keeps option closed', () => {
+      const source = 'reg y x, vce(a /* c */ ///\n)';
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg']);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBeUndefined();
+    });
+
+    test('comment after option continuation keeps closed option argument collecting', () => {
+      const source = 'reg y x, vce(a ///\n/* c */ b)';
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg']);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a b');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBeUndefined();
+    });
+
+    test('comment before continuation still recovers when option never closes', () => {
+      const source = 'reg y x, vce(a /* c */ ///\nb\ndisplay 1';
+      const options = command_options(source);
+
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBe(true);
+    });
+
+    test('comment after continuation still recovers when option never closes', () => {
+      const source = 'reg y x, vce(a ///\n/* c */ b\ndisplay 1';
+      const options = command_options(source);
+
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBe(true);
+    });
+
+    test('many comments inside one closed option argument parse without quadratic blowup', () => {
+      const comment_count = 100_000;
+      const source = `reg y x, vce(a ${'/* c */ '.repeat(comment_count)}b)`;
+      const start_time = performance.now();
+      const options = command_options(source);
+      const elapsed_ms = performance.now() - start_time;
+
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a b');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBeUndefined();
+      expect(elapsed_ms).toBeLessThan(2_000);
+    });
+
     test('unterminated nested option argument recovers at semicolon-mode statement terminator', () => {
       const source = '#delimit ;\nreg y x, vce(seed(123);\ndisplay 1;\n#delimit cr';
 

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1625,6 +1625,7 @@ end`;
       parse(source).ast.nodes
         .filter(n => n.type === 'command')
         .map(n => (n as { name: string }).name);
+    const parse_errors = (source: string) => parse(source).errors;
 
     test('multi-token option argument matches across modes', () => {
       expect(option_arg('reg y x, absorb(firm year)', 'absorb')).toBe(
@@ -1660,6 +1661,24 @@ end`;
       expect(option_arg(source, 'vce')).toBe('seed(123)');
     });
 
+    test('line comment after unterminated cr-mode option argument is trivia', () => {
+      const source = 'reg y x, vce(seed(123) // note\ndisplay 1';
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg', 'display']);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('seed(123)');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBe(true);
+    });
+
+    test('block comment after unterminated cr-mode option argument is trivia', () => {
+      const source = 'reg y x, vce(seed(123) /* note */\ndisplay 1';
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg', 'display']);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('seed(123)');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBe(true);
+    });
+
     test('unterminated option argument is marked on the option node', () => {
       const unclosed = command_options('levelsof rep78, global(G\ndisplay $G');
       const closed = command_options('levelsof rep78, global(G)\ndisplay $G');
@@ -1675,6 +1694,41 @@ end`;
 
       expect(command_names(source)).toEqual(['reg', 'display']);
       expect(option_arg(source, 'vce')).toBe('seed(123)');
+    });
+
+    test('line comment after unterminated semicolon-mode option argument is trivia', () => {
+      const source =
+        '#delimit ;\nreg y x, vce(seed(123) // note\n;\ndisplay 1;\n#delimit cr';
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg', 'display']);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('seed(123)');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBe(true);
+    });
+
+    test('balanced option block comment is omitted without making option unclosed', () => {
+      // Comments are trivia inside a syntactically closed parenthesized option:
+      // omit the comment text from the argument string, keep later argument
+      // tokens, and keep the option semantically closed.
+      const source = 'reg y x, vce(a /* x */ b)';
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg']);
+      expect(parse_errors(source)).toHaveLength(0);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a b');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBeUndefined();
+    });
+
+    test('balanced semicolon-mode option line comment keeps option closed', () => {
+      // Same as the block-comment case above, but the statement continues after
+      // the line comment because semicolon mode uses `;` as the terminator.
+      const source = semi('reg y x, vce(a // note\nb)');
+      const options = command_options(source);
+
+      expect(command_names(source)).toEqual(['reg']);
+      expect(parse_errors(source)).toHaveLength(0);
+      expect(options.find(o => o.name === 'vce')?.argument).toBe('a b');
+      expect(options.find(o => o.name === 'vce')?.argument_unclosed).toBeUndefined();
     });
 
     test('two-level nested option arguments are preserved', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1609,10 +1609,11 @@ end`;
       return my_cmd?.options?.find(o => o.name === name)?.argument;
     };
     const command_options = (source: string): { name: string; argument?: string;
+      argument_unclosed?: true;
       argument_range?: { start: { line: number; character: number };
         end: { line: number; character: number } } }[] => {
       const my_cmd = parse(source).ast.nodes.find(n => n.type === 'command') as
-        { options?: { name: string; argument?: string; argument_range?: {
+        { options?: { name: string; argument?: string; argument_unclosed?: true; argument_range?: {
           start: { line: number; character: number };
           end: { line: number; character: number };
         } }[] } | undefined;
@@ -1657,6 +1658,16 @@ end`;
 
       expect(command_names(source)).toEqual(['reg', 'display', 'display']);
       expect(option_arg(source, 'vce')).toBe('seed(123');
+    });
+
+    test('unterminated option argument is marked on the option node', () => {
+      const unclosed = command_options('levelsof rep78, global(G\ndisplay $G');
+      const closed = command_options('levelsof rep78, global(G)\ndisplay $G');
+
+      expect(unclosed.find(o => o.name === 'global')?.argument).toBe('G');
+      expect(unclosed.find(o => o.name === 'global')?.argument_unclosed).toBe(true);
+      expect(closed.find(o => o.name === 'global')?.argument).toBe('G');
+      expect(closed.find(o => o.name === 'global')?.argument_unclosed).toBeUndefined();
     });
 
     test('unterminated nested option argument recovers at semicolon-mode statement terminator', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1449,12 +1449,30 @@ end`;
       expect(varlist_names(source)).toEqual(['(old1 old2']);
     });
 
+    test('unterminated empty cr-mode parenthesized group keeps authored opener', () => {
+      const source = 'rename (\ndisplay 1';
+
+      expect(command_names(source)).toEqual(['rename', 'display']);
+      expect(varlist_names(source)).toEqual(['(']);
+    });
+
     test('unterminated semicolon-mode parenthesized group does not consume the terminator', () => {
       const source =
         '#delimit ;\nrename (old1 old2;\ndisplay 1;\n#delimit cr';
 
       expect(command_names(source)).toEqual(['rename', 'display']);
       expect(varlist_names(source)).toEqual(['(old1 old2']);
+    });
+
+    test('unterminated empty semicolon-mode parenthesized group keeps authored opener', () => {
+      const source = '#delimit ;\nrename (;\ndisplay 1;\n#delimit cr';
+
+      expect(command_names(source)).toEqual(['rename', 'display']);
+      expect(varlist_names(source)).toEqual(['(']);
+    });
+
+    test('balanced empty parenthesized group is omitted from varlist', () => {
+      expect(varlist_names('mycmd () after')).toEqual(['after']);
     });
 
     test('unterminated assignment expression does not swallow following statements', () => {

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -91,6 +91,26 @@ describe('StataParser', () => {
       }
     });
 
+    test('should preserve cross-line gaps in semicolon-mode string statements', () => {
+      const source = `#delimit ;
+"first" // note
+"second";
+#delimit cr`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(3);
+
+      const node = parseResult.ast.nodes[1];
+      expect(node.type).toBe('command');
+
+      if (node.type === 'command') {
+        expect(node.name).toBe(`"first" // note
+"second"`);
+      }
+    });
+
     test('should parse command with both if and in qualifiers', () => {
       const source = 'list var1 var2 if age > 30 in 1/10';
       const lexResult = lexer.tokenize(source);
@@ -543,6 +563,28 @@ end`;
       }
     });
 
+    test('should preserve multiline mata block content with whitespace tokens', () => {
+      const source = `mata
+real // note
+scalar x
+end`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(1);
+
+      const node = parseResult.ast.nodes[0];
+      expect(node.type).toBe('embedded_block');
+
+      if (node.type === 'embedded_block') {
+        expect(node.language).toBe('mata');
+        expect(node.is_single_line).toBe(false);
+        expect(node.content).toBe(`real // note
+scalar x`);
+      }
+    });
+
     test('should parse python block', () => {
       const source = `python
   x = 1
@@ -598,6 +640,70 @@ end`;
         expect(node.language).toBe('python');
         expect(node.start_command).toBe('python:');
         expect(node.is_single_line).toBe(true);
+      }
+    });
+
+    test('should preserve line boundary in semicolon-mode inline mata content', () => {
+      const source = `#delimit ;
+mata: real // note
+scalar x;
+#delimit cr`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(3);
+
+      const node = parseResult.ast.nodes[1];
+      expect(node.type).toBe('embedded_block');
+
+      if (node.type === 'embedded_block') {
+        expect(node.language).toBe('mata');
+        expect(node.content).toBe(`real // note
+scalar x`);
+      }
+    });
+
+    test('should preserve line boundary in semicolon-mode inline python content', () => {
+      const source = `#delimit ;
+python: value = 1 // note
+print(value);
+#delimit cr`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(3);
+
+      const node = parseResult.ast.nodes[1];
+      expect(node.type).toBe('embedded_block');
+
+      if (node.type === 'embedded_block') {
+        expect(node.language).toBe('python');
+        expect(node.content).toBe(`value = 1 // note
+print(value)`);
+      }
+    });
+
+    test('should not fuse semicolon-mode inline embedded tokens across lines', () => {
+      const source = `#delimit ;
+mata: real
+scalar x;
+#delimit cr`;
+      const lexResult = lexer.tokenize(source);
+      const parseResult = parser.parse(lexResult.tokens);
+
+      expect(parseResult.errors).toHaveLength(0);
+      expect(parseResult.ast.nodes).toHaveLength(3);
+
+      const node = parseResult.ast.nodes[1];
+      expect(node.type).toBe('embedded_block');
+
+      if (node.type === 'embedded_block') {
+        expect(node.language).toBe('mata');
+        expect(node.content).toBe(`real
+scalar x`);
+        expect(node.content).not.toContain('realscalar');
       }
     });
 

--- a/tests/unit/recovery-only-parenthesized-group.test.ts
+++ b/tests/unit/recovery-only-parenthesized-group.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { StataLexer } from '../../src/lexer';
+import { StataParser } from '../../src/parser';
+import { SemanticAnalyzer } from '../../src/analyzer';
+import { CompletionProvider } from '../../src/providers/completion';
+import { CommandDatabase } from '../../src/command-database';
+import { SymbolProvider } from '../../src/providers/symbols';
+import { LanguageContext, type StataAST, type SymbolTable, type Token } from '../../src/types';
+
+interface ParsedDocument {
+    uri: string;
+    content: string;
+    tokens: Token[];
+    ast: StataAST;
+    symbols: SymbolTable;
+    scopes: ReturnType<SemanticAnalyzer['analyze']>['scopes'];
+    line_offsets: number[];
+}
+
+function parse_analyze(source: string): ParsedDocument {
+    const lexer = new StataLexer();
+    const parser = new StataParser();
+    const analyzer = new SemanticAnalyzer();
+    const lexed = lexer.tokenize(source);
+    const parsed = parser.parse(lexed.tokens);
+    const result = analyzer.analyze(
+        parsed.ast,
+        'file:///recovery-only.do',
+        undefined,
+        { undefined_variable_enabled: true },
+        lexed.tokens
+    );
+
+    return {
+        uri: 'file:///recovery-only.do',
+        content: source,
+        tokens: lexed.tokens,
+        ast: parsed.ast,
+        symbols: result.symbols,
+        scopes: result.scopes,
+        line_offsets: lexed.line_offsets,
+    };
+}
+
+function as_document_state(parsed: ParsedDocument) {
+    return {
+        uri: parsed.uri,
+        content: parsed.content,
+        version: 1,
+        tokens: parsed.tokens,
+        ast: parsed.ast,
+        symbols: parsed.symbols,
+        scopes: parsed.scopes,
+        diagnostics: [],
+        context_ranges: [],
+        line_offsets: parsed.line_offsets,
+        language_context: LanguageContext.STATA,
+    };
+}
+
+describe('recovery-only parenthesized varlist opener', () => {
+    const cases = [
+        {
+            label: 'cr',
+            source: (command: string) => `${command} (\ndisplay `,
+            completion_position: { line: 1, character: 'display '.length },
+        },
+        {
+            label: 'semicolon',
+            source: (command: string) => `#delimit ;\n${command} (\n;\ndisplay `,
+            completion_position: { line: 3, character: 'display '.length },
+        },
+    ];
+
+    for (const my_case of cases) {
+        test(`analyzer ignores bare opener definitions in ${my_case.label} mode`, () => {
+            const input = parse_analyze(my_case.source('input'));
+            expect(input.symbols.variables.has('(')).toBe(false);
+
+            const gen = parse_analyze(my_case.source('gen'));
+            expect(gen.symbols.variables.has('(')).toBe(false);
+
+            const scalar = parse_analyze(my_case.source('scalar'));
+            expect(scalar.symbols.scalars.has('(')).toBe(false);
+        });
+
+        test(`completion does not offer bare opener symbols in ${my_case.label} mode`, async () => {
+            for (const command of ['input', 'gen', 'scalar']) {
+                const parsed = parse_analyze(my_case.source(command));
+                const provider = new CompletionProvider(new CommandDatabase());
+                const completions = await provider.get_completions(
+                    as_document_state(parsed),
+                    my_case.completion_position
+                );
+                expect(completions.map(c => c.label)).not.toContain('(');
+            }
+        });
+
+        test(`document symbols do not include bare opener symbols in ${my_case.label} mode`, () => {
+            for (const command of ['gen', 'scalar']) {
+                const parsed = parse_analyze(my_case.source(command));
+                const symbols = new SymbolProvider().get_document_symbols(
+                    as_document_state(parsed)
+                );
+                expect(symbols.map(s => s.name)).not.toContain('(');
+            }
+        });
+    }
+});

--- a/tests/unit/statement-span.test.ts
+++ b/tests/unit/statement-span.test.ts
@@ -88,6 +88,13 @@ describe('next_statement_line_span', () => {
         expect(my_span).toEqual({ start_line: 2, end_line: 4 });
     });
 
+    it('skips embedded-block blank-line whitespace under #delimit ;', () => {
+        const my_span = span_after_directive(
+            '#delimit ;\nmata:\n// @lsp-ignore-next\n\nx = 1;\nend\n#delimit cr'
+        );
+        expect(my_span?.start_line).toBe(4);
+    });
+
     it('ends at a real ; terminator on the line after a /// (semicolon mode)', () => {
         // In `#delimit ;` mode the newline after `///` lexes as
         // WHITESPACE, so a `;` on the following line is a REAL


### PR DESCRIPTION
Fixes #306.

## What this does

`#delimit ;` and `#delimit cr` modes produced different ASTs for identical source because the lexer emitted Stata-context WHITESPACE tokens only in `;` mode, and token-walking parser code diverged wherever it forgot to account for them. This PR fixes the class two ways: it unifies every string-reconstruction site behind a range-based helper, and then removes the root cause in the lexer so the divergence is structurally impossible.

## Commits (each gated on the full suite + lint)

1. **`4e141852` — unify delimiter-mode string reconstruction; fix cr-mode merge coalescing.** Routes 12 parser reconstruction sites (expressions, if/in qualifiers, parenthesized groups, macro values, loop specs, option arguments, extended-macro args, if/while conditions, syntax `default()` values) through the range-based `reconstruct_value_tokens` helper plus a `ContinuationTracker` encoding `///` join semantics (column-0 unbroken chains join with no separator; indented/space-preceded/gapped chains force one space). Also fixes `#delimit cr` file-path coalescing with a range-based adjacency guard (`merge 1:1 id using data` no longer coalesces across gaps) and makes multi-line `syntax` declarations bridge `///`.
2. **`f14f3232` — strengthen the dual-mode property oracle.** The oracle renders generated structured statements in both delimiter modes and asserts identical canonicalized ASTs and error codes. New shapes: `program define`/`end` with syntax declarations, `by`/`bysort`/`quietly` prefixes, `foreach`/`forvalues`/`while`/`if`-`else` brace blocks (nested), frame blocks, subscripts, plain/compound strings with macro refs, `///` variants, extended macro definitions, and gratuitous mid-statement newlines in `;` mode.
3. **`bd5fb2c4` — the root-cause fix.** `;` mode stops emitting Stata-context WHITESPACE tokens (spaces/tabs/newlines return `null`, as cr mode already did), making the two modes' token streams identical except for `STATEMENT_TERMINATOR` (`\n` vs `;` — a genuine language difference). Embedded Mata/Python emission is untouched (intentionally exact-width). Replaced-primitive sweep found every consumer already treats WHITESPACE as trivia or uses range-based adjacency.
4. **`63093aa4` — fix the two consumers where the old tokens were load-bearing.** Inline embedded (`mata:`/`python:`) content and standalone string statements can span physical lines in `;` mode; their exact-width reconstructors used same-line character arithmetic and relied on appended newline-valued WHITESPACE tokens. Without them, content fused across lines (`mata: real // note` + `scalar x;` became `real // notescalar x`, corrupting AST-formatter output). Both now rebuild cross-line gaps from token ranges (newlines + indentation).
5. **`50d338da` — fuzz whitespace widths in the structured oracle shapes** so token-boundary selection at each call site is covered directly, not just through the shared primitive.
6. **`ebeaea18` — delete the now-dead Stata-context WHITESPACE skip-sites** (net −239 lines across parser/analyzer/loop-expander/statement-span), keeping every embedded-reachable path and the `TokenType` member.
7. **`2f844af2` — restore WHITESPACE handling at two whole-document-scan sites** the deletion wrongly removed: embedded-block tokens still include WHITESPACE, so the analyzer's standalone-comment backward scan and statement-span's leading-trivia set must keep handling it. Without this, `@lsp-ignore` on an indented comment line inside a Mata block became a no-op and `@lsp-ignore-next` mis-anchored in `;`-mode embedded blocks. Regression tests cover directive comments inside embedded blocks.
8. **`fb0790da` — thread continuation flags into syntax `default()` reconstruction.** `parseSyntaxCommand` stripped CONTINUATION tokens without preserving metadata, so a column-0 `///` join inside `default()` reconstructed as `a b` instead of `ab`. Flags are now collected alongside `syntax_tokens` with the shared tracker and sliced through `parse_option_spec`.

## Verification

- `bun run test`: 7337 pass / 0 fail (typecheck + full suite)
- `bun run lint`: clean
- Dual-mode property oracle (2000 + 800 runs): green
- Adversarial review gate: 4 rounds; rounds 1–2 findings fixed in-branch or adjudicated pre-existing (verified byte-identical on `main` via worktree comparison); rounds 3 and 4 returned consecutive approvals
- Independent cold reviews of the riskiest commits (oracle, dead-code deletion) — findings fixed in-branch

## Deferrals (pre-existing on `main`, verified unchanged by this branch; follow-up issues filed)

1. **Context tracker treats inline `mata:`/`python:` as single-line even when `#delimit ;` continues the statement across lines.** The parser's `embedded_block` correctly spans the lines, but `ContextTracker` closes the `MATA_INLINE` range on the opener line, so position-keyed providers can offer Stata completions/hover inside continued Mata code. Verified byte-identical on `main`.
2. **Completion context detection is physical-line-based**, so wrapped `;`-mode statements lose option context (`reg y x,` newline `vce(` yields command context instead of options for `reg`). `detect_completion_context`/`detect_option_context` analyze only the current line's text; unchanged by this branch. Fixing it means building completion context from the logical statement prefix via tokens — a separate feature-sized change.

## Review-feedback delta (commits `742141db`..`c90c2273`)

Fourteen further commits address the CodeRabbit and PullFrog review findings across two review passes, each iterated through adversarial review rounds until two consecutive cleans:

**Second pass** (CodeRabbit's follow-up review, commits `35aa6966`..`c90c2273`, 6 rounds): the missing statement-terminator guard in `parseParenthesizedGroup` — confirmed pre-existing on `main` but in this PR's recovery class — fixed, with the sweep finding and fixing the same bug at depth > 0 in `parseExpression` and the if/in qualifier collector; unclosed groups keep only authored text (no synthesized close paren); an empty unclosed group keeps its authored `(` in AST output but is marked `recovery_only` and filtered from all semantic consumers via a single `semantic_varlist()` boundary. CodeRabbit's second finding (`program define` lookahead missing WHITESPACE) was refuted: no Stata-context WHITESPACE tokens exist after this PR's lexer normalization, and the comment-between-words case is byte-identical to `main`.

**First pass** (twelve rounds, rounds 11-12 clean):

- **Nested option arguments** (CodeRabbit): `parse_option_argument_inside_parens` tracks paren depth, so `vce(bootstrap, nodots seed(123) rep(300))` parses as one option with the full argument. Sweep confirmed every other collect-until-`RPAREN` loop was already depth-tracked.
- **Recovery hardening** (found by the review rounds on the fix itself): collection stops at real statement terminators, so a missing outer `)` cannot swallow following statements or fabricate `do`/`run`/`include` forward calls into the dependency graph; recovered options carry `argument_unclosed`, which the analyzer's macro-creating option detection honors (an unclosed `global(G` no longer registers `G` or suppresses the undefined-macro warning) and `printOption` respects (no synthesized closing paren, byte-faithful AST output for malformed options); comments inside option arguments are uniformly pure trivia; `///`-continued tokens stay inside the argument. Format-then-reparse AST equality and format-of-format idempotence are pinned by tests for the recovery shapes in both delimiter modes, plus a 100k-comment perf guard.
- **Oracle comma-gap fuzzing** (PullFrog): the `func_call` generator now renders its drawn gaps, exercising `max(a,b)`, wide, and tab comma spacing identically in both mode renders.

### Pinned decision

**AST formatting mode normalizes comments inside option arguments away** (`vce(a /* keep */ b)` formats to `vce(a b)`). Comments there are trivia to Stata; the previous behavior emitted `vce(a / * keep * / b)` — expression-spacing split the comment delimiters into operator sequences, silently corrupting code semantics. The default source-preserving mode keeps all comments untouched. Full preservation in AST mode would need option-level trivia attachment; possible follow-up if demand exists.

https://claude.ai/code/session_01N1XfzmR354HE7zNLa3bhxY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `#delimit ;` vs `#delimit cr` parsing/formatting consistency, including spacing, line breaks, comments, and `///` continuation behavior.
  * Refined tokenization and reconstruction to prevent whitespace-related fusion/splitting in expressions, embedded blocks, and control-flow conditions.
  * Improved recovery for malformed `(...)` option arguments (including formatter output), and adjusted symbol/diagnostic handling for recovery-only cases.
* **New Features**
  * Expanded delimiter-mode parity checks so both delimiter styles produce structurally matching results.
* **Tests**
  * Added property-based and unit test coverage for delimiter equivalence, continuation/join rules, comment detection, and unclosed/recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

