### PR TITLE
Prevent stale diagnostics after document close

### DIFF
--- a/src/providers/diagnostics-publish-gate.ts
+++ b/src/providers/diagnostics-publish-gate.ts
@@ -1,16 +1,35 @@
 /**
- * Gate diagnostics publication by document version and per-URI force epoch.
+ * Gate diagnostics publication by document version and lifecycle/force epoch.
+ *
+ * Epochs are allocated globally so a URI cannot reuse an epoch after
+ * `forget()`. This makes a close a hard publication boundary: work that
+ * captured the retired epoch before the close cannot publish after the URI is
+ * forgotten or reopened.
  */
 export class DiagnosticsPublishGate {
     private last_published_version: Map<string, number> = new Map();
     private last_published_epoch: Map<string, number> = new Map();
     private current_epoch: Map<string, number> = new Map();
+    private next_epoch = 0;
 
     get_current_epoch(uri: string): number {
-        return this.current_epoch.get(uri) ?? 0;
+        let my_epoch = this.current_epoch.get(uri);
+        if (my_epoch === undefined) {
+            my_epoch = this.allocate_epoch();
+            this.current_epoch.set(uri, my_epoch);
+        }
+        return my_epoch;
+    }
+
+    is_current_epoch(uri: string, epoch: number): boolean {
+        return this.current_epoch.get(uri) === epoch;
     }
 
     would_publish(uri: string, version: number, epoch: number): boolean {
+        if (!this.is_current_epoch(uri, epoch)) {
+            return false;
+        }
+
         const my_last_version = this.last_published_version.get(uri);
         if (my_last_version === undefined || version > my_last_version) {
             return true;
@@ -26,6 +45,10 @@ export class DiagnosticsPublishGate {
     }
 
     try_consume_publish(uri: string, version: number, epoch: number): boolean {
+        if (!this.is_current_epoch(uri, epoch)) {
+            return false;
+        }
+
         const my_last_version = this.last_published_version.get(uri);
         if (my_last_version === undefined || version > my_last_version) {
             this.last_published_version.set(uri, version);
@@ -48,12 +71,18 @@ export class DiagnosticsPublishGate {
     }
 
     mark_force_republish(uri: string): void {
-        this.current_epoch.set(uri, (this.current_epoch.get(uri) ?? 0) + 1);
+        this.current_epoch.set(uri, this.allocate_epoch());
     }
 
     forget(uri: string): void {
         this.last_published_version.delete(uri);
         this.last_published_epoch.delete(uri);
         this.current_epoch.delete(uri);
+    }
+
+    private allocate_epoch(): number {
+        const my_epoch = this.next_epoch;
+        this.next_epoch++;
+        return my_epoch;
     }
 }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -736,10 +736,10 @@ export class DiagnosticsProvider {
         }
 
         // Cache the filtered diagnostics if no force epoch advanced mid-run.
-        if (
-            this.publish_gate.get_current_epoch(document.uri) ===
+        if (this.publish_gate.is_current_epoch(
+            document.uri,
             cache_epoch_at_start
-        ) {
+        )) {
             let cache_for_uri = this.filtered_cache.get(document.uri);
             if (!cache_for_uri) {
                 cache_for_uri = new Map();

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -662,6 +662,66 @@ describe('DiagnosticsProvider', () => {
             const sent_after = mock_connection.get_sent_diagnostics();
             expect(sent_after.length).toBe(1);
         });
+
+        it('should drop an in-flight publish that resumes after close', async () => {
+            const document = create_document_state(
+                'display `undefined\'\n',
+                1
+            );
+            const delayed_scope_resolver = new ScopeResolver();
+            let resolve_scope: (() => void) | undefined;
+            let resolve_started: (() => void) | undefined;
+            const scope_started = new Promise<void>(resolve => {
+                resolve_started = resolve;
+            });
+            const scope_delay = new Promise<void>(resolve => {
+                resolve_scope = resolve;
+            });
+
+            delayed_scope_resolver.resolve = async () => {
+                resolve_started?.();
+                await scope_delay;
+                return create_empty_resolved_scope();
+            };
+
+            const stale_publish = provider.publish_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                delayed_scope_resolver
+            );
+            await scope_started;
+
+            provider.on_document_closed(document.uri);
+
+            const sent_after_close =
+                mock_connection.get_sent_diagnostics();
+            expect(sent_after_close).toHaveLength(1);
+            expect(sent_after_close[0].diagnostics).toEqual([]);
+
+            expect(resolve_scope).toBeDefined();
+            resolve_scope?.();
+            await stale_publish;
+
+            const sent_after_stale_publish =
+                mock_connection.get_sent_diagnostics();
+            expect(sent_after_stale_publish).toHaveLength(1);
+            expect(sent_after_stale_publish[0].diagnostics).toEqual([]);
+
+            const reopened_document = create_document_state(
+                'generate x = 1\n',
+                1
+            );
+            await provider.publish_diagnostics(
+                reopened_document,
+                DEFAULT_CONFIG
+            );
+
+            const sent_after_reopen =
+                mock_connection.get_sent_diagnostics();
+            expect(sent_after_reopen).toHaveLength(2);
+            expect(sent_after_reopen[1].diagnostics).toEqual([]);
+        });
     });
 
     describe('aggregation from multiple sources', () => {

--- a/tests/unit/diagnostics-publish-gate.test.ts
+++ b/tests/unit/diagnostics-publish-gate.test.ts
@@ -94,7 +94,7 @@ describe('DiagnosticsPublishGate', () => {
         expect(gate.try_consume_publish(uri, 1, my_epoch_2)).toBe(true);
     });
 
-    it('should forget all per-uri state', () => {
+    it('should retire the epoch when forgetting per-uri state', () => {
         const gate = new DiagnosticsPublishGate();
         const my_epoch_0 = gate.get_current_epoch(uri);
 
@@ -104,10 +104,15 @@ describe('DiagnosticsPublishGate', () => {
 
         gate.forget(uri);
 
-        expect(gate.get_current_epoch(uri)).toBe(0);
-        expect(gate.would_publish(uri, 1, 0)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, 0)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, 0)).toBe(false);
+        expect(gate.is_current_epoch(uri, my_epoch_0)).toBe(false);
+        expect(gate.would_publish(uri, 1, my_epoch_0)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(false);
+
+        const my_reopened_epoch = gate.get_current_epoch(uri);
+        expect(my_reopened_epoch).not.toBe(my_epoch_0);
+        expect(gate.would_publish(uri, 1, my_reopened_epoch)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_reopened_epoch)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, my_reopened_epoch)).toBe(false);
     });
 
     it('should deny older same-version work after newer work consumes', () => {


### PR DESCRIPTION
## Summary

- retire diagnostic publication epochs when a document closes
- reject in-flight publications from a retired close/reopen lifecycle
- prevent retired work from refilling the filtered diagnostics cache
- cover close, stale-resume, and same-version reopen behavior

## Why

Sight already publishes an empty diagnostics list on textDocument/didClose. However, on_document_closed cleared the publication gate before an in-flight diagnostic computation completed. That old computation could then pass the reset gate and overwrite the empty publication with stale diagnostics.

The gate now allocates globally unique lifecycle/force epochs. Forgetting a URI removes its current epoch, so captured pre-close work cannot become current again, even if the URI immediately reopens at version 1.

## Validation

- bun run test: 7,545 passed, 5 opt-in skipped, 0 failed
- bun run lint: passed
- focused diagnostics provider and publication gate tests: 97 passed