### PR TITLE
Align shared sight.toml paths with Raven

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,11 +17,11 @@ chains resolve correctly. Positional `PATHS...` only filter which files report
 diagnostics. With no paths, Sight reports every `.do`, `.ado`, `.doh`, and
 `.mata` file under the workspace.
 
-Paths matching the `exclude` setting (see
+Paths matching the `workspace.exclude` setting (see
 [configuration](configuration.md#excluding-files-and-directories)) are skipped
 by both the index and the directory walk. An explicitly-named path
-(`sight check output/foo.do`) is always checked, even when it matches `exclude`;
-exclusion only filters directory walks.
+(`sight check output/foo.do`) is always checked, even when it matches
+`workspace.exclude`; exclusion only filters directory walks.
 
 Options:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,10 +173,11 @@ source with generated output (for example, downloaded `.do` files under
 
 You can set this in two places:
 
-- **`sight.toml`** at the project root, as the top-level `exclude` key. This is
+- **`sight.toml`** at the project root, as `workspace.exclude`. This is
   read by both the editor (LSP server) and the `sight check` CLI:
 
   ```toml
+  [workspace]
   exclude = ["output/**", "**/_generated/**", "**/*.gen.do"]
   ```
 
@@ -312,9 +313,11 @@ canonical spelling wins.
 ```toml
 indexWorkspace = true
 adoPaths = []
-exclude = ["output/**"]
 lineCommentStyle = "//"
 debug = false
+
+[workspace]
+exclude = ["output/**"]
 
 [diagnostics]
 enabled = true
@@ -371,7 +374,7 @@ caseMismatch = "auto"
 | --------------------------------------- | -------------------- | --------------- | ----------------------------------------------------------------------- |
 | `indexWorkspace`                        | boolean              | `true`          | Global workspace-indexing switch                                        |
 | `adoPaths`                              | string array         | `[]`            | Additional ADO search paths                                             |
-| `exclude`                               | string array         | `[]`            | Workspace-relative globs to skip during `sight check` and indexing      |
+| `workspace.exclude`                     | string array         | `[]`            | Workspace-relative globs to skip during `sight check` and indexing      |
 | `lineCommentStyle`                      | `"//"` \| `"*"`      | `"//"`         | Line comment style used when formatting resolves `"line"`               |
 | `debug`                                 | boolean              | `false`         | Enable debug logging                                                    |
 | `diagnostics.enabled`                   | boolean              | `true`          | Enable diagnostics                                                      |
@@ -403,6 +406,9 @@ accepts `"auto"` (not valid for other cross-file severity keys).
 Both `indexWorkspace` and `crossFile.indexWorkspace` default to `true`.
 Workspace indexing runs only when both are enabled; setting either to `false`
 disables it.
+
+The shared canonical paths and permanent compatibility aliases are specified
+in [Shared project configuration schema](shared-config-schema.md).
 
 ## See Also
 

--- a/docs/shared-config-schema.md
+++ b/docs/shared-config-schema.md
@@ -1,0 +1,53 @@
+# Shared project configuration schema
+
+Raven and Sight use the same canonical TOML path for settings that represent
+the same concept. They do not need identical schemas: language-specific
+settings keep their natural project-specific sections and may have different
+defaults.
+
+## Canonical shared paths
+
+| Concept | Canonical TOML path |
+|---|---|
+| Workspace exclusions | `workspace.exclude` |
+| Diagnostics master switch | `diagnostics.enabled` |
+| Undefined-variable severity | `diagnostics.severity.undefinedVariable` |
+| Workspace indexing | `crossFile.indexWorkspace` |
+| Backward dependency mode | `crossFile.backwardDependencies` |
+| Assumed call site | `crossFile.assumeCallSite` |
+| Backward traversal depth | `crossFile.maxBackwardDepth` |
+| Forward traversal depth | `crossFile.maxForwardDepth` |
+| Combined traversal depth | `crossFile.maxChainDepth` |
+| Missing-file severity | `crossFile.diagnostics.missingFile` |
+| Case-mismatch severity | `crossFile.diagnostics.caseMismatch` |
+
+Canonical keys use camel case. Defaults and accepted values may differ when
+the underlying languages require different behavior.
+
+## Compatibility aliases
+
+Accepted historical and sibling-project paths remain permanent aliases:
+
+| Project | Alias | Canonical path |
+|---|---|---|
+| Raven | `exclude` | `workspace.exclude` |
+| Raven | `diagnostics.undefinedVariableSeverity` | `diagnostics.severity.undefinedVariable` |
+| Raven | `crossFile.missingFileSeverity` | `crossFile.diagnostics.missingFile` |
+| Raven | `crossFile.caseMismatchSeverity` | `crossFile.diagnostics.caseMismatch` |
+| Sight | `exclude` | `workspace.exclude` |
+| Sight | `diagnostics.undefinedVariableSeverity` | `diagnostics.severity.undefinedVariable` |
+| Sight | `crossFile.missingFileSeverity` | `crossFile.diagnostics.missingFile` |
+| Sight | `crossFile.caseMismatchSeverity` | `crossFile.diagnostics.caseMismatch` |
+
+When an alias and its canonical path both occur, the canonical value wins and
+the loader emits a warning. Documentation and generated examples use only the
+canonical path. A malformed containing section does not disable an otherwise
+valid alias when the canonical path is absent.
+
+## Scope
+
+This contract applies only to genuinely equivalent settings. Raven's
+`[linting]`, `[packages]`, and `[symbols]` settings and Sight's formatting,
+ADO-path, and Stata-specific settings are intentionally outside the shared
+schema. Similarly named cache and revalidation limits are not shared unless
+their behavior is also equivalent.

--- a/src/config-file/schema.ts
+++ b/src/config-file/schema.ts
@@ -62,6 +62,7 @@ const SERVER_TOP_LEVEL_KEYS = [
     'indexWorkspace',
     'adoPaths',
     'exclude',
+    'workspace',
     'lineCommentStyle',
     'debug',
     'diagnostics',
@@ -114,6 +115,20 @@ function warn_unknown_key(
         code: 'unknown-key',
         key_path,
         message: `Unknown project config key '${key_path}.${raw_key}'; ignoring`,
+    });
+}
+
+function warn_compat_collision(
+    canonical_path: string,
+    alias_path: string,
+    warn?: WarningSink
+): void {
+    warn?.({
+        code: 'normalized-key-collision',
+        key_path: canonical_path,
+        message:
+            `Both '${canonical_path}' and compatibility alias '${alias_path}' ` +
+            `are set; using '${canonical_path}'`,
     });
 }
 
@@ -295,7 +310,7 @@ function map_diagnostics(
 ): NonNullable<DeepPartial<StataLSPConfig>['diagnostics']> | undefined {
     warn_unknown_keys(
         raw,
-        ['enabled', 'indentation', 'severity'],
+        ['enabled', 'indentation', 'severity', 'undefinedVariableSeverity'],
         'diagnostics',
         warn
     );
@@ -317,6 +332,8 @@ function map_diagnostics(
         'diagnostics.severity',
         warn
     );
+    const mapped_severity: JsonObject = {};
+    let canonical_undefined_variable: unknown;
     if (severity) {
         warn_unknown_keys(
             severity,
@@ -324,7 +341,6 @@ function map_diagnostics(
             'diagnostics.severity',
             warn
         );
-        const mapped_severity: JsonObject = {};
         for (const my_key of DIAGNOSTIC_SEVERITY_KEYS) {
             const value = pick_key(
                 severity,
@@ -333,6 +349,9 @@ function map_diagnostics(
                 `diagnostics.severity.${my_key}`
             );
             if (value !== undefined) {
+                if (my_key === 'undefinedVariable') {
+                    canonical_undefined_variable = value;
+                }
                 const normalized = normalize_severity_value<Severity>(
                     value,
                     `diagnostics.severity.${my_key}`,
@@ -344,8 +363,34 @@ function map_diagnostics(
                 }
             }
         }
-        maybe_assign_object(mapped, 'severity', mapped_severity);
     }
+
+    const legacy_undefined_variable = pick_key(
+        raw,
+        'undefinedVariableSeverity',
+        warn,
+        'diagnostics.undefinedVariableSeverity'
+    );
+    if (legacy_undefined_variable !== undefined) {
+        if (canonical_undefined_variable !== undefined) {
+            warn_compat_collision(
+                'diagnostics.severity.undefinedVariable',
+                'diagnostics.undefinedVariableSeverity',
+                warn
+            );
+        } else {
+            const normalized = normalize_severity_value<Severity>(
+                legacy_undefined_variable,
+                'diagnostics.undefinedVariableSeverity',
+                SEVERITIES,
+                warn
+            );
+            if (normalized) {
+                mapped_severity.undefinedVariable = normalized;
+            }
+        }
+    }
+    maybe_assign_object(mapped, 'severity', mapped_severity);
 
     return Object.keys(mapped).length > 0
         ? mapped as NonNullable<DeepPartial<StataLSPConfig>['diagnostics']>
@@ -490,6 +535,8 @@ function map_cross_file(
             'maxCachedScopes',
             'maxCachedForwardClosures',
             'diagnostics',
+            'missingFileSeverity',
+            'caseMismatchSeverity',
         ],
         'crossFile',
         warn
@@ -593,6 +640,9 @@ function map_cross_file(
         'crossFile.diagnostics',
         warn
     );
+    const mapped_diagnostics: JsonObject = {};
+    let canonical_missing_file: unknown;
+    let canonical_case_mismatch: unknown;
     if (diagnostics) {
         warn_unknown_keys(
             diagnostics,
@@ -600,7 +650,6 @@ function map_cross_file(
             'crossFile.diagnostics',
             warn
         );
-        const mapped_diagnostics: JsonObject = {};
         for (const [public_key, internal_key] of [
             ['missingFile', 'missing_file'],
             ['maxDepth', 'max_depth'],
@@ -609,6 +658,9 @@ function map_cross_file(
             const key_path = `crossFile.diagnostics.${public_key}`;
             const value = pick_key(diagnostics, public_key, warn, key_path);
             if (value !== undefined) {
+                if (public_key === 'missingFile') {
+                    canonical_missing_file = value;
+                }
                 const normalized = normalize_severity_value<CrossFileSeverity>(
                     value,
                     key_path,
@@ -629,6 +681,7 @@ function map_cross_file(
             case_mismatch_key_path
         );
         if (case_mismatch_value !== undefined) {
+            canonical_case_mismatch = case_mismatch_value;
             const normalized = normalize_severity_value<CrossFileCaseMismatchSeverity>(
                 case_mismatch_value,
                 case_mismatch_key_path,
@@ -639,8 +692,60 @@ function map_cross_file(
                 mapped_diagnostics['case_mismatch'] = normalized;
             }
         }
-        maybe_assign_object(mapped, 'diagnostics', mapped_diagnostics);
     }
+
+    const legacy_missing_file = pick_key(
+        raw,
+        'missingFileSeverity',
+        warn,
+        'crossFile.missingFileSeverity'
+    );
+    if (legacy_missing_file !== undefined) {
+        if (canonical_missing_file !== undefined) {
+            warn_compat_collision(
+                'crossFile.diagnostics.missingFile',
+                'crossFile.missingFileSeverity',
+                warn
+            );
+        } else {
+            const normalized = normalize_severity_value<CrossFileSeverity>(
+                legacy_missing_file,
+                'crossFile.missingFileSeverity',
+                CROSS_FILE_SEVERITIES,
+                warn
+            );
+            if (normalized) {
+                mapped_diagnostics.missing_file = normalized;
+            }
+        }
+    }
+
+    const legacy_case_mismatch = pick_key(
+        raw,
+        'caseMismatchSeverity',
+        warn,
+        'crossFile.caseMismatchSeverity'
+    );
+    if (legacy_case_mismatch !== undefined) {
+        if (canonical_case_mismatch !== undefined) {
+            warn_compat_collision(
+                'crossFile.diagnostics.caseMismatch',
+                'crossFile.caseMismatchSeverity',
+                warn
+            );
+        } else {
+            const normalized = normalize_severity_value<CrossFileCaseMismatchSeverity>(
+                legacy_case_mismatch,
+                'crossFile.caseMismatchSeverity',
+                CROSS_FILE_CASE_MISMATCH_SEVERITIES,
+                warn
+            );
+            if (normalized) {
+                mapped_diagnostics.case_mismatch = normalized;
+            }
+        }
+    }
+    maybe_assign_object(mapped, 'diagnostics', mapped_diagnostics);
 
     return Object.keys(mapped).length > 0
         ? mapped as DeepPartial<StataLSPConfig>['cross_file']
@@ -680,13 +785,30 @@ export function map_public_config_to_partial_config(
         }
     }
 
-    const exclude = pick_key(raw, 'exclude', warn, 'exclude');
+    const workspace = object_value(raw, 'workspace', 'workspace', warn);
+    if (workspace) {
+        warn_unknown_keys(workspace, ['exclude'], 'workspace', warn);
+    }
+    const canonical_exclude = workspace
+        ? pick_key(workspace, 'exclude', warn, 'workspace.exclude')
+        : undefined;
+    const legacy_exclude = pick_key(raw, 'exclude', warn, 'exclude');
+    const exclude = canonical_exclude !== undefined
+        ? canonical_exclude
+        : legacy_exclude;
+    if (canonical_exclude !== undefined && legacy_exclude !== undefined) {
+        warn_compat_collision('workspace.exclude', 'exclude', warn);
+    }
     if (exclude !== undefined) {
         if (Array.isArray(exclude)
             && exclude.every((item) => typeof item === 'string')) {
             mapped.exclude = exclude;
         } else {
-            warn_invalid_value('exclude', exclude, warn);
+            warn_invalid_value(
+                canonical_exclude !== undefined ? 'workspace.exclude' : 'exclude',
+                exclude,
+                warn
+            );
         }
     }
 

--- a/tests/unit/config-file/schema.test.ts
+++ b/tests/unit/config-file/schema.test.ts
@@ -95,6 +95,62 @@ describe('map_public_config_to_partial_config', () => {
         expect(warnings.join('\n')).toContain('exclude');
     });
 
+    it('uses workspace.exclude canonically and keeps root exclude as an alias', () => {
+        const canonical = map_public_config_to_partial_config({
+            workspace: { exclude: ['canonical/**'] },
+        });
+        const legacy = map_public_config_to_partial_config({
+            exclude: ['legacy/**'],
+        });
+
+        expect(canonical.exclude).toEqual(['canonical/**']);
+        expect(legacy.exclude).toEqual(['legacy/**']);
+    });
+
+    it('prefers canonical shared paths over compatibility aliases', () => {
+        const warnings: string[] = [];
+        const result = map_public_config_to_partial_config(
+            {
+                workspace: { exclude: ['canonical/**'] },
+                exclude: ['legacy/**'],
+                diagnostics: {
+                    severity: { undefinedVariable: 'error' },
+                    undefinedVariableSeverity: 'warning',
+                },
+                crossFile: {
+                    diagnostics: {
+                        missingFile: 'off',
+                        caseMismatch: 'auto',
+                    },
+                    missingFileSeverity: 'error',
+                    caseMismatchSeverity: 'warning',
+                },
+            },
+            (warning) => warnings.push(warning.message)
+        );
+
+        expect(result.exclude).toEqual(['canonical/**']);
+        expect(result.diagnostics?.severity?.undefinedVariable).toBe('error');
+        expect(result.cross_file?.diagnostics?.missing_file).toBe('off');
+        expect(result.cross_file?.diagnostics?.case_mismatch).toBe('auto');
+        expect(warnings.filter((warning) => warning.includes('compatibility alias')))
+            .toHaveLength(4);
+    });
+
+    it('accepts Raven diagnostic paths as compatibility aliases', () => {
+        const result = map_public_config_to_partial_config({
+            diagnostics: { undefinedVariableSeverity: 'hint' },
+            crossFile: {
+                missingFileSeverity: 'information',
+                caseMismatchSeverity: 'warning',
+            },
+        });
+
+        expect(result.diagnostics?.severity?.undefinedVariable).toBe('hint');
+        expect(result.cross_file?.diagnostics?.missing_file).toBe('information');
+        expect(result.cross_file?.diagnostics?.case_mismatch).toBe('warning');
+    });
+
     it('warns and ignores colliding aliases when no canonical spelling exists', () => {
         const warnings: string[] = [];
         const result = map_public_config_to_partial_config(

--- a/tests/unit/config-file/toml-loader.test.ts
+++ b/tests/unit/config-file/toml-loader.test.ts
@@ -34,4 +34,33 @@ missingFile = "Info"
             expect(loaded.error).toContain('bad sight.toml');
         }
     });
+
+    it('loads canonical workspace exclusions', () => {
+        const loaded = load_toml_str(
+            '[workspace]\nexclude = ["generated/**"]\n',
+            'test sight.toml'
+        );
+
+        expect(loaded.kind).toBe('loaded');
+        if (loaded.kind === 'loaded') {
+            expect(loaded.partial_config.exclude).toEqual(['generated/**']);
+        }
+    });
+
+    it('honors the root exclude alias when workspace is malformed', () => {
+        const loaded = load_toml_str(
+            'workspace = "bad"\nexclude = ["generated/**"]\n',
+            'test sight.toml'
+        );
+
+        expect(loaded.kind).toBe('loaded');
+        if (loaded.kind === 'loaded') {
+            expect(loaded.partial_config.exclude).toEqual(['generated/**']);
+            expect(loaded.warnings).toContainEqual(expect.objectContaining({
+                code: 'invalid-value',
+                key_path: 'workspace',
+                path: 'test sight.toml',
+            }));
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- define the canonical TOML paths shared by Sight and Raven
- make `workspace.exclude` canonical while retaining root `exclude` permanently
- accept Raven's historical diagnostic severity paths as permanent aliases
- use canonical-wins precedence with collision warnings
- update configuration and CLI documentation

Companion change: https://github.com/jbearak/raven/pull/598

## Tests
- `bun run typecheck`
- `bun run lint`
- `bun test tests/unit/config-file` (71 passed)
