### PR TITLE
Harden diagnostic lifecycle boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,18 @@ This ensures that:
 **Concurrency Handling**:
 Completion requests are race-prone against document updates. The `server-handlers.ts` uses `document_store.wait_for_update(uri)` to ensure any pending `textDocument/didChange` processing completes before serving completions.
 
+Diagnostic publication uses an explicit per-open lifecycle trigger in
+`DiagnosticsPublishGate`. `didOpen` begins the lifecycle; `didClose` and
+shutdown retire it. Validation captures the trigger before debounce and the
+provider rechecks it after asynchronous computation, so retired work cannot
+publish into a close/reopen or after a newer edit is scheduled. The trigger
+carries the document version, lifecycle identity, and a separate force epoch
+that authorizes one same-version republish after dependency or configuration
+changes. The server also checks the
+`TextDocuments` object identity and version after awaited validation stages so
+an active stale callback cannot reopen or overwrite `DocumentStore` from its
+retired snapshot.
+
 **Find References — Three-Tier Scoping**: The references provider uses three
 distinct scoping tiers by design: (1) **local macros** — include-chain files
 only (Stata locals don't propagate through `do`/`run`); (2) **global macros,

--- a/src/document-store.ts
+++ b/src/document-store.ts
@@ -1,4 +1,8 @@
-import { TextDocumentContentChangeEvent, Diagnostic, DiagnosticSeverity } from 'vscode-languageserver';
+import {
+  TextDocumentContentChangeEvent,
+  Diagnostic,
+  DiagnosticSeverity,
+} from 'vscode-languageserver';
 import {
   StataAST,
   SymbolTable,
@@ -29,6 +33,7 @@ import {
   resolve_working_directory_directive,
 } from './utils/workspace-roots';
 import { build_cd_timeline, apply_cd_timeline } from './utils/file-path-utils';
+import { polling_cancellation_token } from './utils/polling-cancellation-token';
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -219,13 +224,16 @@ export class DocumentStore {
   /**
    * Open a document and parse it.
    * Async to support parse timeout wrapper.
+   * `is_operation_current` must be synchronous and side-effect-free; it is
+   * polled before expensive stages and once more at commit.
    */
   async open(
     uri: string,
     content: string,
     version: number,
     workspace_symbols?: SymbolTable,
-    scope_resolver_config?: Partial<ScopeResolverConfig>
+    scope_resolver_config?: Partial<ScopeResolverConfig>,
+    is_operation_current?: () => boolean
   ): Promise<void> {
     this.check_disposed();
     // Capture generation at start of operation (Req 16.2)
@@ -248,15 +256,22 @@ export class DocumentStore {
       if (this.disposed) {
         return;
       }
+      if (is_operation_current && !is_operation_current()) {
+        return;
+      }
       this.evict_if_needed(content.length);
       const outcome = await this.create_document_state(
         uri,
         content,
         version,
         workspace_symbols,
-        scope_resolver_config
+        scope_resolver_config,
+        is_operation_current
       );
-      this.commit_state(uri, outcome, generation);
+      if (!outcome) {
+        return;
+      }
+      this.commit_state(uri, outcome, generation, is_operation_current);
     };
 
     const promise = operation();
@@ -275,13 +290,16 @@ export class DocumentStore {
    * Update a document with text changes.
    * Async to support parse timeout wrapper.
    * Implements fast path for unchanged content.
+   * `is_operation_current` must be synchronous and side-effect-free; it is
+   * polled before expensive stages and once more at commit.
    */
   async update(
     uri: string,
     changes: TextDocumentContentChangeEvent[],
     version: number,
     workspace_symbols?: SymbolTable,
-    scope_resolver_config?: Partial<ScopeResolverConfig>
+    scope_resolver_config?: Partial<ScopeResolverConfig>,
+    is_operation_current?: () => boolean
   ): Promise<void> {
     this.check_disposed();
     // Capture generation at start of operation (Req 16.2)
@@ -302,6 +320,9 @@ export class DocumentStore {
         }
       }
       if (this.disposed) {
+        return;
+      }
+      if (is_operation_current && !is_operation_current()) {
         return;
       }
       const state = this.documents.get(uri);
@@ -351,9 +372,18 @@ export class DocumentStore {
         new_content,
         version,
         workspace_symbols,
-        scope_resolver_config
+        scope_resolver_config,
+        is_operation_current
       );
-      this.commit_state(uri, new_outcome, generation);
+      if (!new_outcome) {
+        return;
+      }
+      this.commit_state(
+        uri,
+        new_outcome,
+        generation,
+        is_operation_current
+      );
     };
 
     const promise = operation();
@@ -427,11 +457,18 @@ export class DocumentStore {
   private commit_state(
     uri: string,
     outcome: ParseOutcome,
-    generation: number
+    generation: number,
+    is_operation_current?: () => boolean
   ): boolean {
     // A parse that was already past the operation closure's disposed
     // check must not mutate shared resolver/indexer state mid-shutdown.
     if (this.disposed) {
+      return false;
+    }
+    // The server uses this guard to couple an async parse to the document and
+    // diagnostic trigger that scheduled it. It runs synchronously before any
+    // state or cross-file side effect is applied.
+    if (is_operation_current && !is_operation_current()) {
       return false;
     }
     const closed_gen = this.closed_generations.get(uri);
@@ -539,14 +576,20 @@ export class DocumentStore {
   private async recover_staged_effects_with_timeout(
     content: string,
     uri: string,
-    scope_resolver_config: Partial<ScopeResolverConfig>
+    scope_resolver_config: Partial<ScopeResolverConfig>,
+    is_operation_current?: () => boolean
   ): Promise<StagedCrossFileEffects | undefined> {
     try {
       const my_directive_parser = new DirectiveParser();
       const my_result = await with_parse_timeout(() =>
-        my_directive_parser.parse(content, uri)
+        is_operation_current?.() === false
+          ? null
+          : my_directive_parser.parse(content, uri)
       );
-      if (!my_result.success || my_result.timed_out || !my_result.result) {
+      if (is_operation_current?.() === false
+          || !my_result.success
+          || my_result.timed_out
+          || !my_result.result) {
         return undefined;
       }
       return this.stage_cross_file_effects(
@@ -756,10 +799,16 @@ export class DocumentStore {
     content: string,
     version: number,
     workspace_symbols?: SymbolTable,
-    scope_resolver_config?: Partial<ScopeResolverConfig>
-  ): Promise<ParseOutcome> {
+    scope_resolver_config?: Partial<ScopeResolverConfig>,
+    is_operation_current?: () => boolean
+  ): Promise<ParseOutcome | undefined> {
     const start_time = Date.now();
     this.metrics.parse_count++;
+    const operation_is_current = (): boolean =>
+      is_operation_current?.() !== false;
+    const cancellation_token = is_operation_current
+      ? polling_cancellation_token(is_operation_current)
+      : undefined;
 
     // Create fresh instances for thread safety (async execution means concurrent calls)
     const lexer = new StataLexer();
@@ -770,8 +819,11 @@ export class DocumentStore {
 
     // Lex with timeout
     const lex_result = await with_parse_timeout(() =>
-      lexer.tokenize(content)
+      operation_is_current() ? lexer.tokenize(content) : null
     );
+    if (!operation_is_current() || lex_result.result === null) {
+      return undefined;
+    }
 
     if (!lex_result.success || lex_result.timed_out) {
       // Recover header facts only when the lexer THREW (fast). On a
@@ -786,8 +838,13 @@ export class DocumentStore {
         : await this.recover_staged_effects_with_timeout(
             content,
             uri,
-            effective_scope_resolver_config
+            effective_scope_resolver_config,
+            is_operation_current
           );
+
+      if (!operation_is_current()) {
+        return undefined;
+      }
 
       // Return minimal state on timeout/error
       return {
@@ -812,8 +869,13 @@ export class DocumentStore {
 
     // Parse with timeout (pass context tracker to avoid re-creation)
     const parse_result = await with_parse_timeout(() =>
-      parser.parse(lex_result.result!.tokens, my_context_tracker)
+      operation_is_current()
+        ? parser.parse(lex_result.result!.tokens, my_context_tracker)
+        : null
     );
+    if (!operation_is_current() || parse_result.result === null) {
+      return undefined;
+    }
 
     if (!parse_result.success || parse_result.timed_out) {
       const recovered_staged_effects =
@@ -870,7 +932,7 @@ export class DocumentStore {
             uri,
             content,
             effective_scope_resolver_config,
-            undefined,
+            cancellation_token,
             { register_dependencies: false }
           );
           if (scope_result.inherited_working_directory) {
@@ -884,18 +946,28 @@ export class DocumentStore {
       // Invalid URI or other error - continue without working directory
     }
 
+    if (!operation_is_current()) {
+      return undefined;
+    }
+
     // Analyze with timeout and explicit parameters (no hidden defaults)
     const analyze_result = await with_parse_timeout(() =>
-      analyzer.analyze(
-        parse_result.result!.ast,
-        uri,
-        workspace_symbols,
-        {
-          working_directory: resolved_working_directory,
-        },
-        lex_result.result!.tokens
-      )
+      operation_is_current()
+        ? analyzer.analyze(
+            parse_result.result!.ast,
+            uri,
+            workspace_symbols,
+            {
+              working_directory: resolved_working_directory,
+            },
+            lex_result.result!.tokens
+          )
+        : null
     );
+
+    if (!operation_is_current() || analyze_result.result === null) {
+      return undefined;
+    }
 
     const elapsed_ms = Date.now() - start_time;
     this.metrics.parse_total_ms += elapsed_ms;

--- a/src/providers/diagnostics-publish-gate.ts
+++ b/src/providers/diagnostics-publish-gate.ts
@@ -1,88 +1,144 @@
+/** Immutable diagnostic state captured when validation is scheduled. */
+export interface DiagnosticsTrigger {
+    readonly lifecycle_epoch: number;
+    readonly document_version: number;
+    readonly force_epoch: number;
+}
+
+interface DiagnosticsLifecycleState {
+    lifecycle_epoch: number;
+    document_version: number;
+    force_epoch: number;
+    last_published_version?: number;
+    last_published_force_epoch?: number;
+}
+
 /**
- * Gate diagnostics publication by document version and lifecycle/force epoch.
+ * Gate diagnostic publication by document version and explicit lifecycle.
  *
- * Epochs are allocated globally so a URI cannot reuse an epoch after
- * `forget()`. This makes a close a hard publication boundary: work that
- * captured the retired epoch before the close cannot publish after the URI is
- * forgotten or reopened.
+ * Only didOpen begins a lifecycle. Close and shutdown retire it, while normal
+ * edits advance its document version and dependency/configuration changes
+ * advance its force epoch. Publication never creates or advances lifecycle
+ * state, so old work fails closed at its final commit.
  */
 export class DiagnosticsPublishGate {
-    private last_published_version: Map<string, number> = new Map();
-    private last_published_epoch: Map<string, number> = new Map();
-    private current_epoch: Map<string, number> = new Map();
-    private next_epoch = 0;
+    private lifecycle_by_uri = new Map<string, DiagnosticsLifecycleState>();
+    private next_lifecycle_epoch = 0;
 
-    get_current_epoch(uri: string): number {
-        let my_epoch = this.current_epoch.get(uri);
-        if (my_epoch === undefined) {
-            my_epoch = this.allocate_epoch();
-            this.current_epoch.set(uri, my_epoch);
+    begin_lifecycle(uri: string, version: number): DiagnosticsTrigger {
+        const state: DiagnosticsLifecycleState = {
+            lifecycle_epoch: this.next_lifecycle_epoch++,
+            document_version: version,
+            force_epoch: 0,
+        };
+        this.lifecycle_by_uri.set(uri, state);
+        return this.trigger_from(state);
+    }
+
+    /**
+     * Record the newest version scheduled for validation and capture its
+     * trigger. Older versions never move the lifecycle backwards; their
+     * returned trigger is intentionally stale and will fail validation.
+     */
+    trigger_for_validation(
+        uri: string,
+        version: number
+    ): DiagnosticsTrigger | undefined {
+        const state = this.lifecycle_by_uri.get(uri);
+        if (!state) {
+            return undefined;
         }
-        return my_epoch;
+        if (version > state.document_version) {
+            state.document_version = version;
+        }
+        return {
+            lifecycle_epoch: state.lifecycle_epoch,
+            document_version: version,
+            force_epoch: state.force_epoch,
+        };
     }
 
-    is_current_epoch(uri: string, epoch: number): boolean {
-        return this.current_epoch.get(uri) === epoch;
+    is_current_trigger(
+        uri: string,
+        trigger: DiagnosticsTrigger | undefined
+    ): boolean {
+        return !!trigger && !!this.state_for_trigger(uri, trigger);
     }
 
-    would_publish(uri: string, version: number, epoch: number): boolean {
-        if (!this.is_current_epoch(uri, epoch)) {
+    would_publish(
+        uri: string,
+        version: number,
+        trigger: DiagnosticsTrigger
+    ): boolean {
+        const state = this.state_for_trigger(uri, trigger);
+        if (!state || version !== trigger.document_version) {
             return false;
         }
 
-        const my_last_version = this.last_published_version.get(uri);
-        if (my_last_version === undefined || version > my_last_version) {
+        if (state.last_published_version === undefined ||
+            version > state.last_published_version) {
             return true;
         }
-
-        if (version < my_last_version) {
+        if (version < state.last_published_version) {
             return false;
         }
-
-        const my_current_epoch = this.current_epoch.get(uri) ?? 0;
-        const my_last_epoch = this.last_published_epoch.get(uri) ?? 0;
-        return epoch === my_current_epoch && epoch > my_last_epoch;
+        return trigger.force_epoch >
+            (state.last_published_force_epoch ?? -1);
     }
 
-    try_consume_publish(uri: string, version: number, epoch: number): boolean {
-        if (!this.is_current_epoch(uri, epoch)) {
+    try_consume_publish(
+        uri: string,
+        version: number,
+        trigger: DiagnosticsTrigger
+    ): boolean {
+        if (!this.would_publish(uri, version, trigger)) {
             return false;
         }
+        const state = this.lifecycle_by_uri.get(uri)!;
+        state.last_published_version = version;
+        state.last_published_force_epoch = trigger.force_epoch;
+        return true;
+    }
 
-        const my_last_version = this.last_published_version.get(uri);
-        if (my_last_version === undefined || version > my_last_version) {
-            this.last_published_version.set(uri, version);
-            this.last_published_epoch.set(uri, epoch);
-            return true;
-        }
-
-        if (version < my_last_version) {
+    /** Authorize one same-version publication without creating a lifecycle. */
+    mark_force_republish(uri: string): boolean {
+        const state = this.lifecycle_by_uri.get(uri);
+        if (!state) {
             return false;
         }
+        state.force_epoch++;
+        return true;
+    }
 
-        const my_current_epoch = this.current_epoch.get(uri) ?? 0;
-        const my_last_epoch = this.last_published_epoch.get(uri) ?? 0;
-        if (epoch === my_current_epoch && epoch > my_last_epoch) {
-            this.last_published_epoch.set(uri, epoch);
-            return true;
+    retire_lifecycle(uri: string): void {
+        this.lifecycle_by_uri.delete(uri);
+    }
+
+    retire_all_lifecycles(): void {
+        this.lifecycle_by_uri.clear();
+    }
+
+    private trigger_from(
+        state: DiagnosticsLifecycleState
+    ): DiagnosticsTrigger {
+        return {
+            lifecycle_epoch: state.lifecycle_epoch,
+            document_version: state.document_version,
+            force_epoch: state.force_epoch,
+        };
+    }
+
+    private state_for_trigger(
+        uri: string,
+        trigger: DiagnosticsTrigger
+    ): DiagnosticsLifecycleState | undefined {
+        const state = this.lifecycle_by_uri.get(uri);
+        if (!state ||
+            state.lifecycle_epoch !== trigger.lifecycle_epoch ||
+            state.document_version !== trigger.document_version ||
+            state.force_epoch !== trigger.force_epoch) {
+            return undefined;
         }
-
-        return false;
-    }
-
-    mark_force_republish(uri: string): void {
-        this.current_epoch.set(uri, this.allocate_epoch());
-    }
-
-    forget(uri: string): void {
-        this.last_published_version.delete(uri);
-        this.last_published_epoch.delete(uri);
-        this.current_epoch.delete(uri);
-    }
-
-    private allocate_epoch(): number {
-        const my_epoch = this.next_epoch;
-        this.next_epoch++;
-        return my_epoch;
+        return state;
     }
 }

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -45,7 +45,13 @@ import { OperatorSequenceAnalyzer } from './operator-sequence-diagnostics';
 import { MixedLogicalOperatorAnalyzer } from './mixed-logical-diagnostics';
 import { ChainedComparisonAnalyzer } from './chained-comparison-diagnostics';
 import { LiteralMacroAdjacencyAnalyzer } from './literal-macro-adjacency-diagnostics';
-import { DiagnosticsPublishGate } from './diagnostics-publish-gate';
+import {
+    DiagnosticsPublishGate,
+    DiagnosticsTrigger,
+} from './diagnostics-publish-gate';
+export type { DiagnosticsTrigger } from './diagnostics-publish-gate';
+import { polling_cancellation_token } from
+    '../utils/polling-cancellation-token';
 type SemanticDiagnostic = {
     message: string;
     range: Range;
@@ -170,6 +176,7 @@ export class DiagnosticsProvider {
 
     // Cache filtered diagnostics by (uri, version, config_hash)
     private filtered_cache: Map<string, Map<string, Diagnostic[]>> = new Map();
+    private cache_generation = 0;
 
     constructor(
         connection: DiagnosticsConnection,
@@ -210,13 +217,35 @@ export class DiagnosticsProvider {
         this.debounce_manager = debounce_manager;
     }
 
+    /** Begin a fresh diagnostic lifecycle for one LSP document open. */
+    on_document_opened(uri: string, version: number): void {
+        this.publish_gate.begin_lifecycle(uri, version);
+        this.clear_cache_for_document(uri);
+    }
+
+    /** Advance document freshness and capture the validation trigger. */
+    trigger_for_validation(
+        uri: string,
+        version: number
+    ): DiagnosticsTrigger | undefined {
+        return this.publish_gate.trigger_for_validation(uri, version);
+    }
+
+    /** Fast pre-compute check; publication repeats this atomically at commit. */
+    is_validation_current(
+        uri: string,
+        trigger: DiagnosticsTrigger | undefined
+    ): boolean {
+        return this.publish_gate.is_current_trigger(uri, trigger);
+    }
+
     /**
      * Mark a document for forced same-version republish.
      * Used when dependencies change and diagnostics need to be recomputed.
      */
     mark_force_republish(uri: string): void {
         this.publish_gate.mark_force_republish(uri);
-        this.filtered_cache.delete(uri);
+        this.clear_cache_for_document(uri);
     }
 
     /**
@@ -225,6 +254,7 @@ export class DiagnosticsProvider {
      * 
      * @param document - The document state to analyze (with cached parse results)
      * @param config - LSP configuration for diagnostic settings
+     * @param diagnostics_trigger - Version/lifecycle/force snapshot captured when validation was scheduled
      * @param workspace_symbols - Optional workspace-level symbols for cross-file resolution
      * @param scope_resolver - Optional scope resolver for cross-file awareness
      * @param cancellation_token - Optional cancellation token
@@ -233,17 +263,27 @@ export class DiagnosticsProvider {
     async publish_diagnostics(
         document: DocumentState,
         config: StataLSPConfig,
+        diagnostics_trigger: DiagnosticsTrigger,
         workspace_symbols?: SymbolTable,
         scope_resolver?: ScopeResolver,
         cancellation_token?: CancellationToken
     ): Promise<{ diagnostics: Diagnostic[]; pending: boolean }> {
-        const my_epoch = this.publish_gate.get_current_epoch(document.uri);
-
         if (!this.publish_gate.would_publish(
             document.uri,
             document.version,
-            my_epoch
+            diagnostics_trigger
         )) {
+            return { diagnostics: [], pending: false };
+        }
+
+        const computation_token = polling_cancellation_token(
+            () => this.publish_gate.is_current_trigger(
+                document.uri,
+                diagnostics_trigger
+            ),
+            cancellation_token
+        );
+        if (computation_token.isCancellationRequested) {
             return { diagnostics: [], pending: false };
         }
 
@@ -252,7 +292,7 @@ export class DiagnosticsProvider {
             if (!this.publish_gate.try_consume_publish(
                 document.uri,
                 document.version,
-                my_epoch
+                diagnostics_trigger
             )) {
                 return { diagnostics: [], pending: false };
             }
@@ -270,13 +310,19 @@ export class DiagnosticsProvider {
             config,
             workspace_symbols,
             scope_resolver,
-            cancellation_token
+            computation_token
         );
+
+        // Cancellation is not a successful empty result: do not clear the
+        // client or consume the trigger, so an uncancelled retry can publish.
+        if (computation_token.isCancellationRequested) {
+            return { diagnostics: [], pending: is_pending };
+        }
 
         if (!this.publish_gate.try_consume_publish(
             document.uri,
             document.version,
-            my_epoch
+            diagnostics_trigger
         )) {
             return { diagnostics: [], pending: is_pending };
         }
@@ -301,8 +347,11 @@ export class DiagnosticsProvider {
         scope_resolver?: ScopeResolver,
         cancellation_token?: CancellationToken
     ): Promise<Diagnostic[]> {
-        const cache_epoch_at_start =
-            this.publish_gate.get_current_epoch(document.uri);
+        if (cancellation_token?.isCancellationRequested) {
+            return [];
+        }
+
+        const cache_generation_at_start = this.cache_generation;
         // Generate config hash for cache key
         const config_hash = this.compute_config_hash(config);
         
@@ -360,6 +409,13 @@ export class DiagnosticsProvider {
             my_resolve_config,
             cancellation_token
         ) : undefined;
+
+        // Scope resolution is the only asynchronous diagnostic stage. A
+        // lifecycle/version change while it is pending must skip all later
+        // semantic and supplemental analyzers, not merely veto publication.
+        if (cancellation_token?.isCancellationRequested) {
+            return [];
+        }
         
         // Diagnostic deferral for auto backward dependency mode:
         // If workspace scan is not yet complete and the file has no explicit
@@ -735,11 +791,10 @@ export class DiagnosticsProvider {
             }
         }
 
-        // Cache the filtered diagnostics if no force epoch advanced mid-run.
-        if (this.publish_gate.is_current_epoch(
-            document.uri,
-            cache_epoch_at_start
-        )) {
+        // Direct/headless callers have no publication lifecycle, so cache
+        // freshness uses an independent generation invalidated by every
+        // document/config/dependency transition.
+        if (this.cache_generation === cache_generation_at_start) {
             let cache_for_uri = this.filtered_cache.get(document.uri);
             if (!cache_for_uri) {
                 cache_for_uri = new Map();
@@ -861,15 +916,23 @@ export class DiagnosticsProvider {
     clear_cache_for_document(uri: string): void {
         // Remove all cached diagnostics for this URI (all versions/configs)
         this.filtered_cache.delete(uri);
+        this.cache_generation++;
     }
 
     /**
      * Remove tracking for a closed document.
      */
     on_document_closed(uri: string): void {
-        this.publish_gate.forget(uri);
+        this.publish_gate.retire_lifecycle(uri);
         this.clear_cache_for_document(uri);
         this.clear_diagnostics(uri);
+    }
+
+    /** Retire every lifecycle so no work can publish after shutdown. */
+    on_shutdown(): void {
+        this.publish_gate.retire_all_lifecycles();
+        this.filtered_cache.clear();
+        this.cache_generation++;
     }
 
     /**

--- a/src/scope-resolver/index.ts
+++ b/src/scope-resolver/index.ts
@@ -1158,6 +1158,16 @@ export class ScopeResolver {
         // perceives as a red-squiggly flicker.
         const scan_complete_at_resolve_time =
             this.dependency_graph?.is_scan_complete();
+        const cancelled_scope = (): ResolvedScope => ({
+            chain: the_chain,
+            symbols: create_empty_symbol_table(),
+            out_of_scope_symbols: the_out_of_scope,
+            diagnostics: [],
+            has_directives,
+            has_auto_parents,
+            is_standalone,
+            scan_complete_at_resolve_time,
+        });
 
         // Follow directive chain
         const normalized_directives = this.normalize_directives(
@@ -1191,16 +1201,7 @@ export class ScopeResolver {
 
         // Check cancellation after directive chain traversal
         if (token?.isCancellationRequested) {
-            return {
-                chain: the_chain,
-                symbols: create_empty_symbol_table(),
-                out_of_scope_symbols: the_out_of_scope,
-                diagnostics: [],
-                has_directives,
-                has_auto_parents,
-                is_standalone,
-                scan_complete_at_resolve_time,
-            };
+            return cancelled_scope();
         }
 
         // Merge symbols with shadowing
@@ -1274,6 +1275,12 @@ export class ScopeResolver {
                     },
                 }
             );
+
+            // A cancelled forward walk can contain a valid-looking partial
+            // result. Never expose or cache it as a completed scope.
+            if (token?.isCancellationRequested) {
+                return cancelled_scope();
+            }
 
             if (forward_result.call_sites.length > 0) {
                 forward_call_symbols = forward_result.call_sites;

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -1047,6 +1047,32 @@ export async function create_server(options: ServerOptions): Promise<void> {
         const snapshot_uri = text_document.uri;
         const snapshot_version = text_document.version;
         const snapshot_content = text_document.getText();
+        const diagnostics_trigger =
+            diagnostics_provider?.trigger_for_validation(
+                snapshot_uri,
+                snapshot_version
+            );
+
+        // TextDocuments mutates one object across changes but creates a new
+        // object for each open. Identity distinguishes close/reopen at the
+        // same version, while the version check catches a newer edit. Check
+        // both after each await before mutating shared state.
+        const snapshot_is_current = (): boolean =>
+            documents.get(snapshot_uri) === text_document &&
+            text_document.version === snapshot_version;
+        const validation_work_is_current = (): boolean => {
+            if (!snapshot_is_current()) {
+                return false;
+            }
+            if (!diagnostics_provider) {
+                return true;
+            }
+            return diagnostics_trigger !== undefined &&
+                diagnostics_provider.is_validation_current(
+                    snapshot_uri,
+                    diagnostics_trigger
+                );
+        };
 
         debounce_manager.schedule_validation(
             snapshot_uri,
@@ -1055,6 +1081,9 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 // Fetch settings inside debounce callback to avoid
                 // delaying the debounce timer start (Req 8.2, 8.3, 8.4)
                 const settings = await get_document_settings(snapshot_uri);
+                if (!validation_work_is_current()) {
+                    return;
+                }
                 const is_debug = settings.debug === true;
                 const my_scope_resolver_config =
                     scope_resolver_config_for(settings);
@@ -1070,7 +1099,8 @@ export async function create_server(options: ServerOptions): Promise<void> {
                         [{ text: snapshot_content }],
                         snapshot_version,
                         workspace_symbols,
-                        my_scope_resolver_config
+                        my_scope_resolver_config,
+                        validation_work_is_current
                     );
                 } else {
                     await document_store.open(
@@ -1078,8 +1108,13 @@ export async function create_server(options: ServerOptions): Promise<void> {
                         snapshot_content,
                         snapshot_version,
                         workspace_symbols,
-                        my_scope_resolver_config
+                        my_scope_resolver_config,
+                        validation_work_is_current
                     );
+                }
+
+                if (!validation_work_is_current()) {
+                    return;
                 }
 
                 // --- Cross-file revalidation scheduling (Req 3.1) ---
@@ -1177,6 +1212,9 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 }
 
                 // --- Diagnostic publication (Req 2.3) ---
+                if (!snapshot_is_current()) {
+                    return;
+                }
                 const document_state = document_store.get(snapshot_uri);
 
                 if (!document_state) {
@@ -1185,6 +1223,9 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 }
 
                 if (diagnostics_provider) {
+                    if (!diagnostics_trigger) {
+                        return;
+                    }
                     const diag_workspace_symbols = workspace_indexer
                         ? workspace_indexer.get_all_symbols()
                         : undefined;
@@ -1192,6 +1233,7 @@ export async function create_server(options: ServerOptions): Promise<void> {
                     const result = await diagnostics_provider.publish_diagnostics(
                         document_state,
                         settings,
+                        diagnostics_trigger,
                         diag_workspace_symbols,
                         scope_resolver || undefined,
                         undefined
@@ -1517,6 +1559,10 @@ export async function create_server(options: ServerOptions): Promise<void> {
 
     // Document open handler - validate when a document is first opened
     documents.onDidOpen((e) => {
+        diagnostics_provider?.on_document_opened(
+            e.document.uri,
+            e.document.version
+        );
         validate_text_document(e.document);
     });
 

--- a/src/server-handlers.ts
+++ b/src/server-handlers.ts
@@ -649,6 +649,11 @@ export function create_shutdown_handler(
     }
 ): () => Promise<void> {
     return async (): Promise<void> => {
+        // Retire publication lifecycles before awaiting any cleanup. Active
+        // diagnostic computations will fail their final trigger check and
+        // cannot publish after the shutdown response.
+        deps?.diagnostics_provider?.on_shutdown();
+
         // Cancel background indexing first to stop new work (Req 15.1)
         deps?.workspace_indexer?.cancel();
 

--- a/src/utils/polling-cancellation-token.ts
+++ b/src/utils/polling-cancellation-token.ts
@@ -1,0 +1,23 @@
+import type { CancellationToken } from 'vscode-languageserver';
+
+const no_op_cancellation_event: CancellationToken['onCancellationRequested'] =
+    () => ({ dispose: () => undefined });
+
+/**
+ * Adapt a current-work predicate to APIs that poll a CancellationToken.
+ * Both sources are exposed only through the polling getter. The event is a
+ * no-op because some valid polling-only parent tokens throw when their event
+ * property is read (for example shared-array cancellation tokens).
+ */
+export function polling_cancellation_token(
+    should_continue: () => boolean,
+    parent?: CancellationToken
+): CancellationToken {
+    return {
+        get isCancellationRequested(): boolean {
+            return parent?.isCancellationRequested === true
+                || !should_continue();
+        },
+        onCancellationRequested: no_op_cancellation_event,
+    };
+}

--- a/tests/integration/bh-merge-c-locals.test.ts
+++ b/tests/integration/bh-merge-c-locals.test.ts
@@ -127,10 +127,18 @@ describe('bh_merge c_locals integration test', () => {
         const mock_connection = { sendDiagnostics: () => {} };
         const debounce_manager = new DocumentDebounceManager();
         const diagnostics_provider = new DiagnosticsProvider(mock_connection as any, debounce_manager);
+        diagnostics_provider.on_document_opened(
+            doc_state!.uri,
+            doc_state!.version
+        );
         
         const result = await diagnostics_provider.publish_diagnostics(
             doc_state!,
             create_test_config(),
+            diagnostics_provider.trigger_for_validation(
+                doc_state!.uri,
+                doc_state!.version
+            )!,
             workspace_symbols,
             scope_resolver
         );
@@ -162,10 +170,18 @@ describe('bh_merge c_locals integration test', () => {
         const mock_connection = { sendDiagnostics: () => {} };
         const debounce_manager = new DocumentDebounceManager();
         const diagnostics_provider = new DiagnosticsProvider(mock_connection as any, debounce_manager);
+        diagnostics_provider.on_document_opened(
+            doc_state!.uri,
+            doc_state!.version
+        );
         
         const result = await diagnostics_provider.publish_diagnostics(
             doc_state!,
             create_test_config(),
+            diagnostics_provider.trigger_for_validation(
+                doc_state!.uri,
+                doc_state!.version
+            )!,
             undefined,
             scope_resolver
         );
@@ -198,10 +214,18 @@ describe('bh_merge c_locals integration test', () => {
         const mock_connection = { sendDiagnostics: () => {} };
         const debounce_manager = new DocumentDebounceManager();
         const diagnostics_provider = new DiagnosticsProvider(mock_connection as any, debounce_manager);
+        diagnostics_provider.on_document_opened(
+            doc_state!.uri,
+            doc_state!.version
+        );
         
         const result = await diagnostics_provider.publish_diagnostics(
             doc_state!,
             create_test_config(),
+            diagnostics_provider.trigger_for_validation(
+                doc_state!.uri,
+                doc_state!.version
+            )!,
             undefined,
             scope_resolver
         );

--- a/tests/integration/server-close-resync-wiring.test.ts
+++ b/tests/integration/server-close-resync-wiring.test.ts
@@ -386,6 +386,39 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
         }
     });
 
+    it('does not let validation awaiting settings reopen a closed document', async () => {
+        const child_uri = file_uri('child.do');
+        let release_settings: (() => void) | undefined;
+        let settings_requested: (() => void) | undefined;
+        const settings_started = new Promise<void>(resolve => {
+            settings_requested = resolve;
+        });
+        const settings_gate = new Promise<void>(resolve => {
+            release_settings = resolve;
+        });
+
+        const handlers = await start_test_server((scope_uri) => {
+            if (scope_uri !== child_uri) {
+                return GLOBAL_PUBLIC_CONFIG;
+            }
+            settings_requested?.();
+            return settings_gate.then(() => GLOBAL_PUBLIC_CONFIG);
+        });
+
+        open_document(handlers, child_uri, CHILD_BUFFER_TEXT);
+        await settings_started;
+
+        handlers.did_close!({ textDocument: { uri: child_uri } });
+        const publishes_after_close = published_uris.length;
+        expect(publishes_after_close).toBeGreaterThan(0);
+
+        release_settings?.();
+        await wait_for_publish_quiescence();
+
+        expect(captured_document_store!.get(child_uri)).toBeUndefined();
+        expect(published_uris).toHaveLength(publishes_after_close);
+    }, TEST_TIMEOUT_MS);
+
     it('converges backward edges to disk on close, passing the closed ' +
         "document's URI and its URI-scoped settings", async () => {
         const child_uri = file_uri('child.do');

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../../src/types';
 import {
     CancellationToken,
+    CancellationTokenSource,
     Diagnostic,
     DiagnosticSeverity,
 } from 'vscode-languageserver';
@@ -156,6 +157,31 @@ function create_document_state(content: string, version: number = 1): DocumentSt
     };
 }
 
+function publish_current(
+    provider: DiagnosticsProvider,
+    document: DocumentState,
+    config: StataLSPConfig,
+    workspace_symbols?: SymbolTable,
+    scope_resolver?: ScopeResolver,
+    cancellation_token?: CancellationToken
+): ReturnType<DiagnosticsProvider['publish_diagnostics']> {
+    const trigger = provider.trigger_for_validation(
+        document.uri,
+        document.version
+    );
+    if (!trigger) {
+        throw new Error(`No live diagnostic lifecycle for ${document.uri}`);
+    }
+    return provider.publish_diagnostics(
+        document,
+        config,
+        trigger,
+        workspace_symbols,
+        scope_resolver,
+        cancellation_token
+    );
+}
+
 describe('DiagnosticsProvider', () => {
     let mock_connection: ReturnType<typeof create_mock_connection>;
     let provider: DiagnosticsProvider;
@@ -163,6 +189,7 @@ describe('DiagnosticsProvider', () => {
     beforeEach(() => {
         mock_connection = create_mock_connection();
         provider = new DiagnosticsProvider(mock_connection);
+        provider.on_document_opened('file:///test.do', 1);
     });
 
     describe('get_diagnostics', () => {
@@ -357,12 +384,39 @@ describe('DiagnosticsProvider', () => {
             expect(second_diagnostics).not.toBe(first_diagnostics);
             expect(second_diagnostics).toEqual(first_diagnostics);
         });
+
+        it('caches direct diagnostics without a publication lifecycle', async () => {
+            const direct_provider = new DiagnosticsProvider(mock_connection);
+            const document = create_document_state('gen x = 1\n', 1);
+            const scope_resolver = new ScopeResolver();
+            let resolve_count = 0;
+            scope_resolver.resolve = async () => {
+                resolve_count++;
+                return create_empty_resolved_scope();
+            };
+
+            const first = await direct_provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                scope_resolver
+            );
+            const second = await direct_provider.get_diagnostics(
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                scope_resolver
+            );
+
+            expect(resolve_count).toBe(1);
+            expect(second).toBe(first);
+        });
     });
 
     describe('publish_diagnostics', () => {
         it('should publish diagnostics to connection', async () => {
             const document = create_document_state('gen x = 1\n');
-            await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+            await publish_current(provider, document, DEFAULT_CONFIG);
             
             const sent = mock_connection.get_sent_diagnostics();
             expect(sent.length).toBe(1);
@@ -379,23 +433,109 @@ describe('DiagnosticsProvider', () => {
                 },
             };
             
-            await provider.publish_diagnostics(document, disabled_config);
+            await publish_current(provider, document, disabled_config);
             
             const sent = mock_connection.get_sent_diagnostics();
             expect(sent.length).toBe(1);
             expect(sent[0].diagnostics).toEqual([]);
         });
 
+        it(
+            'does not consume a trigger when the parent token is cancelled',
+            async () => {
+                const document = create_document_state(
+                    'display `undefined\'\n'
+                );
+                const disabled_config = {
+                    ...DEFAULT_CONFIG,
+                    diagnostics: {
+                        ...DEFAULT_CONFIG.diagnostics,
+                        enabled: false,
+                    },
+                };
+                const cancellation_source = new CancellationTokenSource();
+                cancellation_source.cancel();
+
+                await publish_current(
+                    provider,
+                    document,
+                    disabled_config,
+                    undefined,
+                    undefined,
+                    cancellation_source.token
+                );
+                expect(mock_connection.get_sent_diagnostics()).toHaveLength(0);
+
+                // Cancellation must not consume the same version/force
+                // trigger: an uncancelled retry still publishes the clear.
+                await publish_current(provider, document, disabled_config);
+                expect(mock_connection.get_sent_diagnostics()).toHaveLength(1);
+                cancellation_source.dispose();
+            }
+        );
+
+        it(
+            'does not publish an empty result when parent cancellation ' +
+                'lands during scope resolution',
+            async () => {
+                const document = create_document_state(
+                    'display `undefined\'\n'
+                );
+                const delayed_scope_resolver = new ScopeResolver();
+                const cancellation_source = new CancellationTokenSource();
+                let resolve_scope: (() => void) | undefined;
+                let resolve_started: (() => void) | undefined;
+                const scope_started = new Promise<void>(resolve => {
+                    resolve_started = resolve;
+                });
+                const scope_delay = new Promise<void>(resolve => {
+                    resolve_scope = resolve;
+                });
+
+                delayed_scope_resolver.resolve = async () => {
+                    resolve_started?.();
+                    await scope_delay;
+                    return create_empty_resolved_scope();
+                };
+
+                const cancelled_publish = publish_current(
+                    provider,
+                    document,
+                    DEFAULT_CONFIG,
+                    undefined,
+                    delayed_scope_resolver,
+                    cancellation_source.token
+                );
+                await scope_started;
+                cancellation_source.cancel();
+                resolve_scope?.();
+                await cancelled_publish;
+
+                expect(mock_connection.get_sent_diagnostics()).toHaveLength(0);
+
+                // The cancelled computation did not consume the trigger.
+                await publish_current(
+                    provider,
+                    document,
+                    DEFAULT_CONFIG,
+                    undefined,
+                    delayed_scope_resolver
+                );
+                expect(mock_connection.get_sent_diagnostics()).toHaveLength(1);
+                cancellation_source.dispose();
+            }
+        );
+
         it('should apply version gating', async () => {
             const document_v1 = create_document_state('gen x = 1\n', 1);
             const document_v2 = create_document_state('gen y = 2\n', 2);
             
             // Publish v2 first
-            await provider.publish_diagnostics(document_v2, DEFAULT_CONFIG);
+            await publish_current(provider, document_v2, DEFAULT_CONFIG);
             mock_connection.clear_sent_diagnostics();
             
             // Try to publish v1 (should be skipped due to version gating)
-            await provider.publish_diagnostics(document_v1, DEFAULT_CONFIG);
+            await publish_current(provider, document_v1, DEFAULT_CONFIG);
             
             const sent = mock_connection.get_sent_diagnostics();
             expect(sent.length).toBe(0);
@@ -440,16 +580,19 @@ describe('DiagnosticsProvider', () => {
                 );
             };
 
-            const publish_v1 = provider.publish_diagnostics(
+            const publish_v1 = publish_current(provider,
                 document_v1,
                 DEFAULT_CONFIG
             );
             await v1_started;
 
-            await provider.publish_diagnostics(document_v2, DEFAULT_CONFIG);
-            const sent_after_v2 = mock_connection.get_sent_diagnostics();
-            expect(sent_after_v2.length).toBe(1);
-            expect(sent_after_v2[0].diagnostics).toEqual([]);
+            // Receiving/scheduling v2 must retire v1 immediately; v2 need not
+            // finish publication before the old computation resumes.
+            const trigger_v2 = provider.trigger_for_validation(
+                document_v2.uri,
+                document_v2.version
+            );
+            expect(trigger_v2).toBeDefined();
 
             expect(resolve_v1).toBeDefined();
             resolve_v1?.();
@@ -457,24 +600,30 @@ describe('DiagnosticsProvider', () => {
 
             const sent_after_v1_resumes =
                 mock_connection.get_sent_diagnostics();
-            expect(sent_after_v1_resumes.length).toBe(1);
-            expect(sent_after_v1_resumes[0].diagnostics).toEqual([]);
+            expect(sent_after_v1_resumes).toHaveLength(0);
+
+            await provider.publish_diagnostics(
+                document_v2,
+                DEFAULT_CONFIG,
+                trigger_v2!
+            );
+            expect(mock_connection.get_sent_diagnostics()).toHaveLength(1);
         });
 
         it('should publish once for one same-version force epoch', async () => {
             const document = create_document_state('gen x = 1\n', 1);
 
-            await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+            await publish_current(provider, document, DEFAULT_CONFIG);
             mock_connection.clear_sent_diagnostics();
 
             provider.mark_force_republish(document.uri);
-            await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+            await publish_current(provider, document, DEFAULT_CONFIG);
 
             const sent_after_mark = mock_connection.get_sent_diagnostics();
             expect(sent_after_mark.length).toBe(1);
             mock_connection.clear_sent_diagnostics();
 
-            await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+            await publish_current(provider, document, DEFAULT_CONFIG);
 
             const sent_without_mark = mock_connection.get_sent_diagnostics();
             expect(sent_without_mark.length).toBe(0);
@@ -500,7 +649,7 @@ describe('DiagnosticsProvider', () => {
                     resolve_a = resolve;
                 });
 
-                await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+                await publish_current(provider, document, DEFAULT_CONFIG);
                 mock_connection.clear_sent_diagnostics();
 
                 provider.get_diagnostics = async (
@@ -528,14 +677,14 @@ describe('DiagnosticsProvider', () => {
                 };
 
                 provider.mark_force_republish(document.uri);
-                const publish_a = provider.publish_diagnostics(
+                const publish_a = publish_current(provider,
                     document,
                     DEFAULT_CONFIG
                 );
                 await a_started;
 
                 provider.mark_force_republish(document.uri);
-                await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+                await publish_current(provider, document, DEFAULT_CONFIG);
 
                 const sent_after_b = mock_connection.get_sent_diagnostics();
                 expect(sent_after_b.length).toBe(1);
@@ -573,7 +722,7 @@ describe('DiagnosticsProvider', () => {
                 });
 
                 // Publish v1 so a same-version force is meaningful.
-                await provider.publish_diagnostics(document_v1, DEFAULT_CONFIG);
+                await publish_current(provider, document_v1, DEFAULT_CONFIG);
                 mock_connection.clear_sent_diagnostics();
 
                 provider.get_diagnostics = async (
@@ -603,7 +752,7 @@ describe('DiagnosticsProvider', () => {
                 // Forced same-version republish A captures epoch at v1 and
                 // stalls mid-compute.
                 provider.mark_force_republish(document_v1.uri);
-                const publish_a = provider.publish_diagnostics(
+                const publish_a = publish_current(provider,
                     document_v1,
                     DEFAULT_CONFIG
                 );
@@ -611,7 +760,7 @@ describe('DiagnosticsProvider', () => {
 
                 // The document advances to v2 and publishes to completion
                 // while A is still in flight.
-                await provider.publish_diagnostics(document_v2, DEFAULT_CONFIG);
+                await publish_current(provider, document_v2, DEFAULT_CONFIG);
 
                 const sent_after_v2 = mock_connection.get_sent_diagnostics();
                 expect(sent_after_v2.length).toBe(1);
@@ -645,7 +794,7 @@ describe('DiagnosticsProvider', () => {
             const document = create_document_state('gen x = 1\n', 1);
             
             // First publish
-            await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+            await publish_current(provider, document, DEFAULT_CONFIG);
             mock_connection.clear_sent_diagnostics();
             
             // Close document
@@ -657,7 +806,8 @@ describe('DiagnosticsProvider', () => {
             
             // After closing, should be able to publish v1 again (version tracking cleared)
             mock_connection.clear_sent_diagnostics();
-            await provider.publish_diagnostics(document, DEFAULT_CONFIG);
+            provider.on_document_opened(document.uri, document.version);
+            await publish_current(provider, document, DEFAULT_CONFIG);
             
             const sent_after = mock_connection.get_sent_diagnostics();
             expect(sent_after.length).toBe(1);
@@ -669,6 +819,7 @@ describe('DiagnosticsProvider', () => {
                 1
             );
             const delayed_scope_resolver = new ScopeResolver();
+            let captured_token: CancellationToken | undefined;
             let resolve_scope: (() => void) | undefined;
             let resolve_started: (() => void) | undefined;
             const scope_started = new Promise<void>(resolve => {
@@ -678,13 +829,19 @@ describe('DiagnosticsProvider', () => {
                 resolve_scope = resolve;
             });
 
-            delayed_scope_resolver.resolve = async () => {
+            delayed_scope_resolver.resolve = async (
+                _uri,
+                _content,
+                _config,
+                token
+            ) => {
+                captured_token = token;
                 resolve_started?.();
                 await scope_delay;
                 return create_empty_resolved_scope();
             };
 
-            const stale_publish = provider.publish_diagnostics(
+            const stale_publish = publish_current(provider,
                 document,
                 DEFAULT_CONFIG,
                 undefined,
@@ -693,11 +850,23 @@ describe('DiagnosticsProvider', () => {
             await scope_started;
 
             provider.on_document_closed(document.uri);
+            expect(captured_token?.isCancellationRequested).toBe(true);
 
             const sent_after_close =
                 mock_connection.get_sent_diagnostics();
             expect(sent_after_close).toHaveLength(1);
             expect(sent_after_close[0].diagnostics).toEqual([]);
+
+            // Reopen at the identical version before the retired worker
+            // resumes. Lifecycle identity—not version—must reject it.
+            const reopened_document = create_document_state(
+                'generate x = 1\n',
+                1
+            );
+            provider.on_document_opened(
+                reopened_document.uri,
+                reopened_document.version
+            );
 
             expect(resolve_scope).toBeDefined();
             resolve_scope?.();
@@ -708,11 +877,7 @@ describe('DiagnosticsProvider', () => {
             expect(sent_after_stale_publish).toHaveLength(1);
             expect(sent_after_stale_publish[0].diagnostics).toEqual([]);
 
-            const reopened_document = create_document_state(
-                'generate x = 1\n',
-                1
-            );
-            await provider.publish_diagnostics(
+            await publish_current(provider,
                 reopened_document,
                 DEFAULT_CONFIG
             );
@@ -721,6 +886,57 @@ describe('DiagnosticsProvider', () => {
                 mock_connection.get_sent_diagnostics();
             expect(sent_after_reopen).toHaveLength(2);
             expect(sent_after_reopen[1].diagnostics).toEqual([]);
+        });
+    });
+
+    describe('on_shutdown', () => {
+        it('drops an in-flight publish that resumes after shutdown', async () => {
+            const document = create_document_state(
+                'display `undefined\'\n',
+                1
+            );
+            const delayed_scope_resolver = new ScopeResolver();
+            let captured_token: CancellationToken | undefined;
+            let resolve_scope: (() => void) | undefined;
+            let resolve_started: (() => void) | undefined;
+            const scope_started = new Promise<void>(resolve => {
+                resolve_started = resolve;
+            });
+            const scope_delay = new Promise<void>(resolve => {
+                resolve_scope = resolve;
+            });
+
+            delayed_scope_resolver.resolve = async (
+                _uri,
+                _content,
+                _config,
+                token
+            ) => {
+                captured_token = token;
+                resolve_started?.();
+                await scope_delay;
+                return create_empty_resolved_scope();
+            };
+
+            const stale_publish = publish_current(
+                provider,
+                document,
+                DEFAULT_CONFIG,
+                undefined,
+                delayed_scope_resolver
+            );
+            await scope_started;
+
+            provider.on_shutdown();
+            expect(captured_token?.isCancellationRequested).toBe(true);
+            resolve_scope?.();
+            await stale_publish;
+
+            expect(mock_connection.get_sent_diagnostics()).toHaveLength(0);
+            expect(provider.trigger_for_validation(
+                document.uri,
+                document.version
+            )).toBeUndefined();
         });
     });
 

--- a/tests/unit/diagnostics-publish-gate.test.ts
+++ b/tests/unit/diagnostics-publish-gate.test.ts
@@ -6,143 +6,97 @@ import {
 describe('DiagnosticsPublishGate', () => {
     const uri = 'file:///test.do';
 
-    it('should allow first publishes and strictly newer versions', () => {
+    it('does not create publication state while scheduling', () => {
         const gate = new DiagnosticsPublishGate();
-        const my_epoch_0 = gate.get_current_epoch(uri);
 
-        expect(my_epoch_0).toBe(0);
-        expect(gate.would_publish(uri, 1, my_epoch_0)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
-
-        expect(gate.would_publish(uri, 2, my_epoch_0)).toBe(true);
-        expect(gate.try_consume_publish(uri, 2, my_epoch_0)).toBe(true);
+        expect(gate.trigger_for_validation(uri, 1)).toBeUndefined();
+        expect(gate.mark_force_republish(uri)).toBe(false);
+        expect(gate.trigger_for_validation(uri, 1)).toBeUndefined();
     });
 
-    it('should deny stale versions', () => {
+    it('allows first publishes and strictly newer versions', () => {
         const gate = new DiagnosticsPublishGate();
-        const my_epoch_0 = gate.get_current_epoch(uri);
+        const trigger = gate.begin_lifecycle(uri, 1);
 
-        expect(gate.try_consume_publish(uri, 2, my_epoch_0)).toBe(true);
-        expect(gate.would_publish(uri, 1, my_epoch_0)).toBe(false);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(false);
+        expect(gate.would_publish(uri, 1, trigger)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, trigger)).toBe(true);
+
+        const trigger_v2 = gate.trigger_for_validation(uri, 2)!;
+        expect(gate.would_publish(uri, 2, trigger_v2)).toBe(true);
+        expect(gate.try_consume_publish(uri, 2, trigger_v2)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, trigger)).toBe(false);
     });
 
-    it('should allow only the current unconsumed same-version epoch', () => {
+    it('supersedes an older publish as soon as a newer version is scheduled', () => {
         const gate = new DiagnosticsPublishGate();
-        const my_epoch_0 = gate.get_current_epoch(uri);
+        const trigger_v1 = gate.begin_lifecycle(uri, 1);
 
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
-        expect(gate.would_publish(uri, 1, my_epoch_0)).toBe(false);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(false);
+        const trigger_v2 = gate.trigger_for_validation(uri, 2)!;
 
-        gate.mark_force_republish(uri);
-        const my_epoch_1 = gate.get_current_epoch(uri);
-
-        expect(gate.would_publish(uri, 1, my_epoch_1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_1)).toBe(true);
-        expect(gate.would_publish(uri, 1, my_epoch_1)).toBe(false);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_1)).toBe(false);
+        expect(gate.is_current_trigger(uri, trigger_v1)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, trigger_v1)).toBe(false);
+        expect(gate.try_consume_publish(uri, 2, trigger_v2)).toBe(true);
     });
 
-    it('should deny stale and non-current same-version epochs', () => {
+    it('allows one same-version publish per force epoch', () => {
         const gate = new DiagnosticsPublishGate();
-        const my_epoch_0 = gate.get_current_epoch(uri);
+        const initial = gate.begin_lifecycle(uri, 1);
 
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
-        gate.mark_force_republish(uri);
-        const my_epoch_1 = gate.get_current_epoch(uri);
-        gate.mark_force_republish(uri);
-        const my_epoch_2 = gate.get_current_epoch(uri);
+        expect(gate.try_consume_publish(uri, 1, initial)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, initial)).toBe(false);
 
-        expect(gate.would_publish(uri, 1, my_epoch_0)).toBe(false);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(false);
-        expect(gate.would_publish(uri, 1, my_epoch_1)).toBe(false);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_1)).toBe(false);
-        expect(gate.would_publish(uri, 1, my_epoch_2 + 1)).toBe(false);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_2 + 1)).toBe(false);
-
-        expect(gate.would_publish(uri, 1, my_epoch_2)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_2)).toBe(true);
+        expect(gate.mark_force_republish(uri)).toBe(true);
+        const forced = gate.trigger_for_validation(uri, 1)!;
+        expect(forced.force_epoch).toBe(initial.force_epoch + 1);
+        expect(gate.try_consume_publish(uri, 1, forced)).toBe(true);
+        expect(gate.try_consume_publish(uri, 1, forced)).toBe(false);
     });
 
-    it('should not mutate state when checking would_publish', () => {
+    it('rejects work superseded by a newer force epoch', () => {
         const gate = new DiagnosticsPublishGate();
-        const my_epoch_0 = gate.get_current_epoch(uri);
-
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
+        gate.begin_lifecycle(uri, 1);
         gate.mark_force_republish(uri);
-        const my_epoch_1 = gate.get_current_epoch(uri);
+        const older = gate.trigger_for_validation(uri, 1)!;
+        gate.mark_force_republish(uri);
+        const newer = gate.trigger_for_validation(uri, 1)!;
 
-        expect(gate.would_publish(uri, 1, my_epoch_1)).toBe(true);
-        expect(gate.would_publish(uri, 1, my_epoch_1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_1)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_1)).toBe(false);
+        expect(gate.is_current_trigger(uri, older)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, older)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, newer)).toBe(true);
     });
 
-    it('should bump force epochs and enable same-version consumes', () => {
+    it('retires a lifecycle without reusing its identity', () => {
         const gate = new DiagnosticsPublishGate();
-        const my_epoch_0 = gate.get_current_epoch(uri);
+        const retired = gate.begin_lifecycle(uri, 1);
+        expect(gate.try_consume_publish(uri, 1, retired)).toBe(true);
 
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
-        gate.mark_force_republish(uri);
-        const my_epoch_1 = gate.get_current_epoch(uri);
-        gate.mark_force_republish(uri);
-        const my_epoch_2 = gate.get_current_epoch(uri);
+        gate.retire_lifecycle(uri);
 
-        expect(my_epoch_1).toBe(my_epoch_0 + 1);
-        expect(my_epoch_2).toBe(my_epoch_1 + 1);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_2)).toBe(true);
+        expect(gate.trigger_for_validation(uri, 1)).toBeUndefined();
+        expect(gate.is_current_trigger(uri, retired)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, retired)).toBe(false);
+        expect(gate.mark_force_republish(uri)).toBe(false);
+
+        const reopened = gate.begin_lifecycle(uri, 1);
+        expect(reopened.lifecycle_epoch).not.toBe(retired.lifecycle_epoch);
+        expect(gate.try_consume_publish(uri, 1, retired)).toBe(false);
+        expect(gate.try_consume_publish(uri, 1, reopened)).toBe(true);
     });
 
-    it('should retire the epoch when forgetting per-uri state', () => {
+    it('retires every lifecycle on shutdown', () => {
         const gate = new DiagnosticsPublishGate();
-        const my_epoch_0 = gate.get_current_epoch(uri);
+        const first = gate.begin_lifecycle('file:///first.do', 1);
+        const second = gate.begin_lifecycle('file:///second.do', 1);
 
-        expect(gate.try_consume_publish(uri, 3, my_epoch_0)).toBe(true);
-        gate.mark_force_republish(uri);
-        expect(gate.get_current_epoch(uri)).toBe(1);
+        gate.retire_all_lifecycles();
 
-        gate.forget(uri);
-
-        expect(gate.is_current_epoch(uri, my_epoch_0)).toBe(false);
-        expect(gate.would_publish(uri, 1, my_epoch_0)).toBe(false);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(false);
-
-        const my_reopened_epoch = gate.get_current_epoch(uri);
-        expect(my_reopened_epoch).not.toBe(my_epoch_0);
-        expect(gate.would_publish(uri, 1, my_reopened_epoch)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, my_reopened_epoch)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, my_reopened_epoch)).toBe(false);
-    });
-
-    it('should deny older same-version work after newer work consumes', () => {
-        const gate = new DiagnosticsPublishGate();
-        const my_epoch_0 = gate.get_current_epoch(uri);
-
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
-        gate.mark_force_republish(uri);
-        const my_epoch_a = gate.get_current_epoch(uri);
-        gate.mark_force_republish(uri);
-        const my_epoch_b = gate.get_current_epoch(uri);
-
-        expect(gate.try_consume_publish(uri, 1, my_epoch_b)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_a)).toBe(false);
-    });
-
-    it('should allow newer same-version work after older work consumes', () => {
-        const gate = new DiagnosticsPublishGate();
-        const my_epoch_0 = gate.get_current_epoch(uri);
-
-        expect(gate.try_consume_publish(uri, 1, my_epoch_0)).toBe(true);
-        gate.mark_force_republish(uri);
-        const my_epoch_a = gate.get_current_epoch(uri);
-
-        expect(gate.try_consume_publish(uri, 1, my_epoch_a)).toBe(true);
-
-        gate.mark_force_republish(uri);
-        const my_epoch_b = gate.get_current_epoch(uri);
-
-        expect(gate.try_consume_publish(uri, 1, my_epoch_b)).toBe(true);
-        expect(gate.try_consume_publish(uri, 1, my_epoch_a)).toBe(false);
+        expect(gate.trigger_for_validation('file:///first.do', 1))
+            .toBeUndefined();
+        expect(gate.trigger_for_validation('file:///second.do', 1))
+            .toBeUndefined();
+        expect(gate.try_consume_publish('file:///first.do', 1, first))
+            .toBe(false);
+        expect(gate.try_consume_publish('file:///second.do', 1, second))
+            .toBe(false);
     });
 });

--- a/tests/unit/document-store-version-guard.test.ts
+++ b/tests/unit/document-store-version-guard.test.ts
@@ -3,7 +3,12 @@ import { DocumentState, DocumentStore, ParseOutcome } from '../../src/document-s
 import { DependencyGraph } from '../../src/dependency-graph';
 import { WorkspaceIndexer } from '../../src/indexer';
 import { ScopeResolver } from '../../src/scope-resolver';
-import type { ContentProvider } from '../../src/types';
+import type {
+    ContentProvider,
+    ScopeResolverConfig,
+    SymbolTable,
+} from '../../src/types';
+import type { CancellationToken } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 
 type InspectableDocumentStore = DocumentStore & {
@@ -12,13 +17,17 @@ type InspectableDocumentStore = DocumentStore & {
     commit_state(
         uri: string,
         outcome: ParseOutcome,
-        generation: number
+        generation: number,
+        is_operation_current?: () => boolean
     ): boolean;
     create_document_state(
         uri: string,
         content: string,
-        version: number
-    ): Promise<ParseOutcome>;
+        version: number,
+        workspace_symbols?: SymbolTable,
+        scope_resolver_config?: Partial<ScopeResolverConfig>,
+        is_operation_current?: () => boolean
+    ): Promise<ParseOutcome | undefined>;
 };
 
 describe('DocumentStore version guard', () => {
@@ -168,5 +177,105 @@ describe('DocumentStore version guard', () => {
         expect(state).toBeDefined();
         expect(state!.version).toBe(3);
         expect(state!.content).toBe('content v3');
+    });
+
+    it('stops parsing after awaited scope work when its guard retires', async () => {
+        const document_store = new DocumentStore();
+        const store = document_store as unknown as InspectableDocumentStore;
+        const scope_resolver = new ScopeResolver();
+        const uri = 'file:///lifecycle-parse-cancellation.do';
+        let lifecycle_is_current = true;
+        let captured_token: CancellationToken | undefined;
+        let release_scope: (() => void) | undefined;
+        let scope_started: (() => void) | undefined;
+        const scope_start = new Promise<void>(resolve => {
+            scope_started = resolve;
+        });
+        const scope_gate = new Promise<void>(resolve => {
+            release_scope = resolve;
+        });
+        const original_resolve = scope_resolver.resolve.bind(scope_resolver);
+
+        scope_resolver.resolve = async (...args) => {
+            captured_token = args[3];
+            scope_started?.();
+            await scope_gate;
+            return original_resolve(...args);
+        };
+        document_store.set_scope_resolver(scope_resolver);
+
+        const parse = store.create_document_state(
+            uri,
+            'display 1\n',
+            1,
+            undefined,
+            { backward_dependencies: 'auto' },
+            () => lifecycle_is_current
+        );
+        await scope_start;
+
+        lifecycle_is_current = false;
+        expect(captured_token?.isCancellationRequested).toBe(true);
+        release_scope?.();
+
+        expect(await parse).toBeUndefined();
+    });
+
+    it('rejects a completed parse when its lifecycle guard retires before commit', async () => {
+        const document_store = new DocumentStore();
+        const store = document_store as unknown as InspectableDocumentStore;
+        const uri = 'file:///lifecycle-commit-guard.do';
+        let lifecycle_is_current = true;
+        let release_parse: (() => void) | undefined;
+        let parse_started: (() => void) | undefined;
+        const parse_start = new Promise<void>(resolve => {
+            parse_started = resolve;
+        });
+        const parse_gate = new Promise<void>(resolve => {
+            release_parse = resolve;
+        });
+
+        await document_store.open(uri, 'content v1', 1);
+        const original_create_document_state =
+            store.create_document_state.bind(store);
+        store.create_document_state = async (
+            the_uri,
+            content,
+            version,
+            workspace_symbols,
+            scope_resolver_config,
+            is_operation_current
+        ) => {
+            const outcome = await original_create_document_state(
+                the_uri,
+                content,
+                version,
+                workspace_symbols,
+                scope_resolver_config,
+                is_operation_current
+            );
+            parse_started?.();
+            await parse_gate;
+            return outcome;
+        };
+
+        const retired_update = document_store.update(
+            uri,
+            [{ text: 'retired content v2' }],
+            2,
+            undefined,
+            { backward_dependencies: 'auto' },
+            () => lifecycle_is_current
+        );
+        await parse_start;
+
+        lifecycle_is_current = false;
+        release_parse?.();
+        await retired_update;
+
+        const state = document_store.get(uri);
+        expect(state).toBeDefined();
+        expect(state!.version).toBe(1);
+        expect(state!.content).toBe('content v1');
     });
 });

--- a/tests/unit/polling-cancellation-token.test.ts
+++ b/tests/unit/polling-cancellation-token.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import type { CancellationToken } from 'vscode-languageserver';
+import { polling_cancellation_token } from
+    '../../src/utils/polling-cancellation-token';
+
+describe('polling_cancellation_token', () => {
+    it('does not read an event from a polling-only parent token', () => {
+        let parent_is_cancelled = false;
+        const polling_only_parent = {
+            get isCancellationRequested(): boolean {
+                return parent_is_cancelled;
+            },
+            get onCancellationRequested(): never {
+                throw new Error('Polling-only token has no event');
+            },
+        } as CancellationToken;
+
+        const token = polling_cancellation_token(
+            () => true,
+            polling_only_parent
+        );
+        expect(token.isCancellationRequested).toBe(false);
+
+        parent_is_cancelled = true;
+        expect(token.isCancellationRequested).toBe(true);
+        expect(() => token.onCancellationRequested(() => undefined))
+            .not.toThrow();
+    });
+});

--- a/tests/unit/scope-resolver-cancellation.test.ts
+++ b/tests/unit/scope-resolver-cancellation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'bun:test';
+import { CancellationTokenSource } from 'vscode-languageserver';
+import { create_empty_symbol_table } from '../../src/analyzer';
+import { ScopeResolver } from '../../src/scope-resolver';
+
+describe('ScopeResolver cancellation', () => {
+    it('does not cache a partial forward scope after cancellation', async () => {
+        const resolver = new ScopeResolver();
+        const cancellation_source = new CancellationTokenSource();
+        let resolve_count = 0;
+        let release_forward: (() => void) | undefined;
+        let forward_started: (() => void) | undefined;
+        const first_forward_start = new Promise<void>(resolve => {
+            forward_started = resolve;
+        });
+        const first_forward_gate = new Promise<void>(resolve => {
+            release_forward = resolve;
+        });
+
+        resolver.set_forward_scope_resolver({
+            filter_calls_before_line: calls => calls,
+            resolve: async () => {
+                resolve_count++;
+                if (resolve_count === 1) {
+                    forward_started?.();
+                    await first_forward_gate;
+                }
+                return {
+                    symbols: create_empty_symbol_table(),
+                    call_sites: [],
+                    diagnostics: [],
+                };
+            },
+        });
+
+        const uri = 'file:///scope-cancellation.do';
+        const content = 'do "child.do"\n';
+        const cancelled_resolve = resolver.resolve(
+            uri,
+            content,
+            {},
+            cancellation_source.token
+        );
+        await first_forward_start;
+        cancellation_source.cancel();
+        release_forward?.();
+        await cancelled_resolve;
+
+        expect(resolver.get_cache_sizes().scope).toBe(0);
+
+        await resolver.resolve(uri, content);
+        expect(resolve_count).toBe(2);
+        expect(resolver.get_cache_sizes().scope).toBe(1);
+        cancellation_source.dispose();
+    });
+});

--- a/tests/unit/shutdown-handler.test.ts
+++ b/tests/unit/shutdown-handler.test.ts
@@ -31,6 +31,7 @@ function create_mock_deps(overrides?: Partial<{
     forward_scope_resolver_dispose: () => void;
     workspace_indexer_cancel: () => void;
     rename_handler_dispose: () => void;
+    diagnostics_provider_shutdown: () => void;
 }>) {
     const calls: string[] = [];
 
@@ -47,7 +48,11 @@ function create_mock_deps(overrides?: Partial<{
             close: () => {},
             wait_for_update: async () => {},
         },
-        diagnostics_provider: null,
+        diagnostics_provider: {
+            on_shutdown: overrides?.diagnostics_provider_shutdown ?? (() => {
+                calls.push('diagnostics_provider.on_shutdown');
+            }),
+        },
         completion_provider: null,
         hover_provider: null,
         definition_provider: null,
@@ -358,6 +363,7 @@ describe('Shutdown Handler', () => {
             await handler();
 
             expect(calls).toContain('document_store.dispose');
+            expect(calls).toContain('diagnostics_provider.on_shutdown');
             expect(calls).toContain('scope_resolver.dispose');
             expect(calls).toContain(
                 'forward_scope_resolver.dispose'
@@ -365,6 +371,8 @@ describe('Shutdown Handler', () => {
             expect(calls).toContain('workspace_indexer.cancel');
             expect(calls).toContain('rename_handler.dispose');
             expect(pending_revalidations.size).toBe(0);
+            expect(calls.indexOf('diagnostics_provider.on_shutdown'))
+                .toBeLessThan(calls.indexOf('document_store.dispose'));
         });
 
         it('handles undefined deps and disposables', async () => {


### PR DESCRIPTION
## Summary

- make diagnostic lifecycles explicit and separate them from same-version force republishes
- carry immutable triggers from validation scheduling through final publication
- prevent active stale validation from reopening DocumentStore after close or overwriting a newer edit
- retire every diagnostic lifecycle during shutdown
- add provider, gate, shutdown, and real-server close-race regressions

This completes the Raven #604 lifecycle model beyond the narrower provider-level protection added in Sight #316. It intentionally lands before tab-scoped ownership so the next PR can safely add tab removal and re-addition transitions.

## Verification

- bun run test
- bun run lint
- focused lifecycle suite: 126 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated diagnostics from appearing after document edits, closes, reopens, configuration changes, or shutdown.
  * Prevented stale background validation from recreating or overwriting closed documents.
  * Improved diagnostics cache freshness and same-version republishing behavior.
* **Tests**
  * Added coverage for lifecycle changes, shutdown handling, stale updates, caching, and close/resync scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->