### PR TITLE
Fix #294: bound long-lived cross-file caches with LRU capacity limits

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,6 +356,9 @@ maxBackwardDepth = 10
 maxForwardDepth = 10
 maxChainDepth = 20
 maxCalleeRevalidations = 10
+maxCachedFiles = 2000
+maxCachedScopes = 1000
+maxCachedForwardClosures = 2000
 
 [crossFile.diagnostics]
 missingFile = "warning"
@@ -385,6 +388,9 @@ caseMismatch = "auto"
 | `crossFile.maxForwardDepth`             | number               | `10`            | Maximum recursion depth for forward scope resolution                    |
 | `crossFile.maxChainDepth`               | number               | `20`            | Maximum combined depth for forward + backward resolution                |
 | `crossFile.maxCalleeRevalidations`      | number               | `10`            | Maximum number of open callee documents to revalidate per caller change |
+| `crossFile.maxCachedFiles`              | number               | `2000`          | LRU capacity of the parsed-file cache. A memory-safety backstop: eviction only costs recomputation, never correctness. Very low values degrade performance on deep chains. |
+| `crossFile.maxCachedScopes`             | number               | `1000`          | LRU capacity of the resolved-scope cache                                 |
+| `crossFile.maxCachedForwardClosures`    | number               | `2000`          | LRU capacity of the forward-closure memo (see docs/cross-file.md)        |
 | `crossFile.assumeCallSite`              | `"end"` \| `"start"` | `"end"`         | Where to assume call site when not specified and inference fails        |
 | `crossFile.diagnostics.missingFile`     | severity             | `"warning"`     | Severity for missing directive file diagnostics                         |
 | `crossFile.diagnostics.callSiteIdentification` | severity      | `"information"` | Severity for call site identification diagnostics                       |

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -835,6 +835,9 @@ maxBackwardDepth = 10
 maxForwardDepth = 10
 maxChainDepth = 20
 maxCalleeRevalidations = 10
+maxCachedFiles = 2000
+maxCachedScopes = 1000
+maxCachedForwardClosures = 2000
 assumeCallSite = "end"
 
 [crossFile.diagnostics]
@@ -851,6 +854,9 @@ callSiteIdentification = "information"
 | `crossFile.maxForwardDepth`                   | number   | `10`            | Maximum recursion depth for forward scope resolution   |
 | `crossFile.maxChainDepth`                     | number   | `20`            | Maximum combined depth for forward + backward resolution |
 | `crossFile.maxCalleeRevalidations`            | number   | `10`            | Maximum open callee documents to revalidate per change |
+| `crossFile.maxCachedFiles`                    | number   | `2000`          | LRU capacity of the parsed-file cache (eviction is correctness-neutral) |
+| `crossFile.maxCachedScopes`                   | number   | `1000`          | LRU capacity of the resolved-scope cache               |
+| `crossFile.maxCachedForwardClosures`          | number   | `2000`          | LRU capacity of the forward-closure memo               |
 | `crossFile.assumeCallSite`                    | string   | `"end"`         | Where to assume call site when inference fails (`"end"` or `"start"`) |
 | `crossFile.diagnostics.missingFile`           | severity | `"warning"`     | Severity for missing directive file diagnostics        |
 | `crossFile.diagnostics.callSiteIdentification`| severity | `"information"` | Severity for call site identification diagnostics      |

--- a/docs/cross-file.md
+++ b/docs/cross-file.md
@@ -151,6 +151,17 @@ the resolver reads referenced parent files from disk (even if they are not
 open) and **recursively follows the chain** to build a scope. Results are
 cached and invalidated when relevant files change.
 
+The long-lived caches behind this (the parsed-file cache, the resolved-scope
+cache, and the forward-closure memo) are bounded LRUs (issue #294), sized by
+`crossFile.maxCachedFiles` / `maxCachedScopes` / `maxCachedForwardClosures`
+(defaults 2000 / 1000 / 2000). The bounds are memory-safety backstops for very
+large workspaces and long `sight check` runs: capacity eviction is
+correctness-neutral — an evicted entry is recomputed from disk (or the live
+editor buffer) on the next access, with secondary indexes pruned and the
+forward-closure memo kept consistent on every eviction. Setting the limits
+very low only degrades performance (more re-parsing/re-resolution), never
+results.
+
 Importantly, your editor tab state does not change the *meaning* of the
 analysis for a file: what you see for a given file is determined by that file's
 contents plus its parent chain (and, separately, whatever symbols exist in the

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -384,10 +384,20 @@ export async function build_check_context(
             }
         },
         warn: (message) => console.error(message),
+    }, undefined, {
+        // Cache LRU capacities (#294): the CLI has its validated config in
+        // hand before construction, so pass capacities directly.
+        max_cached_files: config.cross_file.max_cached_files,
+        max_cached_scopes: config.cross_file.max_cached_scopes,
     });
     const forward_scope_resolver = new ForwardScopeResolver(scope_resolver, {
         max_forward_depth: config.cross_file.max_forward_depth,
     });
+    if (config.cross_file.max_cached_forward_closures !== undefined) {
+        forward_scope_resolver.set_forward_closure_memo_capacity(
+            config.cross_file.max_cached_forward_closures
+        );
+    }
     const diagnostics_provider = new DiagnosticsProvider({
         sendDiagnostics: () => undefined,
     });

--- a/src/config-file/schema.ts
+++ b/src/config-file/schema.ts
@@ -486,6 +486,9 @@ function map_cross_file(
             'maxForwardDepth',
             'maxChainDepth',
             'maxCalleeRevalidations',
+            'maxCachedFiles',
+            'maxCachedScopes',
+            'maxCachedForwardClosures',
             'diagnostics',
         ],
         'crossFile',
@@ -557,6 +560,30 @@ function map_cross_file(
         raw,
         'maxCalleeRevalidations',
         'crossFile.maxCalleeRevalidations',
+        warn
+    );
+    assign_number(
+        mapped,
+        'max_cached_files',
+        raw,
+        'maxCachedFiles',
+        'crossFile.maxCachedFiles',
+        warn
+    );
+    assign_number(
+        mapped,
+        'max_cached_scopes',
+        raw,
+        'maxCachedScopes',
+        'crossFile.maxCachedScopes',
+        warn
+    );
+    assign_number(
+        mapped,
+        'max_cached_forward_closures',
+        raw,
+        'maxCachedForwardClosures',
+        'crossFile.maxCachedForwardClosures',
         warn
     );
 

--- a/src/forward-scope-resolver/index.ts
+++ b/src/forward-scope-resolver/index.ts
@@ -33,6 +33,7 @@ import {
     type PathCaseOutcome,
 } from '../utils/file-path-utils';
 import { get_workspace_root_for_path } from '../utils/workspace-roots';
+import { BoundedLruMap } from '../utils/lru-cache';
 import { filter_dofile_locals, is_dofile_local } from '../utils/dofile-locals';
 import { clone_symbol_table } from '../scope-resolver/visible-symbols';
 
@@ -130,11 +131,16 @@ export function build_forward_closure_key(
  *                    miss that built it.
  * - `invalidations`  entries evicted (by URI invalidation, a graph-version
  *                    change, or a full clear).
+ * - `evictions`      entries dropped by LRU capacity pressure (#294) —
+ *                    counted separately from `invalidations` because
+ *                    capacity eviction is not a semantic invalidation (it
+ *                    does not bump the invalidation epoch).
  */
 export interface ForwardClosureMemoMetrics {
     hits: number;
     misses: number;
     invalidations: number;
+    evictions: number;
 }
 
 /**
@@ -185,6 +191,13 @@ const DEFAULT_CONFIG: ForwardScopeConfig = {
     max_forward_depth: 10,
 };
 
+// Default LRU capacity for the forward-closure memo (#294). A memory-
+// safety backstop far above realistic workspace sizes. Kept in sync with
+// DEFAULT_SETTINGS.cross_file in server-handlers.ts. NOT a
+// ForwardScopeConfig field: capacity is instance-lifetime resource state,
+// not per-resolve configuration.
+export const DEFAULT_MAX_CACHED_FORWARD_CLOSURES = 2000;
+
 export class ForwardScopeResolver {
     private scope_resolver: ScopeResolver;
     private default_config: ForwardScopeConfig;
@@ -206,7 +219,23 @@ export class ForwardScopeResolver {
     // scope_cache's index (which covers only each entry's OWN uri and needs
     // an O(N) scan for cascades), this index maps EVERY dependent URI to the
     // keys that depend on it.
-    private forward_closure_memo = new Map<string, ForwardClosureMemoEntry>();
+    // Bounded LRU (#294). Capacity eviction prunes memo_uri_to_keys via
+    // the on_evict hook but deliberately does NOT bump
+    // memo_invalidation_epoch: eviction carries no semantic information
+    // (nothing changed), and bumping would spuriously discard valid
+    // in-flight standalone builds. Contrast with ScopeResolver's
+    // file_cache eviction, which DOES invalidate this memo (epoch bump
+    // included) for the evicted URI — there the eviction destroys the
+    // stale-content hash baseline the defensive purges compare against.
+    private forward_closure_memo = new BoundedLruMap<string, ForwardClosureMemoEntry>(
+        DEFAULT_MAX_CACHED_FORWARD_CLOSURES,
+        {
+            on_evict: (key, entry) => {
+                this.memo_metrics.evictions++;
+                this.prune_memo_uri_to_keys_for_entry(key, entry);
+            },
+        }
+    );
     private memo_uri_to_keys = new Map<string, Set<string>>();
     // The dep-graph version the memo's entries were built against. A
     // version change makes EVERY existing entry dead by construction (all
@@ -224,6 +253,7 @@ export class ForwardScopeResolver {
         hits: 0,
         misses: 0,
         invalidations: 0,
+        evictions: 0,
     };
     // URIs whose standalone closure build is currently in flight. A memo
     // hook firing for one of these is a guaranteed re-entry (the build's
@@ -287,8 +317,15 @@ export class ForwardScopeResolver {
         return { ...this.memo_metrics };
     }
 
+    /** Live memo entry-count gauge (#294) — read fresh, never reset. */
+    get_forward_closure_memo_size(): number {
+        return this.forward_closure_memo.size;
+    }
+
     reset_forward_closure_metrics(): void {
-        this.memo_metrics = { hits: 0, misses: 0, invalidations: 0 };
+        this.memo_metrics = {
+            hits: 0, misses: 0, invalidations: 0, evictions: 0,
+        };
     }
 
     /**
@@ -331,12 +368,28 @@ export class ForwardScopeResolver {
      * Returns true when the key existed.
      */
     private delete_memo_entry(key: string): boolean {
-        const my_entry = this.forward_closure_memo.get(key);
+        // peek: invalidation-path read, must not promote (#294).
+        const my_entry = this.forward_closure_memo.peek(key);
         if (!my_entry) {
             return false;
         }
         this.forward_closure_memo.delete(key);
-        for (const my_dep_uri of my_entry.dependent_uris) {
+        this.prune_memo_uri_to_keys_for_entry(key, my_entry);
+        return true;
+    }
+
+    /**
+     * Remove every memo_uri_to_keys reference to `key`, given the entry's
+     * dependent_uris. The single index-pruning idiom shared by
+     * delete_memo_entry (explicit invalidation) and the LRU eviction hook
+     * (#294) — the memo entry itself must already be (or be about to be)
+     * removed by the caller.
+     */
+    private prune_memo_uri_to_keys_for_entry(
+        key: string,
+        entry: ForwardClosureMemoEntry
+    ): void {
+        for (const my_dep_uri of entry.dependent_uris) {
             const my_key_set = this.memo_uri_to_keys.get(my_dep_uri);
             if (my_key_set) {
                 my_key_set.delete(key);
@@ -345,7 +398,15 @@ export class ForwardScopeResolver {
                 }
             }
         }
-        return true;
+    }
+
+    /**
+     * Update the memo's LRU capacity (#294). Shrinking evicts LRU-first
+     * immediately through the same on_evict hook as normal capacity
+     * pressure (index pruned, no epoch bump).
+     */
+    set_forward_closure_memo_capacity(max_entries: number): void {
+        this.forward_closure_memo.set_max_size(max_entries);
     }
 
     /**
@@ -1353,6 +1414,15 @@ export class ForwardScopeResolver {
         key: string,
         entry: ForwardClosureMemoEntry
     ): ForwardClosureMemoEntry {
+        // Overwriting an existing key must first prune the OLD entry's
+        // index rows — its dependent_uris can differ (e.g. different
+        // missing-probe sets), and set() below fires no eviction hook for
+        // same-key replacement, so skipping this leaks dangling
+        // memo_uri_to_keys rows (#294; pre-existing lockstep gap).
+        const my_previous = this.forward_closure_memo.peek(key);
+        if (my_previous) {
+            this.prune_memo_uri_to_keys_for_entry(key, my_previous);
+        }
         this.forward_closure_memo.set(key, entry);
         for (const my_dep_uri of entry.dependent_uris) {
             let my_key_set = this.memo_uri_to_keys.get(my_dep_uri);

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -19,6 +19,7 @@ import {
     OutOfScopeSymbol,
     ScopeCacheEntry,
     ScopeCacheMetrics,
+    ScopeCacheSizes,
     ScopeResolverLogger,
     ForwardCall,
     CdCommand,
@@ -42,6 +43,7 @@ import { StataParser } from '../parser';
 import { SemanticAnalyzer, create_empty_symbol_table, merge_symbol_tables } from '../analyzer';
 import { logger } from '../utils/logger';
 import { error_message } from '../utils/error-message';
+import { BoundedLruMap } from '../utils/lru-cache';
 import { filter_dofile_locals, is_dofile_local } from '../utils/dofile-locals';
 import { get_line_text, get_line_count, compute_line_offsets } from '../utils/line-utils';
 import {
@@ -78,6 +80,12 @@ const DEFAULT_CONFIG: ScopeResolverConfig = {
     max_forward_depth: 10,
     max_chain_depth: 20,
 };
+
+// Default LRU capacities for the long-lived caches (#294). Memory-safety
+// backstops far above realistic workspace sizes — NOT working-set tuners.
+// Kept in sync with DEFAULT_SETTINGS.cross_file in server-handlers.ts.
+export const DEFAULT_MAX_CACHED_FILES = 2000;
+export const DEFAULT_MAX_CACHED_SCOPES = 1000;
 
 /**
  * Build a Partial<ScopeResolverConfig> with undefined values filtered out.
@@ -152,6 +160,12 @@ type RequestCache = Map<string, Promise<ParsedFileResult>>;
  * path only — see the working_directory_directive note from PR #278).
  */
 type FileCacheEntry = {
+    /**
+     * The entry's own URI (#294). Cache keys are "uri|working_directory",
+     * so the eviction hook stores the URI here instead of parsing it back
+     * out of the key.
+     */
+    uri: string;
     content: string;
     content_hash: string;
     mtimeMs?: number;
@@ -223,8 +237,8 @@ export class ScopeResolver {
     // by an 'auto'-mode resolution. Directive-less auto-mode hits re-sync
     // idempotently because registration is global per URI, not per
     // file_cache entry — see upgrade_registration_on_cache_hit.
-    private file_cache: Map<string, FileCacheEntry>;
-    private scope_cache: Map<string, ScopeCacheEntry>;
+    private file_cache: BoundedLruMap<string, FileCacheEntry>;
+    private scope_cache: BoundedLruMap<string, ScopeCacheEntry>;
     // Secondary index: uri -> Set<cache_keys> for O(1) scope cache invalidation by URI
     private uri_to_cache_keys: Map<string, Set<string>>;
     private cache_metrics: ScopeCacheMetrics;
@@ -240,13 +254,52 @@ export class ScopeResolver {
     // When undefined, resolve_path_rich uses the real Node fs.
     private resolve_fs?: RichResolveFs;
 
-    constructor(logger?: ScopeResolverLogger, content_provider?: ContentProvider) {
+    constructor(
+        logger?: ScopeResolverLogger,
+        content_provider?: ContentProvider,
+        cache_capacities?: {
+            max_cached_files?: number;
+            max_cached_scopes?: number;
+        }
+    ) {
         this.directive_parser = new DirectiveParser();
         this.lexer = new StataLexer();
         this.parser = new StataParser();
         this.analyzer = new SemanticAnalyzer();
-        this.file_cache = new Map();
-        this.scope_cache = new Map();
+        // Bounded caches (#294). Capacity eviction is correctness-neutral
+        // (a miss recomputes from disk/buffer), with one obligation each:
+        // - file_cache: the evicted URI's forward-closure memo entries must
+        //   be invalidated NOW, because the stale-content purges in
+        //   parse_file/_get_parsed_file_impl compare against the old cached
+        //   hash — once the entry is gone, that baseline is gone with it,
+        //   and a memo entry re-poisoned during a debounce window would
+        //   otherwise never be purged. This uses the normal invalidation
+        //   (epoch-bumping) semantics: an eviction during an in-flight
+        //   standalone build's await window makes that build skip its memo
+        //   store and fall back to the live walk (degraded, never wrong).
+        // - scope_cache: prune the uri_to_cache_keys secondary index so it
+        //   cannot leak keys for evicted entries.
+        // Both hooks run synchronously inside set()/set_max_size() and do
+        // not re-enter the evicting map.
+        this.file_cache = new BoundedLruMap(
+            cache_capacities?.max_cached_files ?? DEFAULT_MAX_CACHED_FILES,
+            {
+                on_evict: (_key, entry) => {
+                    this.cache_metrics.file.evictions++;
+                    this.forward_scope_resolver
+                        ?.invalidate_forward_closure_for_uri?.(entry.uri);
+                },
+            }
+        );
+        this.scope_cache = new BoundedLruMap(
+            cache_capacities?.max_cached_scopes ?? DEFAULT_MAX_CACHED_SCOPES,
+            {
+                on_evict: (key) => {
+                    this.cache_metrics.scope.evictions++;
+                    this.prune_uri_to_cache_keys_for_key(key);
+                },
+            }
+        );
         this.uri_to_cache_keys = new Map();
         this.cache_metrics = this.create_metrics();
         this.logger = logger;
@@ -396,8 +449,8 @@ export class ScopeResolver {
      */
     private create_metrics(): ScopeCacheMetrics {
         const metrics = {
-            scope: { hits: 0, misses: 0, invalidations: 0 },
-            file: { hits: 0, misses: 0, invalidations: 0 },
+            scope: { hits: 0, misses: 0, invalidations: 0, evictions: 0 },
+            file: { hits: 0, misses: 0, invalidations: 0, evictions: 0 },
         };
         return {
             ...metrics,
@@ -405,6 +458,42 @@ export class ScopeResolver {
             get misses() { return metrics.scope.misses; },
             get invalidations() { return metrics.scope.invalidations; },
         };
+    }
+
+    /**
+     * Update the LRU capacities of the long-lived caches (#294). Shrinking
+     * below the current size evicts LRU-first immediately (through the
+     * same on_evict hooks as normal capacity pressure, so secondary
+     * indexes and the forward-closure memo stay consistent).
+     */
+    set_cache_capacities(capacities: {
+        max_cached_files?: number;
+        max_cached_scopes?: number;
+    }): void {
+        if (capacities.max_cached_files !== undefined) {
+            this.file_cache.set_max_size(capacities.max_cached_files);
+        }
+        if (capacities.max_cached_scopes !== undefined) {
+            this.scope_cache.set_max_size(capacities.max_cached_scopes);
+        }
+    }
+
+    /**
+     * Remove one scope_cache key's reference from the uri_to_cache_keys
+     * secondary index (dropping the URI's Set when it empties). The single
+     * pruning idiom shared by explicit invalidation scans and the LRU
+     * eviction hook (#294) — the scope_cache entry itself must already be
+     * (or be about to be) removed by the caller.
+     */
+    private prune_uri_to_cache_keys_for_key(cache_key: string): void {
+        const key_uri = this.extract_uri_from_cache_key(cache_key);
+        const key_set = this.uri_to_cache_keys.get(key_uri);
+        if (key_set) {
+            key_set.delete(cache_key);
+            if (key_set.size === 0) {
+                this.uri_to_cache_keys.delete(key_uri);
+            }
+        }
     }
 
     /**
@@ -430,15 +519,7 @@ export class ScopeResolver {
 
         for (const my_key of keys_to_remove) {
             this.scope_cache.delete(my_key);
-            // Update secondary index
-            const key_uri = this.extract_uri_from_cache_key(my_key);
-            const key_set = this.uri_to_cache_keys.get(key_uri);
-            if (key_set) {
-                key_set.delete(my_key);
-                if (key_set.size === 0) {
-                    this.uri_to_cache_keys.delete(key_uri);
-                }
-            }
+            this.prune_uri_to_cache_keys_for_key(my_key);
         }
 
         return keys_to_remove.length;
@@ -1519,6 +1600,12 @@ export class ScopeResolver {
             ...config,
             backward_dependencies: 'explicit',
         };
+        // Probe-only reads (#294): the forced-'explicit' mode above exists
+        // for deterministic WD discovery, not to express registration
+        // intent — letting this walk register would let a post-capacity-
+        // eviction reparse wipe a directive-less file's auto-discovered
+        // parent edges (clear-then-register under 'explicit' with zero raw
+        // directives). Registration stays owned by genuine resolutions.
         return this.discover_working_directory(
             the_backward_directives,
             new Set<string>(),
@@ -1526,6 +1613,8 @@ export class ScopeResolver {
             my_config,
             new Map(),
             current_uri,
+            undefined,
+            /* skip_backward_registration */ true,
         );
     }
 
@@ -1550,7 +1639,8 @@ export class ScopeResolver {
         config: ScopeResolverConfig,
         request_cache: RequestCache,
         current_uri: string,
-        token?: CancellationToken
+        token?: CancellationToken,
+        skip_backward_registration?: boolean
     ): Promise<string | undefined> {
         // Check depth limit
         if (depth > config.max_backward_depth) {
@@ -1598,6 +1688,10 @@ export class ScopeResolver {
                         // mirrors get_effective_backward_directives.
                         backward_dependencies:
                             config.backward_dependencies ?? 'auto',
+                        // Probe-only when driven by the indexer's WD walk
+                        // (#294): its forced-'explicit' mode is a
+                        // determinism hack, not registration intent.
+                        skip_backward_registration,
                     }
                 );
             } catch (error) {
@@ -1673,7 +1767,8 @@ export class ScopeResolver {
                     config,
                     request_cache,
                     my_parent_uri,
-                    token
+                    token,
+                    skip_backward_registration
                 );
 
                 // Allow same file via different paths
@@ -2207,8 +2302,11 @@ export class ScopeResolver {
         diagnostics: DirectiveDiagnostic[];
     } {
         const content_hash = this.hash_content(content);
-        const cached = this.file_cache.get(uri);
+        // peek: this is a validation probe until the hash matches; only a
+        // served hit promotes (#294 recency contract).
+        const cached = this.file_cache.peek(uri);
         if (cached && cached.content_hash === content_hash) {
+            this.file_cache.touch(uri);
             return {
                 symbols: cached.symbols,
                 directives: cached.directives,
@@ -2237,6 +2335,7 @@ export class ScopeResolver {
             const my_parse_result = this.parse_content(uri, content);
 
             this.file_cache.set(uri, {
+                uri,
                 content,
                 content_hash,
                 size: Buffer.byteLength(content, 'utf8'),
@@ -2449,11 +2548,21 @@ export class ScopeResolver {
      *   thread the chain's mode (normalized with ?? 'auto', matching
      *   get_effective_backward_directives). Deliberately NOT part of any
      *   cache key: parsed content is mode-independent.
+     * @param options.skip_backward_registration - Probe-only read (#294):
+     *   perform NO backward-directive registration and write NO
+     *   registered_backward_mode stamp (hit paths also skip the
+     *   registration upgrade). Used by resolve_inherited_working_directory,
+     *   whose forced-'explicit' walk exists purely for deterministic WD
+     *   discovery — letting it register would let a post-eviction reparse
+     *   wipe auto-discovered parent edges, and letting it stamp would let
+     *   an entry claim a registration that never ran. An unstamped entry
+     *   is registered by the next real registering read's hit path (see
+     *   upgrade_registration_on_cache_hit).
      */
     async get_parsed_file(
         uri: string,
         fs_path: string,
-        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache; backward_dependencies?: 'auto' | 'explicit' }
+        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache; backward_dependencies?: 'auto' | 'explicit'; skip_backward_registration?: boolean }
     ): Promise<ParsedFileResult> {
         // Use request cache if available to avoid duplicate reads/parses in same request
         if (options?.request_cache) {
@@ -2507,21 +2616,26 @@ export class ScopeResolver {
     private async _get_parsed_file_impl(
         uri: string,
         fs_path: string,
-        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache; backward_dependencies?: 'auto' | 'explicit' }
+        options?: { skip_disk_if_cached?: boolean; working_directory?: string; request_cache?: RequestCache; backward_dependencies?: 'auto' | 'explicit'; skip_backward_registration?: boolean }
     ): Promise<ParsedFileResult> {
         const inherited_wd = options?.working_directory;
         const cache_key = this.make_file_cache_key(uri, inherited_wd);
 
         // 1. Initial Cache/Stat Check (Avoid Disk Read if possible)
-        const cached = this.file_cache.get(cache_key);
+        // peek: a validation probe until one of the hit branches below
+        // decides to serve it; served hits touch() to promote (#294).
+        const cached = this.file_cache.peek(cache_key);
 
         // Cache-first mode: return cached entry without disk access if available
         if (options?.skip_disk_if_cached && cached) {
             this.log(`[get_parsed_file] file_cache HIT for ${cache_key} (skip_disk_if_cached)`);
             this.cache_metrics.file.hits++;
-            this.upgrade_registration_on_cache_hit(
-                uri, cached, options?.backward_dependencies
-            );
+            this.file_cache.touch(cache_key);
+            if (!options?.skip_backward_registration) {
+                this.upgrade_registration_on_cache_hit(
+                    uri, cached, options?.backward_dependencies
+                );
+            }
             return this.cache_entry_to_parsed_result(
                 cached, cached.content, cached.content_hash
             );
@@ -2541,9 +2655,12 @@ export class ScopeResolver {
                 cached.size !== undefined && cached.size === size) {
                 this.cache_metrics.file.hits++;
                 this.log(`[get_parsed_file] File cache HIT for ${uri} (mtime match, skipped read)`);
-                this.upgrade_registration_on_cache_hit(
-                    uri, cached, options?.backward_dependencies
-                );
+                this.file_cache.touch(cache_key);
+                if (!options?.skip_backward_registration) {
+                    this.upgrade_registration_on_cache_hit(
+                        uri, cached, options?.backward_dependencies
+                    );
+                }
                 return this.cache_entry_to_parsed_result(
                     cached, cached.content, cached.content_hash
                 );
@@ -2568,18 +2685,21 @@ export class ScopeResolver {
                         const fallback_mtimeMs = fallback_stats?.mtimeMs;
                         const fallback_size = fallback_stats?.size;
                         const fallback_cache_key = this.make_file_cache_key(fallback_uri, inherited_wd);
-                        const fallback_cached = this.file_cache.get(fallback_cache_key);
+                        const fallback_cached = this.file_cache.peek(fallback_cache_key);
 
                         if (fallback_cached && fallback_mtimeMs !== undefined && fallback_size !== undefined &&
                             fallback_cached.mtimeMs !== undefined && fallback_cached.mtimeMs === fallback_mtimeMs &&
                             fallback_cached.size !== undefined && fallback_cached.size === fallback_size) {
                             this.cache_metrics.file.hits++;
                             this.log(`[get_parsed_file] File cache HIT for ${fallback_uri} (mtime match, skipped read)`);
-                            this.upgrade_registration_on_cache_hit(
-                                fallback_uri,
-                                fallback_cached,
-                                options?.backward_dependencies
-                            );
+                            this.file_cache.touch(fallback_cache_key);
+                            if (!options?.skip_backward_registration) {
+                                this.upgrade_registration_on_cache_hit(
+                                    fallback_uri,
+                                    fallback_cached,
+                                    options?.backward_dependencies
+                                );
+                            }
                             return this.cache_entry_to_parsed_result(
                                 fallback_cached,
                                 fallback_cached.content,
@@ -2607,15 +2727,18 @@ export class ScopeResolver {
 
         // 3. Final Cache/Hash check (Defensive)
         const actual_cache_key = this.make_file_cache_key(actual_uri, inherited_wd);
-        const actual_cached = this.file_cache.get(actual_cache_key);
+        const actual_cached = this.file_cache.peek(actual_cache_key);
         const disk_hash = this.hash_content(content);
 
         if (actual_cached && actual_cached.content_hash === disk_hash) {
             this.cache_metrics.file.hits++;
             this.log(`[get_parsed_file] File cache HIT for ${actual_uri} (hash match)`);
-            this.upgrade_registration_on_cache_hit(
-                actual_uri, actual_cached, options?.backward_dependencies
-            );
+            this.file_cache.touch(actual_cache_key);
+            if (!options?.skip_backward_registration) {
+                this.upgrade_registration_on_cache_hit(
+                    actual_uri, actual_cached, options?.backward_dependencies
+                );
+            }
             // Return cached results with current content - don't mutate the
             // entry's cached content/symbols (the registration stamp above
             // is the one intentional entry mutation on this hit path)
@@ -2645,6 +2768,7 @@ export class ScopeResolver {
             }
 
             this.file_cache.set(actual_cache_key, {
+                uri: actual_uri,
                 content,
                 content_hash: disk_hash,
                 mtimeMs,
@@ -2659,9 +2783,14 @@ export class ScopeResolver {
                 diagnostics: parse_result.diagnostics,
                 // Stamp the mode the registration below runs under (and
                 // upgrade an 'explicit'-registered entry on later
-                // auto-mode cache hits (issue #286).
-                registered_backward_mode:
-                    options?.backward_dependencies ?? 'explicit',
+                // auto-mode cache hits (issue #286). A probe-only read
+                // (#294) performs no registration and therefore stamps
+                // nothing — an entry must never claim a registration that
+                // never ran; the next real registering read's hit path
+                // registers it (upgrade_registration_on_cache_hit).
+                registered_backward_mode: options?.skip_backward_registration
+                    ? undefined
+                    : (options?.backward_dependencies ?? 'explicit'),
             });
 
             // Register backward directive dependencies from cached file
@@ -2678,12 +2807,14 @@ export class ScopeResolver {
             // with one exception: a `sight: standalone` file's effective
             // directives are EMPTY (issue #208), so its raw done-by edges
             // are deliberately not registered.
-            this.apply_backward_directive_registration(
-                actual_uri,
-                parse_result.directives,
-                { backward_dependencies: options?.backward_dependencies ?? 'explicit' },
-                parse_result.is_standalone
-            );
+            if (!options?.skip_backward_registration) {
+                this.apply_backward_directive_registration(
+                    actual_uri,
+                    parse_result.directives,
+                    { backward_dependencies: options?.backward_dependencies ?? 'explicit' },
+                    parse_result.is_standalone
+                );
+            }
 
             // Register forward call relationships from cached file
             // This ensures callee_to_callers map includes relationships from cached files,
@@ -2705,7 +2836,8 @@ export class ScopeResolver {
             // recovered: a failed recovery must leave the previous
             // registrations unchanged (mirroring DocumentStore's
             // undefined-staged-effects semantics), never clear them.
-            if (my_recovered.recovered) {
+            if (my_recovered.recovered &&
+                !options?.skip_backward_registration) {
                 this.apply_backward_directive_registration(
                     actual_uri,
                     my_recovered.directives,
@@ -3173,6 +3305,17 @@ export class ScopeResolver {
     }
 
     /**
+     * Live entry-count gauges (#294). Read fresh from the caches at call
+     * time — a gauge, not a counter, so it is never reset.
+     */
+    get_cache_sizes(): ScopeCacheSizes {
+        return {
+            scope: this.scope_cache.size,
+            file: this.file_cache.size,
+        };
+    }
+
+    /**
      * Reset cache metrics.
      */
     reset_cache_metrics(): void {
@@ -3547,15 +3690,7 @@ export class ScopeResolver {
             }
             for (const my_key of keys_to_remove) {
                 this.scope_cache.delete(my_key);
-                // Update secondary index
-                const key_uri = this.extract_uri_from_cache_key(my_key);
-                const key_set = this.uri_to_cache_keys.get(key_uri);
-                if (key_set) {
-                    key_set.delete(my_key);
-                    if (key_set.size === 0) {
-                        this.uri_to_cache_keys.delete(key_uri);
-                    }
-                }
+                this.prune_uri_to_cache_keys_for_key(my_key);
                 this.cache_metrics.scope.invalidations++;
             }
         }
@@ -3671,10 +3806,13 @@ export class ScopeResolver {
     /**
      * Registration upgrade on file-cache hit (issue #286). Hit paths do
      * not re-parse, so an entry whose last parse-path registration ran
-     * under 'explicit' — e.g. primed by the indexer's forced-'explicit'
-     * working-directory walk — would leave a directive-less file's
+     * under 'explicit' would leave a directive-less file's
      * dependency-graph parents unregistered for as long as 'auto'-mode
      * resolutions keep hitting the cache (until the content changes).
+     * (The indexer's forced-'explicit' working-directory walk used to
+     * prime such entries; since #294 it is probe-only — it neither
+     * registers nor stamps, so entries it writes arrive here UNSTAMPED
+     * and are healed by the first real registering read of either mode.)
      * When an 'auto'-mode read hits such an entry, apply effective
      * registration and stamp the entry so repeat hits are free.
      * Effective ⊇ raw (except for `sight: standalone` files, whose
@@ -3703,6 +3841,22 @@ export class ScopeResolver {
         requested_mode: 'auto' | 'explicit' | undefined
     ): void {
         if (requested_mode !== 'auto') {
+            // Explicit-mode hits stay side-effect-free for STAMPED entries
+            // (never downgrade), as before. An UNSTAMPED entry, however,
+            // carries no proof any registration ever ran — it may have
+            // been written by a probe-only read (#294,
+            // skip_backward_registration) — so a genuine explicit-mode hit
+            // must self-heal it: register raw directives and stamp, the
+            // same effect an explicit-mode parse would have had.
+            if (requested_mode === 'explicit' &&
+                cached.registered_backward_mode === undefined) {
+                this.apply_backward_directive_registration(
+                    uri, cached.directives,
+                    { backward_dependencies: 'explicit' },
+                    cached.is_standalone
+                );
+                cached.registered_backward_mode = 'explicit';
+            }
             return;
         }
         if (cached.directives.length > 0 &&

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -3848,6 +3848,20 @@ export class ScopeResolver {
             // skip_backward_registration) — so a genuine explicit-mode hit
             // must self-heal it: register raw directives and stamp, the
             // same effect an explicit-mode parse would have had.
+            //
+            // DELIBERATE asymmetry with the miss path's `?? 'explicit'`
+            // default: an UNSPECIFIED requested_mode does NOT self-heal.
+            // Every production caller threads a concrete mode (verified:
+            // discover_working_directory and follow_directives pass
+            // `config.backward_dependencies ?? 'auto'`, and
+            // ForwardScopeResolver normalizes before get_callee_scope), so
+            // undefined cannot reach this branch today. If a future
+            // unthreaded caller appears, healing under a defaulted
+            // 'explicit' would clear-then-register EMPTY raw directives
+            // for a directive-less file and wipe its auto-discovered
+            // parent edges under auto config — the exact #294 bug class
+            // the probe-only walk exists to prevent. Side-effect-free is
+            // the safe default for a mode nobody expressed.
             if (requested_mode === 'explicit' &&
                 cached.registered_backward_mode === undefined) {
                 this.apply_backward_directive_registration(

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -760,6 +760,25 @@ export async function create_server(options: ServerOptions): Promise<void> {
         completion_provider?.configure_completion(settings.completion);
     }
 
+    // Apply the cross-file cache LRU capacities (#294). Capacity is
+    // instance-lifetime resource state on the long-lived resolvers (NOT
+    // per-document resolve config), so it is applied from the
+    // workspace-level settings paths: configure_workspace_indexing plus
+    // both non-indexing config-change branches. Shrinking evicts down
+    // immediately (correctness-neutral).
+    function apply_cache_capacities(settings: StataLSPConfig): void {
+        scope_resolver?.set_cache_capacities({
+            max_cached_files: settings.cross_file?.max_cached_files ??
+                DEFAULT_SETTINGS.cross_file.max_cached_files,
+            max_cached_scopes: settings.cross_file?.max_cached_scopes ??
+                DEFAULT_SETTINGS.cross_file.max_cached_scopes,
+        });
+        forward_scope_resolver?.set_forward_closure_memo_capacity(
+            settings.cross_file?.max_cached_forward_closures ??
+                DEFAULT_SETTINGS.cross_file.max_cached_forward_closures ?? 2000
+        );
+    }
+
     function reset_workspace_indexing_state(): void {
         workspace_indexer?.reset();
         dependency_graph?.reset();
@@ -787,6 +806,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
             indexing_affecting_signature(settings);
 
         configure_completion_provider(settings);
+        apply_cache_capacities(settings);
 
         if (workspace_indexer) {
             workspace_indexer.configure(settings);
@@ -884,6 +904,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
             // settings take effect, instead of tearing down and re-scanning the
             // whole workspace for a cosmetic edit.
             configure_completion_provider(settings);
+            apply_cache_capacities(settings);
             workspace_indexer?.configure(settings);
             revalidate_all_open_docs();
         }
@@ -1460,6 +1481,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
             // immediately against the live index. revalidate_all_open_docs
             // marks each document for forced republish and re-validates.
             configure_completion_provider(settings);
+            apply_cache_capacities(settings);
             workspace_indexer?.configure(settings);
             revalidate_all_open_docs();
         }

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -141,6 +141,9 @@ export const DEFAULT_SETTINGS: StataLSPConfig = {
         max_forward_depth: 10,
         max_chain_depth: 20,
         max_callee_revalidations: 10,
+        max_cached_files: 2000,
+        max_cached_scopes: 1000,
+        max_cached_forward_closures: 2000,
         diagnostics: {
             missing_file: 'warning',
             max_depth: 'information',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -892,14 +892,25 @@ export interface ScopeCacheEntry {
 }
 
 export interface ScopeCacheMetrics {
-  // Nested counters for scope and file caches
-  scope: { hits: number; misses: number; invalidations: number };
-  file: { hits: number; misses: number; invalidations: number };
+  // Nested counters for scope and file caches. `evictions` counts
+  // capacity-driven LRU evictions only (#294) — explicit invalidations
+  // are counted separately in `invalidations`.
+  scope: { hits: number; misses: number; invalidations: number; evictions: number };
+  file: { hits: number; misses: number; invalidations: number; evictions: number };
 
   // Top-level aliases for backward compatibility (implemented as getters in actual object)
   readonly hits: number;         // alias for scope.hits
   readonly misses: number;       // alias for scope.misses
   readonly invalidations: number; // alias for scope.invalidations
+}
+
+/**
+ * Live entry-count gauges included in get_cache_metrics() snapshots
+ * (#294). Read from the caches at snapshot time, never stored counters.
+ */
+export interface ScopeCacheSizes {
+  scope: number;
+  file: number;
 }
 
 export type CrossFileCaseMismatchSeverity =
@@ -914,6 +925,13 @@ export interface CrossFileConfig {
   max_forward_depth: number;       // Limit forward-call recursion depth
   max_chain_depth: number;         // Overall limit for combined resolution
   max_callee_revalidations?: number;  // Maximum callees to revalidate per caller change (default: 10)
+  // LRU capacity limits for the long-lived cross-file caches (#294).
+  // Memory-safety backstops, not working-set tuners: capacity eviction is
+  // correctness-neutral (misses recompute), so defaults are far above
+  // realistic workspace sizes.
+  max_cached_files?: number;             // ScopeResolver.file_cache (default: 2000)
+  max_cached_scopes?: number;            // ScopeResolver.scope_cache (default: 1000)
+  max_cached_forward_closures?: number;  // ForwardScopeResolver memo (default: 2000)
   diagnostics: {
     missing_file: 'error' | 'warning' | 'information' | 'off';
     max_depth: 'error' | 'warning' | 'information' | 'off';

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -310,6 +310,16 @@ export function validate_comment_formatting_config(
             validated_config.cross_file.max_callee_revalidations = cross_file.max_callee_revalidations;
         }
 
+        if (typeof cross_file.max_cached_files === 'number' && cross_file.max_cached_files > 0) {
+            validated_config.cross_file.max_cached_files = cross_file.max_cached_files;
+        }
+        if (typeof cross_file.max_cached_scopes === 'number' && cross_file.max_cached_scopes > 0) {
+            validated_config.cross_file.max_cached_scopes = cross_file.max_cached_scopes;
+        }
+        if (typeof cross_file.max_cached_forward_closures === 'number' && cross_file.max_cached_forward_closures > 0) {
+            validated_config.cross_file.max_cached_forward_closures = cross_file.max_cached_forward_closures;
+        }
+
         if (cross_file.diagnostics) {
             const valid_severities = ['error', 'warning', 'information', 'info', 'off'];
             const valid_case_mismatch_severities = [

--- a/src/utils/lru-cache.ts
+++ b/src/utils/lru-cache.ts
@@ -177,7 +177,11 @@ export interface BoundedLruMapOptions<K, V> {
      * delete()/clear(). Must be synchronous and must not re-enter this
      * map: callers rely on eviction side effects completing before
      * set()/set_max_size() return (e.g. secondary-index pruning read back
-     * immediately after a set()).
+     * immediately after a set()). Must not throw: there is deliberately
+     * no try/catch (fail-fast), so an exception propagates out of
+     * set()/set_max_size() AFTER the victim was removed but BEFORE the
+     * new entry was inserted — the write is lost. Keep hooks infallible
+     * (Map/Set deletes, counter bumps).
      */
     on_evict?: (key: K, value: V) => void;
 }

--- a/src/utils/lru-cache.ts
+++ b/src/utils/lru-cache.ts
@@ -168,6 +168,153 @@ export class LRUCache<K, V> implements ILRUCache<K, V> {
 }
 
 /**
+ * Options for BoundedLruMap.
+ */
+export interface BoundedLruMapOptions<K, V> {
+    /**
+     * Called synchronously for CAPACITY evictions only (a set() of a new
+     * key at capacity, or a set_max_size() shrink) — never for explicit
+     * delete()/clear(). Must be synchronous and must not re-enter this
+     * map: callers rely on eviction side effects completing before
+     * set()/set_max_size() return (e.g. secondary-index pruning read back
+     * immediately after a set()).
+     */
+    on_evict?: (key: K, value: V) => void;
+}
+
+/**
+ * Strict recency-LRU map with bounded capacity (issue #294).
+ *
+ * Unlike LRUCache above (generational scoring, O(n) eviction scan), this
+ * is a plain recency LRU over Map insertion order with O(1) eviction,
+ * plus an eviction callback for secondary-index cleanup. Used to bound
+ * the long-lived cross-file caches (ScopeResolver.file_cache /
+ * scope_cache, ForwardScopeResolver.forward_closure_memo).
+ *
+ * Recency contract: get() and touch() promote; peek()/has() and all
+ * iteration are recency-neutral, so validation/invalidation scans never
+ * perturb eviction order.
+ */
+export class BoundedLruMap<K, V> {
+    private map: Map<K, V> = new Map();
+    private max_size: number;
+    private readonly on_evict?: (key: K, value: V) => void;
+
+    constructor(max_size: number, options?: BoundedLruMapOptions<K, V>) {
+        this.max_size = Math.max(1, Math.floor(max_size));
+        this.on_evict = options?.on_evict;
+    }
+
+    /** Cache read that promotes the key to most-recently-used. */
+    get(key: K): V | undefined {
+        if (!this.map.has(key)) {
+            return undefined;
+        }
+        const value = this.map.get(key) as V;
+        this.map.delete(key);
+        this.map.set(key, value);
+        return value;
+    }
+
+    /** Recency-neutral read (probes, validation scans, bookkeeping). */
+    peek(key: K): V | undefined {
+        return this.map.get(key);
+    }
+
+    /** Recency-neutral membership check. */
+    has(key: K): boolean {
+        return this.map.has(key);
+    }
+
+    /**
+     * Promote an existing key to most-recently-used without reading it.
+     * Use after a peek() once the peeked entry is actually served.
+     * No-op for absent keys.
+     */
+    touch(key: K): void {
+        if (!this.map.has(key)) {
+            return;
+        }
+        const value = this.map.get(key) as V;
+        this.map.delete(key);
+        this.map.set(key, value);
+    }
+
+    /**
+     * Insert or update; promotes to most-recently-used. Inserting a NEW
+     * key at capacity first evicts the least-recently-used entry and
+     * fires on_evict for it. Updating an existing key never evicts.
+     */
+    set(key: K, value: V): this {
+        if (this.map.has(key)) {
+            this.map.delete(key);
+        } else if (this.map.size >= this.max_size) {
+            this.evict_oldest();
+        }
+        this.map.set(key, value);
+        return this;
+    }
+
+    /** Explicit removal — never fires on_evict. */
+    delete(key: K): boolean {
+        return this.map.delete(key);
+    }
+
+    /** Explicit bulk removal — never fires on_evict. */
+    clear(): void {
+        this.map.clear();
+    }
+
+    get size(): number {
+        return this.map.size;
+    }
+
+    get capacity(): number {
+        return this.max_size;
+    }
+
+    /**
+     * Change the capacity at runtime. Shrinking below the current size
+     * evicts LRU-first down to the new capacity, firing on_evict per
+     * evicted entry; growing only updates the limit.
+     */
+    set_max_size(new_max_size: number): void {
+        this.max_size = Math.max(1, Math.floor(new_max_size));
+        while (this.map.size > this.max_size) {
+            this.evict_oldest();
+        }
+    }
+
+    /** Recency-neutral iteration in LRU-first order. */
+    keys(): IterableIterator<K> {
+        return this.map.keys();
+    }
+
+    values(): IterableIterator<V> {
+        return this.map.values();
+    }
+
+    entries(): IterableIterator<[K, V]> {
+        return this.map.entries();
+    }
+
+    [Symbol.iterator](): IterableIterator<[K, V]> {
+        return this.map[Symbol.iterator]();
+    }
+
+    private evict_oldest(): void {
+        const oldest = this.map.keys().next();
+        if (oldest.done) {
+            return;
+        }
+        const oldest_key = oldest.value;
+        const oldest_value = this.map.get(oldest_key) as V;
+        this.map.delete(oldest_key);
+        this.on_evict?.(oldest_key, oldest_value);
+    }
+}
+
+/**
  * Completion Prefix Cache
  *
  * Specialized LRU cache for completion prefix lookups.

--- a/tests/integration/cross-file-cache-capacity.test.ts
+++ b/tests/integration/cross-file-cache-capacity.test.ts
@@ -343,6 +343,61 @@ describe('issue #294 — bounded cross-file caches', () => {
             }
         });
 
+        it('a genuine explicit-mode HIT on a walk-written unstamped entry registers it (self-heal)', async () => {
+            // Round-2 review gap: the miss-path test below never exercises
+            // upgrade_registration_on_cache_hit's explicit+undefined
+            // branch. Here the walk primes an UNSTAMPED cached entry for a
+            // file with its own explicit directive, and a later genuine
+            // explicit-mode resolution HITS that entry (content
+            // unchanged, no eviction) — the hit path must register the
+            // raw directives and stamp 'explicit', else the file's parent
+            // edge stays unregistered until a content change.
+            const scope = new ScopeResolver(
+                create_test_scope_resolver_logger());
+            const forward = new ForwardScopeResolver(scope);
+            scope.set_forward_scope_resolver(forward);
+
+            const parent_path = create_file(
+                'parent.do', 'global g_parent 1\n');
+            const parent_uri = to_uri(parent_path);
+            const b_path = create_file(
+                'b.do',
+                `// @lsp-done-by: "${parent_path}"\nglobal g_b 1\n`);
+            const b_uri = to_uri(b_path);
+
+            // Probe-only walk over a child of B primes B's cache entry:
+            // unstamped, unregistered.
+            const d_path = create_file(
+                'd.do', `// @lsp-done-by: "${b_path}"\ndisplay "d"\n`);
+            const parser = new DirectiveParser();
+            const d_parse = parser.parse(
+                fs.readFileSync(d_path, 'utf8'), to_uri(d_path));
+            await scope.resolve_inherited_working_directory(
+                d_parse.directives, to_uri(d_path), false);
+            expect(
+                scope.get_backward_directive_children(parent_uri).has(b_uri)
+            ).toBe(false);
+
+            // Genuine explicit-mode resolution of another child HITS B's
+            // cached entry and must self-heal the registration.
+            const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+            await scope.resolve(
+                c_uri,
+                `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`,
+                { backward_dependencies: 'explicit' }
+            );
+            expect(
+                scope.get_backward_directive_children(parent_uri).has(b_uri)
+            ).toBe(true);
+            const the_file_cache = (scope as unknown as {
+                file_cache: {
+                    peek(k: string): { registered_backward_mode?: string } | undefined;
+                };
+            }).file_cache;
+            expect(the_file_cache.peek(b_uri)?.registered_backward_mode)
+                .toBe('explicit');
+        });
+
         it('genuine explicit-mode resolution still clears vestigial auto edges (pinned self-heal)', async () => {
             const dependency_graph = new DependencyGraph();
             const scope = new ScopeResolver(

--- a/tests/integration/cross-file-cache-capacity.test.ts
+++ b/tests/integration/cross-file-cache-capacity.test.ts
@@ -1,0 +1,627 @@
+/**
+ * Issue #294 — bounded cross-file caches (LRU capacity limits).
+ *
+ * Pins the eviction contracts of the three bounded caches:
+ *  - scope_cache eviction prunes uri_to_cache_keys and counts in
+ *    `evictions` (never `invalidations`), and does NOT invalidate the
+ *    forward-closure memo (capacity pressure is not a content change);
+ *  - file_cache eviction DOES invalidate the forward-closure memo for the
+ *    evicted URI (the stale-content purges compare against the evicted
+ *    entry's hash baseline — without this, a memo entry re-poisoned in a
+ *    debounce window would never be purged);
+ *  - forward_closure_memo eviction prunes memo_uri_to_keys, counts in its
+ *    own `evictions`, and does NOT bump the invalidation epoch;
+ *  - the indexer's forced-'explicit' WD walk is probe-only
+ *    (skip_backward_registration): a post-eviction reparse driven by it
+ *    can neither wipe auto-registered edges nor stamp a registration that
+ *    never ran, while genuine explicit-mode resolutions keep the pinned
+ *    auto→explicit self-heal;
+ *  - capacity 1 produces byte-identical resolution results to the default
+ *    capacity (eviction is a performance knob, never a correctness one);
+ *  - the config knobs map and validate end-to-end.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import { DependencyGraph } from '../../src/dependency-graph';
+import { DirectiveParser } from '../../src/directive-parser';
+import { map_public_config_to_partial_config } from '../../src/config-file/schema';
+import { validate_comment_formatting_config } from '../../src/utils/config-validator';
+import type { ForwardCallSite, ResolvedScope } from '../../src/types';
+import { create_test_scope_resolver_logger } from '../test-logger';
+
+describe('issue #294 — bounded cross-file caches', () => {
+    let temp_dir: string;
+
+    beforeEach(() => {
+        temp_dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sight-294-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(temp_dir, { recursive: true, force: true });
+    });
+
+    const create_file = (name: string, content: string): string => {
+        const file_path = path.join(temp_dir, name);
+        fs.writeFileSync(file_path, content);
+        return file_path;
+    };
+    const to_uri = (file_path: string): string =>
+        URI.file(file_path).toString();
+
+    /** Do any of the file's own forward-call sites carry this global? */
+    const site_has_global = (r: ResolvedScope, name: string): boolean =>
+        (r.forward_call_symbols ?? []).some(
+            (s: ForwardCallSite) => s.symbols.globalMacros.has(name));
+
+    /** Internal-state accessors (test-only; fields are private). */
+    const uri_index_of = (resolver: ScopeResolver): Map<string, Set<string>> =>
+        (resolver as unknown as {
+            uri_to_cache_keys: Map<string, Set<string>>;
+        }).uri_to_cache_keys;
+    const scope_cache_of = (resolver: ScopeResolver): { size: number } =>
+        (resolver as unknown as {
+            scope_cache: { size: number };
+        }).scope_cache;
+    const memo_index_of = (
+        forward: ForwardScopeResolver
+    ): Map<string, Set<string>> =>
+        (forward as unknown as {
+            memo_uri_to_keys: Map<string, Set<string>>;
+        }).memo_uri_to_keys;
+    const epoch_of = (forward: ForwardScopeResolver): number =>
+        (forward as unknown as {
+            memo_invalidation_epoch: number;
+        }).memo_invalidation_epoch;
+
+    describe('scope_cache eviction', () => {
+        it('prunes uri_to_cache_keys, counts evictions (not invalidations), and does not touch the memo', async () => {
+            const scope = new ScopeResolver(
+                create_test_scope_resolver_logger(), undefined,
+                { max_cached_scopes: 1 }
+            );
+            const the_memo_invalidations: string[] = [];
+            // Minimal ForwardScopeResolverInterface spy: records memo
+            // invalidations so we can assert scope_cache eviction never
+            // fires one (only file_cache eviction and real invalidation do).
+            scope.set_forward_scope_resolver({
+                filter_calls_before_line: (calls) => calls,
+                resolve: async () => ({
+                    symbols: {
+                        programs: new Map(), localMacros: new Map(),
+                        globalMacros: new Map(), variables: new Map(),
+                        scalars: new Map(), matrices: new Map(),
+                    },
+                    call_sites: [], diagnostics: [],
+                } as never),
+                invalidate_forward_closure_for_uri: (uri: string) => {
+                    the_memo_invalidations.push(uri);
+                    return 0;
+                },
+            });
+
+            const a_uri = to_uri(path.join(temp_dir, 'a.do'));
+            const b_uri = to_uri(path.join(temp_dir, 'b.do'));
+            await scope.resolve(a_uri, 'global g_a 1\n', {});
+            const invalidations_before =
+                scope.get_cache_metrics().scope.invalidations;
+            await scope.resolve(b_uri, 'global g_b 1\n', {});
+
+            const metrics = scope.get_cache_metrics();
+            expect(metrics.scope.evictions).toBe(1);
+            expect(metrics.scope.invalidations).toBe(invalidations_before);
+            expect(scope.get_cache_sizes().scope).toBe(1);
+
+            // The index must hold no rows beyond the live cache entries —
+            // an eviction that skipped pruning would leak a's key here.
+            const the_index = uri_index_of(scope);
+            let total_indexed_keys = 0;
+            for (const my_key_set of the_index.values()) {
+                total_indexed_keys += my_key_set.size;
+            }
+            expect(total_indexed_keys).toBe(scope_cache_of(scope).size);
+            expect(the_index.has(a_uri)).toBe(false);
+
+            // Roots without forward calls never reach the memo; and
+            // scope_cache CAPACITY eviction must not invalidate it either.
+            expect(the_memo_invalidations).toEqual([]);
+        });
+
+        it('set_cache_capacities shrink evicts immediately through the same hook', async () => {
+            const scope = new ScopeResolver(
+                create_test_scope_resolver_logger());
+            for (let i = 0; i < 4; i++) {
+                await scope.resolve(
+                    to_uri(path.join(temp_dir, `f${i}.do`)),
+                    `global g_${i} 1\n`, {});
+            }
+            expect(scope.get_cache_sizes().scope).toBe(4);
+            scope.set_cache_capacities({ max_cached_scopes: 2 });
+            expect(scope.get_cache_sizes().scope).toBe(2);
+            expect(scope.get_cache_metrics().scope.evictions).toBe(2);
+            const the_index = uri_index_of(scope);
+            let total_indexed_keys = 0;
+            for (const my_key_set of the_index.values()) {
+                total_indexed_keys += my_key_set.size;
+            }
+            expect(total_indexed_keys).toBe(2);
+        });
+    });
+
+    describe('file_cache eviction', () => {
+        it('invalidates the forward-closure memo for the evicted URI', async () => {
+            const scope = new ScopeResolver(
+                create_test_scope_resolver_logger(), undefined,
+                { max_cached_files: 1 }
+            );
+            const the_memo_invalidations: string[] = [];
+            scope.set_forward_scope_resolver({
+                filter_calls_before_line: (calls) => calls,
+                resolve: async () => ({
+                    symbols: {
+                        programs: new Map(), localMacros: new Map(),
+                        globalMacros: new Map(), variables: new Map(),
+                        scalars: new Map(), matrices: new Map(),
+                    },
+                    call_sites: [], diagnostics: [],
+                } as never),
+                invalidate_forward_closure_for_uri: (uri: string) => {
+                    the_memo_invalidations.push(uri);
+                    return 0;
+                },
+            });
+
+            const a_uri = to_uri(path.join(temp_dir, 'a.do'));
+            const b_uri = to_uri(path.join(temp_dir, 'b.do'));
+            await scope.resolve(a_uri, 'global g_a 1\n', {});
+            // Resolving b writes b's root entry, evicting a's (capacity 1):
+            // the eviction hook must invalidate the memo for a.
+            await scope.resolve(b_uri, 'global g_b 1\n', {});
+
+            expect(scope.get_cache_metrics().file.evictions).toBe(1);
+            expect(the_memo_invalidations).toContain(a_uri);
+            expect(scope.get_cache_sizes().file).toBe(1);
+        });
+    });
+
+    describe('forward_closure_memo eviction', () => {
+        it('prunes memo_uri_to_keys, counts evictions, and does not bump the epoch', async () => {
+            const scope = new ScopeResolver(
+                create_test_scope_resolver_logger());
+            const forward = new ForwardScopeResolver(scope);
+            scope.set_forward_scope_resolver(forward);
+            forward.set_forward_closure_memo_capacity(1);
+
+            // Closures are stored per callee WITH forward calls (leaves
+            // have none), so each root needs a mid-file: root → mid → leaf.
+            const x_path = create_file('x.do', 'global g_x 1\n');
+            const y_path = create_file('y.do', 'global g_y 1\n');
+            const mid1_path = create_file(
+                'mid1.do', `do "${x_path}"\nglobal g_m1 1\n`);
+            const mid2_path = create_file(
+                'mid2.do', `do "${y_path}"\nglobal g_m2 1\n`);
+            const root1_path = create_file('root1.do', `do "${mid1_path}"\n`);
+            const root2_path = create_file('root2.do', `do "${mid2_path}"\n`);
+
+            await scope.resolve(
+                to_uri(root1_path), fs.readFileSync(root1_path, 'utf8'), {});
+            const epoch_before = epoch_of(forward);
+            const invalidations_before =
+                forward.get_forward_closure_metrics().invalidations;
+
+            // Storing y's closure evicts x's (capacity 1).
+            await scope.resolve(
+                to_uri(root2_path), fs.readFileSync(root2_path, 'utf8'), {});
+
+            const metrics = forward.get_forward_closure_metrics();
+            expect(metrics.evictions).toBeGreaterThanOrEqual(1);
+            expect(metrics.invalidations).toBe(invalidations_before);
+            expect(epoch_of(forward)).toBe(epoch_before);
+            expect(forward.get_forward_closure_memo_size()).toBeLessThanOrEqual(1);
+
+            // No dangling index rows: every indexed key must exist in the
+            // memo.
+            const the_index = memo_index_of(forward);
+            const memo = (forward as unknown as {
+                forward_closure_memo: { has(k: string): boolean };
+            }).forward_closure_memo;
+            for (const my_key_set of the_index.values()) {
+                for (const my_key of my_key_set) {
+                    expect(memo.has(my_key)).toBe(true);
+                }
+            }
+        });
+
+        it('same-key overwrite prunes the old entry\'s index rows (lockstep gap)', () => {
+            const scope = new ScopeResolver(
+                create_test_scope_resolver_logger());
+            const forward = new ForwardScopeResolver(scope);
+            const internals = forward as unknown as {
+                store_memo_entry(key: string, entry: unknown): unknown;
+                memo_uri_to_keys: Map<string, Set<string>>;
+            };
+            const make_entry = (deps: string[]) => ({
+                kind: 'unservable',
+                dependent_uris: new Set(deps),
+            });
+            internals.store_memo_entry(
+                'k1', make_entry(['file:///old-dep.do']));
+            expect(
+                internals.memo_uri_to_keys.get('file:///old-dep.do')?.has('k1')
+            ).toBe(true);
+            // Overwrite with a different dependent set: the old row must go.
+            internals.store_memo_entry(
+                'k1', make_entry(['file:///new-dep.do']));
+            expect(internals.memo_uri_to_keys.has('file:///old-dep.do'))
+                .toBe(false);
+            expect(
+                internals.memo_uri_to_keys.get('file:///new-dep.do')?.has('k1')
+            ).toBe(true);
+        });
+    });
+
+    describe('probe-only WD walk (skip_backward_registration)', () => {
+        it('a post-eviction WD-walk reparse cannot wipe auto-registered edges', async () => {
+            const dependency_graph = new DependencyGraph();
+            const scope = new ScopeResolver(
+                create_test_scope_resolver_logger(), undefined,
+                { max_cached_files: 1 }
+            );
+            const forward = new ForwardScopeResolver(scope);
+            scope.set_forward_scope_resolver(forward);
+            scope.set_dependency_graph(dependency_graph);
+
+            // A --do--> B (auto-discovered; B has no explicit directives).
+            const b_path = create_file('b.do', 'global g_b 1\n');
+            const a_path = create_file('a.do', 'do b.do\n');
+            const a_uri = to_uri(a_path);
+            const b_uri = to_uri(b_path);
+            dependency_graph.update_caller(a_uri, [{
+                type: 'do',
+                raw_path: 'b.do',
+                is_static: true,
+                call_site_line: 0,
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 10 },
+                },
+                source: 'command',
+            }]);
+
+            // An auto-mode resolution of C (done-by B) reads B as an
+            // ancestor and registers B's auto parents: A → B.
+            const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+            await scope.resolve(
+                c_uri,
+                `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`,
+                {}
+            );
+            expect(
+                scope.get_backward_directive_children(a_uri).has(b_uri)
+            ).toBe(true);
+
+            // Capacity pressure evicts B's file_cache entry (capacity 1;
+            // resolving another root's parse_file write is enough).
+            await scope.resolve(
+                to_uri(path.join(temp_dir, 'noise.do')),
+                'global g_noise 1\n', {});
+
+            // The indexer's WD walk over a child of B misses the cache and
+            // reparses B under forced-'explicit'. Probe-only (#294): it
+            // must neither register (which would clear-then-register B's
+            // edges to empty) nor stamp.
+            const d_path = create_file(
+                'd.do', `// @lsp-done-by: "${b_path}"\ndisplay "d"\n`);
+            const parser = new DirectiveParser();
+            const d_parse = parser.parse(
+                fs.readFileSync(d_path, 'utf8'), to_uri(d_path));
+            await scope.resolve_inherited_working_directory(
+                d_parse.directives, to_uri(d_path), false);
+
+            expect(
+                scope.get_backward_directive_children(a_uri).has(b_uri)
+            ).toBe(true);
+
+            // The walk-written entry carries no registration stamp: it
+            // must not claim a registration that never ran.
+            const the_file_cache = (scope as unknown as {
+                file_cache: {
+                    peek(k: string): { registered_backward_mode?: string } | undefined;
+                    keys(): IterableIterator<string>;
+                };
+            }).file_cache;
+            for (const my_key of the_file_cache.keys()) {
+                if (my_key.startsWith(b_uri)) {
+                    expect(the_file_cache.peek(my_key)?.registered_backward_mode)
+                        .toBeUndefined();
+                }
+            }
+        });
+
+        it('genuine explicit-mode resolution still clears vestigial auto edges (pinned self-heal)', async () => {
+            const dependency_graph = new DependencyGraph();
+            const scope = new ScopeResolver(
+                create_test_scope_resolver_logger(), undefined,
+                { max_cached_files: 1 }
+            );
+            const forward = new ForwardScopeResolver(scope);
+            scope.set_forward_scope_resolver(forward);
+            scope.set_dependency_graph(dependency_graph);
+
+            const b_path = create_file('b.do', 'global g_b 1\n');
+            const a_path = create_file('a.do', 'do b.do\n');
+            const a_uri = to_uri(a_path);
+            const b_uri = to_uri(b_path);
+            dependency_graph.update_caller(a_uri, [{
+                type: 'do',
+                raw_path: 'b.do',
+                is_static: true,
+                call_site_line: 0,
+                range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 10 },
+                },
+                source: 'command',
+            }]);
+
+            const c_uri = to_uri(path.join(temp_dir, 'c.do'));
+            await scope.resolve(
+                c_uri, `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`, {});
+            expect(
+                scope.get_backward_directive_children(a_uri).has(b_uri)
+            ).toBe(true);
+
+            // Evict B, then resolve under GENUINE explicit config: the
+            // miss-reparse registers B's raw (empty) directives, clearing
+            // the vestigial auto edge — the documented auto→explicit
+            // mid-session self-heal must survive #294.
+            await scope.resolve(
+                to_uri(path.join(temp_dir, 'noise.do')),
+                'global g_noise 1\n', {});
+            await scope.resolve(
+                c_uri,
+                `// @lsp-done-by: "${b_path}"\ndisplay "c"\n`,
+                { backward_dependencies: 'explicit' }
+            );
+            expect(
+                scope.get_backward_directive_children(a_uri).has(b_uri)
+            ).toBe(false);
+        });
+    });
+
+    describe('debounce-window re-poisoning survives eviction (the #294 file_cache hook)', () => {
+        it('an evicted stale baseline still gets its memo entries purged', async () => {
+            // Replays the #278 debounce-window scenario (see
+            // forward-closure-memo-store-serve.test.ts) with one twist:
+            // the callee's stale file_cache entry is capacity-EVICTED
+            // before the debounced parse lands, so parse_file's
+            // `if (cached)` purge can never fire. The eviction hook's memo
+            // invalidation must cover it instead.
+            const x_v1 = 'global x_v1 1\n';
+            const x_v2 = 'global x_v2 1\n';
+            let x_content = x_v1;
+
+            const the_contents = new Map<string, string>();
+            const content_for = (uri: string): string =>
+                uri.endsWith('x.do') ? x_content
+                    : (the_contents.get(uri) ?? '');
+            const provider = {
+                read_file: async (uri: string) => content_for(uri),
+                exists: async () => true,
+                // Constant mtime: the fast path keeps serving the cached
+                // (stale) entry during the window.
+                stat: async (uri: string) => ({
+                    mtimeMs: 1000,
+                    size: Buffer.byteLength(content_for(uri), 'utf8'),
+                }),
+            };
+            const scope = new ScopeResolver(
+                create_test_scope_resolver_logger(), provider);
+            const forward = new ForwardScopeResolver(scope);
+            scope.set_forward_scope_resolver(forward);
+
+            const x_uri = 'file:///ws/x.do';
+            const a_uri = 'file:///ws/a.do';
+            const root1_uri = 'file:///ws/root1.do';
+            const root2_uri = 'file:///ws/root2.do';
+            the_contents.set(a_uri, 'do "x.do"\nglobal a_g 1\n');
+            const root_content = 'do "a.do"\ndisplay "x"\n';
+            the_contents.set(root1_uri, root_content);
+            the_contents.set(root2_uri, root_content);
+
+            // Warm: a's closure embeds x v1.
+            const warm = await scope.resolve(root1_uri, root_content);
+            expect(site_has_global(warm, 'x_v1')).toBe(true);
+
+            // Edit x; eager didChange invalidation runs; the debounced
+            // parse has not landed yet.
+            x_content = x_v2;
+            scope.invalidate_scope_cache(x_uri);
+
+            // A resolution inside the window re-poisons the memo from the
+            // stale cached x (constant mtime serves v1).
+            const in_window = await scope.resolve(root2_uri, root_content);
+            expect(site_has_global(in_window, 'x_v1')).toBe(true);
+
+            // Capacity pressure now evicts EVERYTHING down to one entry —
+            // including x's stale baseline. Without the eviction hook, the
+            // debounced parse below would find no cached entry, skip its
+            // `if (cached)` purge, and the poisoned closure would serve
+            // forever.
+            scope.set_cache_capacities({ max_cached_files: 1 });
+
+            // The debounced parse of x lands; a later resolution must see
+            // v2, not the window-pinned v1.
+            await scope.resolve(x_uri, x_v2);
+            scope.invalidate_scope_cache(root1_uri);
+            const after = await scope.resolve(root1_uri, root_content);
+            expect(site_has_global(after, 'x_v2')).toBe(true);
+            expect(site_has_global(after, 'x_v1')).toBe(false);
+        });
+    });
+
+    describe('eviction during an in-flight standalone build', () => {
+        it('skips the memo store (degraded) but the result is still correct', async () => {
+            // A file_cache eviction fires invalidate_forward_closure_for_uri,
+            // which bumps the memo epoch — and ANY epoch movement during an
+            // in-flight standalone build's await window makes that build
+            // refuse to store (the #234 guard against publishing stale
+            // closures). Documented degradation: under eviction churn the
+            // memo may never populate; the resolution itself must still be
+            // correct via the live walk.
+            const the_contents = new Map<string, string>();
+            let scope: ScopeResolver | undefined;
+            let evict_on_leaf_read = false;
+            const provider = {
+                read_file: async (uri: string) => {
+                    if (evict_on_leaf_read && uri.endsWith('leaf.do')) {
+                        // Unrelated capacity pressure mid-build: shrink the
+                        // file cache, evicting entries and bumping the memo
+                        // epoch through the eviction hook.
+                        evict_on_leaf_read = false;
+                        scope?.set_cache_capacities({ max_cached_files: 1 });
+                    }
+                    return the_contents.get(uri) ?? '';
+                },
+                exists: async () => true,
+            };
+            scope = new ScopeResolver(
+                create_test_scope_resolver_logger(), provider);
+            const forward = new ForwardScopeResolver(scope);
+            scope.set_forward_scope_resolver(forward);
+
+            const leaf_uri = 'file:///ws/leaf.do';
+            const mid_uri = 'file:///ws/mid.do';
+            const root_uri = 'file:///ws/root.do';
+            const unrelated_uri = 'file:///ws/unrelated.do';
+            the_contents.set(leaf_uri, 'global g_leaf 1\n');
+            the_contents.set(mid_uri, 'do "leaf.do"\nglobal g_mid 1\n');
+            the_contents.set(root_uri, 'do "mid.do"\n');
+            the_contents.set(unrelated_uri, 'global g_u 1\n');
+
+            // Seed an unrelated file_cache entry so the shrink has
+            // something to evict.
+            await scope.resolve(
+                unrelated_uri, the_contents.get(unrelated_uri) as string);
+
+            evict_on_leaf_read = true;
+            const resolved = await scope.resolve(
+                root_uri, the_contents.get(root_uri) as string);
+
+            // Correct result via the live walk...
+            expect(site_has_global(resolved, 'g_mid')).toBe(true);
+            // ...but the epoch moved mid-build, so nothing was stored.
+            expect(forward.get_forward_closure_memo_size()).toBe(0);
+
+            // A later, undisturbed resolution stores normally again. (At
+            // capacity 1 the memo stays starved by design — every read's
+            // eviction re-bumps the epoch — so restore headroom first.)
+            scope.set_cache_capacities({ max_cached_files: 2000 });
+            scope.invalidate_scope_cache(root_uri);
+            await scope.resolve(
+                root_uri, the_contents.get(root_uri) as string);
+            expect(forward.get_forward_closure_memo_size())
+                .toBeGreaterThanOrEqual(1);
+        });
+    });
+
+    describe('capacity 1 vs default produce identical results', () => {
+        const build_workspace = () => {
+            const x_path = create_file('x.do', 'global g_x 1\nlocal l_x 2\n');
+            const mid_path = create_file(
+                'mid.do', `do "${x_path}"\nglobal g_mid 1\n`);
+            const top_path = create_file(
+                'top.do', `do "${mid_path}"\nglobal g_top 1\n`);
+            const leaf_content = [
+                `// @lsp-done-by: "${top_path}"`,
+                'display "$g_top $g_mid $g_x"',
+                `do "${x_path}"`,
+                '',
+            ].join('\n');
+            const leaf_path = create_file('leaf.do', leaf_content);
+            return { leaf_path, leaf_content };
+        };
+
+        const resolve_with = async (capacities: {
+            max_cached_files?: number;
+            max_cached_scopes?: number;
+            memo?: number;
+        }) => {
+            const scope = new ScopeResolver(
+                create_test_scope_resolver_logger(), undefined, capacities);
+            const forward = new ForwardScopeResolver(scope);
+            if (capacities.memo !== undefined) {
+                forward.set_forward_closure_memo_capacity(capacities.memo);
+            }
+            scope.set_forward_scope_resolver(forward);
+            const { leaf_path, leaf_content } = build_workspace();
+            // Resolve twice (second pass exercises post-eviction rereads).
+            await scope.resolve(to_uri(leaf_path), leaf_content, {});
+            scope.invalidate_scope_cache(to_uri(leaf_path));
+            return scope.resolve(to_uri(leaf_path), leaf_content, {});
+        };
+
+        it('chain + forward-call fixture resolves identically', async () => {
+            const generous = await resolve_with({});
+            const starved = await resolve_with({
+                max_cached_files: 1, max_cached_scopes: 1, memo: 1,
+            });
+
+            const globals = (r: ResolvedScope) =>
+                Array.from(r.symbols.globalMacros.keys()).sort();
+            expect(globals(starved)).toEqual(globals(generous));
+            expect(Array.from(starved.symbols.programs.keys()).sort())
+                .toEqual(Array.from(generous.symbols.programs.keys()).sort());
+            expect(starved.diagnostics).toEqual(generous.diagnostics);
+            // Backward-inherited globals live in the merged symbol table;
+            // the leaf's own `do` carries g_x at its forward-call site.
+            expect(starved.symbols.globalMacros.has('g_top')).toBe(true);
+            expect(starved.symbols.globalMacros.has('g_mid')).toBe(true);
+            expect(site_has_global(starved, 'g_x')).toBe(true);
+        });
+    });
+
+    describe('config plumbing', () => {
+        it('maps crossFile.maxCached* to cross_file.max_cached_*', () => {
+            const partial = map_public_config_to_partial_config({
+                crossFile: {
+                    maxCachedFiles: 50,
+                    maxCachedScopes: 25,
+                    maxCachedForwardClosures: 75,
+                },
+            });
+            expect(partial.cross_file?.max_cached_files).toBe(50);
+            expect(partial.cross_file?.max_cached_scopes).toBe(25);
+            expect(partial.cross_file?.max_cached_forward_closures).toBe(75);
+        });
+
+        it('validator accepts positive numbers and falls back to defaults otherwise', () => {
+            const valid = validate_comment_formatting_config({
+                cross_file: {
+                    max_cached_files: 10,
+                    max_cached_scopes: 5,
+                    max_cached_forward_closures: 15,
+                },
+            } as never);
+            expect(valid.cross_file.max_cached_files).toBe(10);
+            expect(valid.cross_file.max_cached_scopes).toBe(5);
+            expect(valid.cross_file.max_cached_forward_closures).toBe(15);
+
+            const invalid = validate_comment_formatting_config({
+                cross_file: {
+                    max_cached_files: -1,
+                    max_cached_scopes: 0,
+                    max_cached_forward_closures: 'lots',
+                },
+            } as never);
+            expect(invalid.cross_file.max_cached_files).toBe(2000);
+            expect(invalid.cross_file.max_cached_scopes).toBe(1000);
+            expect(invalid.cross_file.max_cached_forward_closures).toBe(2000);
+        });
+    });
+});

--- a/tests/property/bounded-cache-equivalence.prop.test.ts
+++ b/tests/property/bounded-cache-equivalence.prop.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Issue #294 — property: cache capacity never changes resolution results.
+ *
+ * For randomly shaped backward chains with forward calls, resolving with
+ * pathologically small LRU capacities (file/scope/memo all 1) must produce
+ * results deep-equal to resolving with the default capacities. Capacity
+ * eviction is a performance knob, never a correctness one.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import * as fc from 'fast-check';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { URI } from 'vscode-uri';
+import { ScopeResolver } from '../../src/scope-resolver';
+import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
+import type { ResolvedScope } from '../../src/types';
+import { create_test_scope_resolver_logger } from '../test-logger';
+
+const arbitrary_symbol_name = fc
+    .stringMatching(/^[a-z][a-z0-9_]{0,8}$/)
+    .filter((s) => !['if', 'in', 'do', 'run', 'end'].includes(s));
+
+const observable = (r: ResolvedScope) => ({
+    globals: Array.from(r.symbols.globalMacros.keys()).sort(),
+    locals: Array.from(r.symbols.localMacros.keys()).sort(),
+    programs: Array.from(r.symbols.programs.keys()).sort(),
+    diagnostics: r.diagnostics,
+    forward_sites: (r.forward_call_symbols ?? []).map((s) =>
+        Array.from(s.symbols.globalMacros.keys()).sort()),
+});
+
+describe('issue #294 — bounded-cache equivalence property', () => {
+    test('capacity 1 resolves identically to default capacity', async () => {
+        await fc.assert(
+            fc.asyncProperty(
+                fc.integer({ min: 2, max: 4 }),
+                fc.array(arbitrary_symbol_name, {
+                    minLength: 4, maxLength: 4,
+                }),
+                async (chain_depth, the_names) => {
+                    const temp_dir = fs.mkdtempSync(
+                        path.join(os.tmpdir(), 'sight-294-prop-'));
+                    try {
+                        // leaf defines a global; each ancestor i defines a
+                        // global and does the next file down; the resolved
+                        // file names the top of the chain via done-by and
+                        // also `do`s the leaf directly.
+                        const leaf_path = path.join(temp_dir, 'leaf.do');
+                        fs.writeFileSync(
+                            leaf_path, `global ${the_names[0]}_leaf 1\n`);
+                        let child_path = leaf_path;
+                        for (let i = 0; i < chain_depth; i++) {
+                            const my_path = path.join(
+                                temp_dir, `anc_${i}.do`);
+                            fs.writeFileSync(
+                                my_path,
+                                `do "${child_path}"\n` +
+                                `global ${the_names[i % 4]}_${i} 1\n`);
+                            child_path = my_path;
+                        }
+                        const target_uri = URI.file(
+                            path.join(temp_dir, 'target.do')).toString();
+                        const target_content =
+                            `// @lsp-done-by: "${child_path}"\n` +
+                            `do "${leaf_path}"\n` +
+                            'display "hello"\n';
+
+                        const resolve_with = async (starved: boolean) => {
+                            const scope = new ScopeResolver(
+                                create_test_scope_resolver_logger(),
+                                undefined,
+                                starved
+                                    ? {
+                                        max_cached_files: 1,
+                                        max_cached_scopes: 1,
+                                    }
+                                    : undefined);
+                            const forward = new ForwardScopeResolver(scope);
+                            if (starved) {
+                                forward
+                                    .set_forward_closure_memo_capacity(1);
+                            }
+                            scope.set_forward_scope_resolver(forward);
+                            // Two passes: the second exercises
+                            // post-eviction re-reads on warm-ish state.
+                            await scope.resolve(
+                                target_uri, target_content, {});
+                            scope.invalidate_scope_cache(target_uri);
+                            return scope.resolve(
+                                target_uri, target_content, {});
+                        };
+
+                        const generous = await resolve_with(false);
+                        const starved = await resolve_with(true);
+                        expect(observable(starved))
+                            .toEqual(observable(generous));
+                    } finally {
+                        fs.rmSync(temp_dir, {
+                            recursive: true, force: true,
+                        });
+                    }
+                }
+            ),
+            { numRuns: 15 }
+        );
+    }, 60000);
+});

--- a/tests/property/bounded-cache-equivalence.prop.test.ts
+++ b/tests/property/bounded-cache-equivalence.prop.test.ts
@@ -17,10 +17,7 @@ import { ScopeResolver } from '../../src/scope-resolver';
 import { ForwardScopeResolver } from '../../src/forward-scope-resolver';
 import type { ResolvedScope } from '../../src/types';
 import { create_test_scope_resolver_logger } from '../test-logger';
-
-const arbitrary_symbol_name = fc
-    .stringMatching(/^[a-z][a-z0-9_]{0,8}$/)
-    .filter((s) => !['if', 'in', 'do', 'run', 'end'].includes(s));
+import { arbitrary_non_reserved_identifier } from './generators';
 
 const observable = (r: ResolvedScope) => ({
     globals: Array.from(r.symbols.globalMacros.keys()).sort(),
@@ -36,7 +33,7 @@ describe('issue #294 — bounded-cache equivalence property', () => {
         await fc.assert(
             fc.asyncProperty(
                 fc.integer({ min: 2, max: 4 }),
-                fc.array(arbitrary_symbol_name, {
+                fc.array(arbitrary_non_reserved_identifier(), {
                     minLength: 4, maxLength: 4,
                 }),
                 async (chain_depth, the_names) => {

--- a/tests/unit/bounded-lru-map.test.ts
+++ b/tests/unit/bounded-lru-map.test.ts
@@ -170,6 +170,22 @@ describe('BoundedLruMap', () => {
         expect(evict_seen_before_set_returned).toBe(true);
     });
 
+    it('a throwing on_evict propagates fail-fast out of set() (documented contract)', () => {
+        // No try/catch by design: hooks must be infallible. This pins the
+        // CURRENT contract so a future change (e.g. swallowing errors) is
+        // a conscious decision — the victim is already gone and the new
+        // write is lost when the hook throws.
+        const cache = new BoundedLruMap<string, number>(1, {
+            on_evict: () => {
+                throw new Error('hook failure');
+            },
+        });
+        cache.set('a', 1);
+        expect(() => cache.set('b', 2)).toThrow('hook failure');
+        expect(cache.has('a')).toBe(false);
+        expect(cache.has('b')).toBe(false);
+    });
+
     it('stores undefined-tolerant values without breaking has/get distinction', () => {
         const cache = new BoundedLruMap<string, number | undefined>(2);
         cache.set('a', undefined);

--- a/tests/unit/bounded-lru-map.test.ts
+++ b/tests/unit/bounded-lru-map.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'bun:test';
+import { BoundedLruMap } from '../../src/utils/lru-cache';
+
+describe('BoundedLruMap', () => {
+    it('evicts the least-recently-used entry when a new key exceeds capacity', () => {
+        const cache = new BoundedLruMap<string, number>(2);
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.set('c', 3);
+        expect(cache.has('a')).toBe(false);
+        expect(cache.has('b')).toBe(true);
+        expect(cache.has('c')).toBe(true);
+        expect(cache.size).toBe(2);
+    });
+
+    it('get() promotes: a read key survives the next eviction', () => {
+        const cache = new BoundedLruMap<string, number>(2);
+        cache.set('a', 1);
+        cache.set('b', 2);
+        expect(cache.get('a')).toBe(1);
+        cache.set('c', 3);
+        expect(cache.has('a')).toBe(true);
+        expect(cache.has('b')).toBe(false);
+    });
+
+    it('touch() promotes without reading', () => {
+        const cache = new BoundedLruMap<string, number>(2);
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.touch('a');
+        cache.set('c', 3);
+        expect(cache.has('a')).toBe(true);
+        expect(cache.has('b')).toBe(false);
+    });
+
+    it('touch() of an absent key is a no-op', () => {
+        const cache = new BoundedLruMap<string, number>(2);
+        cache.set('a', 1);
+        cache.touch('missing');
+        expect(cache.size).toBe(1);
+        expect(cache.has('missing')).toBe(false);
+    });
+
+    it('peek() and has() do not promote', () => {
+        const cache = new BoundedLruMap<string, number>(2);
+        cache.set('a', 1);
+        cache.set('b', 2);
+        expect(cache.peek('a')).toBe(1);
+        expect(cache.has('a')).toBe(true);
+        cache.set('c', 3);
+        // 'a' was only peeked, so it is still the LRU entry and gets evicted
+        expect(cache.has('a')).toBe(false);
+        expect(cache.has('b')).toBe(true);
+    });
+
+    it('iteration does not promote', () => {
+        const cache = new BoundedLruMap<string, number>(2);
+        cache.set('a', 1);
+        cache.set('b', 2);
+        for (const [my_key, my_value] of cache) {
+            expect(typeof my_key).toBe('string');
+            expect(typeof my_value).toBe('number');
+        }
+        Array.from(cache.keys());
+        Array.from(cache.values());
+        Array.from(cache.entries());
+        cache.set('c', 3);
+        expect(cache.has('a')).toBe(false);
+    });
+
+    it('iteration order is LRU-first and stable across repeated iteration', () => {
+        const cache = new BoundedLruMap<string, number>(3);
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.set('c', 3);
+        cache.get('a'); // now order is b, c, a
+        const first_pass = Array.from(cache.keys());
+        const second_pass = Array.from(cache.keys());
+        expect(first_pass).toEqual(['b', 'c', 'a']);
+        expect(second_pass).toEqual(first_pass);
+    });
+
+    it('on_evict fires exactly once per capacity eviction with the evicted pair', () => {
+        const the_evicted: Array<[string, number]> = [];
+        const cache = new BoundedLruMap<string, number>(2, {
+            on_evict: (key, value) => the_evicted.push([key, value]),
+        });
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.set('c', 3);
+        expect(the_evicted).toEqual([['a', 1]]);
+    });
+
+    it('on_evict does not fire on delete() or clear()', () => {
+        const the_evicted: string[] = [];
+        const cache = new BoundedLruMap<string, number>(2, {
+            on_evict: (key) => the_evicted.push(key),
+        });
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.delete('a');
+        cache.clear();
+        expect(the_evicted).toEqual([]);
+    });
+
+    it('updating an existing key never evicts and promotes the key', () => {
+        const the_evicted: string[] = [];
+        const cache = new BoundedLruMap<string, number>(2, {
+            on_evict: (key) => the_evicted.push(key),
+        });
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.set('a', 10);
+        expect(the_evicted).toEqual([]);
+        expect(cache.get('a')).toBe(10);
+        cache.set('c', 3);
+        // 'a' was promoted by the update, so 'b' is evicted
+        expect(the_evicted).toEqual(['b']);
+    });
+
+    it('set_max_size shrink evicts LRU-first down to the new capacity', () => {
+        const the_evicted: string[] = [];
+        const cache = new BoundedLruMap<string, number>(4, {
+            on_evict: (key) => the_evicted.push(key),
+        });
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.set('c', 3);
+        cache.set('d', 4);
+        cache.get('a'); // promote 'a' past b/c/d
+        cache.set_max_size(2);
+        expect(the_evicted).toEqual(['b', 'c']);
+        expect(Array.from(cache.keys())).toEqual(['d', 'a']);
+        expect(cache.capacity).toBe(2);
+    });
+
+    it('set_max_size grow is a no-op beyond the capacity update', () => {
+        const the_evicted: string[] = [];
+        const cache = new BoundedLruMap<string, number>(2, {
+            on_evict: (key) => the_evicted.push(key),
+        });
+        cache.set('a', 1);
+        cache.set('b', 2);
+        cache.set_max_size(10);
+        expect(the_evicted).toEqual([]);
+        expect(cache.size).toBe(2);
+        expect(cache.capacity).toBe(10);
+    });
+
+    it('capacity has a floor of 1', () => {
+        const cache = new BoundedLruMap<string, number>(0);
+        expect(cache.capacity).toBe(1);
+        cache.set('a', 1);
+        cache.set('b', 2);
+        expect(cache.size).toBe(1);
+        expect(cache.has('b')).toBe(true);
+        cache.set_max_size(-5);
+        expect(cache.capacity).toBe(1);
+    });
+
+    it('on_evict completes synchronously inside set()', () => {
+        let evict_seen_before_set_returned = false;
+        const cache = new BoundedLruMap<string, number>(1, {
+            on_evict: () => {
+                evict_seen_before_set_returned = true;
+            },
+        });
+        cache.set('a', 1);
+        cache.set('b', 2);
+        expect(evict_seen_before_set_returned).toBe(true);
+    });
+
+    it('stores undefined-tolerant values without breaking has/get distinction', () => {
+        const cache = new BoundedLruMap<string, number | undefined>(2);
+        cache.set('a', undefined);
+        cache.set('b', 1);
+        expect(cache.has('a')).toBe(true);
+        expect(cache.get('a')).toBeUndefined();
+        // The get() above must still have promoted 'a' past 'b'
+        cache.set('c', 2);
+        expect(cache.has('a')).toBe(true);
+        expect(cache.has('b')).toBe(false);
+    });
+});


### PR DESCRIPTION
Fixes #294.

## Summary

Bounds the three unbounded cross-file caches — `ScopeResolver.file_cache`, `ScopeResolver.scope_cache`, and `ForwardScopeResolver.forward_closure_memo` — with a new strict-recency `BoundedLruMap` utility (O(1) eviction, `on_evict` hook for secondary-index cleanup, `peek`/`touch` recency-neutral probe reads), configurable via `crossFile.maxCachedFiles` / `maxCachedScopes` / `maxCachedForwardClosures` in `sight.toml` (defaults 2000 / 1000 / 2000 — memory-safety backstops, not working-set tuners).

## Eviction contracts

- **scope_cache** eviction prunes `uri_to_cache_keys` (idiom factored into a shared helper, deduplicating two prior copies) and counts in a new `evictions` metric, never in `invalidations`; it does not touch the forward-closure memo.
- **file_cache** eviction DOES invalidate the forward-closure memo for the evicted URI (`FileCacheEntry` gained a `uri` field for this): the parse-time stale-content purges compare against the evicted entry's hash baseline, so a memo entry re-poisoned during a debounce window would otherwise never be purged. Epoch-bumping semantics are deliberate; an eviction landing mid-standalone-build skips that build's memo store (degraded, never wrong — pinned by test).
- **memo** eviction prunes `memo_uri_to_keys` without bumping the #234 invalidation epoch; `store_memo_entry` now also prunes the old entry's index rows on same-key overwrite (pre-existing lockstep leak).
- The indexer's forced-`'explicit'` WD walk is now **probe-only** (`skip_backward_registration`): it neither registers backward-directive edges nor stamps `registered_backward_mode`, so a post-eviction reparse driven by it can no longer wipe auto-discovered edges. Unstamped entries self-heal on the next genuine registering hit (auto or explicit mode); the pinned auto→explicit mid-session self-heal is unchanged. Both directions are test-pinned, with the hit-path test verified to fail when the branch is reverted.
- Capacity eviction is correctness-neutral end-to-end: pinned by a capacity-1-vs-default deep-equal integration fixture and a fast-check property over randomized chain shapes.

## Review gate

Plan was adversarially reviewed for 3 rounds (codex + Sonnet) before implementation — round 1 found two P1 design flaws (the debounce-window memo baseline and the registration-mode downgrade), round 2 replaced the side-map fix with the probe-only walk, round 3 adjudicated the stamp/self-heal shape. The diff then went through 5 review rounds (codex + Sonnet each): round 2 findings (docs section, hit-path self-heal coverage gap, throwing-`on_evict` contract) fixed in-branch; round 3's undefined-mode asymmetry adjudicated as deliberate and documented in-code (normalizing it would reintroduce the auto-edge-wipe bug class); rounds 4 and 5 clean from both reviewers on the final diff.

## Deferrals (non-blocking, from review)

- The new size gauges (`get_cache_sizes`, `get_forward_closure_memo_size`) and eviction counters have no operator-facing surface yet — consistent with the existing `get_cache_metrics` test-only pattern.
- `ScopeCacheMetrics` top-level back-compat aliases were not extended with an `evictions` alias (nothing consumes the alias form).
- LSP-server startup has a brief window where the resolvers run with default capacities until workspace config loads (the CLI passes capacities at construction); defaults are generous backstops, consistent with how other workspace settings land.

## Testing

- `bun run test` (typecheck + full suite): 7550 pass, 0 fail
- `bun run lint`: clean (not in CI, run manually)
- New: `tests/unit/bounded-lru-map.test.ts` (16 tests), `tests/integration/cross-file-cache-capacity.test.ts` (13 tests incl. debounce-window+eviction, mixed-mode registration both directions, mid-build starvation), `tests/property/bounded-cache-equivalence.prop.test.ts`

https://claude.ai/code/session_0114zF2WByBWgPPQiyBrRtWZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for cross-file caching, including file, scope, and forward-closure cache sizes.
  * Cache usage is now tracked with live size and eviction metrics.

* **Bug Fixes**
  * Improved cache eviction behavior to keep results consistent even when entries are removed.
  * Reduced stale cross-file state by ensuring related caches stay in sync during updates.

* **Documentation**
  * Updated configuration and cross-file docs with the new cache settings, defaults, and behavior details.

* **Tests**
  * Added integration, property-based, and unit coverage for bounded cache behavior and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->