### PR TITLE
Fix #310: build completion context from the logical statement, not the physical line

### DIFF
--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -311,8 +311,13 @@ export function detect_completion_context(
         return cached_logical_text;
     };
 
-    // Check for extended macro function context (`: list`, `: word`, etc.)
-    const extended_macro_context = detect_extended_macro_context(get_logical_text(), position);
+    // Check for extended macro function context (`: list`, `: word`, etc.).
+    // Kept on the physical line, alongside detect_macro_context below: these
+    // are the only two detectors that return a `macro` context, and the
+    // server-handlers isIncomplete probe relies on macro-ness being decided
+    // without the logical-statement token walk. Extended macro functions are
+    // authored on one line in practice, so this costs no real coverage.
+    const extended_macro_context = detect_extended_macro_context(text_before_cursor, position);
     if (extended_macro_context) {
         return extended_macro_context;
     }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -200,6 +200,33 @@ const LOGICAL_FLATTEN_SKIP_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * First line of the cursor's contiguous Stata region: the line just after
+ * the nearest `mata`/`python` block that ends above the cursor (#310). The
+ * logical-statement walk is clamped to this floor so it never absorbs
+ * embedded-language tokens from a block above the cursor — including a
+ * nested `{ }` inside a `mata { ... }` block, which token types alone cannot
+ * tell apart from a real Stata block. Uses the per-document `context_ranges`
+ * (not the shared provider tracker), so it is unaffected by cross-document
+ * tracker caching. Returns 0 when there is no embedded block above.
+ */
+function stata_region_floor_line(document: DocumentState, position: Position): number {
+    const the_ranges = document.context_ranges;
+    if (!the_ranges || the_ranges.length === 0) {
+        return 0;
+    }
+    let floor_line = 0;
+    for (const my_range of the_ranges) {
+        if (my_range.context === LanguageContext.STATA) {
+            continue;
+        }
+        if (my_range.range.end.line < position.line) {
+            floor_line = Math.max(floor_line, my_range.range.end.line + 1);
+        }
+    }
+    return floor_line;
+}
+
+/**
  * Build the "logical statement" text before the cursor for the
  * statement-scoped detectors (command-path, subcommand, option, command,
  * variable) — issue #310.
@@ -306,7 +333,11 @@ export function detect_completion_context(
                 document,
                 position,
                 tokens,
-                logical_statement_start(tokens, position),
+                logical_statement_start(
+                    tokens,
+                    position,
+                    stata_region_floor_line(document, position)
+                ),
                 text_before_cursor
             );
         }
@@ -1833,7 +1864,11 @@ export class CompletionProvider {
             document,
             position,
             document.tokens,
-            logical_statement_start(document.tokens, position),
+            logical_statement_start(
+                document.tokens,
+                position,
+                stata_region_floor_line(document, position)
+            ),
             physical_text_before_cursor
         );
 

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -68,6 +68,10 @@ import {
 } from './completion/macro-completion';
 import { get_line_text, get_line_count } from '../utils/line-utils';
 import { format_help_link } from '../utils/help-link';
+import {
+    logical_statement_start,
+    LogicalStatementStart,
+} from '../utils/statement-span';
 
 // Directive at the start of its own comment line, applied to the comment body
 // after the `//`/`*` marker has been stripped. Capture group 1 is the
@@ -179,11 +183,94 @@ export interface CompletionClientCapabilities {
 }
 
 /**
+ * Token types dropped when flattening a wrapped statement's prior physical
+ * lines into logical text (#310): whitespace, comments, `///` continuations,
+ * statement terminators, `#delimit` mode switches, and EOF. Their values carry
+ * no command/punctuation the text-based detectors need, and dropping comments
+ * avoids leaking a `,` from a `// note` on an earlier wrapped line.
+ */
+const LOGICAL_FLATTEN_SKIP_TYPES: ReadonlySet<string> = new Set([
+    'WHITESPACE',
+    'COMMENT_LINE',
+    'COMMENT_BLOCK',
+    'CONTINUATION',
+    'STATEMENT_TERMINATOR',
+    'DELIMIT_DIRECTIVE',
+    'EOF',
+]);
+
+/**
+ * Build the "logical statement" text before the cursor for the
+ * statement-scoped detectors (option/command/variable) — issue #310.
+ *
+ * The text detectors historically saw only the current physical line, so a
+ * statement wrapped across lines (via `#delimit ;` newlines or `///` in
+ * `#delimit cr`) lost its command and thus its option context. This flattens
+ * the wrapped statement into one line: the prior physical lines come from the
+ * token stream (trivia/comments/continuations dropped), and the current
+ * physical line is taken verbatim so the partial word being typed is preserved.
+ *
+ * When the statement begins on the cursor's own physical line the current line
+ * is sliced from the statement-start character — that both preserves today's
+ * single-line behavior (only leading indentation is trimmed, which every
+ * detector already `.trim()`s) and fixes multiple statements sharing one
+ * physical line (`display 1; reg y x,` resolves to `reg`, not `display`).
+ *
+ * `start` is `logical_statement_start(...)`; when it is `undefined` (no tokens,
+ * cursor past all tokens, walk cap hit, or a blank line after a terminator) the
+ * physical line is returned unchanged.
+ */
+function build_logical_text_before_cursor(
+    document: DocumentState,
+    position: Position,
+    tokens: Token[] | undefined,
+    start: LogicalStatementStart | undefined,
+    physical_text_before_cursor: string
+): string {
+    if (start === undefined || tokens === undefined) {
+        return physical_text_before_cursor;
+    }
+
+    const current_line = get_line_text(document, position.line);
+    const physical_current = current_line.substring(
+        start.line === position.line ? start.character : 0,
+        position.character
+    );
+
+    if (start.line === position.line) {
+        // No prior physical lines: single statement (or the last of several)
+        // beginning on this line.
+        return physical_current;
+    }
+
+    // Flatten the prior physical lines of the wrapped statement.
+    const the_parts: string[] = [];
+    for (
+        let my_i = start.index;
+        my_i < tokens.length &&
+        tokens[my_i].range.start.line < position.line;
+        my_i++
+    ) {
+        const my_token = tokens[my_i];
+        if (LOGICAL_FLATTEN_SKIP_TYPES.has(my_token.type)) {
+            continue;
+        }
+        the_parts.push(my_token.value);
+    }
+    const prior_text = the_parts.join(' ');
+    return prior_text === ''
+        ? physical_current
+        : prior_text + ' ' + physical_current;
+}
+
+/**
  * Detect the completion context at a given position in the document.
  *
  * @param document - The document state
  * @param position - The cursor position
- * @param tokens - Optional token stream for more accurate detection
+ * @param tokens - Optional token stream for more accurate detection. When
+ *   provided, statement-scoped detectors (option/command/variable) see the
+ *   whole logical statement, not just the current physical line (#310).
  * @param command_db - Optional command database for subcommand detection
  * @returns The detected completion context
  */
@@ -201,10 +288,44 @@ export function detect_completion_context(
     const current_line = get_line_text(document, position.line);
     const text_before_cursor = current_line.substring(0, position.character);
 
+    // Locate the logical statement (#310). `start` is used both to detect a
+    // continuation line and (lazily) to build the flattened logical text for
+    // the statement-scoped detectors. The flatten is deferred so the hot
+    // macro/directive paths, which return before it is needed, never pay for
+    // building the string.
+    const logical_start = logical_statement_start(tokens, position);
+    const is_continuation_line =
+        logical_start !== undefined && logical_start.line < position.line;
+    let cached_logical_text: string | undefined;
+    let has_logical_text = false;
+    const get_logical_text = (): string => {
+        if (!has_logical_text) {
+            cached_logical_text = build_logical_text_before_cursor(
+                document,
+                position,
+                tokens,
+                logical_start,
+                text_before_cursor
+            );
+            has_logical_text = true;
+        }
+        return cached_logical_text!;
+    };
+
+    // Extended-macro, command-path, and subcommand detection all presuppose the
+    // physical line begins a fresh statement (they match the first word / a
+    // `local`/`global` head / a prefix command). On a wrapped statement's
+    // continuation line that is false, so they are skipped there — otherwise a
+    // continuation line whose first word happens to be a file command (`use`,
+    // `save`, ...) or a subcommand prefix (`frame`) would shadow the option
+    // context the logical text now enables (#310).
+
     // Check for extended macro function context (`: list`, `: word`, etc.)
-    const extended_macro_context = detect_extended_macro_context(text_before_cursor, position);
-    if (extended_macro_context) {
-        return extended_macro_context;
+    if (!is_continuation_line) {
+        const extended_macro_context = detect_extended_macro_context(text_before_cursor, position);
+        if (extended_macro_context) {
+            return extended_macro_context;
+        }
     }
 
     // Check for directive path context (e.g., @lsp-done-by:). Directives are
@@ -215,9 +336,11 @@ export function detect_completion_context(
     }
 
     // Check for command path context (e.g., do file.do)
-    const command_path_context = detect_command_path_context(text_before_cursor);
-    if (command_path_context) {
-        return command_path_context;
+    if (!is_continuation_line) {
+        const command_path_context = detect_command_path_context(text_before_cursor);
+        if (command_path_context) {
+            return command_path_context;
+        }
     }
 
     // Check for macro context first (highest priority)
@@ -226,25 +349,27 @@ export function detect_completion_context(
         return macro_context;
     }
 
-    // Check for option context (after comma)
-    const option_context = detect_option_context(text_before_cursor, document, position);
+    // Check for option context (after comma) — over the logical statement.
+    const option_context = detect_option_context(get_logical_text(), document, position);
     if (option_context) {
         return option_context;
     }
 
     // Check for subcommand context (after prefix command like 'frame ')
-    const subcommand_context = detect_subcommand_context(text_before_cursor, command_db);
-    if (subcommand_context) {
-        return subcommand_context;
+    if (!is_continuation_line) {
+        const subcommand_context = detect_subcommand_context(text_before_cursor, command_db);
+        if (subcommand_context) {
+            return subcommand_context;
+        }
     }
 
-    // Check for command context (start of statement)
-    if (is_command_context(text_before_cursor)) {
+    // Check for command context (start of statement) — over the logical statement.
+    if (is_command_context(get_logical_text())) {
         return { type: 'command' };
     }
 
-    // Check for variable context (after command name)
-    if (is_variable_context(text_before_cursor)) {
+    // Check for variable context (after command name) — over the logical statement.
+    if (is_variable_context(get_logical_text())) {
         return { type: 'variable' };
     }
 
@@ -1019,8 +1144,20 @@ export class CompletionProvider {
                 return [];
             }
 
-            // Detect completion context (sync)
-            const context = detect_completion_context(document, position, undefined, this.command_db);
+            // Detect completion context (sync). Pass tokens (for logical
+            // wrapped-statement detection, #310) ONLY in STATA context: inside
+            // embedded Mata/Python the statement-scoped Stata detectors are
+            // suppressed below anyway, and skipping the token walk avoids an
+            // unbounded backward scan through a `#delimit ;` `mata`/`end` block
+            // whose embedded content carries no statement-boundary token.
+            const context = detect_completion_context(
+                document,
+                position,
+                my_current_context === LanguageContext.STATA
+                    ? document.tokens
+                    : undefined,
+                this.command_db
+            );
 
             // Fast path: embedded context with no macro - return early
             if (my_current_context !== LanguageContext.STATA && context.type !== 'macro') {
@@ -1680,10 +1817,21 @@ export class CompletionProvider {
         if (position.line >= get_line_count(document)) {
             return '';
         }
-        
+
         const current_line = get_line_text(document, position.line);
-        const text_before_cursor = current_line.substring(0, position.character);
-        
+        const physical_text_before_cursor = current_line.substring(0, position.character);
+        // Scan the logical statement, not just the physical line, so the
+        // last-comma / option-prefix search works on wrapped statements (#310).
+        // Same synthesis as detect_completion_context's option context, so the
+        // two never disagree about where the option region begins.
+        const text_before_cursor = build_logical_text_before_cursor(
+            document,
+            position,
+            document.tokens,
+            logical_statement_start(document.tokens, position),
+            physical_text_before_cursor
+        );
+
         // Find the last comma that's not inside quotes or parentheses
         let paren_depth = 0;
         let in_string = false;

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -288,18 +288,18 @@ export function detect_completion_context(
     const current_line = get_line_text(document, position.line);
     const text_before_cursor = current_line.substring(0, position.character);
 
-    // Locate the logical statement (#310). `start` is used both to detect a
-    // continuation line and (lazily) to build the flattened logical text for
-    // the statement-scoped detectors. The flatten is deferred so the hot
-    // macro/directive paths, which return before it is needed, never pay for
-    // building the string.
+    // Logical statement text before the cursor (#310). The statement-scoped
+    // detectors below run over the whole logical statement (wrapped across
+    // physical lines via `#delimit ;` newlines or `///` continuations, and
+    // correctly sliced when several statements share one physical line),
+    // rather than just the current physical line. For a genuine single-line
+    // statement the logical text equals the physical text (modulo leading
+    // indentation, which every detector already trims), so single-line
+    // behavior is unchanged. Built once, lazily.
     const logical_start = logical_statement_start(tokens, position);
-    const is_continuation_line =
-        logical_start !== undefined && logical_start.line < position.line;
     let cached_logical_text: string | undefined;
-    let has_logical_text = false;
     const get_logical_text = (): string => {
-        if (!has_logical_text) {
+        if (cached_logical_text === undefined) {
             cached_logical_text = build_logical_text_before_cursor(
                 document,
                 position,
@@ -307,43 +307,35 @@ export function detect_completion_context(
                 logical_start,
                 text_before_cursor
             );
-            has_logical_text = true;
         }
-        return cached_logical_text!;
+        return cached_logical_text;
     };
 
-    // Extended-macro, command-path, and subcommand detection all presuppose the
-    // physical line begins a fresh statement (they match the first word / a
-    // `local`/`global` head / a prefix command). On a wrapped statement's
-    // continuation line that is false, so they are skipped there — otherwise a
-    // continuation line whose first word happens to be a file command (`use`,
-    // `save`, ...) or a subcommand prefix (`frame`) would shadow the option
-    // context the logical text now enables (#310).
-
     // Check for extended macro function context (`: list`, `: word`, etc.)
-    if (!is_continuation_line) {
-        const extended_macro_context = detect_extended_macro_context(text_before_cursor, position);
-        if (extended_macro_context) {
-            return extended_macro_context;
-        }
+    const extended_macro_context = detect_extended_macro_context(get_logical_text(), position);
+    if (extended_macro_context) {
+        return extended_macro_context;
     }
 
     // Check for directive path context (e.g., @lsp-done-by:). Directives are
-    // inert inside `/* ... */` block comments, so skip block-commented lines.
+    // read from the raw physical line: they are their own comment line, never
+    // a wrapped code statement, and are inert inside `/* ... */` block
+    // comments, so skip block-commented lines.
     const directive_context = detect_directive_context(text_before_cursor);
     if (directive_context && !is_cursor_in_block_comment(document, position)) {
         return directive_context;
     }
 
-    // Check for command path context (e.g., do file.do)
-    if (!is_continuation_line) {
-        const command_path_context = detect_command_path_context(text_before_cursor);
-        if (command_path_context) {
-            return command_path_context;
-        }
+    // Check for command path context (e.g., do file.do). Over the logical
+    // statement so a wrapped/second-on-line `do`/`use`/... resolves, while a
+    // wrapped option statement (whose logical text carries the comma) bails
+    // here and falls through to option context.
+    const command_path_context = detect_command_path_context(get_logical_text());
+    if (command_path_context) {
+        return command_path_context;
     }
 
-    // Check for macro context first (highest priority)
+    // Check for macro context (cursor-local `` ` `` / `$` on the physical line).
     const macro_context = detect_macro_context(text_before_cursor, document, position);
     if (macro_context) {
         return macro_context;
@@ -355,12 +347,10 @@ export function detect_completion_context(
         return option_context;
     }
 
-    // Check for subcommand context (after prefix command like 'frame ')
-    if (!is_continuation_line) {
-        const subcommand_context = detect_subcommand_context(text_before_cursor, command_db);
-        if (subcommand_context) {
-            return subcommand_context;
-        }
+    // Check for subcommand context (after prefix command like 'frame ').
+    const subcommand_context = detect_subcommand_context(get_logical_text(), command_db);
+    if (subcommand_context) {
+        return subcommand_context;
     }
 
     // Check for command context (start of statement) — over the logical statement.

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -219,6 +219,16 @@ function stata_region_floor_line(document: DocumentState, position: Position): n
         if (my_range.context === LanguageContext.STATA) {
             continue;
         }
+        // Only true BLOCK regions (`mata`/`python` ... `end`, or `mata { }`)
+        // wall off the lines above the cursor. An inline `mata:`/`python:`
+        // statement (start delimiter ending in `:`) shares its physical line
+        // with any trailing Stata after its `;`/newline terminator and never
+        // traps the backward walk (that terminator is itself a boundary), so
+        // it must not raise the floor — otherwise a wrapped statement after an
+        // inline `mata:` on the same line would be clamped away (#310).
+        if (my_range.start_delimiter?.command?.endsWith(':')) {
+            continue;
+        }
         if (my_range.range.end.line < position.line) {
             floor_line = Math.max(floor_line, my_range.range.end.line + 1);
         }

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -201,7 +201,8 @@ const LOGICAL_FLATTEN_SKIP_TYPES: ReadonlySet<string> = new Set([
 
 /**
  * Build the "logical statement" text before the cursor for the
- * statement-scoped detectors (option/command/variable) — issue #310.
+ * statement-scoped detectors (command-path, subcommand, option, command,
+ * variable) — issue #310.
  *
  * The text detectors historically saw only the current physical line, so a
  * statement wrapped across lines (via `#delimit ;` newlines or `///` in
@@ -295,8 +296,9 @@ export function detect_completion_context(
     // rather than just the current physical line. For a genuine single-line
     // statement the logical text equals the physical text (modulo leading
     // indentation, which every detector already trims), so single-line
-    // behavior is unchanged. Built once, lazily.
-    const logical_start = logical_statement_start(tokens, position);
+    // behavior is unchanged. Built once, lazily — including the backward token
+    // walk — so the extended-macro and directive checks below (which run
+    // first and use only the physical line) never pay for it.
     let cached_logical_text: string | undefined;
     const get_logical_text = (): string => {
         if (cached_logical_text === undefined) {
@@ -304,7 +306,7 @@ export function detect_completion_context(
                 document,
                 position,
                 tokens,
-                logical_start,
+                logical_statement_start(tokens, position),
                 text_before_cursor
             );
         }
@@ -556,9 +558,17 @@ function extract_command_name(text: string): string | null {
     }
     
     const the_words = working_text.split(/\s+/).filter(w => w.length > 0);
-    
+
     // Skip prefix commands to find the main command
     for (const my_word of the_words) {
+        // A lone `:` appears only when the logical-statement flattening (#310)
+        // joins a prefix command and its colon with a space
+        // (`capture : reg` from a wrapped `capture: reg`). It never begins a
+        // command, so skip it — otherwise it would be returned as the command
+        // name and no options would resolve.
+        if (my_word === ':') {
+            continue;
+        }
         const lower_word = my_word.toLowerCase();
         if (!PREFIX_COMMANDS.includes(lower_word)) {
             return my_word;

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -357,10 +357,15 @@ export function create_completion_handler(
             // Macro contexts need isIncomplete=true because the replacement range
             // changes dynamically as the user types macro delimiters.
             // Non-macro contexts return isIncomplete=false so the client can cache results.
+            // Tokens are intentionally omitted: this call only reads whether the
+            // context is macro, which is decided from the physical line before
+            // the logical-statement token walk is ever consulted (#310). Passing
+            // tokens here would make every keystroke redo the backward walk —
+            // including an unbounded scan through a `#delimit ;` `mata`/`end`
+            // block — purely to compute a flag the walk cannot change.
             const completion_context = detect_completion_context(
                 document_state,
-                params.position,
-                document_state.tokens
+                params.position
             );
             const is_macro_context = completion_context.type === 'macro';
 

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -358,15 +358,18 @@ export function create_completion_handler(
             // Macro contexts need isIncomplete=true because the replacement range
             // changes dynamically as the user types macro delimiters.
             // Non-macro contexts return isIncomplete=false so the client can cache results.
-            // Mirror get_completions' token gating EXACTLY so this probe's
-            // context matches the one the real completion path used (#310).
-            // The logical-statement walk affects non-macro detectors too, and
+            // Mirror get_completions' token gating so this probe's context
+            // matches the one the real completion path used (#310). The
+            // logical-statement walk affects non-macro detectors too, and
             // command_path detection (over the logical text) precedes macro
             // detection — so a token-vs-no-token difference there can change
             // whether macro detection is even reached, flipping isIncomplete.
-            // Passing the same tokens (only in STATA context, as
-            // get_completions does) keeps the two calls consistent. The walk is
-            // bounded by MAX_STATEMENT_TOKENS and skipped in embedded context.
+            // Gating tokens on STATA context (as get_completions does) keeps the
+            // two consistent. We read the per-document context tracker here;
+            // that matches get_completions for the common single-document case
+            // (get_completions caches the first document's tracker, a
+            // pre-existing quirk unrelated to #310). The walk is bounded by
+            // MAX_STATEMENT_TOKENS and skipped in embedded context.
             const probe_context = document_state.context_tracker
                 ? document_state.context_tracker.get_context_at_position(
                       params.position

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -358,11 +358,15 @@ export function create_completion_handler(
             // changes dynamically as the user types macro delimiters.
             // Non-macro contexts return isIncomplete=false so the client can cache results.
             // Tokens are intentionally omitted: this call only reads whether the
-            // context is macro, which is decided from the physical line before
-            // the logical-statement token walk is ever consulted (#310). Passing
-            // tokens here would make every keystroke redo the backward walk —
-            // including an unbounded scan through a `#delimit ;` `mata`/`end`
-            // block — purely to compute a flag the walk cannot change.
+            // context is macro, and BOTH macro-returning detectors
+            // (detect_macro_context and detect_extended_macro_context) run on
+            // the physical line — the logical-statement token walk (#310) only
+            // affects the non-macro option/command/variable/command_path/
+            // subcommand contexts. So the macro flag is identical with or
+            // without tokens, and omitting them keeps every keystroke from
+            // redoing the backward walk (including through a `#delimit ;`
+            // `mata`/`end` block) purely to compute a flag the walk cannot
+            // change.
             const completion_context = detect_completion_context(
                 document_state,
                 params.position

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -42,6 +42,7 @@ import { CodeFormatter } from './providers/formatter';
 import { WorkspaceIndexer } from './indexer';
 import { StataLSPConfig } from './types';
 import { ContextTracker } from './context-tracker';
+import { LanguageContext } from './context-tracker/types';
 import { ScopeResolver, scope_resolver_config_for } from './scope-resolver';
 import { ForwardScopeResolver } from './forward-scope-resolver';
 import { DependencyGraph } from './dependency-graph';
@@ -357,19 +358,26 @@ export function create_completion_handler(
             // Macro contexts need isIncomplete=true because the replacement range
             // changes dynamically as the user types macro delimiters.
             // Non-macro contexts return isIncomplete=false so the client can cache results.
-            // Tokens are intentionally omitted: this call only reads whether the
-            // context is macro, and BOTH macro-returning detectors
-            // (detect_macro_context and detect_extended_macro_context) run on
-            // the physical line — the logical-statement token walk (#310) only
-            // affects the non-macro option/command/variable/command_path/
-            // subcommand contexts. So the macro flag is identical with or
-            // without tokens, and omitting them keeps every keystroke from
-            // redoing the backward walk (including through a `#delimit ;`
-            // `mata`/`end` block) purely to compute a flag the walk cannot
-            // change.
+            // Mirror get_completions' token gating EXACTLY so this probe's
+            // context matches the one the real completion path used (#310).
+            // The logical-statement walk affects non-macro detectors too, and
+            // command_path detection (over the logical text) precedes macro
+            // detection — so a token-vs-no-token difference there can change
+            // whether macro detection is even reached, flipping isIncomplete.
+            // Passing the same tokens (only in STATA context, as
+            // get_completions does) keeps the two calls consistent. The walk is
+            // bounded by MAX_STATEMENT_TOKENS and skipped in embedded context.
+            const probe_context = document_state.context_tracker
+                ? document_state.context_tracker.get_context_at_position(
+                      params.position
+                  )
+                : LanguageContext.STATA;
             const completion_context = detect_completion_context(
                 document_state,
-                params.position
+                params.position,
+                probe_context === LanguageContext.STATA
+                    ? document_state.tokens
+                    : undefined
             );
             const is_macro_context = completion_context.type === 'macro';
 

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -296,6 +296,14 @@ export interface LogicalStatementStart {
  * and returns the first non-trivia token after that boundary (or the
  * first token of the file). The scan is bounded by MAX_STATEMENT_TOKENS.
  *
+ * `min_line` clamps the walk: it never inspects a token that starts on a
+ * line before `min_line`. Callers pass the first line of the cursor's
+ * contiguous Stata region (the line after the nearest `mata`/`python`
+ * block that ends above the cursor) so the logical statement can never
+ * absorb embedded-language tokens from a block above — including a
+ * nested `{ }` inside a `mata { ... }` block, which no token-type
+ * boundary alone distinguishes from a real Stata block.
+ *
  * Returns `undefined` when there is no usable start — empty/undefined
  * tokens, no token at or before the cursor, the cap is hit, or the
  * boundary is immediately before the cursor with no statement token
@@ -304,7 +312,8 @@ export interface LogicalStatementStart {
  */
 export function logical_statement_start(
     tokens: Token[] | undefined,
-    position: Position
+    position: Position,
+    min_line: number = 0
 ): LogicalStatementStart | undefined {
     if (tokens === undefined || tokens.length === 0) {
         return undefined;
@@ -326,7 +335,8 @@ export function logical_statement_start(
     }
 
     // Walk backward to the token index of the nearest real boundary, or
-    // -1 for the start of the file. Bounded by MAX_STATEMENT_TOKENS.
+    // -1 for the start of the file (or the region floor `min_line`).
+    // Bounded by MAX_STATEMENT_TOKENS.
     let boundary_index = -1;
     let my_steps = 0;
     for (let my_i = search_index; my_i >= 0; my_i--) {
@@ -334,6 +344,12 @@ export function logical_statement_start(
             return undefined;
         }
         const my_token = tokens[my_i];
+        if (my_token.range.start.line < min_line) {
+            // Reached the floor of the cursor's Stata region: an embedded
+            // block sits above. Do not absorb its tokens; stop here as if at
+            // the start of input.
+            break;
+        }
         if (
             is_swallowed_continuation_terminator(
                 my_token,
@@ -381,11 +397,17 @@ export function logical_statement_start(
     }
 
     // First non-trivia token after the boundary (the statement's head).
+    // Start at the boundary, or at the region floor when the walk stopped
+    // there (boundary_index === -1), whichever is later, and never accept a
+    // token below the floor.
     let first_index = -1;
     for (let my_i = boundary_index + 1; my_i < tokens.length; my_i++) {
         const my_token = tokens[my_i];
         if (my_token.type === 'EOF') {
             break;
+        }
+        if (my_token.range.start.line < min_line) {
+            continue;
         }
         if (!STATEMENT_LEADING_TRIVIA_TYPES.has(my_token.type)) {
             first_index = my_i;

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -349,6 +349,37 @@ export function logical_statement_start(
         }
     }
 
+    // Whether the tokens after the boundary are a `mata`/`python` block BODY
+    // (embedded content), not a Stata statement: the boundary is the block
+    // opener itself, or the `{` of a `mata { ... }` / `python { ... }` block.
+    // Reached only when the cursor sits at/just before the block's closer
+    // (`end` / `}`) on a line the context tracker calls Stata — the backward
+    // walk then lands inside the block body. Treating that body as a Stata
+    // statement would offer variable/command completions built from embedded
+    // code, so fall through to the fresh-position Case B instead.
+    let boundary_opens_embedded_body = false;
+    if (boundary_index >= 0) {
+        const my_boundary_type = tokens[boundary_index].type;
+        if (
+            my_boundary_type === 'MATA_START' ||
+            my_boundary_type === 'PYTHON_START'
+        ) {
+            boundary_opens_embedded_body = true;
+        } else if (my_boundary_type === 'LBRACE') {
+            for (let my_j = boundary_index - 1; my_j >= 0; my_j--) {
+                const my_prev_type = tokens[my_j].type;
+                if (CONTINUATION_NEUTRAL_TYPES.has(my_prev_type) ||
+                    my_prev_type === 'WHITESPACE') {
+                    continue;
+                }
+                boundary_opens_embedded_body =
+                    my_prev_type === 'MATA_START' ||
+                    my_prev_type === 'PYTHON_START';
+                break;
+            }
+        }
+    }
+
     // First non-trivia token after the boundary (the statement's head).
     let first_index = -1;
     for (let my_i = boundary_index + 1; my_i < tokens.length; my_i++) {
@@ -363,7 +394,7 @@ export function logical_statement_start(
     }
 
     // Case A: the statement has a real head token at or before the cursor.
-    if (first_index !== -1) {
+    if (first_index !== -1 && !boundary_opens_embedded_body) {
         const my_start = tokens[first_index].range.start;
         const at_or_before_cursor =
             my_start.line < position.line ||

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -1,7 +1,7 @@
 import { Position } from 'vscode-languageserver';
 import { Token } from '../types';
 import { is_swallowed_continuation_terminator } from './continuation';
-import { find_last_token_starting_at_or_before } from './token-utils';
+import { find_last_token_starting_before } from './token-utils';
 
 /**
  * Inclusive physical-line span, zero-based LSP line numbers.
@@ -250,14 +250,15 @@ const STATEMENT_LEADING_TRIVIA_TYPES: ReadonlySet<string> = new Set([
 /**
  * Upper bound on how many tokens the backward walk inspects before
  * giving up and reporting "no usable start" (caller then falls back to
- * physical-line behavior). A real wrapped statement never approaches
- * this; the cap only fires on pathological or embedded input — most
- * importantly a `#delimit ;` bare `mata`/`end` block, whose embedded
+ * physical-line behavior). A real wrapped statement — even a very long
+ * wrapped varlist (~2000 variables) — stays well under this; the cap
+ * only fires on pathological input, e.g. an unterminated `#delimit ;`
+ * statement, or a `#delimit ;` bare `mata`/`end` block whose embedded
  * content carries NO boundary token (no STATEMENT_TERMINATOR, no braces,
- * no DELIMIT_DIRECTIVE), so an uncapped walk would scan the whole block
- * on every keystroke.
+ * no DELIMIT_DIRECTIVE) reached via a non-STATA-gated caller. It bounds
+ * per-keystroke cost without truncating realistic statements.
  */
-const MAX_STATEMENT_TOKENS = 512;
+const MAX_STATEMENT_TOKENS = 4096;
 
 /**
  * The first token of the logical statement that contains `position`.
@@ -301,9 +302,14 @@ export function logical_statement_start(
         return undefined;
     }
 
-    let search_index = find_last_token_starting_at_or_before(tokens, position);
-    // Never anchor on EOF (it starts at or before every cursor at the
-    // end of the file); step back to the last real token.
+    // Anchor on the last token starting STRICTLY BEFORE the cursor, not
+    // at-or-before: a boundary token whose start equals the cursor (the
+    // common "cursor at end of a line, immediately before its `;`/newline
+    // terminator" position) is the current statement's terminator, not a
+    // token the cursor is inside. Anchoring at-or-before would self-match
+    // that terminator as the boundary and wrongly report "no statement".
+    let search_index = find_last_token_starting_before(tokens, position);
+    // Defensive: never anchor on EOF.
     while (search_index >= 0 && tokens[search_index].type === 'EOF') {
         search_index--;
     }

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -231,6 +231,14 @@ const LOGICAL_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
     'LBRACE',
     'RBRACE',
     'DELIMIT_DIRECTIVE',
+    // A `mata`/`python` block opener and its `end` bound statements too:
+    // under `#delimit ;` the block body carries no STATEMENT_TERMINATOR, so
+    // without these a Stata statement right after `end` would walk back into
+    // the block and mis-read its command as `mata`/`python`.
+    'MATA_START',
+    'PYTHON_START',
+    'END_MATA',
+    'END_PYTHON',
 ]);
 
 /**
@@ -378,10 +386,18 @@ export function logical_statement_start(
     // line from just after the boundary (dropping any earlier statement that
     // shares the line) and treats it as a fresh — not continuation —
     // statement.
+    // Clamp to the cursor: when the cursor sits INSIDE a multi-character
+    // boundary token (e.g. editing within `#delimit ;` or a `mata` opener),
+    // the boundary's end is past the cursor, and an unclamped resume character
+    // would make the caller's `substring(resume, cursor)` reverse its
+    // arguments and splice in text after the cursor.
     const resume_character =
         boundary_index >= 0 &&
         tokens[boundary_index].range.end.line === position.line
-            ? tokens[boundary_index].range.end.character
+            ? Math.min(
+                  tokens[boundary_index].range.end.character,
+                  position.character
+              )
             : 0;
     return {
         index: first_index >= 0 ? first_index : boundary_index + 1,

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -259,7 +259,9 @@ const STATEMENT_LEADING_TRIVIA_TYPES: ReadonlySet<string> = new Set([
  * Upper bound on how many tokens the backward walk inspects before
  * giving up and reporting "no usable start" (caller then falls back to
  * physical-line behavior). A real wrapped statement — even a very long
- * wrapped varlist (~2000 variables) — stays well under this; the cap
+ * wrapped varlist (roughly 4000 variables, since Stata context emits no
+ * WHITESPACE tokens so each identifier costs one token) — stays under this;
+ * the cap
  * only fires on pathological input, e.g. an unterminated `#delimit ;`
  * statement, or a `#delimit ;` bare `mata`/`end` block whose embedded
  * content carries NO boundary token (no STATEMENT_TERMINATOR, no braces,

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -341,26 +341,51 @@ export function logical_statement_start(
         }
     }
 
-    // First non-trivia token after the boundary, not past the cursor.
-    for (
-        let my_i = boundary_index + 1;
-        my_i <= search_index;
-        my_i++
-    ) {
+    // First non-trivia token after the boundary (the statement's head).
+    let first_index = -1;
+    for (let my_i = boundary_index + 1; my_i < tokens.length; my_i++) {
         const my_token = tokens[my_i];
         if (my_token.type === 'EOF') {
             break;
         }
         if (!STATEMENT_LEADING_TRIVIA_TYPES.has(my_token.type)) {
+            first_index = my_i;
+            break;
+        }
+    }
+
+    // Case A: the statement has a real head token at or before the cursor.
+    if (first_index !== -1) {
+        const my_start = tokens[first_index].range.start;
+        const at_or_before_cursor =
+            my_start.line < position.line ||
+            (my_start.line === position.line &&
+                my_start.character <= position.character);
+        if (at_or_before_cursor) {
             return {
-                index: my_i,
-                line: my_token.range.start.line,
-                character: my_token.range.start.character,
+                index: first_index,
+                line: my_start.line,
+                character: my_start.character,
             };
         }
     }
 
-    // Boundary sits right before the cursor with only trivia between:
-    // no statement has started yet (blank line after a terminator).
-    return undefined;
+    // Case B: an empty statement position — the cursor sits at/just after a
+    // boundary with no statement token yet before it (right after a `;` on a
+    // shared physical line, in a new statement's leading whitespace, or on a
+    // blank line). The statement "starts" where the boundary left off. Report
+    // it on the cursor's own line so the caller slices the current physical
+    // line from just after the boundary (dropping any earlier statement that
+    // shares the line) and treats it as a fresh — not continuation —
+    // statement.
+    const resume_character =
+        boundary_index >= 0 &&
+        tokens[boundary_index].range.end.line === position.line
+            ? tokens[boundary_index].range.end.character
+            : 0;
+    return {
+        index: first_index >= 0 ? first_index : boundary_index + 1,
+        line: position.line,
+        character: resume_character,
+    };
 }

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -1,5 +1,7 @@
+import { Position } from 'vscode-languageserver';
 import { Token } from '../types';
 import { is_swallowed_continuation_terminator } from './continuation';
+import { find_last_token_starting_at_or_before } from './token-utils';
 
 /**
  * Inclusive physical-line span, zero-based LSP line numbers.
@@ -213,4 +215,146 @@ export function inline_embedded_statement_end(
             : my_last_content_index;
 
     return { end_index, end_line };
+}
+
+/**
+ * Token types after which the next significant token begins a new
+ * statement (mirrors STATEMENT_BOUNDARY_TYPES in
+ * src/providers/command-position.ts): a real statement terminator, a
+ * `{`/`}` block delimiter, or a `#delimit` mode switch. A
+ * STATEMENT_TERMINATOR is only a boundary when it is a REAL end — a
+ * `\n` swallowed by a preceding `///` continuation is trivia, not a
+ * boundary (see `is_swallowed_continuation_terminator`).
+ */
+const LOGICAL_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
+    'STATEMENT_TERMINATOR',
+    'LBRACE',
+    'RBRACE',
+    'DELIMIT_DIRECTIVE',
+]);
+
+/**
+ * Trivia skipped when locating the first real token of a statement
+ * (after a boundary). Same membership as LEADING_TRIVIA_TYPES minus the
+ * `#delimit` switch, which is itself a boundary and never leads a
+ * statement body.
+ */
+const STATEMENT_LEADING_TRIVIA_TYPES: ReadonlySet<string> = new Set([
+    'COMMENT_LINE',
+    'COMMENT_BLOCK',
+    'CONTINUATION',
+    'WHITESPACE',
+    'STATEMENT_TERMINATOR',
+]);
+
+/**
+ * Upper bound on how many tokens the backward walk inspects before
+ * giving up and reporting "no usable start" (caller then falls back to
+ * physical-line behavior). A real wrapped statement never approaches
+ * this; the cap only fires on pathological or embedded input — most
+ * importantly a `#delimit ;` bare `mata`/`end` block, whose embedded
+ * content carries NO boundary token (no STATEMENT_TERMINATOR, no braces,
+ * no DELIMIT_DIRECTIVE), so an uncapped walk would scan the whole block
+ * on every keystroke.
+ */
+const MAX_STATEMENT_TOKENS = 512;
+
+/**
+ * The first token of the logical statement that contains `position`.
+ */
+export interface LogicalStatementStart {
+    /** Index into `tokens` of the statement's first significant token. */
+    index: number;
+    /** Zero-based line of that token's start. */
+    line: number;
+    /** Zero-based character of that token's start. */
+    character: number;
+}
+
+/**
+ * Locate the first token of the logical statement containing the cursor
+ * `position`, walking backward over the token stream (issue #310).
+ *
+ * A logical statement can span several physical lines: `#delimit ;`
+ * makes newlines insignificant, and `///` continues a line under
+ * `#delimit cr`. Physical-line-only heuristics therefore lose the
+ * command on wrapped statements; this walk recovers it from the tokens.
+ *
+ * The cursor token is found in O(log n) via
+ * `find_last_token_starting_at_or_before` (shared with hover). The walk
+ * then scans backward to the nearest real boundary
+ * (LOGICAL_BOUNDARY_TYPES), skipping `///`-swallowed `\n` terminators,
+ * and returns the first non-trivia token after that boundary (or the
+ * first token of the file). The scan is bounded by MAX_STATEMENT_TOKENS.
+ *
+ * Returns `undefined` when there is no usable start — empty/undefined
+ * tokens, no token at or before the cursor, the cap is hit, or the
+ * boundary is immediately before the cursor with no statement token
+ * between them (e.g. a fresh blank line right after a terminator). The
+ * caller falls back to physical-line behavior in every such case.
+ */
+export function logical_statement_start(
+    tokens: Token[] | undefined,
+    position: Position
+): LogicalStatementStart | undefined {
+    if (tokens === undefined || tokens.length === 0) {
+        return undefined;
+    }
+
+    let search_index = find_last_token_starting_at_or_before(tokens, position);
+    // Never anchor on EOF (it starts at or before every cursor at the
+    // end of the file); step back to the last real token.
+    while (search_index >= 0 && tokens[search_index].type === 'EOF') {
+        search_index--;
+    }
+    if (search_index < 0) {
+        return undefined;
+    }
+
+    // Walk backward to the token index of the nearest real boundary, or
+    // -1 for the start of the file. Bounded by MAX_STATEMENT_TOKENS.
+    let boundary_index = -1;
+    let my_steps = 0;
+    for (let my_i = search_index; my_i >= 0; my_i--) {
+        if (++my_steps > MAX_STATEMENT_TOKENS) {
+            return undefined;
+        }
+        const my_token = tokens[my_i];
+        if (
+            is_swallowed_continuation_terminator(
+                my_token,
+                my_i > 0 && tokens[my_i - 1].type === 'CONTINUATION'
+            )
+        ) {
+            // Swallowed `///` newline: trivia, keep walking.
+            continue;
+        }
+        if (LOGICAL_BOUNDARY_TYPES.has(my_token.type)) {
+            boundary_index = my_i;
+            break;
+        }
+    }
+
+    // First non-trivia token after the boundary, not past the cursor.
+    for (
+        let my_i = boundary_index + 1;
+        my_i <= search_index;
+        my_i++
+    ) {
+        const my_token = tokens[my_i];
+        if (my_token.type === 'EOF') {
+            break;
+        }
+        if (!STATEMENT_LEADING_TRIVIA_TYPES.has(my_token.type)) {
+            return {
+                index: my_i,
+                line: my_token.range.start.line,
+                character: my_token.range.start.character,
+            };
+        }
+    }
+
+    // Boundary sits right before the cursor with only trivia between:
+    // no statement has started yet (blank line after a terminator).
+    return undefined;
 }

--- a/tests/property/wrapped-option-context.prop.test.ts
+++ b/tests/property/wrapped-option-context.prop.test.ts
@@ -37,15 +37,22 @@ describe('wrapped option context is stable (property, #310)', () => {
                         character: single.length,
                     });
 
-                    // (b) ;-mode wrap: comma ends line 1, option on line 2.
-                    const semi = `#delimit ;\n${command} ${variable},\n    ${option_fragment}`;
+                    // (b) ;-mode wrap, with a following statement so the cursor
+                    // sits before a REAL terminator (not EOF) — this also guards
+                    // the "cursor immediately before the statement terminator"
+                    // anchor case.
+                    const semi =
+                        `#delimit ;\n${command} ${variable},\n` +
+                        `    ${option_fragment} ;\ndisplay 1 ;`;
                     const semi_ctx = option_context(semi, {
                         line: 2,
                         character: 4 + option_fragment.length,
                     });
 
-                    // (c) cr-mode /// wrap.
-                    const cr = `${command} ${variable}, ///\n    ${option_fragment}`;
+                    // (c) cr-mode /// wrap, again with a following statement.
+                    const cr =
+                        `${command} ${variable}, ///\n` +
+                        `    ${option_fragment}\ndisplay 1`;
                     const cr_ctx = option_context(cr, {
                         line: 1,
                         character: 4 + option_fragment.length,

--- a/tests/property/wrapped-option-context.prop.test.ts
+++ b/tests/property/wrapped-option-context.prop.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Property test: option context is stable across statement wrapping (#310).
+ *
+ * A command with a trailing comma (`<cmd> <var>, <opt>`) is in OPTION context
+ * regardless of how the statement is wrapped across physical lines. Rendering
+ * the same statement (a) on a single line, (b) `#delimit ;`-wrapped at the
+ * comma, and (c) `#delimit cr` `///`-wrapped at the comma must all detect
+ * option context for the same command. This is the executable oracle for the
+ * logical-statement-prefix fix: any wrapping that still lost the command would
+ * produce a counter-example.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import * as fc from 'fast-check';
+import { Position } from 'vscode-languageserver';
+import { detect_completion_context } from '../../src/providers/completion';
+import { create_real_document_state } from '../test-context-helper';
+import { arbitrary_non_reserved_identifier } from './generators';
+
+function option_context(source: string, position: Position) {
+    const doc = create_real_document_state(source);
+    return detect_completion_context(doc, position, doc.tokens);
+}
+
+describe('wrapped option context is stable (property, #310)', () => {
+    it('detects option context for the same command in single-line, ;-wrap, and ///-wrap renderings', () => {
+        fc.assert(
+            fc.property(
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                fc.constantFrom('', 'x', 'no', 'vc'),
+                (command, variable, option_fragment) => {
+                    // (a) single line: `cmd var, frag|`
+                    const single = `${command} ${variable}, ${option_fragment}`;
+                    const single_ctx = option_context(single, {
+                        line: 0,
+                        character: single.length,
+                    });
+
+                    // (b) ;-mode wrap: comma ends line 1, option on line 2.
+                    const semi = `#delimit ;\n${command} ${variable},\n    ${option_fragment}`;
+                    const semi_ctx = option_context(semi, {
+                        line: 2,
+                        character: 4 + option_fragment.length,
+                    });
+
+                    // (c) cr-mode /// wrap.
+                    const cr = `${command} ${variable}, ///\n    ${option_fragment}`;
+                    const cr_ctx = option_context(cr, {
+                        line: 1,
+                        character: 4 + option_fragment.length,
+                    });
+
+                    expect(single_ctx.type).toBe('option');
+                    expect(semi_ctx.type).toBe('option');
+                    expect(cr_ctx.type).toBe('option');
+                    if (
+                        single_ctx.type === 'option' &&
+                        semi_ctx.type === 'option' &&
+                        cr_ctx.type === 'option'
+                    ) {
+                        expect(semi_ctx.command).toBe(single_ctx.command);
+                        expect(cr_ctx.command).toBe(single_ctx.command);
+                        expect(single_ctx.command).toBe(command);
+                    }
+                }
+            ),
+            { numRuns: 200 }
+        );
+    });
+});

--- a/tests/unit/completion-wrapped-context.test.ts
+++ b/tests/unit/completion-wrapped-context.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Wrapped-statement completion context (issue #310).
+ *
+ * `detect_completion_context` historically saw only the current physical
+ * line, so a statement wrapped across lines (via `#delimit ;` newlines or
+ * `///` continuations in `#delimit cr`) lost its command and thus its option
+ * context. These tests pin the logical-statement behavior in both delimiter
+ * modes, the multi-statement-per-line fix, the continuation-line detector
+ * guard, the #309 embedded-suppression interaction, and the single-line /
+ * tokenless regressions.
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { Position } from 'vscode-languageserver';
+import {
+    CompletionProvider,
+    detect_completion_context,
+} from '../../src/providers/completion';
+import { CommandDatabase } from '../../src/commands';
+import { StataLexer } from '../../src/lexer';
+import { logical_statement_start } from '../../src/utils/statement-span';
+import { create_real_document_state } from '../test-context-helper';
+
+function tokens_of(source: string) {
+    return new StataLexer().tokenize(source).tokens;
+}
+
+function context_of(source: string, position: Position, db?: CommandDatabase) {
+    const doc = create_real_document_state(source);
+    return detect_completion_context(doc, position, doc.tokens, db);
+}
+
+function create_test_command_db(): CommandDatabase {
+    const db = new CommandDatabase();
+    db.register({
+        name: 'regress',
+        minAbbreviation: 'reg',
+        syntax: 'regress depvar [indepvars]',
+        description: 'Linear regression',
+        options: [
+            { name: 'noconstant', minAbbreviation: 'nocons', description: 'No constant', hasArgument: false },
+            { name: 'vce', minAbbreviation: 'vce', description: 'Variance estimator', hasArgument: true },
+        ],
+        category: 'regression',
+        isBuiltin: true,
+    });
+    db.register({
+        name: 'summarize',
+        minAbbreviation: 'su',
+        syntax: 'summarize [varlist]',
+        description: 'Summary statistics',
+        options: [
+            { name: 'detail', minAbbreviation: 'd', description: 'Detailed output', hasArgument: false },
+        ],
+        category: 'statistics',
+        isBuiltin: true,
+    });
+    return db;
+}
+
+describe('logical_statement_start (issue #310)', () => {
+    it('finds the command start across a semicolon-mode newline wrap', () => {
+        const source = '#delimit ;\nreg y x,\n    vce(';
+        const start = logical_statement_start(tokens_of(source), { line: 2, character: 8 });
+        expect(start).toBeDefined();
+        expect(start!.line).toBe(1);
+        expect(start!.character).toBe(0);
+    });
+
+    it('finds the command start across a /// continuation in cr mode', () => {
+        const source = 'reg y x, ///\n    vce(';
+        const start = logical_statement_start(tokens_of(source), { line: 1, character: 8 });
+        expect(start).toBeDefined();
+        expect(start!.line).toBe(0);
+    });
+
+    it('returns the second statement for two statements on one line', () => {
+        const source = '#delimit ;\ngen a = 1 ; gen b = 2 ,';
+        const start = logical_statement_start(tokens_of(source), { line: 1, character: 22 });
+        expect(start).toBeDefined();
+        expect(start!.line).toBe(1);
+        // The second `gen`, not the first.
+        expect(start!.character).toBeGreaterThan(0);
+    });
+
+    it('returns undefined on a blank line after a terminator', () => {
+        const source = 'reg y x\n';
+        const start = logical_statement_start(tokens_of(source), { line: 1, character: 0 });
+        expect(start).toBeUndefined();
+    });
+
+    it('returns undefined for undefined/empty tokens', () => {
+        expect(logical_statement_start(undefined, { line: 0, character: 0 })).toBeUndefined();
+        expect(logical_statement_start([], { line: 0, character: 0 })).toBeUndefined();
+    });
+});
+
+describe('detect_completion_context — wrapped statements (issue #310)', () => {
+    it('detects option context for a semicolon-mode wrapped statement (repro)', () => {
+        const source = '#delimit ;\nreg y x,\n    vce(';
+        const context = context_of(source, { line: 2, character: 8 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('reg');
+        }
+    });
+
+    it('detects option context for a /// wrapped statement in cr mode (repro)', () => {
+        const source = 'reg y x, ///\n    vce(';
+        const context = context_of(source, { line: 1, character: 8 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('reg');
+        }
+    });
+
+    it('detects option context when typing an option name on a wrapped line', () => {
+        const source = 'reg y x, ///\n    nocon';
+        const context = context_of(source, { line: 1, character: 9 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('reg');
+        }
+    });
+
+    it('detects option context with the comma at the end of the first line', () => {
+        const source = '#delimit ;\nregress y x,\n    ';
+        const context = context_of(source, { line: 2, character: 4 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('regress');
+        }
+    });
+});
+
+describe('detect_completion_context — multiple statements on one line (#310)', () => {
+    it('attributes option context to the second statement, not the first', () => {
+        // `display 1; reg y x, |` on one physical line under #delimit ;
+        const source = '#delimit ;\ndisplay 1; reg y x, ';
+        const context = context_of(source, { line: 1, character: 20 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('reg');
+        }
+    });
+});
+
+describe('detect_completion_context — continuation-line guard (#310)', () => {
+    it('does not return command_path for a continuation line starting with a file command', () => {
+        // `merge` wrapped; continuation line begins with `keepusing(` — but a
+        // continuation line that started with a file-command word must not
+        // shadow option context. Use `using` which is a file-ish word.
+        const source = '#delimit ;\nmerge 1:1 id using "f.dta",\n    keepusing(';
+        const context = context_of(source, { line: 2, character: 14 });
+        expect(context.type).toBe('option');
+    });
+
+    it('still returns command_path for a genuine single-line file command', () => {
+        const source = 'do myfile.do';
+        const context = context_of(source, { line: 0, character: 4 });
+        expect(context.type).toBe('command_path');
+    });
+
+    it('still returns subcommand for a genuine single-line prefix command', () => {
+        const db = create_test_command_db();
+        // `frame ` needs subcommands in the db; use the real command db shape.
+        const real_db = new CommandDatabase();
+        real_db.register({
+            name: 'frame',
+            minAbbreviation: 'frame',
+            syntax: 'frame ...',
+            description: 'frames',
+            options: [],
+            category: 'data',
+            isBuiltin: true,
+            subcommands: [{ name: 'create', minAbbreviation: 'cr' }],
+        });
+        const context = context_of('frame ', { line: 0, character: 6 }, real_db);
+        expect(context.type).toBe('subcommand');
+        void db;
+    });
+});
+
+describe('detect_completion_context — single-line regressions (#310)', () => {
+    it('detects option context on a single physical line (unchanged)', () => {
+        const source = 'reg y x, vce(';
+        const context = context_of(source, { line: 0, character: 13 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('reg');
+        }
+    });
+
+    it('detects command context while typing the first word (unchanged)', () => {
+        const context = context_of('reg', { line: 0, character: 3 });
+        expect(context.type).toBe('command');
+    });
+
+    it('detects variable context in the varlist (unchanged)', () => {
+        const context = context_of('regress y ', { line: 0, character: 10 });
+        expect(context.type).toBe('variable');
+    });
+
+    it('behaves identically with and without tokens on a single line', () => {
+        const source = 'regress y x, nocon';
+        const doc = create_real_document_state(source);
+        const with_tokens = detect_completion_context(doc, { line: 0, character: 18 }, doc.tokens);
+        const without_tokens = detect_completion_context(doc, { line: 0, character: 18 }, undefined);
+        expect(with_tokens).toEqual(without_tokens);
+    });
+
+    it('does not detect option context for a comma inside parentheses (unchanged)', () => {
+        const context = context_of('gen x = func(a, b)', { line: 0, character: 16 });
+        expect(context.type).not.toBe('option');
+    });
+});
+
+describe('get_completions — wrapped option completions (#310)', () => {
+    let provider: CompletionProvider;
+    beforeEach(() => {
+        provider = new CompletionProvider(create_test_command_db(), { snippet_support: true });
+    });
+
+    it('offers option completions on a semicolon-mode wrapped line', async () => {
+        const source = '#delimit ;\nregress y x,\n    ';
+        const doc = create_real_document_state(source);
+        const completions = await provider.get_completions(doc, { line: 2, character: 4 });
+        const labels = completions.map(c => c.label);
+        expect(labels).toContain('vce');
+        expect(labels).toContain('noconstant');
+    });
+
+    it('filters wrapped option completions by the typed prefix', async () => {
+        const source = 'regress y x, ///\n    noc';
+        const doc = create_real_document_state(source);
+        const completions = await provider.get_completions(doc, { line: 1, character: 7 });
+        const labels = completions.map(c => c.label);
+        expect(labels).toContain('noconstant');
+        expect(labels).not.toContain('vce');
+    });
+});
+
+describe('get_completions — #309 interaction: embedded continuation under #delimit ; (#310)', () => {
+    it('offers no Stata command/option completions on a continued inline mata line', async () => {
+        const provider = new CompletionProvider(create_test_command_db(), { snippet_support: true });
+        // Inline `mata:` legally continues onto the next physical line under
+        // `#delimit ;` and ends at the `;`. The continuation line is Mata, so
+        // no Stata command/option completions must appear there.
+        const source = '#delimit ;\nmata: x = 1,\n    2 ;';
+        const doc = create_real_document_state(source);
+        const completions = await provider.get_completions(doc, { line: 2, character: 5 });
+        const labels = completions.map(c => c.label);
+        // No Stata command completions (regress) and no option items leaked.
+        expect(labels).not.toContain('regress');
+        expect(labels).not.toContain('vce');
+        expect(labels).not.toContain('noconstant');
+    });
+});

--- a/tests/unit/completion-wrapped-context.test.ts
+++ b/tests/unit/completion-wrapped-context.test.ts
@@ -193,6 +193,26 @@ describe('detect_completion_context — mata/python block boundaries (#310)', ()
         expect(context.type).toBe('command');
     });
 
+    it('resolves trailing Stata after an inline mata: on the same physical line (wrapped)', () => {
+        // An inline `mata:` statement shares its line with the trailing
+        // `regress y x,`; the region floor must not clamp that away.
+        const source = '#delimit ;\nmata: x = 1 ; regress y x,\n    vce(';
+        const context = context_of(source, { line: 2, character: 8 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('regress');
+        }
+    });
+
+    it('resolves trailing Stata after an inline python: on the same physical line (wrapped)', () => {
+        const source = '#delimit ;\npython: x = 1 ; regress y x,\n    vce(';
+        const context = context_of(source, { line: 2, character: 8 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('regress');
+        }
+    });
+
     it('gives command context at the closer of a mata brace block containing nested braces', () => {
         // The nested inner `}` must not stop the walk inside the embedded body:
         // the walk is clamped to the cursor's Stata region, above which the

--- a/tests/unit/completion-wrapped-context.test.ts
+++ b/tests/unit/completion-wrapped-context.test.ts
@@ -193,6 +193,16 @@ describe('detect_completion_context — mata/python block boundaries (#310)', ()
         expect(context.type).toBe('command');
     });
 
+    it('gives command context at the closer of a mata brace block containing nested braces', () => {
+        // The nested inner `}` must not stop the walk inside the embedded body:
+        // the walk is clamped to the cursor's Stata region, above which the
+        // whole `mata { ... }` block lives.
+        const source =
+            '#delimit ;\nmata {\n  for (i=1;i<=10;i++) {\n    x = x + i\n  }\n  y = 5\n}';
+        const context = context_of(source, { line: 6, character: 0 });
+        expect(context.type).toBe('command');
+    });
+
     it('still gives option context inside a regular Stata brace block wrapped statement', () => {
         // A non-embedded `{ }` block body is real Stata; option context for the
         // inner command must be preserved.

--- a/tests/unit/completion-wrapped-context.test.ts
+++ b/tests/unit/completion-wrapped-context.test.ts
@@ -133,6 +133,41 @@ describe('detect_completion_context — wrapped statements (issue #310)', () => 
     });
 });
 
+describe('detect_completion_context — cursor before a mid-document terminator (#310)', () => {
+    it('detects option context with the cursor immediately before a following ; (semicolon mode)', () => {
+        // Content continues after the statement, so the token right after the
+        // cursor is a real STATEMENT_TERMINATOR, not EOF. The statement-start
+        // walk must not self-match that terminator as its own boundary.
+        const source = '#delimit ;\nregress y x ,\nrobust;\ndisplay 1 ;';
+        const context = context_of(source, { line: 2, character: 6 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('regress');
+        }
+    });
+
+    it('detects option context with the cursor before a following newline terminator (/// wrap)', () => {
+        const source = 'regress y x, ///\n    nocon\ndisplay 1';
+        const context = context_of(source, { line: 1, character: 9 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('regress');
+        }
+    });
+});
+
+describe('detect_completion_context — long wrapped varlist (#310)', () => {
+    it('still detects option context for a wrapped statement with hundreds of tokens', () => {
+        const the_vars = Array.from({ length: 800 }, (_, i) => `x${i}`).join(' ');
+        const source = `#delimit ;\nregress y ${the_vars},\n    `;
+        const context = context_of(source, { line: 2, character: 4 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('regress');
+        }
+    });
+});
+
 describe('detect_completion_context — multiple statements on one line (#310)', () => {
     it('attributes option context to the second statement, not the first', () => {
         // `display 1; reg y x, |` on one physical line under #delimit ;

--- a/tests/unit/completion-wrapped-context.test.ts
+++ b/tests/unit/completion-wrapped-context.test.ts
@@ -20,6 +20,9 @@ import { CommandDatabase } from '../../src/commands';
 import { StataLexer } from '../../src/lexer';
 import { logical_statement_start } from '../../src/utils/statement-span';
 import { create_real_document_state } from '../test-context-helper';
+import { DocumentStore } from '../../src/document-store';
+import { create_completion_handler } from '../../src/server-handlers';
+import type { HandlerDependencies } from '../../src/server-handlers';
 
 function tokens_of(source: string) {
     return new StataLexer().tokenize(source).tokens;
@@ -172,6 +175,29 @@ describe('detect_completion_context — mata/python block boundaries (#310)', ()
     it('does not walk into a preceding bare python/end block under #delimit ;', () => {
         const source = '#delimit ;\npython\nx=1\nend\nreg y x,\n robust';
         const context = context_of(source, { line: 5, character: 7 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('reg');
+        }
+    });
+
+    it('gives command context at column 0 of a bare mata block closer (end)', () => {
+        const source = 'generate foo = 1;\n#delimit ;\nmata\nx=1\nend';
+        const context = context_of(source, { line: 4, character: 0 });
+        expect(context.type).toBe('command');
+    });
+
+    it('gives command context at column 0 of a mata brace-block closer (})', () => {
+        const source = '#delimit ;\nmata {\n x=1\n}';
+        const context = context_of(source, { line: 3, character: 0 });
+        expect(context.type).toBe('command');
+    });
+
+    it('still gives option context inside a regular Stata brace block wrapped statement', () => {
+        // A non-embedded `{ }` block body is real Stata; option context for the
+        // inner command must be preserved.
+        const source = '#delimit ;\nforeach v of varlist a b {\n    reg y `v\',\n        vce(';
+        const context = context_of(source, { line: 3, character: 12 });
         expect(context.type).toBe('option');
         if (context.type === 'option') {
             expect(context.command).toBe('reg');
@@ -354,6 +380,63 @@ describe('get_completions — wrapped option completions (#310)', () => {
         const labels = completions.map(c => c.label);
         expect(labels).toContain('noconstant');
         expect(labels).not.toContain('vce');
+    });
+});
+
+describe('detect_completion_context — colon-suffixed prefix wrapped (#310)', () => {
+    it('resolves the command past a wrapped capture: prefix', () => {
+        const source = '#delimit ;\ncapture: regress y x,\n    vce(';
+        const context = context_of(source, { line: 2, character: 8 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('regress');
+        }
+    });
+});
+
+describe('create_completion_handler — isIncomplete matches the real context on wrapped statements (#310)', () => {
+    async function is_incomplete_for(source: string, position: Position): Promise<boolean> {
+        const uri = 'file:///wrapped-isincomplete.do';
+        const document_store = new DocumentStore();
+        try {
+            await document_store.open(uri, source, 1);
+            const deps: HandlerDependencies = {
+                debounce_manager: null,
+                document_store,
+                diagnostics_provider: null,
+                completion_provider: { get_completions: async () => [] },
+                hover_provider: null,
+                definition_provider: null,
+                references_provider: null,
+                symbol_provider: null,
+                formatter_provider: null,
+                workspace_indexer: null,
+                scope_resolver: null,
+                forward_scope_resolver: null,
+                dependency_graph: null,
+                rename_handler: null,
+                get_document_settings: async () => ({}) as any,
+                connection: { sendDiagnostics: () => {}, console: { log: () => {} } },
+            } as any;
+            const handler = create_completion_handler(deps);
+            const result = await handler(
+                { textDocument: { uri }, position },
+                undefined
+            );
+            return result.isIncomplete;
+        } finally {
+            await document_store.dispose();
+        }
+    }
+
+    it('reports isIncomplete=true for a macro context on a /// continuation line, where the tokenless physical line alone would look like a file command', async () => {
+        // `foo ///` then `  use ` + a local-macro backtick. The real completion
+        // path (tokens) sees a macro context (dynamic range -> isIncomplete);
+        // the current physical line alone (`  use ` + backtick) would look like
+        // a `use` file command. The probe must gate tokens by context exactly
+        // like the real path so the two agree.
+        const source = 'foo ///\n  use `';
+        expect(await is_incomplete_for(source, Position.create(1, 7))).toBe(true);
     });
 });
 

--- a/tests/unit/completion-wrapped-context.test.ts
+++ b/tests/unit/completion-wrapped-context.test.ts
@@ -83,10 +83,13 @@ describe('logical_statement_start (issue #310)', () => {
         expect(start!.character).toBeGreaterThan(0);
     });
 
-    it('returns undefined on a blank line after a terminator', () => {
+    it('reports a fresh statement position on a blank line after a terminator', () => {
+        // No statement token yet: the start is on the cursor's own line so the
+        // caller treats it as a fresh (command) position, not a continuation.
         const source = 'reg y x\n';
         const start = logical_statement_start(tokens_of(source), { line: 1, character: 0 });
-        expect(start).toBeUndefined();
+        expect(start).toBeDefined();
+        expect(start!.line).toBe(1);
     });
 
     it('returns undefined for undefined/empty tokens', () => {
@@ -178,29 +181,45 @@ describe('detect_completion_context — multiple statements on one line (#310)',
             expect(context.command).toBe('reg');
         }
     });
+
+    it('gives command context at the start of a new statement after a ; on the same line', () => {
+        // Cursor at the first character of `reg`, right after `display 1; `.
+        const source = '#delimit ;\ndisplay 1; reg y x,';
+        const context = context_of(source, { line: 1, character: 11 });
+        expect(context.type).toBe('command');
+    });
+
+    it('gives command context immediately after a ; with nothing typed yet', () => {
+        const source = '#delimit ;\ndisplay 1; ';
+        const context = context_of(source, { line: 1, character: 11 });
+        expect(context.type).toBe('command');
+    });
+
+    it('gives command context while typing the second statement command word', () => {
+        const source = '#delimit ;\ndisplay 1; re';
+        const context = context_of(source, { line: 1, character: 13 });
+        expect(context.type).toBe('command');
+    });
+
+    it('does not offer the prior command\'s options for an empty statement after its ;', () => {
+        // Cursor right after `regress y x, robust; ` — a brand-new empty
+        // statement, not more options for regress.
+        const source = '#delimit ;\nregress y x, robust; ';
+        const context = context_of(source, { line: 1, character: 22 });
+        expect(context.type).toBe('command');
+    });
+
+    it('gives command context right after a { block opener on the same line', () => {
+        const source = 'foreach v of varlist a b { \n}\n';
+        const context = context_of(source, { line: 0, character: 27 });
+        expect(context.type).toBe('command');
+    });
 });
 
-describe('detect_completion_context — continuation-line guard (#310)', () => {
-    it('does not return command_path for a continuation line starting with a file command', () => {
-        // `merge` wrapped; continuation line begins with `keepusing(` — but a
-        // continuation line that started with a file-command word must not
-        // shadow option context. Use `using` which is a file-ish word.
-        const source = '#delimit ;\nmerge 1:1 id using "f.dta",\n    keepusing(';
-        const context = context_of(source, { line: 2, character: 14 });
-        expect(context.type).toBe('option');
-    });
-
-    it('still returns command_path for a genuine single-line file command', () => {
-        const source = 'do myfile.do';
-        const context = context_of(source, { line: 0, character: 4 });
-        expect(context.type).toBe('command_path');
-    });
-
-    it('still returns subcommand for a genuine single-line prefix command', () => {
-        const db = create_test_command_db();
-        // `frame ` needs subcommands in the db; use the real command db shape.
-        const real_db = new CommandDatabase();
-        real_db.register({
+describe('detect_completion_context — statement-scoped detectors over logical text (#310)', () => {
+    function frame_command_db(): CommandDatabase {
+        const db = new CommandDatabase();
+        db.register({
             name: 'frame',
             minAbbreviation: 'frame',
             syntax: 'frame ...',
@@ -210,9 +229,49 @@ describe('detect_completion_context — continuation-line guard (#310)', () => {
             isBuiltin: true,
             subcommands: [{ name: 'create', minAbbreviation: 'cr' }],
         });
-        const context = context_of('frame ', { line: 0, character: 6 }, real_db);
+        return db;
+    }
+
+    it('does not return command_path on a wrapped option statement (comma carries through)', () => {
+        // The logical text `merge 1:1 id using "f.dta" , keepusing(` contains
+        // the comma, so command_path bails and option context wins.
+        const source = '#delimit ;\nmerge 1:1 id using "f.dta",\n    keepusing(';
+        const context = context_of(source, { line: 2, character: 14 });
+        expect(context.type).toBe('option');
+    });
+
+    it('resolves command_path for a file command that is the second statement on a line', () => {
+        const source = '#delimit ;\ndisplay 1 ; use "data';
+        const context = context_of(source, { line: 1, character: 21 });
+        expect(context.type).toBe('command_path');
+        if (context.type === 'command_path') {
+            expect(context.command).toBe('use');
+        }
+    });
+
+    it('resolves an extended-macro function split across a /// continuation', () => {
+        const source = '#delimit ;\nlocal x : ///\n    list a b';
+        const context = context_of(source, { line: 2, character: 8 });
+        expect(context.type).toBe('macro');
+    });
+
+    it('resolves a subcommand split across a /// continuation', () => {
+        const source = '#delimit ;\nframe ///\n    cr';
+        const context = context_of(source, { line: 2, character: 6 }, frame_command_db());
         expect(context.type).toBe('subcommand');
-        void db;
+        if (context.type === 'subcommand') {
+            expect(context.prefix_command).toBe('frame');
+        }
+    });
+
+    it('still returns command_path for a genuine single-line file command', () => {
+        const context = context_of('do myfile.do', { line: 0, character: 4 });
+        expect(context.type).toBe('command_path');
+    });
+
+    it('still returns subcommand for a genuine single-line prefix command', () => {
+        const context = context_of('frame ', { line: 0, character: 6 }, frame_command_db());
+        expect(context.type).toBe('subcommand');
     });
 });
 

--- a/tests/unit/completion-wrapped-context.test.ts
+++ b/tests/unit/completion-wrapped-context.test.ts
@@ -159,6 +159,35 @@ describe('detect_completion_context — cursor before a mid-document terminator 
     });
 });
 
+describe('detect_completion_context — mata/python block boundaries (#310)', () => {
+    it('does not walk into a preceding bare mata/end block under #delimit ;', () => {
+        const source = '#delimit ;\nmata\nx=1\nend\nreg y x,\n robust';
+        const context = context_of(source, { line: 5, character: 7 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('reg');
+        }
+    });
+
+    it('does not walk into a preceding bare python/end block under #delimit ;', () => {
+        const source = '#delimit ;\npython\nx=1\nend\nreg y x,\n robust';
+        const context = context_of(source, { line: 5, character: 7 });
+        expect(context.type).toBe('option');
+        if (context.type === 'option') {
+            expect(context.command).toBe('reg');
+        }
+    });
+});
+
+describe('detect_completion_context — cursor inside a multi-char boundary token (#310)', () => {
+    it('does not synthesize reversed text when the cursor is inside a #delimit directive', () => {
+        // Cursor mid-`#delimit ;`: must not slice substring(boundaryEnd, cursor)
+        // with boundaryEnd > cursor.
+        const context = context_of('#delimit ;', { line: 0, character: 5 });
+        expect(context.type).toBe('command');
+    });
+});
+
 describe('detect_completion_context — long wrapped varlist (#310)', () => {
     it('still detects option context for a wrapped statement with hundreds of tokens', () => {
         const the_vars = Array.from({ length: 800 }, (_, i) => `x${i}`).join(' ');
@@ -247,12 +276,6 @@ describe('detect_completion_context — statement-scoped detectors over logical 
         if (context.type === 'command_path') {
             expect(context.command).toBe('use');
         }
-    });
-
-    it('resolves an extended-macro function split across a /// continuation', () => {
-        const source = '#delimit ;\nlocal x : ///\n    list a b';
-        const context = context_of(source, { line: 2, character: 8 });
-        expect(context.type).toBe('macro');
     });
 
     it('resolves a subcommand split across a /// continuation', () => {


### PR DESCRIPTION
## Summary

Fixes #310. `detect_completion_context` / `detect_option_context` /
`get_option_prefix_at_position` analyzed only the current **physical** line
before the cursor, so any statement wrapped across physical lines lost its
completion context. Most visibly under `#delimit ;`:

```stata
#delimit ;
reg y x,
    vce(
```

with the cursor after `vce(` yielded command context instead of option context
for `reg`. The same class affected `///`-wrapped statements in `#delimit cr`
mode, and multiple statements sharing one physical line.

Completion now builds the context from the **logical statement** the cursor is
in, recovered from the token stream, then runs the existing text-based detectors
over that synthesized prefix — preserving the deliberately text-first design
that survives mid-typing/unparseable states.

## Design

- **`logical_statement_start(tokens, position, min_line)`** (new, in
  `src/utils/statement-span.ts`): finds the cursor token via the existing
  O(log n) `find_last_token_starting_before` (shared with hover), then walks
  backward to the nearest real boundary — `STATEMENT_TERMINATOR` (honoring
  `///`-swallowed `\n` terminators), `{`/`}`, `#delimit`, and mata/python block
  markers — and returns the statement's first token. Two safeguards:
  - **Case B (empty statement)**: when the cursor sits at/just after a boundary
    with no statement token yet (right after a `;` on a shared line, in a new
    statement's leading whitespace, or a blank line), it reports a fresh
    position on the cursor's own line.
  - **`min_line` region floor**: the walk never crosses into a `mata`/`python`
    block above the cursor (computed from the per-document `context_ranges`), so
    embedded-language tokens — including a nested `{ }` inside a `mata { ... }`
    block — never leak into the Stata detectors.
  - Bounded by `MAX_STATEMENT_TOKENS` (4096) so a pathological/unterminated
    statement can never cause an unbounded per-keystroke scan.

- **`build_logical_text_before_cursor`** (`src/providers/completion.ts`):
  flattens the wrapped statement's prior physical lines from the token stream
  (dropping comments/continuations so a `,` inside a `// note` can't leak) and
  appends the current physical line verbatim (preserving the partial word being
  typed). When the statement begins on the cursor's own line it slices from the
  statement-start character, which both keeps single-line behavior identical
  (only leading indentation is trimmed — every detector already trims it) and
  correctly attributes `display 1; reg y x,` to `reg`, not `display`.

- **Wiring**: `command_path`, `subcommand`, `option`, `command`, and `variable`
  detection run over the logical text; `directive` and macro detection stay on
  the physical line (single-line constructs, and macro delimiters are
  cursor-local). The logical text is built lazily, and tokens are passed to
  `detect_completion_context` only in STATA context (so embedded blocks and the
  hot macro path pay nothing). The `server-handlers` `isIncomplete` probe gates
  tokens identically, so it can never disagree with the real path.

- **#309 interaction**: with the context tracker fixed (#311), completion now
  suppresses Stata command/option completions on a continued inline `mata:` line
  under `#delimit ;` (covered by a test).

## Test evidence

New tests: `tests/unit/completion-wrapped-context.test.ts` (both-mode repros,
wrapped option-argument prefix, mid-option-after-wrapped-comma, multi-statement
per line, new-statement-after-`;`, cursor-before-mid-document-terminator, long
wrapped varlist, mata/python block boundaries and closers, nested-brace mata
closer, cursor-inside-`#delimit`, wrapped `capture:` prefix, isIncomplete
handler consistency, #309 embedded suppression, single-line/tokenless
regressions) and a property test `tests/property/wrapped-option-context.prop.test.ts`
(option context stable across single-line / `;`-wrap / `///`-wrap renderings).

Gates (all green):
- `bun run test` (typecheck + full suite): 7474 pass, 5 skip, 0 fail.
- `bun run lint` (eslint, not in CI): clean.
- `bun test tests/property/delimiter-mode-equivalence.prop.test.ts`: 3 pass.

## Review gate

Adversarial design review (codex + Sonnet, 2 rounds) before implementation, then
the working diff went through repeated code-review rounds — codex as primary
reviewer plus multiple cold Sonnet subagents each round — until two consecutive
fully-clean rounds. Real issues found and fixed in-branch along the way:
statement-start anchor self-matching a terminator at the cursor; a 512-token cap
truncating long varlists; the empty-statement-after-a-boundary position;
command_path/subcommand asymmetry on multi-statement lines; bare `mata`/`python`
block boundaries; a reversed substring when the cursor sits inside a multi-char
boundary; the `isIncomplete` probe diverging from the real path (command_path
precedes macro detection); and a nested-brace `mata { }` closer leaking embedded
tokens (fixed by the region-floor clamp).

## Deferrals (documented, not regressions vs. pre-existing single-line behavior)

- `extract_command_name` treats a mis-cased prefix (`BY id:`) leniently — a
  pre-existing case-insensitivity in the hardcoded prefix list, identical to
  single-line behavior.
- Option context is still offered inside a trailing `//` line comment — pre-
  existing single-line behavior (`reg y x, // note` already does this).
- An unbalanced quote/paren inside a `/* */` block comment that spans onto the
  cursor line can desync the char scanner — pre-existing single-line limitation.
- A wrapped extended-macro *function* (`local x : list` split across lines) is
  not specially detected (extended-macro detection stays on the physical line so
  the `isIncomplete` macro flag never depends on the token walk).
- A wrapped statement exceeding `MAX_STATEMENT_TOKENS` (4096) falls back to
  physical-line behavior (bounded per-keystroke cost).
- `CompletionProvider` caches the first document's context tracker across
  documents — a pre-existing quirk unrelated to #310.
- Trailing Stata on the *same physical line* as an inline `mata:`/`python:`
  statement (`mata: x = 1 ; regress y x, `) gets no completions, because the
  context tracker classifies the whole physical line as embedded. Verified
  identical on `main` — a pre-existing line-granularity limitation (a physical
  line cannot hold two languages), unrelated to #310. The *wrapped* form (the
  trailing statement continuing onto the next line) does work.

https://claude.ai/code/session_0114zF2WByBWgPPQiyBrRtWZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completion context now follows the full logical statement across wrapped lines, improving suggestions for `#delimit ;` and `///` continuations.
  * Option-prefix detection is now consistent across multi-line statements and better handles colon-prefixed commands.

* **Bug Fixes**
  * Fixed incorrect completion contexts when commands or options span multiple physical lines.
  * Improved handling near statement boundaries, embedded blocks, and multi-statement lines.
  * Completion behavior now stays accurate in wrapped statements and avoids leaking unrelated suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->