### PR TITLE
Fix #304: reposition block-ending comments inside the block

### DIFF
--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -701,7 +701,18 @@ export class SemanticAnalyzer {
         }
     }
 
-    private extract_directives_from_nodes(nodes: StataNode[]): void {
+    /**
+     * `outer_successor` is the statement that follows this whole node list in
+     * document order (undefined at the top level or when nothing follows the
+     * enclosing block). It lets a block-ending directive on the LAST child of a
+     * block target the statement after all the enclosing closers, matching the
+     * pre-#304 behavior where the comment flowed forward through pending trivia
+     * to that statement.
+     */
+    private extract_directives_from_nodes(
+        nodes: StataNode[],
+        outer_successor?: StataNode
+    ): void {
         for (let my_index = 0; my_index < nodes.length; my_index++) {
             const node = nodes[my_index];
 
@@ -712,47 +723,51 @@ export class SemanticAnalyzer {
                 }
             }
 
+            // The statement that follows this node in document order: its next
+            // sibling, or (when it is the last child) the statement after the
+            // enclosing block.
+            const following_node = nodes[my_index + 1] ?? outer_successor;
+
             // Block-ending trivia (a comment on its own line just before this
-            // block's closer) targets the statement AFTER the block — the same
-            // node that held the comment as leading trivia before issue #304
-            // moved it into blockEndingTrivia. That is this node's next sibling,
-            // NOT this (block) node: using the block node would wrongly suppress
-            // the block header line.
+            // block's closer) targets that following statement — the same node
+            // that held the comment as leading trivia before issue #304 moved it
+            // into blockEndingTrivia. It is never this (block) node, so the
+            // block header line is never suppressed.
             const node_with_block_ending_trivia = node as StataNode & {
                 blockEndingTrivia?: TriviaNode[];
             };
             if (node_with_block_ending_trivia.blockEndingTrivia) {
-                const following_node = nodes[my_index + 1];
                 for (const trivia of node_with_block_ending_trivia.blockEndingTrivia) {
                     this.parse_directive(trivia, following_node);
                 }
             }
 
-            // Recurse into nested node bodies.
+            // Recurse into nested node bodies. The body's successor is the
+            // statement after this block (following_node).
             if (node.type === 'program') {
-                this.extract_directives_from_nodes(node.body);
+                this.extract_directives_from_nodes(node.body, following_node);
             } else if (this.is_control_flow(node)) {
-                this.extract_directives_from_nodes(node.body);
+                this.extract_directives_from_nodes(node.body, following_node);
             }
         }
     }
 
     /**
-     * AST-trivia fallback for comment directives. Ignore directives here
-     * add only the following node's FIRST line, by design: a control-flow
-     * node's range spans its whole block body, so marking the full range
-     * would over-suppress everything inside the block. `following_node` is the
-     * node the comment precedes: the trivia's own node for leading trivia, or
-     * the block's next sibling for block-ending trivia (undefined when the
-     * block is the last statement in its scope — then the ignore directive has
-     * no statement to target and only `@lsp-variables` still applies). Every
-     * production caller of analyze() passes tokens, making the token path
-     * (extract_comment_directives_from_tokens ->
-     * ignore_next_non_trivia_line) authoritative with full statement-span
-     * suppression; this narrower single-line contribution is a redundant
-     * subset when tokens are present, never a source of over-suppression.
-     * If a caller ever stops passing tokens, `@lsp-ignore-next` regresses
-     * to single-line suppression for that caller — keep tokens flowing.
+     * AST-trivia path for comment directives. Ignore directives add only the
+     * following node's FIRST line, by design: a control-flow node's range spans
+     * its whole block body, so marking the full range would over-suppress
+     * everything inside the block. `following_node` is the node the comment
+     * precedes: the trivia's own node for leading trivia, or the statement after
+     * the block for block-ending trivia (undefined when nothing follows the
+     * enclosing scope — then the ignore directive has no statement to target and
+     * only `@lsp-variables` still applies).
+     *
+     * This path runs on every analyze() call and unions into the same
+     * `ignored_lines` set the token path uses. It is NOT purely redundant with
+     * the token path: for a comment sitting before a closer, the token path's
+     * `next_statement_line_span` stops at the closing brace, so only this path
+     * contributes the real post-block statement line. Over-suppression is still
+     * impossible because it adds at most a single, real following-statement line.
      */
     private parse_directive(trivia: TriviaNode, following_node: StataNode | undefined): void {
         const content = trivia.content.trim();

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -711,6 +711,15 @@ export class SemanticAnalyzer {
             }
         }
 
+        const node_with_block_ending_trivia = node as StataNode & {
+            blockEndingTrivia?: TriviaNode[];
+        };
+        if (node_with_block_ending_trivia.blockEndingTrivia) {
+            for (const trivia of node_with_block_ending_trivia.blockEndingTrivia) {
+                this.parse_block_ending_directive(trivia);
+            }
+        }
+
         // Recurse into nested nodes
         if (node.type === 'program') {
             for (const child of node.body) {
@@ -719,6 +728,33 @@ export class SemanticAnalyzer {
         } else if (this.is_control_flow(node)) {
             for (const child of node.body) {
                 this.extract_directives_from_node(child);
+            }
+        }
+    }
+
+    /**
+     * Parse directives attached immediately before a block closer using only
+     * the trivia's own range. The token path is authoritative for
+     * `@lsp-ignore-next`; resolving that here through the block node would
+     * wrongly suppress the block header instead of the next statement.
+     */
+    private parse_block_ending_directive(trivia: TriviaNode): void {
+        const content = trivia.content.trim();
+
+        if (has_ignore_directive(content) && !has_ignore_next_directive(content)) {
+            this.config.ignored_lines.add(trivia.range.start.line);
+        }
+
+        const variables_match = content.match(VARIABLES_DIRECTIVE_PATTERN);
+        if (variables_match) {
+            const the_var_names = this.parse_identifier_list(
+                variables_match[1]
+            );
+            for (const my_var_name of the_var_names) {
+                this.register_declared_variable(
+                    my_var_name,
+                    trivia.range.start.line
+                );
             }
         }
     }

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -763,8 +763,15 @@ export class SemanticAnalyzer {
         if (node.type === 'program') {
             return node.body;
         }
-        if (this.is_control_flow(node) || node.type === 'frame') {
-            return (node as ControlFlowNode).body;
+        // Check `frame` via the discriminant before the is_control_flow type
+        // predicate: is_control_flow narrows to ControlFlowNode but excludes
+        // 'frame' at runtime, so `is_control_flow(node) || node.type === 'frame'`
+        // would leave TypeScript with no overlap for the 'frame' comparison.
+        if (node.type === 'frame') {
+            return node.body;
+        }
+        if (this.is_control_flow(node)) {
+            return node.body;
         }
         if (node.type === 'command' && node.body) {
             return node.body;

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -745,17 +745,23 @@ export class SemanticAnalyzer {
             this.config.ignored_lines.add(trivia.range.start.line);
         }
 
+        this.register_variables_directive(content, trivia.range.start.line);
+    }
+
+    /**
+     * Register any `@lsp-variables` / `@lsp-var` declarations found in a
+     * comment's content, keyed to the comment's own line. Shared by the
+     * leading-trivia fallback (`parse_directive`) and the block-ending fallback
+     * (`parse_block_ending_directive`) so the parse contract lives in one place.
+     */
+    private register_variables_directive(content: string, line: number): void {
         const variables_match = content.match(VARIABLES_DIRECTIVE_PATTERN);
-        if (variables_match) {
-            const the_var_names = this.parse_identifier_list(
-                variables_match[1]
-            );
-            for (const my_var_name of the_var_names) {
-                this.register_declared_variable(
-                    my_var_name,
-                    trivia.range.start.line
-                );
-            }
+        if (!variables_match) {
+            return;
+        }
+        const the_var_names = this.parse_identifier_list(variables_match[1]);
+        for (const my_var_name of the_var_names) {
+            this.register_declared_variable(my_var_name, line);
         }
     }
 
@@ -783,18 +789,7 @@ export class SemanticAnalyzer {
         }
 
         // Check for @lsp-variables / @lsp-var directive
-        const variables_match = content.match(VARIABLES_DIRECTIVE_PATTERN);
-        if (variables_match) {
-            const the_var_names = this.parse_identifier_list(
-                variables_match[1]
-            );
-            for (const my_var_name of the_var_names) {
-                this.register_declared_variable(
-                    my_var_name,
-                    trivia.range.start.line
-                );
-            }
-        }
+        this.register_variables_directive(content, trivia.range.start.line);
     }
 
     private is_standalone_comment_token(tokens: Token[], comment_index: number): boolean {

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -438,9 +438,7 @@ export class SemanticAnalyzer {
      * Handles @lsp-ignore-next and @lsp-variables directives.
      */
     private extract_comment_directives(ast: StataAST): void {
-        for (const node of ast.nodes) {
-            this.extract_directives_from_node(node);
-        }
+        this.extract_directives_from_nodes(ast.nodes);
     }
 
     /**
@@ -703,65 +701,39 @@ export class SemanticAnalyzer {
         }
     }
 
-    private extract_directives_from_node(node: StataNode): void {
-        // Check leading trivia for directives
-        if (this.has_trivia(node) && node.leadingTrivia) {
-            for (const trivia of node.leadingTrivia) {
-                this.parse_directive(trivia, node);
+    private extract_directives_from_nodes(nodes: StataNode[]): void {
+        for (let my_index = 0; my_index < nodes.length; my_index++) {
+            const node = nodes[my_index];
+
+            // Check leading trivia for directives (target: this node).
+            if (this.has_trivia(node) && node.leadingTrivia) {
+                for (const trivia of node.leadingTrivia) {
+                    this.parse_directive(trivia, node);
+                }
             }
-        }
 
-        const node_with_block_ending_trivia = node as StataNode & {
-            blockEndingTrivia?: TriviaNode[];
-        };
-        if (node_with_block_ending_trivia.blockEndingTrivia) {
-            for (const trivia of node_with_block_ending_trivia.blockEndingTrivia) {
-                this.parse_block_ending_directive(trivia);
+            // Block-ending trivia (a comment on its own line just before this
+            // block's closer) targets the statement AFTER the block — the same
+            // node that held the comment as leading trivia before issue #304
+            // moved it into blockEndingTrivia. That is this node's next sibling,
+            // NOT this (block) node: using the block node would wrongly suppress
+            // the block header line.
+            const node_with_block_ending_trivia = node as StataNode & {
+                blockEndingTrivia?: TriviaNode[];
+            };
+            if (node_with_block_ending_trivia.blockEndingTrivia) {
+                const following_node = nodes[my_index + 1];
+                for (const trivia of node_with_block_ending_trivia.blockEndingTrivia) {
+                    this.parse_directive(trivia, following_node);
+                }
             }
-        }
 
-        // Recurse into nested nodes
-        if (node.type === 'program') {
-            for (const child of node.body) {
-                this.extract_directives_from_node(child);
+            // Recurse into nested node bodies.
+            if (node.type === 'program') {
+                this.extract_directives_from_nodes(node.body);
+            } else if (this.is_control_flow(node)) {
+                this.extract_directives_from_nodes(node.body);
             }
-        } else if (this.is_control_flow(node)) {
-            for (const child of node.body) {
-                this.extract_directives_from_node(child);
-            }
-        }
-    }
-
-    /**
-     * Parse directives attached immediately before a block closer using only
-     * the trivia's own range. The token path is authoritative for
-     * `@lsp-ignore-next`; resolving that here through the block node would
-     * wrongly suppress the block header instead of the next statement.
-     */
-    private parse_block_ending_directive(trivia: TriviaNode): void {
-        const content = trivia.content.trim();
-
-        if (has_ignore_directive(content) && !has_ignore_next_directive(content)) {
-            this.config.ignored_lines.add(trivia.range.start.line);
-        }
-
-        this.register_variables_directive(content, trivia.range.start.line);
-    }
-
-    /**
-     * Register any `@lsp-variables` / `@lsp-var` declarations found in a
-     * comment's content, keyed to the comment's own line. Shared by the
-     * leading-trivia fallback (`parse_directive`) and the block-ending fallback
-     * (`parse_block_ending_directive`) so the parse contract lives in one place.
-     */
-    private register_variables_directive(content: string, line: number): void {
-        const variables_match = content.match(VARIABLES_DIRECTIVE_PATTERN);
-        if (!variables_match) {
-            return;
-        }
-        const the_var_names = this.parse_identifier_list(variables_match[1]);
-        for (const my_var_name of the_var_names) {
-            this.register_declared_variable(my_var_name, line);
         }
     }
 
@@ -769,8 +741,12 @@ export class SemanticAnalyzer {
      * AST-trivia fallback for comment directives. Ignore directives here
      * add only the following node's FIRST line, by design: a control-flow
      * node's range spans its whole block body, so marking the full range
-     * would over-suppress everything inside the block. Every production
-     * caller of analyze() passes tokens, making the token path
+     * would over-suppress everything inside the block. `following_node` is the
+     * node the comment precedes: the trivia's own node for leading trivia, or
+     * the block's next sibling for block-ending trivia (undefined when the
+     * block is the last statement in its scope — then the ignore directive has
+     * no statement to target and only `@lsp-variables` still applies). Every
+     * production caller of analyze() passes tokens, making the token path
      * (extract_comment_directives_from_tokens ->
      * ignore_next_non_trivia_line) authoritative with full statement-span
      * suppression; this narrower single-line contribution is a redundant
@@ -778,18 +754,32 @@ export class SemanticAnalyzer {
      * If a caller ever stops passing tokens, `@lsp-ignore-next` regresses
      * to single-line suppression for that caller — keep tokens flowing.
      */
-    private parse_directive(trivia: TriviaNode, following_node: StataNode): void {
+    private parse_directive(trivia: TriviaNode, following_node: StataNode | undefined): void {
         const content = trivia.content.trim();
 
         // Standalone ignore directives target the following node.
-        if (has_ignore_directive(content) || has_ignore_next_directive(content)) {
+        if (
+            following_node &&
+            (has_ignore_directive(content) || has_ignore_next_directive(content))
+        ) {
             // Ignore the line of the following node
             const line_to_ignore = following_node.range.start.line;
             this.config.ignored_lines.add(line_to_ignore);
         }
 
-        // Check for @lsp-variables / @lsp-var directive
-        this.register_variables_directive(content, trivia.range.start.line);
+        // Check for @lsp-variables / @lsp-var directive (keyed to its own line).
+        const variables_match = content.match(VARIABLES_DIRECTIVE_PATTERN);
+        if (variables_match) {
+            const the_var_names = this.parse_identifier_list(
+                variables_match[1]
+            );
+            for (const my_var_name of the_var_names) {
+                this.register_declared_variable(
+                    my_var_name,
+                    trivia.range.start.line
+                );
+            }
+        }
     }
 
     private is_standalone_comment_token(tokens: Token[], comment_index: number): boolean {

--- a/src/analyzer/index.ts
+++ b/src/analyzer/index.ts
@@ -742,14 +742,34 @@ export class SemanticAnalyzer {
                 }
             }
 
-            // Recurse into nested node bodies. The body's successor is the
-            // statement after this block (following_node).
-            if (node.type === 'program') {
-                this.extract_directives_from_nodes(node.body, following_node);
-            } else if (this.is_control_flow(node)) {
-                this.extract_directives_from_nodes(node.body, following_node);
+            // Recurse into nested block bodies (program, control flow including
+            // frame, and prefix brace-command blocks). The body's successor is
+            // the statement after this block (following_node), so a directive on
+            // the body's last child still reaches past all enclosing closers.
+            const the_child_body = this.directive_recursion_body(node);
+            if (the_child_body) {
+                this.extract_directives_from_nodes(the_child_body, following_node);
             }
         }
+    }
+
+    /**
+     * The child statement list to recurse into for directive extraction:
+     * program bodies, control-flow bodies (including `frame`, which
+     * is_control_flow excludes), and prefix brace-command blocks
+     * (`capture { ... }`). Other nodes have no nested statement list.
+     */
+    private directive_recursion_body(node: StataNode): StataNode[] | undefined {
+        if (node.type === 'program') {
+            return node.body;
+        }
+        if (this.is_control_flow(node) || node.type === 'frame') {
+            return (node as ControlFlowNode).body;
+        }
+        if (node.type === 'command' && node.body) {
+            return node.body;
+        }
+        return undefined;
     }
 
     /**

--- a/src/formatter/indentation-analyzer.ts
+++ b/src/formatter/indentation-analyzer.ts
@@ -112,31 +112,26 @@ export class IndentationAnalyzer {
         };
 
         // Process leading trivia - these should be indented at the current depth
-        if (node_with_trivia.leadingTrivia) {
-            for (const my_trivia of node_with_trivia.leadingTrivia) {
-                if (my_trivia.type === 'comment') {
-                    const trivia_line = my_trivia.range.start.line;
-                    // Only set if not already set (don't override block markers)
-                    if (!this.indentation_map.has(trivia_line)) {
-                        const { delta, original_indent } = this.calculate_indent_delta(trivia_line, this.current_depth);
-                        this.set_indentation(trivia_line, this.current_depth, false, false, false, false, delta, original_indent);
-                    }
-                }
-            }
-        }
+        this.mark_comment_trivia_indentation(node_with_trivia.leadingTrivia);
 
         // Process trailing trivia - these should also be at current depth
-        if (node_with_trivia.trailingTrivia) {
-            for (const my_trivia of node_with_trivia.trailingTrivia) {
-                if (my_trivia.type === 'comment') {
-                    const trivia_line = my_trivia.range.start.line;
-                    // Only set if not already set
-                    if (!this.indentation_map.has(trivia_line)) {
-                        const { delta, original_indent } = this.calculate_indent_delta(trivia_line, this.current_depth);
-                        this.set_indentation(trivia_line, this.current_depth, false, false, false, false, delta, original_indent);
-                    }
-                }
-            }
+        this.mark_comment_trivia_indentation(node_with_trivia.trailingTrivia);
+    }
+
+    /**
+     * Mark each comment in a trivia list at the current depth, unless the line
+     * already has an indentation entry (never override a block marker). Shared
+     * by leading/trailing trivia and block-ending trivia so the "only set if
+     * not already set" contract lives in one place.
+     */
+    private mark_comment_trivia_indentation(the_trivia?: TriviaNode[]): void {
+        if (!the_trivia) return;
+        for (const my_trivia of the_trivia) {
+            if (my_trivia.type !== 'comment') continue;
+            const trivia_line = my_trivia.range.start.line;
+            if (this.indentation_map.has(trivia_line)) continue;
+            const { delta, original_indent } = this.calculate_indent_delta(trivia_line, this.current_depth);
+            this.set_indentation(trivia_line, this.current_depth, false, false, false, false, delta, original_indent);
         }
     }
 
@@ -257,18 +252,9 @@ export class IndentationAnalyzer {
         const node_with_trivia = node as StataNode & {
             blockEndingTrivia?: TriviaNode[];
         };
-
-        if (!node_with_trivia.blockEndingTrivia) return;
-
-        for (const my_trivia of node_with_trivia.blockEndingTrivia) {
-            if (my_trivia.type === 'comment') {
-                const trivia_line = my_trivia.range.start.line;
-                if (!this.indentation_map.has(trivia_line)) {
-                    const { delta, original_indent } = this.calculate_indent_delta(trivia_line, this.current_depth);
-                    this.set_indentation(trivia_line, this.current_depth, false, false, false, false, delta, original_indent);
-                }
-            }
-        }
+        // Emitted while current_depth is still body depth, so block-ending
+        // comments indent inside the block rather than at the outer scope.
+        this.mark_comment_trivia_indentation(node_with_trivia.blockEndingTrivia);
     }
 
     private process_continuations(tokens: Token[]): void {

--- a/src/formatter/indentation-analyzer.ts
+++ b/src/formatter/indentation-analyzer.ts
@@ -178,6 +178,8 @@ export class IndentationAnalyzer {
             }
         }
 
+        this.process_block_ending_trivia(node);
+
         this.current_depth--;
 
         if (end_line !== start_line) {
@@ -233,6 +235,8 @@ export class IndentationAnalyzer {
             }
         }
 
+        this.process_block_ending_trivia(node);
+
         // Decrease depth back to original
         this.current_depth--;
 
@@ -247,6 +251,24 @@ export class IndentationAnalyzer {
         const start_line = node.range.start.line;
         const { delta, original_indent } = this.calculate_indent_delta(start_line, this.current_depth);
         this.set_indentation(start_line, this.current_depth, false, false, false, false, delta, original_indent);
+    }
+
+    private process_block_ending_trivia(node: StataNode): void {
+        const node_with_trivia = node as StataNode & {
+            blockEndingTrivia?: TriviaNode[];
+        };
+
+        if (!node_with_trivia.blockEndingTrivia) return;
+
+        for (const my_trivia of node_with_trivia.blockEndingTrivia) {
+            if (my_trivia.type === 'comment') {
+                const trivia_line = my_trivia.range.start.line;
+                if (!this.indentation_map.has(trivia_line)) {
+                    const { delta, original_indent } = this.calculate_indent_delta(trivia_line, this.current_depth);
+                    this.set_indentation(trivia_line, this.current_depth, false, false, false, false, delta, original_indent);
+                }
+            }
+        }
     }
 
     private process_continuations(tokens: Token[]): void {

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -2828,28 +2828,28 @@ export class StataParser {
   }
 
   private drainBlockEndingTrivia(): TriviaNode[] | undefined {
-    const block_ending_trivia: TriviaNode[] = [];
-    const remaining_trivia: TriviaNode[] = [];
-
-    for (const my_trivia of this.pending_trivia) {
-      if (this.isBlockEndingCommentTrivia(my_trivia)) {
-        block_ending_trivia.push(my_trivia);
-      } else {
-        remaining_trivia.push(my_trivia);
-      }
+    if (this.pending_trivia.length === 0) {
+      return undefined;
     }
 
-    this.pending_trivia = remaining_trivia;
-    return block_ending_trivia.length > 0 ? block_ending_trivia : undefined;
-  }
-
-  private isBlockEndingCommentTrivia(trivia: TriviaNode): boolean {
-    return (
-      trivia.type === 'comment' &&
-      (trivia.style === 'star' ||
-        trivia.style === 'slash' ||
-        trivia.style === 'block')
+    // Only reposition a PURE run of comments into the block. If a `///`
+    // continuation is interleaved with the trailing comments, leave the whole
+    // group in pending_trivia untouched: draining only the comments would
+    // reorder the continuation relative to the comment across the closer (and
+    // a continuation is not a block-ending comment). The mixed case then keeps
+    // its pre-existing behavior (all pending trivia flows to the next
+    // statement, or to the end-of-parse flush).
+    const has_continuation = this.pending_trivia.some(
+      my_trivia =>
+        my_trivia.type === 'comment' && my_trivia.style === 'continuation'
     );
+    if (has_continuation) {
+      return undefined;
+    }
+
+    const block_ending_trivia = this.pending_trivia;
+    this.pending_trivia = [];
+    return block_ending_trivia;
   }
 
   // Skip trivia within a macro definition statement, bridging `///`

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -450,9 +450,7 @@ export class StataParser {
     this.inside_program = true;
 
     // Collect any leading trivia before re-checking `end`, mirroring
-    // parseBraceBody (issue #301). Carrying the trivia forward via
-    // pending_trivia so it attaches to the statement after the program matches
-    // how parseBraceBody handles a comment before `}`.
+    // parseBraceBody (issue #301).
     while (!this.isAtEnd()) {
       const my_trivia = this.collectTrivia();
       if (my_trivia.length > 0) {
@@ -466,6 +464,10 @@ export class StataParser {
         body.push(stmt);
       }
     }
+
+    const program_block_ending_trivia = this.checkWord('end')
+      ? this.drainBlockEndingTrivia()
+      : undefined;
 
     this.inside_program = was_inside_program;
 
@@ -488,6 +490,7 @@ export class StataParser {
         start_token.range.start,
         this.previous().range.end
       ),
+      blockEndingTrivia: program_block_ending_trivia,
     };
   }
 
@@ -913,7 +916,8 @@ export class StataParser {
       this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
       const body: StataNode[] = [];
-      body.push(...this.parseBraceBody());
+      const { body: my_body, blockEndingTrivia } = this.parseBraceBody();
+      body.push(...my_body);
       if (this.check('RBRACE')) {
         const rbrace_index = this.current;
         const rbrace_token = this.advance(); // consume }
@@ -933,6 +937,7 @@ export class StataParser {
           start_token.range.start,
           this.previous().range.end
         ),
+        blockEndingTrivia,
       };
     }
 
@@ -2185,6 +2190,7 @@ export class StataParser {
 
     // Parse body
     const body: StataNode[] = [];
+    let blockEndingTrivia: TriviaNode[] | undefined;
     if (this.check('LBRACE')) {
       const lbrace_index = this.current;
       const lbrace_token = this.advance(); // consume {
@@ -2194,7 +2200,9 @@ export class StataParser {
       const has_condition_before = lbrace_token.range.start.line === condition_start_line;
       this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
-      body.push(...this.parseBraceBody());
+      const { body: my_body, blockEndingTrivia: my_block_ending_trivia } = this.parseBraceBody();
+      body.push(...my_body);
+      blockEndingTrivia = my_block_ending_trivia;
 
       if (this.check('RBRACE')) {
         const rbrace_index = this.current;
@@ -2212,6 +2220,7 @@ export class StataParser {
       condition: condition.trim(),
       body,
       range: this.makeRange(ifToken.range.start, this.previous().range.end),
+      blockEndingTrivia,
     };
   }
 
@@ -2230,6 +2239,7 @@ export class StataParser {
 
     // Parse body
     const body: StataNode[] = [];
+    let blockEndingTrivia: TriviaNode[] | undefined;
     let is_brace_else = false;
     if (this.check('LBRACE')) {
       is_brace_else = true;
@@ -2241,7 +2251,9 @@ export class StataParser {
       const has_condition_before = lbrace_token.range.start.line === elseToken.range.start.line;
       this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
-      body.push(...this.parseBraceBody());
+      const { body: my_body, blockEndingTrivia: my_block_ending_trivia } = this.parseBraceBody();
+      body.push(...my_body);
+      blockEndingTrivia = my_block_ending_trivia;
 
       if (this.check('RBRACE')) {
         const rbrace_index = this.current;
@@ -2275,6 +2287,7 @@ export class StataParser {
       type: 'else',
       body,
       range: this.makeRange(elseToken.range.start, end_position),
+      blockEndingTrivia,
     };
   }
 
@@ -2344,6 +2357,7 @@ export class StataParser {
 
     // Parse body
     const body: StataNode[] = [];
+    let blockEndingTrivia: TriviaNode[] | undefined;
     if (this.check('LBRACE')) {
       const lbrace_index = this.current;
       const lbrace_token = this.advance(); // consume {
@@ -2353,7 +2367,9 @@ export class StataParser {
       const has_condition_before = lbrace_token.range.start.line === loop_start_line;
       this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
-      body.push(...this.parseBraceBody());
+      const { body: my_body, blockEndingTrivia: my_block_ending_trivia } = this.parseBraceBody();
+      body.push(...my_body);
+      blockEndingTrivia = my_block_ending_trivia;
 
       if (this.check('RBRACE')) {
         const rbrace_index = this.current;
@@ -2372,6 +2388,7 @@ export class StataParser {
       loopSpec,
       body,
       range: this.makeRange(loopToken.range.start, this.previous().range.end),
+      blockEndingTrivia,
     };
   }
 
@@ -2435,6 +2452,7 @@ export class StataParser {
 
     // Parse body
     const body: StataNode[] = [];
+    let blockEndingTrivia: TriviaNode[] | undefined;
     if (this.check('LBRACE')) {
       const lbrace_index = this.current;
       const lbrace_token = this.advance(); // consume {
@@ -2444,7 +2462,9 @@ export class StataParser {
       const has_condition_before = lbrace_token.range.start.line === while_start_line;
       this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
-      body.push(...this.parseBraceBody());
+      const { body: my_body, blockEndingTrivia: my_block_ending_trivia } = this.parseBraceBody();
+      body.push(...my_body);
+      blockEndingTrivia = my_block_ending_trivia;
 
       if (this.check('RBRACE')) {
         const rbrace_index = this.current;
@@ -2462,6 +2482,7 @@ export class StataParser {
       condition: condition.trim(),
       body,
       range: this.makeRange(whileToken.range.start, this.previous().range.end),
+      blockEndingTrivia,
     };
   }
 
@@ -2575,7 +2596,7 @@ export class StataParser {
     this.validate_open_brace(lbrace_token, lbrace_index, has_condition_before);
 
     // Parse body
-    const body: StataNode[] = this.parseBraceBody();
+    const { body, blockEndingTrivia } = this.parseBraceBody();
 
     if (this.check('RBRACE')) {
       const rbrace_index = this.current;
@@ -2592,6 +2613,7 @@ export class StataParser {
       frameName: frame_name,
       body,
       range: this.makeRange(frame_token.range.start, this.previous().range.end),
+      blockEndingTrivia,
     };
   }
 
@@ -2777,14 +2799,12 @@ export class StataParser {
    * itself, so the closing brace is never handed to parseStatement, which
    * would misreport it as an orphan (issue #301).
    *
-   * A comment sitting between the last body statement and the closing brace is
-   * left in pending_trivia so it attaches to the statement after the block —
-   * identical to how the parser already handles that comment in `#delimit cr`
-   * mode. (Folding it into the last body node's trailing trivia instead makes
-   * the AST pretty-printer emit it inline on the preceding statement's line,
-   * corrupting output; repositioning block-ending comments is out of scope.)
+   * A comment sitting between the last body statement and a real closing brace
+   * belongs to the block body, not to the following statement. It is returned
+   * separately so printers and formatters can keep it before the closer at
+   * body indentation.
    */
-  private parseBraceBody(): StataNode[] {
+  private parseBraceBody(): { body: StataNode[]; blockEndingTrivia?: TriviaNode[] } {
     const body: StataNode[] = [];
     while (!this.isAtEnd()) {
       const my_trivia = this.collectTrivia();
@@ -2799,7 +2819,37 @@ export class StataParser {
         body.push(stmt);
       }
     }
-    return body;
+
+    const blockEndingTrivia = this.check('RBRACE')
+      ? this.drainBlockEndingTrivia()
+      : undefined;
+
+    return { body, blockEndingTrivia };
+  }
+
+  private drainBlockEndingTrivia(): TriviaNode[] | undefined {
+    const block_ending_trivia: TriviaNode[] = [];
+    const remaining_trivia: TriviaNode[] = [];
+
+    for (const my_trivia of this.pending_trivia) {
+      if (this.isBlockEndingCommentTrivia(my_trivia)) {
+        block_ending_trivia.push(my_trivia);
+      } else {
+        remaining_trivia.push(my_trivia);
+      }
+    }
+
+    this.pending_trivia = remaining_trivia;
+    return block_ending_trivia.length > 0 ? block_ending_trivia : undefined;
+  }
+
+  private isBlockEndingCommentTrivia(trivia: TriviaNode): boolean {
+    return (
+      trivia.type === 'comment' &&
+      (trivia.style === 'star' ||
+        trivia.style === 'slash' ||
+        trivia.style === 'block')
+    );
   }
 
   // Skip trivia within a macro definition statement, bridging `///`

--- a/src/pretty-printer/index.ts
+++ b/src/pretty-printer/index.ts
@@ -275,6 +275,8 @@ export class PrettyPrinter {
                 the_parts.push(this.printNode(my_stmt));
             }
 
+            the_parts.push(this.printBlockEndingTrivia(node));
+
             // Decrease indent
             this.current_indent--;
 
@@ -340,6 +342,8 @@ export class PrettyPrinter {
         for (const my_stmt of node.body) {
             the_lines.push(this.printNode(my_stmt));
         }
+
+        the_lines.push(this.printBlockEndingTrivia(node));
 
         // Decrease indent
         this.current_indent--;
@@ -435,6 +439,8 @@ export class PrettyPrinter {
             the_lines.push(this.printNode(my_stmt));
         }
 
+        the_lines.push(this.printBlockEndingTrivia(node));
+
         // Decrease indent
         this.current_indent--;
 
@@ -528,6 +534,26 @@ export class PrettyPrinter {
             // Trailing trivia on same line - add space before
             the_parts.push(' ');
             the_parts.push(this.printTrivia(my_trivia));
+        }
+
+        return the_parts.join('');
+    }
+
+    /**
+     * Print comments that belong immediately before a block closer.
+     */
+    private printBlockEndingTrivia(node: CommandNode | ProgramNode | ControlFlowNode): string {
+        if (!node.blockEndingTrivia || node.blockEndingTrivia.length === 0) {
+            return '';
+        }
+
+        const the_parts: string[] = [];
+        for (const my_trivia of node.blockEndingTrivia) {
+            the_parts.push(this.getIndent());
+            the_parts.push(this.printTrivia(my_trivia));
+            // Block-ending comments are not statements and do not take `;` in
+            // semicolon-delimit mode, unlike leading trivia before statements.
+            the_parts.push('\n');
         }
 
         return the_parts.join('');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -269,6 +269,7 @@ export interface CommandNode {
   body?: StataNode[];  // For prefix command brace blocks (e.g., capture { })
   range: Range;
   leadingTrivia?: TriviaNode[];
+  blockEndingTrivia?: TriviaNode[];
   trailingTrivia?: TriviaNode[];
 }
 
@@ -279,6 +280,7 @@ export interface ProgramNode {
   signature?: ProgramSignature; // Extracted from syntax command
   range: Range;
   leadingTrivia?: TriviaNode[];
+  blockEndingTrivia?: TriviaNode[];
   trailingTrivia?: TriviaNode[];
 }
 
@@ -323,6 +325,7 @@ export interface ControlFlowNode {
   body: StataNode[];
   range: Range;
   leadingTrivia?: TriviaNode[];
+  blockEndingTrivia?: TriviaNode[];
   trailingTrivia?: TriviaNode[];
 }
 

--- a/tests/property/block-ending-trivia-formatting.prop.test.ts
+++ b/tests/property/block-ending-trivia-formatting.prop.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect } from 'bun:test';
+import { CodeFormatter } from '../../src/providers/formatter';
+import { create_document_state } from './helpers/document-utils';
+import {
+    DEFAULT_FORMATTING_OPTIONS,
+    FormatterMode,
+    create_formatter_config,
+    for_each_formatter_mode,
+} from './helpers/formatter-test-utils';
+
+function format_source(source: string, mode: FormatterMode): string {
+    const formatter = new CodeFormatter();
+    const document = create_document_state(source);
+    const edits = formatter.format(
+        document,
+        DEFAULT_FORMATTING_OPTIONS,
+        create_formatter_config(mode)
+    );
+    return edits.length > 0 ? edits[0].newText : source;
+}
+
+function expect_comment_inside_block(
+    formatted: string,
+    comment: string,
+    closer: string = '}'
+): void {
+    const lines = formatted.split('\n');
+    const comment_index = lines.findIndex(line => line.trim() === comment);
+    const closer_index = lines.findIndex(
+        (line, index) => index > comment_index && line.trim() === closer
+    );
+
+    expect(comment_index).toBeGreaterThan(-1);
+    expect(closer_index).toBeGreaterThan(comment_index);
+    expect(lines[comment_index]).toBe(`    ${comment}`);
+}
+
+describe('formatter block-ending trivia placement', () => {
+    for_each_formatter_mode(
+        'keeps a block-ending comment at body indentation before close brace',
+        (mode: FormatterMode) => {
+            const source = 'if 1 {\ndisplay 1\n* keep\n}\n';
+            const formatted = format_source(source, mode);
+
+            expect_comment_inside_block(formatted, '* keep');
+        }
+    );
+
+    for_each_formatter_mode(
+        'is idempotent for cr-delimit block-ending comments',
+        (mode: FormatterMode) => {
+            const source = 'while 1 {\ndisplay 1\n* keep\n}\n';
+            const formatted = format_source(source, mode);
+            const reformatted = format_source(formatted, mode);
+
+            expect(reformatted).toBe(formatted);
+        }
+    );
+
+    for_each_formatter_mode(
+        'keeps a program-ending comment at body indentation before end',
+        (mode: FormatterMode) => {
+            const source = 'program define p\ndisplay 1\n* keep\nend\n';
+            const formatted = format_source(source, mode);
+
+            expect_comment_inside_block(formatted, '* keep', 'end');
+        }
+    );
+
+    for_each_formatter_mode(
+        'keeps a prefix brace-block comment at body indentation before close brace',
+        (mode: FormatterMode) => {
+            const source = 'capture {\ndisplay 1\n* keep\n}\n';
+            const formatted = format_source(source, mode);
+
+            expect_comment_inside_block(formatted, '* keep');
+        }
+    );
+
+    for_each_formatter_mode(
+        'places semicolon-delimit block-ending comments inside the block',
+        (mode: FormatterMode) => {
+            const source = '#delimit ;\nif 1 {;\ndisplay 1;\n* keep\n};\n#delimit cr';
+            const formatted = format_source(source, mode);
+
+            expect_comment_inside_block(formatted, '* keep', '};');
+        }
+    );
+});

--- a/tests/property/helpers/ast-comparison.ts
+++ b/tests/property/helpers/ast-comparison.ts
@@ -179,6 +179,20 @@ function command_nodes_equal(my_a: CommandNode, my_b: CommandNode): boolean {
     }
   }
 
+  // Compare brace-block body (e.g. capture { ... }), mirroring how
+  // program/control-flow bodies are compared, so a differing nested body cannot
+  // pass as equivalent.
+  if ((my_a.body?.length ?? 0) !== (my_b.body?.length ?? 0)) {
+    return false;
+  }
+  if (my_a.body && my_b.body) {
+    for (let my_i = 0; my_i < my_a.body.length; my_i++) {
+      if (!nodes_equal(my_a.body[my_i], my_b.body[my_i])) {
+        return false;
+      }
+    }
+  }
+
   // Compare trivia
   return trivia_equal(my_a.leadingTrivia, my_b.leadingTrivia) &&
     trivia_equal(my_a.blockEndingTrivia, my_b.blockEndingTrivia) &&

--- a/tests/property/helpers/ast-comparison.ts
+++ b/tests/property/helpers/ast-comparison.ts
@@ -181,6 +181,7 @@ function command_nodes_equal(my_a: CommandNode, my_b: CommandNode): boolean {
 
   // Compare trivia
   return trivia_equal(my_a.leadingTrivia, my_b.leadingTrivia) &&
+    trivia_equal(my_a.blockEndingTrivia, my_b.blockEndingTrivia) &&
     trivia_equal(my_a.trailingTrivia, my_b.trailingTrivia);
 }
 
@@ -200,6 +201,7 @@ function program_nodes_equal(my_a: ProgramNode, my_b: ProgramNode): boolean {
   }
 
   return trivia_equal(my_a.leadingTrivia, my_b.leadingTrivia) &&
+    trivia_equal(my_a.blockEndingTrivia, my_b.blockEndingTrivia) &&
     trivia_equal(my_a.trailingTrivia, my_b.trailingTrivia);
 }
 
@@ -234,6 +236,7 @@ function control_flow_nodes_equal(my_a: ControlFlowNode, my_b: ControlFlowNode):
   }
 
   return trivia_equal(my_a.leadingTrivia, my_b.leadingTrivia) &&
+    trivia_equal(my_a.blockEndingTrivia, my_b.blockEndingTrivia) &&
     trivia_equal(my_a.trailingTrivia, my_b.trailingTrivia);
 }
 

--- a/tests/property/helpers/document-utils.ts
+++ b/tests/property/helpers/document-utils.ts
@@ -171,6 +171,23 @@ function extract_comments_from_node(
     }
   }
 
+  // Extract block-ending trivia (a comment on its own line just before the
+  // block closer, owned by the block since issue #304). Without this the
+  // comment-preservation property would miss exactly the comments this feature
+  // moves off the following node's leading trivia.
+  if (my_node.blockEndingTrivia && Array.isArray(my_node.blockEndingTrivia)) {
+    for (const my_trivia of my_node.blockEndingTrivia) {
+      if (my_trivia.type === 'comment') {
+        my_comments.push({
+          content: my_trivia.content,
+          style: my_trivia.style,
+          line: my_trivia.range.start.line,
+          column: my_trivia.range.start.character,
+        });
+      }
+    }
+  }
+
   // Extract trailing trivia
   if (my_node.trailingTrivia && Array.isArray(my_node.trailingTrivia)) {
     for (const my_trivia of my_node.trailingTrivia) {

--- a/tests/unit/block-ending-directives.test.ts
+++ b/tests/unit/block-ending-directives.test.ts
@@ -59,6 +59,22 @@ describe('block-ending comment directives', () => {
         }
     });
 
+    test('block-ending @lsp-ignore-next on the last child of nested blocks targets the statement after all closers', () => {
+        // Lines: 0 `if 1 {`, 1 `while 1 {`, 2 `display 1`, 3 directive,
+        // 4 `}`, 5 `}`, 6 `list missing_var`. The while block is the last child
+        // of the if block, so the directive must reach line 6 (the statement
+        // after both closers), matching pre-#304 forward-flow behavior.
+        const source =
+            'if 1 {\n    while 1 {\n        display 1\n        // @lsp-ignore-next\n    }\n}\nlist missing_var\n';
+        for (const with_tokens of [true, false]) {
+            const result = analyze(source, { with_tokens });
+            expect(result.ignored_lines.has(6)).toBe(true);
+            expect(
+                result.diagnostics.filter(d => d.message.includes('missing_var'))
+            ).toHaveLength(0);
+        }
+    });
+
     test('@lsp-variables before a closer suppresses the later undefined-variable warning', () => {
         const with_directive =
             'if 1 {\n    display 1\n    // @lsp-variables income_usd\n}\nlist income_usd\n';

--- a/tests/unit/block-ending-directives.test.ts
+++ b/tests/unit/block-ending-directives.test.ts
@@ -75,6 +75,34 @@ describe('block-ending comment directives', () => {
         }
     });
 
+    test('block-ending directive recurses through a prefix brace-command block', () => {
+        // capture { if 1 { ... // @lsp-ignore-next } } / list missing_var
+        // Lines: 0 capture {, 1 if 1 {, 2 display 1, 3 directive, 4 }, 5 }, 6 stmt.
+        const source =
+            'capture {\n    if 1 {\n        display 1\n        // @lsp-ignore-next\n    }\n}\nlist missing_var\n';
+        for (const with_tokens of [true, false]) {
+            const result = analyze(source, { with_tokens });
+            expect(result.ignored_lines.has(6)).toBe(true);
+            expect(
+                result.diagnostics.filter(d => d.message.includes('missing_var'))
+            ).toHaveLength(0);
+        }
+    });
+
+    test('block-ending directive recurses through a frame block', () => {
+        // frame scratch { if 1 { ... // @lsp-ignore-next } list missing_var }
+        // Lines: 0 frame {, 1 if {, 2 display, 3 directive, 4 }, 5 list, 6 }.
+        const source =
+            'frame scratch {\n    if 1 {\n        display 1\n        // @lsp-ignore-next\n    }\n    list missing_var\n}\n';
+        for (const with_tokens of [true, false]) {
+            const result = analyze(source, { with_tokens });
+            expect(result.ignored_lines.has(5)).toBe(true);
+            expect(
+                result.diagnostics.filter(d => d.message.includes('missing_var'))
+            ).toHaveLength(0);
+        }
+    });
+
     test('@lsp-variables before a closer suppresses the later undefined-variable warning', () => {
         const with_directive =
             'if 1 {\n    display 1\n    // @lsp-variables income_usd\n}\nlist income_usd\n';

--- a/tests/unit/block-ending-directives.test.ts
+++ b/tests/unit/block-ending-directives.test.ts
@@ -3,11 +3,13 @@ import { SemanticAnalyzer } from '../../src/analyzer';
 import { StataLexer } from '../../src/lexer';
 import { StataParser } from '../../src/parser';
 
-// The analyzer must still honor range-based comment directives when they sit
-// immediately before a block closer and are therefore owned by the block's
-// blockEndingTrivia (issue #304). @lsp-ignore-next is intentionally left to the
-// authoritative token path: resolving it through the block node would wrongly
-// suppress the block header rather than the next statement.
+// A comment on its own line just before a block closer is now owned by the
+// block's blockEndingTrivia (issue #304). Its directive semantics must be
+// unchanged from before the move: a standalone @lsp-ignore / @lsp-ignore-next
+// suppresses the statement AFTER the block (the node that held the comment as
+// leading trivia before #304), never the block header; @lsp-variables declares
+// the variable keyed to its own line. The token path stays authoritative in
+// production; these AST-fallback assertions also run the no-tokens path.
 function analyze(source: string, opts?: { with_tokens?: boolean }) {
     const lexer = new StataLexer();
     const parser = new StataParser();
@@ -27,37 +29,45 @@ function analyze(source: string, opts?: { with_tokens?: boolean }) {
     );
 }
 
-function variable_warnings(source: string, name: string, opts?: { with_tokens?: boolean }) {
-    return analyze(source, opts).diagnostics.filter(d =>
-        d.message.includes(name)
-    );
+function warnings_for(source: string, name: string, opts?: { with_tokens?: boolean }) {
+    return analyze(source, opts).diagnostics.filter(d => d.message.includes(name));
 }
 
 describe('block-ending comment directives', () => {
-    const with_directive =
-        'if 1 {\n    display 1\n    // @lsp-variables income_usd\n}\nlist income_usd\n';
-    const without_directive = 'if 1 {\n    display 1\n}\nlist income_usd\n';
+    // Lines: 0 `if 1 {`, 1 `gen y = 1`, 2 directive, 3 `}`, 4 following stmt.
+    const ignore_next =
+        'if 1 {\n    gen y = 1\n    // @lsp-ignore-next\n}\nlist missing_var\n';
+    const ignore =
+        'if 1 {\n    gen y = 1\n    // @lsp-ignore\n}\nlist missing_var\n';
+
+    test('@lsp-ignore-next before a closer suppresses the statement after the block, not the header', () => {
+        for (const with_tokens of [true, false]) {
+            const result = analyze(ignore_next, { with_tokens });
+            expect(result.ignored_lines.has(4)).toBe(true); // list missing_var
+            expect(result.ignored_lines.has(0)).toBe(false); // if header
+            expect(
+                result.diagnostics.filter(d => d.message.includes('missing_var'))
+            ).toHaveLength(0);
+        }
+    });
+
+    test('standalone @lsp-ignore before a closer also targets the following statement', () => {
+        for (const with_tokens of [true, false]) {
+            const result = analyze(ignore, { with_tokens });
+            expect(result.ignored_lines.has(4)).toBe(true);
+            expect(result.ignored_lines.has(0)).toBe(false);
+        }
+    });
 
     test('@lsp-variables before a closer suppresses the later undefined-variable warning', () => {
-        expect(variable_warnings(without_directive, 'income_usd')).not.toHaveLength(0);
-        expect(variable_warnings(with_directive, 'income_usd')).toHaveLength(0);
-    });
-
-    test('@lsp-variables before a closer works via the AST fallback (no tokens)', () => {
+        const with_directive =
+            'if 1 {\n    display 1\n    // @lsp-variables income_usd\n}\nlist income_usd\n';
+        const without_directive = 'if 1 {\n    display 1\n}\nlist income_usd\n';
+        expect(warnings_for(without_directive, 'income_usd')).not.toHaveLength(0);
+        expect(warnings_for(with_directive, 'income_usd')).toHaveLength(0);
+        // AST fallback (no tokens) also honors it.
         expect(
-            variable_warnings(with_directive, 'income_usd', { with_tokens: false })
+            warnings_for(with_directive, 'income_usd', { with_tokens: false })
         ).toHaveLength(0);
-    });
-
-    test('@lsp-ignore before a closer targets its own line, never the block header', () => {
-        // Exercise the AST fallback (no tokens) so parse_block_ending_directive
-        // is the code under test. The block header (line 0) must NOT be
-        // suppressed; only the comment's own line (line 2) is ignored.
-        const result = analyze(
-            'if 1 {\n    display 1\n    // @lsp-ignore\n}\n',
-            { with_tokens: false }
-        );
-        expect(result.ignored_lines.has(0)).toBe(false);
-        expect(result.ignored_lines.has(2)).toBe(true);
     });
 });

--- a/tests/unit/block-ending-directives.test.ts
+++ b/tests/unit/block-ending-directives.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import { SemanticAnalyzer } from '../../src/analyzer';
+import { StataLexer } from '../../src/lexer';
+import { StataParser } from '../../src/parser';
+
+// The analyzer must still honor range-based comment directives when they sit
+// immediately before a block closer and are therefore owned by the block's
+// blockEndingTrivia (issue #304). @lsp-ignore-next is intentionally left to the
+// authoritative token path: resolving it through the block node would wrongly
+// suppress the block header rather than the next statement.
+function analyze(source: string, opts?: { with_tokens?: boolean }) {
+    const lexer = new StataLexer();
+    const parser = new StataParser();
+    const analyzer = new SemanticAnalyzer();
+    const { tokens } = lexer.tokenize(source);
+    const { ast } = parser.parse(tokens);
+    const config = {
+        undefined_macro_enabled: true,
+        undefined_variable_enabled: true,
+    };
+    return analyzer.analyze(
+        ast,
+        'file:///test.do',
+        undefined,
+        config,
+        opts?.with_tokens === false ? undefined : tokens
+    );
+}
+
+function variable_warnings(source: string, name: string, opts?: { with_tokens?: boolean }) {
+    return analyze(source, opts).diagnostics.filter(d =>
+        d.message.includes(name)
+    );
+}
+
+describe('block-ending comment directives', () => {
+    const with_directive =
+        'if 1 {\n    display 1\n    // @lsp-variables income_usd\n}\nlist income_usd\n';
+    const without_directive = 'if 1 {\n    display 1\n}\nlist income_usd\n';
+
+    test('@lsp-variables before a closer suppresses the later undefined-variable warning', () => {
+        expect(variable_warnings(without_directive, 'income_usd')).not.toHaveLength(0);
+        expect(variable_warnings(with_directive, 'income_usd')).toHaveLength(0);
+    });
+
+    test('@lsp-variables before a closer works via the AST fallback (no tokens)', () => {
+        expect(
+            variable_warnings(with_directive, 'income_usd', { with_tokens: false })
+        ).toHaveLength(0);
+    });
+
+    test('@lsp-ignore before a closer targets its own line, never the block header', () => {
+        // Exercise the AST fallback (no tokens) so parse_block_ending_directive
+        // is the code under test. The block header (line 0) must NOT be
+        // suppressed; only the comment's own line (line 2) is ignored.
+        const result = analyze(
+            'if 1 {\n    display 1\n    // @lsp-ignore\n}\n',
+            { with_tokens: false }
+        );
+        expect(result.ignored_lines.has(0)).toBe(false);
+        expect(result.ignored_lines.has(2)).toBe(true);
+    });
+});

--- a/tests/unit/block-ending-trivia.test.ts
+++ b/tests/unit/block-ending-trivia.test.ts
@@ -32,6 +32,25 @@ function block_comment_contents(node: NodeWithBlockEndingTrivia): string[] {
     return (node.blockEndingTrivia ?? []).map(t => t.content);
 }
 
+// Collect every comment's content anywhere in the tree (leading, trailing, or
+// block-ending), so a "comment must never be dropped" assertion is independent
+// of which owner the parser chose.
+function collect_all_trivia(nodes: StataNode[]): string[] {
+    const the_contents: string[] = [];
+    const walk = (the_nodes: (StataNode | undefined)[]): void => {
+        for (const my_node of the_nodes) {
+            if (!my_node) continue;
+            const my_typed = my_node as NodeWithBlockEndingTrivia;
+            for (const t of my_typed.leadingTrivia ?? []) the_contents.push(t.content);
+            for (const t of my_typed.blockEndingTrivia ?? []) the_contents.push(t.content);
+            for (const t of my_typed.trailingTrivia ?? []) the_contents.push(t.content);
+            if (my_typed.body) walk(my_typed.body);
+        }
+    };
+    walk(nodes);
+    return the_contents;
+}
+
 function expect_block_ending_comment(
     node: StataNode | undefined,
     expected_comments: string[]
@@ -160,17 +179,20 @@ describe('block-ending trivia ownership', () => {
         ]);
     });
 
-    test('unclosed brace block does not populate blockEndingTrivia', () => {
+    test('unclosed brace block does not populate blockEndingTrivia but keeps the comment', () => {
         const result = parse_result('if 1 {\n    display 1\n    * keep');
         const block_node = as_block_node(result.ast.nodes.find(n => n.type === 'if'));
 
         expect(block_node.blockEndingTrivia).toBeUndefined();
+        // The comment must never be dropped on the recovery path.
+        expect(collect_all_trivia(result.ast.nodes)).toContain('* keep');
     });
 
-    test('program missing end does not populate blockEndingTrivia', () => {
+    test('program missing end does not populate blockEndingTrivia but keeps the comment', () => {
         const result = parse_result('program define p\n    display 1\n    * keep');
         const program = as_block_node(result.ast.nodes.find(n => n.type === 'program'));
 
         expect(program.blockEndingTrivia).toBeUndefined();
+        expect(collect_all_trivia(result.ast.nodes)).toContain('* keep');
     });
 });

--- a/tests/unit/block-ending-trivia.test.ts
+++ b/tests/unit/block-ending-trivia.test.ts
@@ -142,6 +142,24 @@ describe('block-ending trivia ownership', () => {
         expect(inner.leadingTrivia ?? []).toHaveLength(0);
     });
 
+    test('a continuation before the comment leaves the group intact (no split)', () => {
+        // A `///` continuation interleaved with the trailing comment must NOT be
+        // split: draining only the comment would reorder the continuation
+        // relative to the comment across the closer. The whole group stays with
+        // the following statement, preserving pre-existing order.
+        const nodes = parse_nodes(
+            'if 1 {\n    display 1\n    ///\n    * keep\n}\ndisplay 2'
+        );
+        const block_node = as_block_node(nodes.find(n => n.type === 'if'));
+        const following_node = nodes[nodes.length - 1] as NodeWithBlockEndingTrivia;
+
+        expect(block_node.blockEndingTrivia).toBeUndefined();
+        expect((following_node.leadingTrivia ?? []).map(t => t.content)).toEqual([
+            '///',
+            '* keep',
+        ]);
+    });
+
     test('unclosed brace block does not populate blockEndingTrivia', () => {
         const result = parse_result('if 1 {\n    display 1\n    * keep');
         const block_node = as_block_node(result.ast.nodes.find(n => n.type === 'if'));

--- a/tests/unit/block-ending-trivia.test.ts
+++ b/tests/unit/block-ending-trivia.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'bun:test';
+import { StataLexer } from '../../src/lexer';
+import { StataParser } from '../../src/parser';
+import { StataNode, TriviaNode } from '../../src/types';
+
+type NodeWithBlockEndingTrivia = StataNode & {
+    body?: StataNode[];
+    leadingTrivia?: TriviaNode[];
+    trailingTrivia?: TriviaNode[];
+    blockEndingTrivia?: TriviaNode[];
+};
+
+function parse_nodes(source: string): StataNode[] {
+    const lexer = new StataLexer();
+    const parser = new StataParser();
+    const result = parser.parse(lexer.tokenize(source).tokens);
+    return result.ast.nodes;
+}
+
+function parse_result(source: string) {
+    const lexer = new StataLexer();
+    const parser = new StataParser();
+    return parser.parse(lexer.tokenize(source).tokens);
+}
+
+function as_block_node(node: StataNode | undefined): NodeWithBlockEndingTrivia {
+    expect(node).toBeDefined();
+    return node as NodeWithBlockEndingTrivia;
+}
+
+function block_comment_contents(node: NodeWithBlockEndingTrivia): string[] {
+    return (node.blockEndingTrivia ?? []).map(t => t.content);
+}
+
+function expect_block_ending_comment(
+    node: StataNode | undefined,
+    expected_comments: string[]
+): NodeWithBlockEndingTrivia {
+    const block_node = as_block_node(node);
+    expect(block_comment_contents(block_node)).toEqual(expected_comments);
+    expect(block_node.trailingTrivia ?? []).toHaveLength(0);
+    return block_node;
+}
+
+describe('block-ending trivia ownership', () => {
+    test.each([
+        {
+            name: 'forvalues',
+            source: 'forvalues i=1/2 {\n    display 1\n    * keep\n}\ndisplay 2',
+            find: (nodes: StataNode[]) => nodes.find(n => n.type === 'forvalues'),
+        },
+        {
+            name: 'foreach',
+            source: 'foreach x in a b {\n    display "`x\'"\n    * keep\n}\ndisplay 2',
+            find: (nodes: StataNode[]) => nodes.find(n => n.type === 'foreach'),
+        },
+        {
+            name: 'while',
+            source: 'while 1 {\n    display 1\n    * keep\n}\ndisplay 2',
+            find: (nodes: StataNode[]) => nodes.find(n => n.type === 'while'),
+        },
+        {
+            name: 'if',
+            source: 'if 1 {\n    display 1\n    * keep\n}\ndisplay 2',
+            find: (nodes: StataNode[]) => nodes.find(n => n.type === 'if'),
+        },
+        {
+            name: 'else',
+            source: 'if 0 {\n    display 0\n}\nelse {\n    display 1\n    * keep\n}\ndisplay 2',
+            find: (nodes: StataNode[]) => nodes.find(n => n.type === 'else'),
+        },
+        {
+            name: 'frame',
+            source: 'frame scratch {\n    display 1\n    * keep\n}\ndisplay 2',
+            find: (nodes: StataNode[]) => nodes.find(n => n.type === 'frame'),
+        },
+        {
+            name: 'prefix brace block',
+            source: 'capture {\n    display 1\n    * keep\n}\ndisplay 2',
+            find: (nodes: StataNode[]) =>
+                nodes.find(n => n.type === 'command' && n.name === '{'),
+        },
+    ])('$name comment before closer belongs to blockEndingTrivia', ({ source, find }) => {
+        const nodes = parse_nodes(source);
+        const block_node = expect_block_ending_comment(find(nodes), ['* keep']);
+        const following_node = nodes[nodes.length - 1] as NodeWithBlockEndingTrivia;
+
+        expect(block_node.body ?? []).toHaveLength(1);
+        expect(following_node.type).toBe('command');
+        expect(following_node.leadingTrivia ?? []).toHaveLength(0);
+    });
+
+    test('comment before program end belongs to program blockEndingTrivia', () => {
+        const nodes = parse_nodes(
+            'program define p\n    display 1\n    * keep\nend\ndisplay 2'
+        );
+        const program = expect_block_ending_comment(
+            nodes.find(n => n.type === 'program'),
+            ['* keep']
+        );
+        const following_node = nodes[nodes.length - 1] as NodeWithBlockEndingTrivia;
+
+        expect(program.body ?? []).toHaveLength(1);
+        expect(following_node.type).toBe('command');
+        expect(following_node.leadingTrivia ?? []).toHaveLength(0);
+    });
+
+    test('empty-body block can own its only comment as blockEndingTrivia', () => {
+        const nodes = parse_nodes('if 1 {\n    * only\n}\ndisplay 2');
+        const block_node = expect_block_ending_comment(
+            nodes.find(n => n.type === 'if'),
+            ['* only']
+        );
+
+        expect(block_node.body ?? []).toHaveLength(0);
+    });
+
+    test('multiple consecutive comments before a closer stay in order', () => {
+        const nodes = parse_nodes(
+            'while 1 {\n    display 1\n    * first\n    // second\n}\ndisplay 2'
+        );
+
+        expect_block_ending_comment(
+            nodes.find(n => n.type === 'while'),
+            ['* first', '// second']
+        );
+    });
+
+    test('nested blocks keep inner and outer block-ending comments separate', () => {
+        const nodes = parse_nodes(
+            'if 1 {\n    while 1 {\n        display 1\n        * inner\n    }\n    * outer\n}\ndisplay 2'
+        );
+        const outer = expect_block_ending_comment(
+            nodes.find(n => n.type === 'if'),
+            ['* outer']
+        );
+        const inner = expect_block_ending_comment(
+            (outer.body ?? []).find(n => n.type === 'while'),
+            ['* inner']
+        );
+
+        expect(inner.leadingTrivia ?? []).toHaveLength(0);
+    });
+
+    test('unclosed brace block does not populate blockEndingTrivia', () => {
+        const result = parse_result('if 1 {\n    display 1\n    * keep');
+        const block_node = as_block_node(result.ast.nodes.find(n => n.type === 'if'));
+
+        expect(block_node.blockEndingTrivia).toBeUndefined();
+    });
+
+    test('program missing end does not populate blockEndingTrivia', () => {
+        const result = parse_result('program define p\n    display 1\n    * keep');
+        const program = as_block_node(result.ast.nodes.find(n => n.type === 'program'));
+
+        expect(program.blockEndingTrivia).toBeUndefined();
+    });
+});

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -933,6 +933,7 @@ end`;
     // in the tree, tolerant of union members that do not carry trivia.
     type MaybeTriviaNode = {
       leadingTrivia?: { content: string }[];
+      blockEndingTrivia?: { content: string }[];
       trailingTrivia?: { content: string }[];
       body?: MaybeTriviaNode[];
     };
@@ -941,6 +942,7 @@ end`;
       const walk = (the_nodes: MaybeTriviaNode[]): void => {
         for (const my_node of the_nodes) {
           for (const t of my_node.leadingTrivia ?? []) contents.push(t.content);
+          for (const t of my_node.blockEndingTrivia ?? []) contents.push(t.content);
           for (const t of my_node.trailingTrivia ?? []) contents.push(t.content);
           if (my_node.body) walk(my_node.body);
         }
@@ -1050,16 +1052,17 @@ end`;
       expect(codes).toContain('ORPHAN_CLOSE_BRACE');
     });
 
-    test('comment before } is preserved and not corrupted', () => {
+    test('comment before } is preserved as block-ending trivia', () => {
       // A comment on its own line just before the closing brace must survive in
-      // the AST (it must never be dropped). Its attachment point matches the
-      // pre-existing `#delimit cr` behavior; this fix does not reposition it.
+      // the AST (it must never be dropped) and belongs to the block body.
       const source =
         '#delimit ;\nforvalues i=1/3 {;\n    display 1;\n' +
         '    * inner;\n};\ndisplay 2;\n#delimit cr';
       const result = parse(source);
       const loop = result.ast.nodes.find(n => n.type === 'forvalues');
       expect(loop && loop.type === 'forvalues' && loop.body).toHaveLength(1);
+      expect(loop && loop.type === 'forvalues' && loop.blockEndingTrivia?.[0]?.content)
+        .toContain('* inner');
       expect(collect_all_trivia(result.ast.nodes).join('')).toContain('* inner');
     });
 


### PR DESCRIPTION
## Summary

Fixes #304. A comment on its own line immediately before a block's closing brace
(or a program's `end`) used to attach to the wrong owner: to the statement
**after** the block (as `leadingTrivia`), or at EOF to the block's
`trailingTrivia`. AST-mode formatting then emitted it after the `}`/`end`;
source-preserving mode de-indented it to the outer scope. This was pre-existing
(present in `#delimit cr` on `main`) and explicitly deferred from #301/PR #303.

The fix gives the comment a dedicated owner: a new `blockEndingTrivia?: TriviaNode[]`
field on `ControlFlowNode`, `ProgramNode`, and the brace-block `CommandNode`. The
comment now stays **inside** the block, on its own line, at body indentation,
before the closer — in both formatter modes.

## Design

- **Parser** (`src/parser/index.ts`): `parseBraceBody()` returns
  `{ body, blockEndingTrivia }`. `drainBlockEndingTrivia()` moves the trailing
  comment run out of `pending_trivia` **only** when the next token is the real
  `RBRACE` (and, for programs, the real `end`); on EOF/missing-closer it leaves
  `pending_trivia` untouched so error recovery is unchanged. A `///` continuation
  interleaved with the comments makes the drain bail entirely (no split/reorder).
  All six brace-body callers and the program body assign the field.
- **AST pretty-printer** (`src/pretty-printer/index.ts`): `printBlockEndingTrivia()`
  emits each comment on its own line at body indent, after the body loop and
  before the indent decrement, in `printControlFlow` / `printProgram` /
  `printCommand` (brace branch). It uses a plain `\n` terminator (not the `;`
  statement terminator) — comments are not statements — which keeps block-ending
  comments idempotent even under `#delimit ;`.
- **Source-preserving formatter** (`src/formatter/indentation-analyzer.ts`):
  `process_block_ending_trivia()` marks the comment lines at body depth in
  `process_block_node` and `process_command_brace_block` (via the new shared
  `mark_comment_trivia_indentation` helper), not in the generic outer-depth path.
- **Analyzer** (`src/analyzer/index.ts`): directive extraction now walks node
  lists with an `outer_successor`, so a block-ending `@lsp-ignore` /
  `@lsp-ignore-next` targets the statement **after the block** (its next sibling,
  or the statement after the enclosing block when it is the last child) — exactly
  the node that held the comment as leading trivia before this change — and never
  the block header. Recursion (`directive_recursion_body`) descends into program,
  control-flow, `frame`, and prefix brace-command bodies. `@lsp-variables` is
  keyed to the comment's own line as before. The authoritative token path is
  unchanged.
- **Test helpers**: `ast-comparison.ts` compares `blockEndingTrivia` (and now the
  brace-command `body`); `document-utils.ts::extract_comments` walks
  `blockEndingTrivia` so the comment-preservation property sees the moved comment.

## Test evidence

- `bun run typecheck`: clean (exit 0).
- `bun test ./tests`: **7506 pass, 5 skip, 0 fail** (629 files).
- `bun run lint` (eslint, not in CI): clean, no warnings.
- `bun test tests/property/delimiter-mode-equivalence.prop.test.ts`: 3 pass.
- New tests: `tests/unit/block-ending-trivia.test.ts` (ownership across
  forvalues/foreach/while/if/else/frame/prefix-brace/program, empty body,
  multiple comments, nesting, continuation no-split, missing-closer/`end`
  recovery keeping the comment), `tests/unit/block-ending-directives.test.ts`
  (block-ending `@lsp-ignore`/`@lsp-ignore-next`/`@lsp-variables` semantics incl.
  doubly-nested + frame + capture, token and AST-fallback paths),
  `tests/property/block-ending-trivia-formatting.prop.test.ts` (dual-mode,
  asserts formatted output: comment at body indent before the closer, cr-mode
  idempotency, semicolon-mode placement). New tests confirmed to fail on `main`
  (20/23 initial) — they pin the fixed behavior.

## Review-gate history

Architecture was adversarially reviewed (codex + a Sonnet subagent) before
implementation. Implementation was reviewed each round by codex (task-mode) plus
cold Sonnet subagents diffing `main...HEAD`, with regressions verified against
`main` in a throwaway `git worktree`:

- **R1** — codex: parser drained a contiguous trivia group when a `///`
  preceded the comment (split/reorder). Sonnet: analyzer directive fallback
  would target the block header. Fixed (bail on continuation; dedicated helpers).
- **R2** — codex: block-ending `@lsp-ignore-next` lost the following-statement
  suppression `main` applied (verified regression). Fixed by routing block-ending
  trivia through `parse_directive` with the block's next sibling.
- **R3** — both: doubly-nested "block is last child" case still dropped the
  target (verified regression). Fixed by threading `outer_successor`.
- **R4** — codex: prefix brace-command blocks not recursed (verified regression);
  frame gap (pre-existing). Fixed by `directive_recursion_body` (frame + brace).
- **R5** — both: `bun run typecheck` TS2367 on the `is_control_flow || 'frame'`
  predicate (CI gate). Fixed (check `frame` via discriminant first).
- **R6** — codex: `command_nodes_equal` ignored `.body`. Fixed. Other findings
  verified byte-identical on `main` (deferrals below).
- **R7** — codex: `extract_comments` helper missed `blockEndingTrivia`. Fixed;
  swept all trivia consumers.
- **R8 + R9** — both reviewers: **NO SUBSTANTIVE ISSUES** (two consecutive
  fully-clean rounds; each verified strictly-better-or-identical vs `main`).

## Deferrals (verified pre-existing on `main`, out of scope for #304)

- AST-mode formatting emits a doubled `#delimit ;;` terminator in semicolon mode;
  it affects leading/trailing trivia identically on `main`. (Block-ending
  comments themselves are idempotent because they use a plain-newline terminator.)
- `@lsp-ignore`/`@lsp-ignore-next` on a comment before a closer suppresses the
  following statement; if that statement is itself a block header, the whole
  block is skipped (existing ignore + `check_node_references` behavior).
- A `///` continuation interleaved with trailing comments before a closer keeps
  the whole group flowing forward (AST mode may reorder across the closer); a
  descendant block that bails on a continuation can sweep an outer clean comment
  forward too. Byte-identical on `main`.
- `next_statement_line_span` stops at a closing brace (the AST path compensates
  by contributing the real post-block line); unchanged here.

https://claude.ai/code/session_0114zF2WByBWgPPQiyBrRtWZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of comments and directives at the end of blocks, so they stay attached to the correct closing brace or `end`.
  * Enhanced formatting to preserve block-ending comments in the right place across nested blocks and semicolon-delimited mode.

* **Bug Fixes**
  * Fixed cases where block-ending comments could be associated with the wrong statement.
  * Corrected directive behavior so ignored lines and variable directives apply to the intended following code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->