### PR TITLE
Fix #309: end inline embedded context ranges at the real terminator under #delimit ;

### DIFF
--- a/src/context-tracker/index.ts
+++ b/src/context-tracker/index.ts
@@ -8,6 +8,7 @@ import {
 import { ContextErrorCode, Token, TokenType } from '../types';
 import { get_line_text, get_line_count, compute_line_offsets } from '../utils/line-utils';
 import { block_comment_lines } from '../utils/block-comment-utils';
+import { inline_embedded_statement_end } from '../utils/statement-span';
 
 // Token types that carry no live code. A line whose only tokens are
 // these (and that the lexer placed inside a block comment) is safe to
@@ -114,15 +115,24 @@ export class ContextTracker implements IContextTracker {
         };
         
         if (my_token.type === 'MATA_INLINE') {
-          // Single-line mata context ends at end of token line
-          my_current_range.end_delimiter = {
-            command: my_token.value,
-            range: my_token.range,
-          };
+          // Inline mata (`mata:`) is a single statement. Under `#delimit ;`
+          // it can continue onto later physical lines and ends at the `;`,
+          // so compute the real end line from the token stream (issue #309)
+          // rather than assuming it ends on the opener line. No
+          // end_delimiter: inline forms have no `end`, and leaving it
+          // undefined keeps the formatter's whole-line replace/extract
+          // regions consistent.
+          const my_inline_end = inline_embedded_statement_end(tokens, my_i);
           this.context_ranges.push(
-            this.complete_context_range_from_token(my_current_range)
+            this.complete_context_range_from_token(
+              my_current_range,
+              my_inline_end.end_line
+            )
           );
           my_current_range = null;
+          // Skip the tokens the inline statement consumed so nothing inside
+          // it (or a trailing same-line opener) spawns an overlapping range.
+          my_i = my_inline_end.end_index;
         } else {
           this.context_stack.push(LanguageContext.MATA);
           my_current_context = LanguageContext.MATA;
@@ -152,15 +162,18 @@ export class ContextTracker implements IContextTracker {
         };
         
         if (my_token.type === 'PYTHON_INLINE') {
-          // Single-line python context ends at end of token line
-          my_current_range.end_delimiter = {
-            command: my_token.value,
-            range: my_token.range,
-          };
+          // Inline python (`python:`) mirrors inline mata: a single
+          // statement that can continue onto later lines under `#delimit ;`
+          // (ends at the `;`). See the MATA_INLINE branch above (issue #309).
+          const my_inline_end = inline_embedded_statement_end(tokens, my_i);
           this.context_ranges.push(
-            this.complete_context_range_from_token(my_current_range)
+            this.complete_context_range_from_token(
+              my_current_range,
+              my_inline_end.end_line
+            )
           );
           my_current_range = null;
+          my_i = my_inline_end.end_index;
         } else {
           this.context_stack.push(LanguageContext.PYTHON);
           my_current_context = LanguageContext.PYTHON;
@@ -624,14 +637,18 @@ export class ContextTracker implements IContextTracker {
    * For multi-line contexts, the range includes the start delimiter line but excludes the end delimiter line.
    */
   private complete_context_range_from_token(
-    partial_range: Partial<ContextRange>
+    partial_range: Partial<ContextRange>,
+    single_line_end_line?: number
   ): ContextRange {
     const my_start_line = partial_range.start_delimiter!.range.start.line;
     let my_end_line: number;
 
     if (partial_range.is_single_line) {
-      // For single-line contexts, the entire line is included
-      my_end_line = my_start_line;
+      // Inline contexts (`mata:`/`python:`) cover whole physical lines. The
+      // caller passes the real end line computed from the token stream so
+      // `#delimit ;` continuation lines are included (issue #309); when it
+      // is omitted, fall back to the opener line.
+      my_end_line = single_line_end_line ?? my_start_line;
     } else {
       // For multi-line contexts, exclude the end delimiter line
       if (partial_range.end_delimiter) {

--- a/src/providers/formatter.ts
+++ b/src/providers/formatter.ts
@@ -165,17 +165,17 @@ export class CodeFormatter {
             (a, b) => b.range.start.line - a.range.start.line
         );
 
+        // Smallest start line of a range already replaced. Ranges are
+        // processed in descending start-line order, so this only decreases;
+        // a later range whose end line reaches it shares a physical line with
+        // an already-replaced range (see the overlap guard below).
+        let my_min_replaced_start_line = Number.MAX_SAFE_INTEGER;
+
         for (const my_range of the_sorted_ranges) {
             // Prevent resource exhaustion from too many embedded blocks
             if (my_placeholder_counter >= MAX_EMBEDDED_BLOCKS) {
                 break;
             }
-            
-            const my_placeholder = `__EMBEDDED_BLOCK_${my_placeholder_counter}__`;
-            the_embedded_blocks.set(my_placeholder, {
-                content: this.extract_block_content(the_doc, my_range),
-                range: my_range
-            });
 
             // Calculate the actual range to replace
             // For single-line contexts (mata:, python:), use the range as-is
@@ -198,6 +198,23 @@ export class CodeFormatter {
                 };
             }
 
+            // Skip a range that shares a physical line with one already
+            // replaced. Whole-line embedded ranges can overlap when two
+            // embedded statements sit on one physical line (e.g. an inline
+            // `mata:` statement and a trailing `python:` under #delimit ;).
+            // Replacing both would double-cover the shared line and drop an
+            // already-inserted placeholder, deleting source text. The shared
+            // line's text is preserved verbatim inside the range that is kept.
+            if (actual_range.end.line >= my_min_replaced_start_line) {
+                continue;
+            }
+
+            const my_placeholder = `__EMBEDDED_BLOCK_${my_placeholder_counter}__`;
+            the_embedded_blocks.set(my_placeholder, {
+                content: this.extract_block_content(the_doc, my_range),
+                range: my_range
+            });
+
             // Replace the block with placeholder using the actual range
             my_modified_content = this.replace_range_in_content(
                 my_modified_content,
@@ -205,6 +222,10 @@ export class CodeFormatter {
                 my_placeholder
             );
 
+            my_min_replaced_start_line = Math.min(
+                my_min_replaced_start_line,
+                actual_range.start.line
+            );
             my_placeholder_counter++;
         }
 

--- a/src/providers/formatter.ts
+++ b/src/providers/formatter.ts
@@ -159,82 +159,42 @@ export class CodeFormatter {
         const the_embedded_blocks: Map<string, { content: string; range: ContextRange }> = new Map();
         let my_placeholder_counter = 0;
 
-        // Extract embedded blocks and replace with placeholders
+        // Extract embedded blocks and replace with placeholders.
         let my_modified_content = document.content;
-        // Process bottom-up (descending start line) so earlier replacements
-        // never shift the offsets of later ones. At equal start lines, process
-        // the WIDER range (larger end line) first: when two whole-line embedded
-        // ranges share their start line, the narrower one is fully contained in
-        // the wider, so keeping the wider and skipping the narrower (via the
-        // overlap guard below) preserves every embedded line verbatim.
-        const the_sorted_ranges = [...context_ranges].sort((a, b) => {
-            if (b.range.start.line !== a.range.start.line) {
-                return b.range.start.line - a.range.start.line;
-            }
-            return b.range.end.line - a.range.end.line;
-        });
 
-        // Smallest start line of a range already replaced. Ranges are
-        // processed in descending start-line order, so this only decreases;
-        // a later range whose end line reaches it shares a physical line with
-        // an already-replaced range (see the overlap guard below).
-        let my_min_replaced_start_line = Number.MAX_SAFE_INTEGER;
+        // Coalesce the context ranges into non-overlapping replacement units.
+        // A unit is one context range, unless two or more ranges share a
+        // physical line (e.g. an inline `mata:` statement and a trailing
+        // `python:` on the same line under #delimit ;, or an inline range
+        // widened to its continuation line that straddles a following
+        // statement). Overlapping ranges are merged into a single verbatim
+        // span: replacing them independently would double-cover the shared
+        // line and drop an already-inserted placeholder (deleting source), or
+        // leave a range's unique lines unprotected (mangling their layout).
+        const the_replacement_units = this.coalesce_embedded_ranges(
+            the_doc,
+            context_ranges
+        );
 
-        for (const my_range of the_sorted_ranges) {
+        for (const my_unit of the_replacement_units) {
             // Prevent resource exhaustion from too many embedded blocks
             if (my_placeholder_counter >= MAX_EMBEDDED_BLOCKS) {
                 break;
             }
 
-            // Calculate the actual range to replace
-            // For single-line contexts (mata:, python:), use the range as-is
-            // For multi-line blocks, include the end delimiter line
-            let actual_range: Range;
-            if (my_range.is_single_line) {
-                // Single-line context: range already covers the entire line
-                actual_range = my_range.range;
-            } else {
-                // Multi-line block: context_range.range excludes the end delimiter,
-                // but we need to include it
-                const actual_end_line = my_range.end_delimiter
-                    ? my_range.end_delimiter.range.start.line
-                    : my_range.range.end.line;
-                // Get the length of the end line to use as the end character
-                const end_line_text = get_line_text(the_doc, actual_end_line);
-                actual_range = {
-                    start: my_range.range.start,
-                    end: { line: actual_end_line, character: end_line_text.length }
-                };
-            }
-
-            // Skip a range that shares a physical line with one already
-            // replaced. Whole-line embedded ranges can overlap when two
-            // embedded statements sit on one physical line (e.g. an inline
-            // `mata:` statement and a trailing `python:` under #delimit ;).
-            // Replacing both would double-cover the shared line and drop an
-            // already-inserted placeholder, deleting source text. The shared
-            // line's text is preserved verbatim inside the range that is kept.
-            if (actual_range.end.line >= my_min_replaced_start_line) {
-                continue;
-            }
-
             const my_placeholder = `__EMBEDDED_BLOCK_${my_placeholder_counter}__`;
             the_embedded_blocks.set(my_placeholder, {
-                content: this.extract_block_content(the_doc, my_range),
-                range: my_range
+                content: my_unit.content,
+                range: my_unit.range
             });
 
-            // Replace the block with placeholder using the actual range
+            // Replace the unit with the placeholder using its actual range
             my_modified_content = this.replace_range_in_content(
                 my_modified_content,
-                actual_range,
+                my_unit.actual_range,
                 my_placeholder
             );
 
-            my_min_replaced_start_line = Math.min(
-                my_min_replaced_start_line,
-                actual_range.start.line
-            );
             my_placeholder_counter++;
         }
 
@@ -330,12 +290,155 @@ export class CodeFormatter {
     }
 
     /**
+     * The physical line span a context range occupies when replaced with a
+     * placeholder: for single-line (inline) ranges the range itself; for
+     * multi-line blocks, extended to include the end-delimiter line.
+     */
+    private embedded_range_span(
+        doc: DocumentLike,
+        context_range: ContextRange
+    ): { start_line: number; end_line: number } {
+        if (context_range.is_single_line) {
+            return {
+                start_line: context_range.range.start.line,
+                end_line: context_range.range.end.line,
+            };
+        }
+        const my_end_line = context_range.end_delimiter
+            ? context_range.end_delimiter.range.start.line
+            : context_range.range.end.line;
+        return { start_line: context_range.range.start.line, end_line: my_end_line };
+    }
+
+    /**
+     * Coalesce embedded context ranges into non-overlapping replacement units,
+     * ordered bottom-up (descending start line) so each placeholder
+     * substitution leaves the offsets of the not-yet-processed units intact.
+     *
+     * Ranges that share a physical line are merged into ONE verbatim unit
+     * (whole lines from the group's first start line to its last end line).
+     * A physical line cannot hold two languages, so overlapping whole-line
+     * ranges cannot be replaced independently without either double-covering
+     * the shared line (dropping a placeholder, deleting source) or leaving a
+     * range's unique lines unprotected. Preserving the union verbatim avoids
+     * both. A lone range keeps its exact prior behavior (block end-delimiter
+     * reindentation via `extract_block_content`).
+     */
+    private coalesce_embedded_ranges(
+        doc: DocumentLike,
+        context_ranges: ContextRange[]
+    ): Array<{ content: string; range: ContextRange; actual_range: Range }> {
+        // Group ranges that overlap or touch on a shared physical line.
+        const the_spans = context_ranges
+            .map((my_range) => ({
+                my_range,
+                span: this.embedded_range_span(doc, my_range),
+            }))
+            .sort((a, b) => {
+                if (a.span.start_line !== b.span.start_line) {
+                    return a.span.start_line - b.span.start_line;
+                }
+                return a.span.end_line - b.span.end_line;
+            });
+
+        const the_groups: Array<{
+            start_line: number;
+            end_line: number;
+            members: ContextRange[];
+        }> = [];
+        for (const my_item of the_spans) {
+            const my_last = the_groups[the_groups.length - 1];
+            if (my_last && my_item.span.start_line <= my_last.end_line) {
+                // Shares a physical line with the current group: merge.
+                my_last.end_line = Math.max(my_last.end_line, my_item.span.end_line);
+                my_last.members.push(my_item.my_range);
+            } else {
+                the_groups.push({
+                    start_line: my_item.span.start_line,
+                    end_line: my_item.span.end_line,
+                    members: [my_item.my_range],
+                });
+            }
+        }
+
+        const the_line_count = get_line_count(doc);
+        const the_units: Array<{
+            content: string;
+            range: ContextRange;
+            actual_range: Range;
+        }> = [];
+        for (const my_group of the_groups) {
+            if (my_group.members.length === 1) {
+                // Lone range: preserve exact prior behavior.
+                const my_range = my_group.members[0];
+                const my_end_line_text = get_line_text(doc, my_group.end_line);
+                the_units.push({
+                    content: this.extract_block_content(doc, my_range),
+                    range: my_range,
+                    actual_range: {
+                        start: { line: my_group.start_line, character: 0 },
+                        end: {
+                            line: my_group.end_line,
+                            character: my_end_line_text.length,
+                        },
+                    },
+                });
+                continue;
+            }
+
+            // Merged group: preserve the union of physical lines verbatim.
+            const my_lines: string[] = [];
+            for (
+                let my_line = my_group.start_line;
+                my_line <= my_group.end_line && my_line < the_line_count;
+                my_line++
+            ) {
+                const my_text = get_line_text(doc, my_line);
+                // Strip the first line's indentation only; the formatter
+                // reapplies the placeholder's indentation to it on restore.
+                my_lines.push(
+                    my_line === my_group.start_line ? my_text.trimStart() : my_text
+                );
+            }
+            const my_end_line_text = get_line_text(doc, my_group.end_line);
+            // Synthetic single-line range: restore preserves it verbatim
+            // (leading indent on the first line only, no end-delimiter reindent).
+            const my_synthetic_range: ContextRange = {
+                context: my_group.members[0].context,
+                range: {
+                    start: { line: my_group.start_line, character: 0 },
+                    end: { line: my_group.end_line, character: Number.MAX_SAFE_INTEGER },
+                },
+                start_delimiter: my_group.members[0].start_delimiter,
+                is_single_line: true,
+            };
+            the_units.push({
+                content: my_lines.join('\n'),
+                range: my_synthetic_range,
+                actual_range: {
+                    start: { line: my_group.start_line, character: 0 },
+                    end: {
+                        line: my_group.end_line,
+                        character: my_end_line_text.length,
+                    },
+                },
+            });
+        }
+
+        // Bottom-up so replacements do not shift later units' offsets.
+        the_units.sort(
+            (a, b) => b.actual_range.start.line - a.actual_range.start.line
+        );
+        return the_units;
+    }
+
+    /**
      * Extract the full content of an embedded language block including delimiters.
-     * 
+     *
      * Note: context_range.range excludes the end delimiter line, but we need to
      * include it. Use end_delimiter.range.start.line if available, otherwise
      * fall back to context_range.range.end.line.
-     * 
+     *
      * The first line's (opening delimiter) and last line's (closing delimiter)
      * leading whitespace is stripped since the formatter will handle indentation.
      * This prevents double-indentation when the block is restored.

--- a/src/providers/formatter.ts
+++ b/src/providers/formatter.ts
@@ -257,8 +257,17 @@ export class CodeFormatter {
                             if (index === 0) {
                                 // First line (opening delimiter): add placeholder indentation
                                 return leading_indent + line;
-                            } else if (index === block_lines.length - 1 && line.trim() === expected_end_delimiter) {
-                                // Last line is the end delimiter: add placeholder indentation
+                            } else if (
+                                !my_block_info.range.is_single_line &&
+                                index === block_lines.length - 1 &&
+                                line.trim() === expected_end_delimiter
+                            ) {
+                                // Last line is the end delimiter: add placeholder indentation.
+                                // Inline (`mata:`/`python:`) ranges have no `end`
+                                // delimiter line; under #delimit ; they can span
+                                // multiple physical lines, and a continuation line
+                                // that happens to trim to "end" must be preserved
+                                // as-is, not reindented as a block terminator.
                                 return leading_indent + line;
                             } else {
                                 // Middle lines (embedded content): preserve as-is

--- a/src/providers/formatter.ts
+++ b/src/providers/formatter.ts
@@ -161,9 +161,18 @@ export class CodeFormatter {
 
         // Extract embedded blocks and replace with placeholders
         let my_modified_content = document.content;
-        const the_sorted_ranges = [...context_ranges].sort(
-            (a, b) => b.range.start.line - a.range.start.line
-        );
+        // Process bottom-up (descending start line) so earlier replacements
+        // never shift the offsets of later ones. At equal start lines, process
+        // the WIDER range (larger end line) first: when two whole-line embedded
+        // ranges share their start line, the narrower one is fully contained in
+        // the wider, so keeping the wider and skipping the narrower (via the
+        // overlap guard below) preserves every embedded line verbatim.
+        const the_sorted_ranges = [...context_ranges].sort((a, b) => {
+            if (b.range.start.line !== a.range.start.line) {
+                return b.range.start.line - a.range.start.line;
+            }
+            return b.range.end.line - a.range.end.line;
+        });
 
         // Smallest start line of a range already replaced. Ranges are
         // processed in descending start-line order, so this only decreases;

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -173,15 +173,16 @@ export interface InlineEmbeddedEnd {
  * `end_index` consumes the terminating `STATEMENT_TERMINATOR` (when
  * present); otherwise it is the last content token (EOF / ran off the end).
  * The context tracker advances its main loop to this index, which skips
- * every token BETWEEN the opener and the terminator (so an opener that the
- * lexer re-triggers mid-statement cannot spawn an interior overlapping
- * range) while still letting the main loop process anything AFTER the
- * terminator on the same physical line — in particular a trailing block
- * opener (`mata`/`python`) that opens a real multi-line block. A trailing
- * inline opener sharing the terminator line still produces its own
- * whole-line range (a documented same-physical-line limitation); it is NOT
- * swallowed, because swallowing by line number alone would also drop a
- * trailing block opener's entire body.
+ * every token BETWEEN the opener and the terminator (so an opener the lexer
+ * re-triggers mid-statement cannot spawn an interior overlapping range).
+ *
+ * Because the context range spans the WHOLE of `end_line`, `end_index` then
+ * also consumes any trailing tokens on `end_line` — INCLUDING a trailing
+ * inline opener (`mata:`/`python:`), which would otherwise produce a second
+ * whole-line range overlapping this one. It STOPS at a trailing block opener
+ * (`mata`/`python`, i.e. `MATA_START`/`PYTHON_START`), so the main loop still
+ * processes it and opens its real multi-line block: swallowing a block opener
+ * by line number would silently drop its whole body's context.
  *
  * Bounded: never scans past `EOF`; an unterminated inline in `;` mode ends
  * at the last content line, matching the AST.
@@ -205,10 +206,24 @@ export function inline_embedded_statement_end(
 
     // Consume the real terminator too (when there is one); otherwise resume
     // after the last content token (EOF / ran off the end).
-    const end_index =
+    let end_index =
         my_i < tokens.length && tokens[my_i].type === 'STATEMENT_TERMINATOR'
             ? my_i
             : my_last_content_index;
 
-    return { end_line, end_index };
+    // Swallow trailing tokens on end_line so a second inline statement sharing
+    // the line cannot spawn an overlapping whole-line range. Stop before a
+    // block opener, whose multi-line body the main loop must still process.
+    while (end_index + 1 < tokens.length) {
+        const my_next = tokens[end_index + 1];
+        if (my_next.range.start.line > end_line) {
+            break;
+        }
+        if (my_next.type === 'MATA_START' || my_next.type === 'PYTHON_START') {
+            break;
+        }
+        end_index++;
+    }
+
+    return { end_index, end_line };
 }

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -174,15 +174,16 @@ export interface InlineEmbeddedEnd {
  * present); otherwise it is the last content token (EOF / ran off the end).
  * The context tracker advances its main loop to this index, which skips
  * every token BETWEEN the opener and the terminator (so an opener the lexer
- * re-triggers mid-statement cannot spawn an interior overlapping range).
- *
- * Because the context range spans the WHOLE of `end_line`, `end_index` then
- * also consumes any trailing tokens on `end_line` — INCLUDING a trailing
- * inline opener (`mata:`/`python:`), which would otherwise produce a second
- * whole-line range overlapping this one. It STOPS at a trailing block opener
- * (`mata`/`python`, i.e. `MATA_START`/`PYTHON_START`), so the main loop still
- * processes it and opens its real multi-line block: swallowing a block opener
- * by line number would silently drop its whole body's context.
+ * re-triggers mid-statement cannot spawn an interior overlapping range) but
+ * still lets the main loop process whatever follows the terminator on the
+ * same physical line — a trailing block opener (which must open its
+ * multi-line body) or a trailing inline opener (which the parser treats as
+ * its own embedded_block, so it gets its own range too). A second inline
+ * statement sharing the terminator line therefore keeps full context
+ * coverage; the two whole-line ranges overlap only on that shared line, an
+ * unavoidable and pre-existing limitation of line-granular context ranges
+ * (a physical line cannot hold two languages), consistent with the parser's
+ * overlapping single-line embedded_block spans.
  *
  * Bounded: never scans past `EOF`; an unterminated inline in `;` mode ends
  * at the last content line, matching the AST.
@@ -206,24 +207,10 @@ export function inline_embedded_statement_end(
 
     // Consume the real terminator too (when there is one); otherwise resume
     // after the last content token (EOF / ran off the end).
-    let end_index =
+    const end_index =
         my_i < tokens.length && tokens[my_i].type === 'STATEMENT_TERMINATOR'
             ? my_i
             : my_last_content_index;
-
-    // Swallow trailing tokens on end_line so a second inline statement sharing
-    // the line cannot spawn an overlapping whole-line range. Stop before a
-    // block opener, whose multi-line body the main loop must still process.
-    while (end_index + 1 < tokens.length) {
-        const my_next = tokens[end_index + 1];
-        if (my_next.range.start.line > end_line) {
-            break;
-        }
-        if (my_next.type === 'MATA_START' || my_next.type === 'PYTHON_START') {
-            break;
-        }
-        end_index++;
-    }
 
     return { end_index, end_line };
 }

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -134,3 +134,83 @@ export function next_statement_line_span(
 
     return { start_line, end_line };
 }
+
+/**
+ * The physical end of an inline embedded statement (`mata:` / `python:`,
+ * i.e. a `MATA_INLINE` / `PYTHON_INLINE` opener at `tokens[opener_index]`).
+ */
+export interface InlineEmbeddedEnd {
+    /** Last physical line (0-based) covered by the inline statement. */
+    end_line: number;
+    /**
+     * Index of the last token the inline statement consumes. The context
+     * tracker advances its main loop to this index so no token inside the
+     * statement — nor a trailing same-line opener after its terminator —
+     * spawns a second, overlapping context range.
+     */
+    end_index: number;
+}
+
+/**
+ * Compute where an inline `mata:` / `python:` statement ends (issue #309).
+ *
+ * Under `#delimit ;` an inline embedded statement legally continues onto
+ * later physical lines and ends at the `;`; the context tracker must report
+ * the embedded language on those continuation lines. This mirrors the
+ * parser's single-line `parseEmbeddedLanguageBlock` collection exactly (see
+ * `src/parser/index.ts`): scan forward from the opener collecting tokens
+ * until the first `STATEMENT_TERMINATOR` or `EOF`. It is deliberately NOT
+ * continuation-aware and does not special-case `DELIMIT_DIRECTIVE`, so the
+ * computed range agrees with the AST's `embedded_block` span in every mode.
+ *
+ * `end_line` is the last CONTENT token's `range.end.line` (the terminating
+ * `STATEMENT_TERMINATOR` is never a content token, so a `#delimit cr`
+ * newline terminator's end-line-overshoots-to-next-line quirk never leaks
+ * in; a multi-line content token such as a block comment correctly
+ * contributes its own `end.line`). This equals the parser's
+ * `previous().range.end.line`.
+ *
+ * `end_index` consumes the terminating `STATEMENT_TERMINATOR` (when present)
+ * and, because the context range spans the WHOLE of `end_line`, every
+ * remaining token that starts on `end_line`. That prevents a trailing
+ * same-line opener (e.g. `"2"); python: x = 1;`) from producing a second
+ * whole-line range overlapping this one.
+ *
+ * Bounded: never scans past `EOF`; an unterminated inline in `;` mode ends
+ * at the last content line, matching the AST.
+ */
+export function inline_embedded_statement_end(
+    tokens: Token[],
+    opener_index: number
+): InlineEmbeddedEnd {
+    let my_last_content_index = opener_index; // opener itself when no content
+    let my_i = opener_index + 1;
+    while (
+        my_i < tokens.length &&
+        tokens[my_i].type !== 'STATEMENT_TERMINATOR' &&
+        tokens[my_i].type !== 'EOF'
+    ) {
+        my_last_content_index = my_i;
+        my_i++;
+    }
+
+    const end_line = tokens[my_last_content_index].range.end.line;
+
+    // Consume the real terminator too (when there is one); otherwise resume
+    // after the last content token (EOF / ran off the end).
+    let end_index =
+        my_i < tokens.length && tokens[my_i].type === 'STATEMENT_TERMINATOR'
+            ? my_i
+            : my_last_content_index;
+
+    // The range covers all of `end_line`, so swallow every remaining token on
+    // that line to keep context ranges non-overlapping.
+    while (
+        end_index + 1 < tokens.length &&
+        tokens[end_index + 1].range.start.line <= end_line
+    ) {
+        end_index++;
+    }
+
+    return { end_line, end_index };
+}

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -170,11 +170,18 @@ export interface InlineEmbeddedEnd {
  * contributes its own `end.line`). This equals the parser's
  * `previous().range.end.line`.
  *
- * `end_index` consumes the terminating `STATEMENT_TERMINATOR` (when present)
- * and, because the context range spans the WHOLE of `end_line`, every
- * remaining token that starts on `end_line`. That prevents a trailing
- * same-line opener (e.g. `"2"); python: x = 1;`) from producing a second
- * whole-line range overlapping this one.
+ * `end_index` consumes the terminating `STATEMENT_TERMINATOR` (when
+ * present); otherwise it is the last content token (EOF / ran off the end).
+ * The context tracker advances its main loop to this index, which skips
+ * every token BETWEEN the opener and the terminator (so an opener that the
+ * lexer re-triggers mid-statement cannot spawn an interior overlapping
+ * range) while still letting the main loop process anything AFTER the
+ * terminator on the same physical line — in particular a trailing block
+ * opener (`mata`/`python`) that opens a real multi-line block. A trailing
+ * inline opener sharing the terminator line still produces its own
+ * whole-line range (a documented same-physical-line limitation); it is NOT
+ * swallowed, because swallowing by line number alone would also drop a
+ * trailing block opener's entire body.
  *
  * Bounded: never scans past `EOF`; an unterminated inline in `;` mode ends
  * at the last content line, matching the AST.
@@ -198,19 +205,10 @@ export function inline_embedded_statement_end(
 
     // Consume the real terminator too (when there is one); otherwise resume
     // after the last content token (EOF / ran off the end).
-    let end_index =
+    const end_index =
         my_i < tokens.length && tokens[my_i].type === 'STATEMENT_TERMINATOR'
             ? my_i
             : my_last_content_index;
-
-    // The range covers all of `end_line`, so swallow every remaining token on
-    // that line to keep context ranges non-overlapping.
-    while (
-        end_index + 1 < tokens.length &&
-        tokens[end_index + 1].range.start.line <= end_line
-    ) {
-        end_index++;
-    }
 
     return { end_line, end_index };
 }

--- a/tests/integration/embedded-language-lsp.test.ts
+++ b/tests/integration/embedded-language-lsp.test.ts
@@ -475,6 +475,41 @@ gen`;
             const stata_labels = stata_completions.map(c => c.label);
             expect(stata_labels).toContain('generate');
         });
+
+        it('should keep mata context on #delimit ; inline continuation line (issue #309)', async () => {
+            const my_content = `#delimit ;
+mata: st_local("b",
+"2") ;
+#delimit cr
+gen`;
+
+            const my_uri = 'file:///test_delimit_inline_mata.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            // The continuation line (line 2) is inside the inline mata
+            // statement: Stata command completions must be suppressed there.
+            const my_context_tracker = my_document.context_tracker;
+            expect(
+                my_context_tracker.get_context_at_position({ line: 2, character: 1 })
+            ).toBe(LanguageContext.MATA);
+
+            const continuation_completions =
+                await completion_provider.get_completions(my_document, {
+                    line: 2,
+                    character: 1,
+                });
+            const continuation_labels = continuation_completions.map(c => c.label);
+            expect(continuation_labels).not.toContain('generate');
+
+            // The line after #delimit cr is plain Stata again.
+            const stata_completions = await completion_provider.get_completions(
+                my_document,
+                { line: 4, character: 3 }
+            );
+            const stata_labels = stata_completions.map(c => c.label);
+            expect(stata_labels).toContain('generate');
+        });
     });
 
     describe('Block structure validation', () => {

--- a/tests/repro_mata_inline.test.ts
+++ b/tests/repro_mata_inline.test.ts
@@ -183,4 +183,49 @@ display "done"
             expect(out).toContain('display "done"');
         }
     );
+
+    for_each_formatter_mode(
+        'formatter preserves indentation of a trailing inline statement sharing the opener line (issue #309)',
+        (mode) => {
+            // mata: foo(); python: x = (1+ ... shares the OPENER line: the mata
+            // range (line 1) and the wider python range (lines 1-2) share their
+            // start line. The wider (python) range must be kept so the indented
+            // continuation line is preserved verbatim, not reindented.
+            const source = `#delimit ;
+mata: foo(); python: x = (1+
+    2);
+#delimit cr
+`;
+
+            const lexer = new StataLexer();
+            const lex_result = lexer.tokenize(source);
+            const parser = new StataParser();
+            const parse_result = parser.parse(lex_result.tokens);
+
+            const context_tracker = new ContextTracker();
+            context_tracker.initialize_from_tokens(lex_result.tokens, source);
+            const context_ranges = context_tracker.get_all_context_ranges();
+
+            const config = create_formatter_config(mode);
+            const formatter = new CodeFormatter(config);
+            const document_state = {
+                content: source,
+                tokens: lex_result.tokens,
+                ast: parse_result.ast,
+                line_offsets: lex_result.line_offsets,
+                context_ranges: context_ranges,
+            };
+
+            const edits = formatter.format(document_state as any, {
+                tabSize: 4,
+                insertSpaces: true,
+            });
+
+            expect(edits.length).toBeGreaterThan(0);
+            const out = edits[0].newText;
+            // The embedded continuation line keeps its original indentation.
+            expect(out).toContain('    2);');
+            expect(out).toContain('mata: foo(); python: x = (1+');
+        }
+    );
 });

--- a/tests/repro_mata_inline.test.ts
+++ b/tests/repro_mata_inline.test.ts
@@ -228,4 +228,52 @@ mata: foo(); python: x = (1+
             expect(out).toContain('mata: foo(); python: x = (1+');
         }
     );
+
+    // Source-preserving mode only: the AST formatter ignores context ranges
+    // (it prints embedded_block nodes directly) and has unrelated pre-existing
+    // #delimit ; pretty-printer artifacts.
+    test('preserves indentation of overlapping inline ranges nested in a block (issue #309)', () => {
+        // mata range (lines 2-3) and python range (lines 3-4) overlap on line
+        // 3 with DIFFERENT start lines; neither contains the other. Coalescing
+        // them into one verbatim span preserves every line's indentation,
+        // including mata's own opener line, rather than leaving it reindented.
+        const source = `foreach x in 1 2 {
+    #delimit ;
+    mata: st_local("b",
+    "2"); python: x = (1+
+    2);
+    #delimit cr
+}
+`;
+
+        const lexer = new StataLexer();
+        const lex_result = lexer.tokenize(source);
+        const parser = new StataParser();
+        const parse_result = parser.parse(lex_result.tokens);
+
+        const context_tracker = new ContextTracker();
+        context_tracker.initialize_from_tokens(lex_result.tokens, source);
+        const context_ranges = context_tracker.get_all_context_ranges();
+
+        const formatter = new CodeFormatter(create_formatter_config('source-preserving'));
+        const document_state = {
+            content: source,
+            tokens: lex_result.tokens,
+            ast: parse_result.ast,
+            line_offsets: lex_result.line_offsets,
+            context_ranges: context_ranges,
+        };
+
+        const edits = formatter.format(document_state as any, {
+            tabSize: 4,
+            insertSpaces: true,
+        });
+
+        expect(edits.length).toBeGreaterThan(0);
+        const out = edits[0].newText;
+        // Every embedded line keeps its 4-space indentation; none is mangled.
+        expect(out).toContain('    mata: st_local("b",');
+        expect(out).toContain('    "2"); python: x = (1+');
+        expect(out).toContain('    2);');
+    });
 });

--- a/tests/repro_mata_inline.test.ts
+++ b/tests/repro_mata_inline.test.ts
@@ -177,7 +177,8 @@ display "done"
 
             expect(edits.length).toBeGreaterThan(0);
             const out = edits[0].newText;
-            // No source text lost: both continuation lines survive.
+            // No source text lost: the mata half and both continuation lines survive.
+            expect(out).toContain('st_local("b",');
             expect(out).toContain('x = (1+');
             expect(out).toContain('2);');
             expect(out).toContain('display "done"');

--- a/tests/repro_mata_inline.test.ts
+++ b/tests/repro_mata_inline.test.ts
@@ -47,4 +47,50 @@ if (_rc == 170) {
             expect(edits[0].newText).toContain('mkdir "output"');
         }
     });
+
+    for_each_formatter_mode(
+        'formatter preserves a #delimit ; multiline inline mata statement (issue #309)',
+        (mode) => {
+            const source = `#delimit ;
+mata: st_local("b",
+"2");
+#delimit cr
+display "done"
+`;
+
+            const lexer = new StataLexer();
+            const lex_result = lexer.tokenize(source);
+            const parser = new StataParser();
+            const parse_result = parser.parse(lex_result.tokens);
+
+            const context_tracker = new ContextTracker();
+            context_tracker.initialize_from_tokens(lex_result.tokens, source);
+            const context_ranges = context_tracker.get_all_context_ranges();
+
+            const config = create_formatter_config(mode);
+            const formatter = new CodeFormatter(config);
+            const document_state = {
+                content: source,
+                tokens: lex_result.tokens,
+                ast: parse_result.ast,
+                line_offsets: lex_result.line_offsets,
+                context_ranges: context_ranges,
+            };
+
+            const edits = formatter.format(document_state as any, {
+                tabSize: 4,
+                insertSpaces: true,
+            });
+
+            if (edits.length > 0) {
+                const out = edits[0].newText;
+                // Content preserved: both continuation lines survive intact and
+                // the terminator is not duplicated or dropped.
+                expect(out).toContain('mata: st_local("b",');
+                expect(out).toContain('"2");');
+                expect(out).not.toContain('"2");;');
+                expect(out).toContain('display "done"');
+            }
+        }
+    );
 });

--- a/tests/repro_mata_inline.test.ts
+++ b/tests/repro_mata_inline.test.ts
@@ -82,15 +82,58 @@ display "done"
                 insertSpaces: true,
             });
 
-            if (edits.length > 0) {
-                const out = edits[0].newText;
-                // Content preserved: both continuation lines survive intact and
-                // the terminator is not duplicated or dropped.
-                expect(out).toContain('mata: st_local("b",');
-                expect(out).toContain('"2");');
-                expect(out).not.toContain('"2");;');
-                expect(out).toContain('display "done"');
-            }
+            expect(edits.length).toBeGreaterThan(0);
+            const out = edits[0].newText;
+            // Content preserved: both continuation lines survive intact and
+            // the terminator is not duplicated or dropped.
+            expect(out).toContain('mata: st_local("b",');
+            expect(out).toContain('"2");');
+            expect(out).not.toContain('"2");;');
+            expect(out).toContain('display "done"');
+        }
+    );
+
+    for_each_formatter_mode(
+        'formatter preserves a bare `end` continuation line of a #delimit ; inline mata (issue #309)',
+        (mode) => {
+            // A continuation line trimming to exactly `end` must not be
+            // reindented as a block terminator: inline ranges have no `end`.
+            const source = `#delimit ;
+mata: foo(bar,
+end
+) ;
+#delimit cr
+`;
+
+            const lexer = new StataLexer();
+            const lex_result = lexer.tokenize(source);
+            const parser = new StataParser();
+            const parse_result = parser.parse(lex_result.tokens);
+
+            const context_tracker = new ContextTracker();
+            context_tracker.initialize_from_tokens(lex_result.tokens, source);
+            const context_ranges = context_tracker.get_all_context_ranges();
+
+            const config = create_formatter_config(mode);
+            const formatter = new CodeFormatter(config);
+            const document_state = {
+                content: source,
+                tokens: lex_result.tokens,
+                ast: parse_result.ast,
+                line_offsets: lex_result.line_offsets,
+                context_ranges: context_ranges,
+            };
+
+            const edits = formatter.format(document_state as any, {
+                tabSize: 4,
+                insertSpaces: true,
+            });
+
+            expect(edits.length).toBeGreaterThan(0);
+            const out = edits[0].newText;
+            expect(out).toContain('mata: foo(bar,');
+            expect(out).toContain('end');
+            expect(out).toContain(') ;');
         }
     );
 });

--- a/tests/repro_mata_inline.test.ts
+++ b/tests/repro_mata_inline.test.ts
@@ -136,4 +136,51 @@ end
             expect(out).toContain(') ;');
         }
     );
+
+    for_each_formatter_mode(
+        'formatter does not drop a trailing inline statement overlapping the terminator line (issue #309)',
+        (mode) => {
+            // The mata range (lines 1-2) and the trailing python range
+            // (lines 2-3) overlap on line 2. The formatter must not
+            // double-replace line 2 and drop the python continuation.
+            const source = `#delimit ;
+mata: st_local("b",
+"2"); python: x = (1+
+2);
+#delimit cr
+display "done"
+`;
+
+            const lexer = new StataLexer();
+            const lex_result = lexer.tokenize(source);
+            const parser = new StataParser();
+            const parse_result = parser.parse(lex_result.tokens);
+
+            const context_tracker = new ContextTracker();
+            context_tracker.initialize_from_tokens(lex_result.tokens, source);
+            const context_ranges = context_tracker.get_all_context_ranges();
+
+            const config = create_formatter_config(mode);
+            const formatter = new CodeFormatter(config);
+            const document_state = {
+                content: source,
+                tokens: lex_result.tokens,
+                ast: parse_result.ast,
+                line_offsets: lex_result.line_offsets,
+                context_ranges: context_ranges,
+            };
+
+            const edits = formatter.format(document_state as any, {
+                tabSize: 4,
+                insertSpaces: true,
+            });
+
+            expect(edits.length).toBeGreaterThan(0);
+            const out = edits[0].newText;
+            // No source text lost: both continuation lines survive.
+            expect(out).toContain('x = (1+');
+            expect(out).toContain('2);');
+            expect(out).toContain('display "done"');
+        }
+    );
 });

--- a/tests/unit/context-tracker-initialize-from-tokens.test.ts
+++ b/tests/unit/context-tracker-initialize-from-tokens.test.ts
@@ -459,6 +459,29 @@ mata: foo();
     ).toBe(LanguageContext.MATA);
   });
 
+  it('produces no overlapping range for a trailing same-line inline opener', () => {
+    const my_content = `#delimit ;
+mata: st_local("b",
+"2"); python: x = 1;
+#delimit cr
+`;
+    const my_lex_result = lexer.tokenize(my_content);
+    tracker.initialize_from_tokens(my_lex_result.tokens, my_content);
+
+    const my_ranges = tracker.get_all_context_ranges();
+    // The trailing inline python: is swallowed into the mata whole-line span,
+    // so ranges stay non-overlapping and the mata continuation content on the
+    // terminator line still resolves to mata (not python).
+    for (let my_i = 1; my_i < my_ranges.length; my_i++) {
+      const my_prev = my_ranges[my_i - 1];
+      const my_curr = my_ranges[my_i];
+      expect(my_curr.range.start.line).toBeGreaterThan(my_prev.range.end.line);
+    }
+    expect(
+      tracker.get_context_at_position({ line: 2, character: 1 })
+    ).toBe(LanguageContext.MATA);
+  });
+
   it('still opens a real block opener trailing an inline terminator (regression #309)', () => {
     // A bare `mata:` block opener after an inline mata statement's `;` on the
     // same #delimit ; line must still open its multi-line block; the inline

--- a/tests/unit/context-tracker-initialize-from-tokens.test.ts
+++ b/tests/unit/context-tracker-initialize-from-tokens.test.ts
@@ -376,4 +376,122 @@ end`;
     const my_diagnostics = tracker.validate_context_structure();
     expect(my_diagnostics).toHaveLength(0);
   });
+
+  /**
+   * Issue #309: under #delimit ; an inline mata: statement can continue
+   * onto later physical lines (statement ends at ;). The context tracker
+   * must report MATA on those continuation lines, not STATA.
+   */
+  it('reports mata on #delimit ; inline mata continuation lines', () => {
+    const my_content = `#delimit ;
+mata: st_local("b",
+"2");
+#delimit cr
+`;
+    const my_lex_result = lexer.tokenize(my_content);
+    tracker.initialize_from_tokens(my_lex_result.tokens, my_content);
+
+    // The repro position: line 2 (the "2") is inside the mata statement.
+    expect(
+      tracker.get_context_at_position({ line: 2, character: 1 })
+    ).toBe(LanguageContext.MATA);
+    // Opener line is also mata.
+    expect(
+      tracker.get_context_at_position({ line: 1, character: 0 })
+    ).toBe(LanguageContext.MATA);
+    // The #delimit cr line is not part of the mata statement.
+    expect(
+      tracker.get_context_at_position({ line: 3, character: 0 })
+    ).toBe(LanguageContext.STATA);
+  });
+
+  it('reports python on #delimit ; inline python continuation lines', () => {
+    const my_content = `#delimit ;
+python: x = (1 +
+2);
+`;
+    const my_lex_result = lexer.tokenize(my_content);
+    tracker.initialize_from_tokens(my_lex_result.tokens, my_content);
+
+    expect(
+      tracker.get_context_at_position({ line: 2, character: 0 })
+    ).toBe(LanguageContext.PYTHON);
+  });
+
+  it('leaves cr single-line inline mata ending on the opener line', () => {
+    const my_content = `mata: st_local("b", "2")
+display 1
+`;
+    const my_lex_result = lexer.tokenize(my_content);
+    tracker.initialize_from_tokens(my_lex_result.tokens, my_content);
+
+    const my_ranges = tracker.get_all_context_ranges();
+    expect(my_ranges).toHaveLength(1);
+    expect(my_ranges[0].is_single_line).toBe(true);
+    expect(my_ranges[0].range.end.line).toBe(0);
+    // The next physical line is plain Stata.
+    expect(
+      tracker.get_context_at_position({ line: 1, character: 0 })
+    ).toBe(LanguageContext.STATA);
+  });
+
+  it('produces exactly one non-overlapping range for a #delimit ; multiline inline', () => {
+    const my_content = `#delimit ;
+mata: st_local("b",
+"2");
+mata: foo();
+#delimit cr
+`;
+    const my_lex_result = lexer.tokenize(my_content);
+    tracker.initialize_from_tokens(my_lex_result.tokens, my_content);
+
+    const my_ranges = tracker.get_all_context_ranges();
+    // Two separate inline mata statements, each its own range, no overlap.
+    expect(my_ranges).toHaveLength(2);
+    for (let my_i = 1; my_i < my_ranges.length; my_i++) {
+      const my_prev = my_ranges[my_i - 1];
+      const my_curr = my_ranges[my_i];
+      expect(my_curr.range.start.line).toBeGreaterThan(my_prev.range.end.line);
+    }
+    // The second inline opener (line 3) is mata.
+    expect(
+      tracker.get_context_at_position({ line: 3, character: 0 })
+    ).toBe(LanguageContext.MATA);
+  });
+
+  it('does not spawn an overlapping range for a trailing same-line inline opener', () => {
+    const my_content = `#delimit ;
+mata: st_local("b",
+"2"); python: x = 1;
+#delimit cr
+`;
+    const my_lex_result = lexer.tokenize(my_content);
+    tracker.initialize_from_tokens(my_lex_result.tokens, my_content);
+
+    const my_ranges = tracker.get_all_context_ranges();
+    // The trailing python: on the terminator line is swallowed into the
+    // mata whole-line span; no second overlapping range is produced.
+    for (let my_i = 1; my_i < my_ranges.length; my_i++) {
+      const my_prev = my_ranges[my_i - 1];
+      const my_curr = my_ranges[my_i];
+      expect(my_curr.range.start.line).toBeGreaterThan(my_prev.range.end.line);
+    }
+  });
+
+  it('reports mata across a multi-line block comment in a cr inline', () => {
+    const my_content = `mata: st_local("a", /* c
+*/ "1")
+display 1
+`;
+    const my_lex_result = lexer.tokenize(my_content);
+    tracker.initialize_from_tokens(my_lex_result.tokens, my_content);
+
+    // The comment continuation line is part of the mata statement.
+    expect(
+      tracker.get_context_at_position({ line: 1, character: 0 })
+    ).toBe(LanguageContext.MATA);
+    expect(
+      tracker.get_context_at_position({ line: 2, character: 0 })
+    ).toBe(LanguageContext.STATA);
+  });
 });

--- a/tests/unit/context-tracker-initialize-from-tokens.test.ts
+++ b/tests/unit/context-tracker-initialize-from-tokens.test.ts
@@ -459,23 +459,26 @@ mata: foo();
     ).toBe(LanguageContext.MATA);
   });
 
-  it('does not spawn an overlapping range for a trailing same-line inline opener', () => {
+  it('still opens a real block opener trailing an inline terminator (regression #309)', () => {
+    // A bare `mata:` block opener after an inline mata statement's `;` on the
+    // same #delimit ; line must still open its multi-line block; the inline
+    // statement's end handling must not swallow it.
     const my_content = `#delimit ;
-mata: st_local("b",
-"2"); python: x = 1;
+mata: st_local("a", "1"); mata:
+x = 1;
+end;
 #delimit cr
 `;
     const my_lex_result = lexer.tokenize(my_content);
     tracker.initialize_from_tokens(my_lex_result.tokens, my_content);
 
-    const my_ranges = tracker.get_all_context_ranges();
-    // The trailing python: on the terminator line is swallowed into the
-    // mata whole-line span; no second overlapping range is produced.
-    for (let my_i = 1; my_i < my_ranges.length; my_i++) {
-      const my_prev = my_ranges[my_i - 1];
-      const my_curr = my_ranges[my_i];
-      expect(my_curr.range.start.line).toBeGreaterThan(my_prev.range.end.line);
-    }
+    // Lines 2-3 are the body of the real mata block opened at end of line 1.
+    expect(
+      tracker.get_context_at_position({ line: 2, character: 0 })
+    ).toBe(LanguageContext.MATA);
+    expect(
+      tracker.get_context_at_position({ line: 3, character: 0 })
+    ).toBe(LanguageContext.MATA);
   });
 
   it('reports mata across a multi-line block comment in a cr inline', () => {

--- a/tests/unit/context-tracker-initialize-from-tokens.test.ts
+++ b/tests/unit/context-tracker-initialize-from-tokens.test.ts
@@ -459,26 +459,27 @@ mata: foo();
     ).toBe(LanguageContext.MATA);
   });
 
-  it('produces no overlapping range for a trailing same-line inline opener', () => {
+  it('keeps full context for a trailing inline opener that spills to a later line', () => {
+    // `"2"); python: x = (1+\n2);` — the trailing inline python: statement
+    // continues onto line 3. Its continuation content must NOT be dropped to
+    // stata: the tracker creates a separate python range covering it (matching
+    // the parser's separate embedded_block).
     const my_content = `#delimit ;
 mata: st_local("b",
-"2"); python: x = 1;
+"2"); python: x = (1+
+2);
 #delimit cr
 `;
     const my_lex_result = lexer.tokenize(my_content);
     tracker.initialize_from_tokens(my_lex_result.tokens, my_content);
 
-    const my_ranges = tracker.get_all_context_ranges();
-    // The trailing inline python: is swallowed into the mata whole-line span,
-    // so ranges stay non-overlapping and the mata continuation content on the
-    // terminator line still resolves to mata (not python).
-    for (let my_i = 1; my_i < my_ranges.length; my_i++) {
-      const my_prev = my_ranges[my_i - 1];
-      const my_curr = my_ranges[my_i];
-      expect(my_curr.range.start.line).toBeGreaterThan(my_prev.range.end.line);
-    }
+    // The spilled python continuation line is embedded python, not stata.
     expect(
-      tracker.get_context_at_position({ line: 2, character: 1 })
+      tracker.get_context_at_position({ line: 3, character: 0 })
+    ).toBe(LanguageContext.PYTHON);
+    // The mata continuation line before the trailing statement is still mata.
+    expect(
+      tracker.get_context_at_position({ line: 1, character: 0 })
     ).toBe(LanguageContext.MATA);
   });
 

--- a/tests/unit/statement-span.test.ts
+++ b/tests/unit/statement-span.test.ts
@@ -287,21 +287,33 @@ describe('inline_embedded_statement_end', () => {
         expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
     });
 
-    it('stops at the terminator, not swallowing a trailing same-line token', () => {
-        // `"2"); python: x = 1;` — end_index is the mata statement's own `;`
-        // (index just before the trailing PYTHON_INLINE), so the context
-        // tracker's main loop still gets to process whatever follows on the
-        // terminator line rather than the helper swallowing it by line number
-        // (which would also drop a trailing block opener's body).
+    it('swallows a trailing same-line INLINE opener to avoid an overlapping range', () => {
+        // `"2"); python: x = 1;` — the trailing inline python: shares the
+        // terminator line, so it is consumed into the mata whole-line span
+        // rather than spawning a second overlapping range.
         const my_source =
             '#delimit ;\nmata: st_local("b",\n"2"); python: x = 1;\n';
         const { tokens } = lexer.tokenize(my_source);
         const my_opener = opener_index(tokens);
         const my_end = inline_embedded_statement_end(tokens, my_opener);
         expect(my_end.end_line).toBe(2);
+        // Nothing after end_index starts on the terminator line.
+        const my_next = tokens[my_end.end_index + 1];
+        if (my_next && my_next.type !== 'EOF') {
+            expect(my_next.range.start.line).toBeGreaterThan(2);
+        }
+    });
+
+    it('stops before a trailing same-line BLOCK opener so its body is processed', () => {
+        // `st_local("a", "1"); mata:` — the trailing bare `mata:` is a block
+        // opener; it must NOT be swallowed, or the whole block would lose its
+        // context. end_index stays at the inline statement's own `;`.
+        const my_source =
+            '#delimit ;\nmata: st_local("a", "1"); mata:\nx = 1;\nend;\n';
+        const { tokens } = lexer.tokenize(my_source);
+        const my_opener = opener_index(tokens);
+        const my_end = inline_embedded_statement_end(tokens, my_opener);
         expect(tokens[my_end.end_index].type).toBe('STATEMENT_TERMINATOR');
-        expect(tokens[my_end.end_index].value).toBe(';');
-        // The trailing PYTHON_INLINE is left for the caller, not consumed.
-        expect(tokens[my_end.end_index + 1].type).toBe('PYTHON_INLINE');
+        expect(tokens[my_end.end_index + 1].type).toBe('MATA_START');
     });
 });

--- a/tests/unit/statement-span.test.ts
+++ b/tests/unit/statement-span.test.ts
@@ -8,7 +8,11 @@
 
 import { describe, it, expect } from 'bun:test';
 import { StataLexer } from '../../src/lexer';
-import { next_statement_line_span } from '../../src/utils/statement-span';
+import {
+    next_statement_line_span,
+    inline_embedded_statement_end,
+} from '../../src/utils/statement-span';
+import { StataParser } from '../../src/parser';
 
 const lexer = new StataLexer();
 
@@ -130,5 +134,174 @@ describe('next_statement_line_span', () => {
             '// @lsp-ignore-next\nmata:\n    x = 1 < 2 < 3\nend'
         );
         expect(my_span).toEqual({ start_line: 1, end_line: 1 });
+    });
+});
+
+/**
+ * inline_embedded_statement_end (issue #309): computes the physical end
+ * line of an inline `mata:`/`python:` statement so the context tracker can
+ * report the embedded language on `#delimit ;` continuation lines. It must
+ * agree with the parser's embedded_block span (the governing principle).
+ */
+function opener_index(tokens: ReturnType<StataLexer['tokenize']>['tokens']) {
+    const my_index = tokens.findIndex(
+        (my_token) =>
+            my_token.type === 'MATA_INLINE' ||
+            my_token.type === 'PYTHON_INLINE'
+    );
+    expect(my_index).toBeGreaterThanOrEqual(0);
+    return my_index;
+}
+
+/**
+ * The parser's single-line embedded_block range.end.line is the ground
+ * truth the helper must match.
+ */
+function parser_inline_end_line(source: string): number {
+    const { tokens } = lexer.tokenize(source);
+    const my_parse = new StataParser().parse(tokens);
+    let my_end_line = -1;
+    const my_seen = new WeakSet<object>();
+    const walk = (node: unknown): void => {
+        if (!node || typeof node !== 'object') {
+            return;
+        }
+        if (my_seen.has(node as object)) {
+            return;
+        }
+        my_seen.add(node as object);
+        const my_node = node as Record<string, unknown>;
+        if (
+            my_node.type === 'embedded_block' &&
+            my_node.is_single_line === true
+        ) {
+            const my_range = my_node.range as {
+                end: { line: number };
+            };
+            my_end_line = my_range.end.line;
+        }
+        for (const my_key of Object.keys(my_node)) {
+            const my_value = my_node[my_key];
+            if (Array.isArray(my_value)) {
+                my_value.forEach(walk);
+            } else if (my_value && typeof my_value === 'object') {
+                walk(my_value);
+            }
+        }
+    };
+    walk(my_parse.ast);
+    return my_end_line;
+}
+
+describe('inline_embedded_statement_end', () => {
+    it('spans to the ; terminator line for a #delimit ; multiline mata', () => {
+        const my_source = '#delimit ;\nmata: st_local("b",\n"2");\n#delimit cr\n';
+        const { tokens } = lexer.tokenize(my_source);
+        const my_end = inline_embedded_statement_end(
+            tokens,
+            opener_index(tokens)
+        );
+        expect(my_end.end_line).toBe(2);
+        expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
+        // end_index consumes the ; terminator.
+        expect(tokens[my_end.end_index].type).toBe('STATEMENT_TERMINATOR');
+        expect(tokens[my_end.end_index].value).toBe(';');
+    });
+
+    it('spans to the ; terminator line for a #delimit ; multiline python', () => {
+        const my_source = '#delimit ;\npython: x = (1 +\n2);\n';
+        const { tokens } = lexer.tokenize(my_source);
+        const my_end = inline_embedded_statement_end(
+            tokens,
+            opener_index(tokens)
+        );
+        expect(my_end.end_line).toBe(2);
+        expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
+    });
+
+    it('ends on the opener line for a cr single-line inline (unchanged)', () => {
+        const my_source = 'mata: st_local("b", "2")\ndisplay 1\n';
+        const { tokens } = lexer.tokenize(my_source);
+        const my_end = inline_embedded_statement_end(
+            tokens,
+            opener_index(tokens)
+        );
+        expect(my_end.end_line).toBe(0);
+        expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
+    });
+
+    it('ends on the opener line for a ; inline terminating on that line', () => {
+        const my_source = '#delimit ;\nmata: foo() ;\ndisplay 1 ;\n';
+        const { tokens } = lexer.tokenize(my_source);
+        const my_end = inline_embedded_statement_end(
+            tokens,
+            opener_index(tokens)
+        );
+        expect(my_end.end_line).toBe(1);
+        expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
+    });
+
+    it('bounds an unterminated inline at EOF (no file swallow)', () => {
+        const my_source = '#delimit ;\nmata: st_local("b",\n"2")';
+        const { tokens } = lexer.tokenize(my_source);
+        const my_end = inline_embedded_statement_end(
+            tokens,
+            opener_index(tokens)
+        );
+        expect(my_end.end_line).toBe(2);
+        expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
+        // end_index must not run past the final token index.
+        expect(my_end.end_index).toBeLessThan(tokens.length);
+    });
+
+    it('matches the parser when #delimit cr appears before the terminator', () => {
+        const my_source = '#delimit ;\nmata: foo(\n#delimit cr\ndisplay 1\n';
+        const { tokens } = lexer.tokenize(my_source);
+        const my_end = inline_embedded_statement_end(
+            tokens,
+            opener_index(tokens)
+        );
+        expect(my_end.end_line).toBe(2);
+        expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
+    });
+
+    it('ends on the opener line for a cr /// continued inline (matches parser)', () => {
+        const my_source = 'mata: st_local("b", ///\n"2")\ndisplay 1\n';
+        const { tokens } = lexer.tokenize(my_source);
+        const my_end = inline_embedded_statement_end(
+            tokens,
+            opener_index(tokens)
+        );
+        expect(my_end.end_line).toBe(0);
+        expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
+    });
+
+    it('spans a multi-line /* */ block comment inside a cr inline (matches parser)', () => {
+        const my_source = 'mata: st_local("a", /* c\n*/ "1")\ndisplay 1\n';
+        const { tokens } = lexer.tokenize(my_source);
+        const my_end = inline_embedded_statement_end(
+            tokens,
+            opener_index(tokens)
+        );
+        expect(my_end.end_line).toBe(1);
+        expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
+    });
+
+    it('consumes a trailing same-line embedded opener after the terminator', () => {
+        // `"2"); python: x = 1;` — the trailing python: on the terminator
+        // line must be swallowed into the mata whole-line span so it cannot
+        // spawn a second, overlapping context range.
+        const my_source =
+            '#delimit ;\nmata: st_local("b",\n"2"); python: x = 1;\n';
+        const { tokens } = lexer.tokenize(my_source);
+        const my_opener = opener_index(tokens);
+        const my_end = inline_embedded_statement_end(tokens, my_opener);
+        expect(my_end.end_line).toBe(2);
+        // Every remaining token on line 2 (including the trailing PYTHON_INLINE)
+        // is consumed: no token after end_index starts on line 2.
+        const my_next = tokens[my_end.end_index + 1];
+        if (my_next && my_next.type !== 'EOF') {
+            expect(my_next.range.start.line).toBeGreaterThan(2);
+        }
     });
 });

--- a/tests/unit/statement-span.test.ts
+++ b/tests/unit/statement-span.test.ts
@@ -287,21 +287,21 @@ describe('inline_embedded_statement_end', () => {
         expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
     });
 
-    it('consumes a trailing same-line embedded opener after the terminator', () => {
-        // `"2"); python: x = 1;` — the trailing python: on the terminator
-        // line must be swallowed into the mata whole-line span so it cannot
-        // spawn a second, overlapping context range.
+    it('stops at the terminator, not swallowing a trailing same-line token', () => {
+        // `"2"); python: x = 1;` — end_index is the mata statement's own `;`
+        // (index just before the trailing PYTHON_INLINE), so the context
+        // tracker's main loop still gets to process whatever follows on the
+        // terminator line rather than the helper swallowing it by line number
+        // (which would also drop a trailing block opener's body).
         const my_source =
             '#delimit ;\nmata: st_local("b",\n"2"); python: x = 1;\n';
         const { tokens } = lexer.tokenize(my_source);
         const my_opener = opener_index(tokens);
         const my_end = inline_embedded_statement_end(tokens, my_opener);
         expect(my_end.end_line).toBe(2);
-        // Every remaining token on line 2 (including the trailing PYTHON_INLINE)
-        // is consumed: no token after end_index starts on line 2.
-        const my_next = tokens[my_end.end_index + 1];
-        if (my_next && my_next.type !== 'EOF') {
-            expect(my_next.range.start.line).toBeGreaterThan(2);
-        }
+        expect(tokens[my_end.end_index].type).toBe('STATEMENT_TERMINATOR');
+        expect(tokens[my_end.end_index].value).toBe(';');
+        // The trailing PYTHON_INLINE is left for the caller, not consumed.
+        expect(tokens[my_end.end_index + 1].type).toBe('PYTHON_INLINE');
     });
 });

--- a/tests/unit/statement-span.test.ts
+++ b/tests/unit/statement-span.test.ts
@@ -287,27 +287,26 @@ describe('inline_embedded_statement_end', () => {
         expect(my_end.end_line).toBe(parser_inline_end_line(my_source));
     });
 
-    it('swallows a trailing same-line INLINE opener to avoid an overlapping range', () => {
-        // `"2"); python: x = 1;` — the trailing inline python: shares the
-        // terminator line, so it is consumed into the mata whole-line span
-        // rather than spawning a second overlapping range.
+    it('ends at its own terminator, leaving a trailing same-line inline opener for the caller', () => {
+        // `"2"); python: x = 1;` — the mata statement ends at its own `;`; the
+        // trailing inline python: is NOT consumed, so the caller (context
+        // tracker) still creates a range for it (matching the parser's
+        // separate embedded_block) rather than dropping its content.
         const my_source =
             '#delimit ;\nmata: st_local("b",\n"2"); python: x = 1;\n';
         const { tokens } = lexer.tokenize(my_source);
         const my_opener = opener_index(tokens);
         const my_end = inline_embedded_statement_end(tokens, my_opener);
         expect(my_end.end_line).toBe(2);
-        // Nothing after end_index starts on the terminator line.
-        const my_next = tokens[my_end.end_index + 1];
-        if (my_next && my_next.type !== 'EOF') {
-            expect(my_next.range.start.line).toBeGreaterThan(2);
-        }
+        expect(tokens[my_end.end_index].type).toBe('STATEMENT_TERMINATOR');
+        expect(tokens[my_end.end_index].value).toBe(';');
+        expect(tokens[my_end.end_index + 1].type).toBe('PYTHON_INLINE');
     });
 
-    it('stops before a trailing same-line BLOCK opener so its body is processed', () => {
+    it('ends at its own terminator, leaving a trailing same-line block opener for the caller', () => {
         // `st_local("a", "1"); mata:` — the trailing bare `mata:` is a block
-        // opener; it must NOT be swallowed, or the whole block would lose its
-        // context. end_index stays at the inline statement's own `;`.
+        // opener; end_index stays at the inline statement's own `;` so the
+        // caller processes the opener and opens its multi-line block.
         const my_source =
             '#delimit ;\nmata: st_local("a", "1"); mata:\nx = 1;\nend;\n';
         const { tokens } = lexer.tokenize(my_source);


### PR DESCRIPTION
## Summary

Fixes #309. `ContextTracker` closed inline `mata:`/`python:` (`MATA_INLINE`/`PYTHON_INLINE`) context ranges at the opener's physical line. Under `#delimit ;`, an inline embedded statement can continue onto later physical lines (it ends at the `;`), and the parser's `embedded_block` node spans those lines correctly — but the context tracker reported `stata` for the continuation lines, so context-keyed providers (completion, hover, diagnostics suppression) ran Stata logic inside continued Mata/Python code.

Repro: `#delimit ;` + `mata: st_local("b",` + `"2");` → `get_context_at_position({line:2,character:1})` returned `stata`; now returns `mata`.

## Design

Governing principle: the context range must agree with the parser's `embedded_block` span at the line level.

- **`src/utils/statement-span.ts`** — new `inline_embedded_statement_end(tokens, opener_index)`, a bounded forward scan that mirrors the parser's single-line `parseEmbeddedLanguageBlock` collection: scan to the first `STATEMENT_TERMINATOR` or `EOF`. `end_line` = the last content token's `range.end.line` (the terminating `STATEMENT_TERMINATOR` is never a content token, so a cr-mode `\n` terminator's end-line overshoot never leaks in; a multi-line content token contributes its own `end.line`). Bounded: never scans past `EOF`; an unterminated inline in `;` mode ends at the last content line, matching the AST. This equals the parser's `previous().range.end.line` in every probed case (`;` multiline, cr single-line, unterminated-at-EOF, `#delimit cr` mid-statement, cr `///`, multi-line block comment).
- **`src/context-tracker/index.ts`** — the `MATA_INLINE`/`PYTHON_INLINE` branches keep `is_single_line: true`, drop the redundant self-referential `end_delimiter`, compute the range end via the helper, and advance the main loop past the consumed tokens so no interior (lexer-retriggered) opener spawns an overlapping range.
- **`src/providers/formatter.ts`** — because an inline range can now span multiple physical lines, two whole-line embedded ranges can share a physical line (two embedded statements on one line). The embedded-block preservation now **coalesces** ranges that share a physical line into one verbatim replacement unit spanning the union of their lines (`coalesce_embedded_ranges`), so no line is ever double-covered (data loss) or left unprotected (indentation mangled). A lone, non-overlapping range keeps its exact prior behavior (block `end`-delimiter reindentation). The placeholder-restore reindent branch is additionally gated on `!is_single_line`.

cr mode is unchanged whenever the statement ends on the opener line (the common case and cr `///`, both of which the parser also ends on the opener line). A cr statement that legitimately spans lines via a multi-line block comment now matches the parser (previously a latent miss).

## Test evidence

New/updated tests:
- `tests/unit/statement-span.test.ts` — `inline_embedded_statement_end` across `;` multiline (mata + python), cr single-line, `;` single-line, unterminated-at-EOF, `#delimit cr` before terminator, cr `///`, multi-line block comment, and trailing same-line inline/block openers; each cross-checked against the parser's `embedded_block` end line.
- `tests/unit/context-tracker-initialize-from-tokens.test.ts` — the repro (mata + python continuation lines), cr single-line unchanged, a trailing inline opener spilling to a later line keeps its content embedded, and a trailing block opener still opens its multi-line block.
- `tests/integration/embedded-language-lsp.test.ts` — the completion provider now sees `mata` context (suppresses Stata completions) on a `#delimit ;` inline continuation line.
- `tests/repro_mata_inline.test.ts` — formatter round-trips (both modes) for `;` multiline inline, a bare `end` continuation line, an overlapping trailing inline statement (no dropped/duplicated `;`), and overlapping inline ranges nested in a block (indentation preserved).

Gate (all green):
```
bun run test    # typecheck + full suite: 7433 pass, 5 skip, 0 fail
bun run lint    # eslint src client/src: clean
bun test tests/property/delimiter-mode-equivalence.prop.test.ts   # 3 pass
```

## Review-gate history

Adversarial review with codex (primary) + a cold Sonnet subagent, on the design and then the diff:
- **Design rounds** surfaced and fixed: formatter column-corruption risk (→ keep whole-line MAX end char), overlapping/O(n²) risk (→ advance the main loop), and parser-agreement for cr `///` (→ match the parser exactly, no continuation-awareness).
- **Diff rounds** surfaced and fixed, each verified against `main`:
  1. Swallowing trailing tokens dropped a trailing **block** opener's body (Sonnet) — reverted the swallow.
  2. Widened ranges overlapping on the terminator line caused formatter **data loss** (codex) — added an overlap guard, then a wider-first tie-break.
  3. A **nested** different-start overlap mangled a range's unique-line indentation (Sonnet) — replaced the guard/tie-break with a full **coalesce** of overlapping ranges.
- Final two consecutive rounds: **codex NO ISSUES + Sonnet NO ISSUES** (twice).

## Deferred / known limitations (pre-existing, verified identical on `main`; orthogonal to #309)

- When two embedded statements share **one physical line**, the two whole-line **context** ranges overlap and `get_context_at_position` returns the lattermost language for that shared line. Line-granular context ranges cannot hold two languages on one line; this matches the parser's overlapping single-line `embedded_block` spans and is byte-identical to `main`. The **formatting** side of the same construct is fully handled by the coalesce.
- AST-formatter-mode `#delimit ;` PrettyPrinter artifacts (e.g. `;;`) are pre-existing and unrelated (AST mode ignores context ranges).
- A multi-line `mata`/`end` block whose `end` line shares a physical line with a following inline opener would take the coalesce verbatim path rather than the lone-range `end`-reindent path; this is strictly better than `main` (which had no merge logic) and has no known way to trigger from real Stata syntax.

https://claude.ai/code/session_0114zF2WByBWgPPQiyBrRtWZ
