### PR TITLE
Scope diagnostics to editor-owned resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,17 +251,25 @@ This ensures that:
 **Concurrency Handling**:
 Completion requests are race-prone against document updates. The `server-handlers.ts` uses `document_store.wait_for_update(uri)` to ensure any pending `textDocument/didChange` processing completes before serving completions.
 
-Diagnostic publication uses an explicit per-open lifecycle trigger in
-`DiagnosticsPublishGate`. `didOpen` begins the lifecycle; `didClose` and
-shutdown retire it. Validation captures the trigger before debounce and the
-provider rechecks it after asynchronous computation, so retired work cannot
-publish into a close/reopen or after a newer edit is scheduled. The trigger
-carries the document version, lifecycle identity, and a separate force epoch
-that authorizes one same-version republish after dependency or configuration
-changes. The server also checks the
-`TextDocuments` object identity and version after awaited validation stages so
-an active stale callback cannot reopen or overwrite `DocumentStore` from its
-retired snapshot.
+Diagnostic publication uses an explicit per-open/per-tab lifecycle trigger in
+`DiagnosticsPublishGate`. For clients that provide editor diagnostic ownership,
+an eligible `didOpen` or tab re-addition begins the lifecycle; tab removal,
+`didClose`, and shutdown retire it. Clients without the ownership extension keep
+normal LSP behavior, where every `didOpen` is eligible. Validation captures the
+trigger before debounce and the provider rechecks it after asynchronous
+computation, so retired work cannot publish into a close/reopen, tab
+remove/re-add, or after a newer edit is scheduled. The trigger carries the
+document version, lifecycle identity, and a separate force epoch that authorizes
+one same-version republish after dependency or configuration changes.
+
+Tab removal does **not** close the LSP document or remove its `DocumentStore`,
+index, or dependency state. Hidden documents opened by other extensions remain
+parse/index inputs for cross-file analysis; only their own push diagnostics are
+suppressed. The validation-current predicate therefore permits hidden work but
+becomes fail-closed again if the URI is re-added under a new lifecycle. The
+server also checks `TextDocuments` object identity and version after awaited
+validation stages so an active stale callback cannot reopen or overwrite
+`DocumentStore` from its retired snapshot.
 
 **Find References — Three-Tier Scoping**: The references provider uses three
 distinct scoping tiers by design: (1) **local macros** — include-chain files

--- a/client/src/diagnostic-resources-core.ts
+++ b/client/src/diagnostic-resources-core.ts
@@ -1,0 +1,104 @@
+export type DiagnosticTabResource =
+    | {
+        kind: 'resource';
+        uri: string;
+    }
+    | {
+        kind: 'diff';
+        modified_uri: string;
+        original_uri?: string;
+        is_active: boolean;
+    };
+
+export interface StringableUri {
+    toString(): string;
+}
+
+export interface DiagnosticCollectionLike<TUri extends StringableUri> {
+    forEach(callback: (uri: TUri) => void): void;
+    delete(uri: TUri): void;
+}
+
+/** Compare canonical URI snapshots without allocating another set. */
+export function same_diagnostic_resource_uris(
+    first: readonly string[] | undefined,
+    second: readonly string[]
+): boolean {
+    return first !== undefined && first.length === second.length &&
+        first.every((uri, index) => uri === second[index]);
+}
+
+/**
+ * Collect resources that own editor diagnostics.
+ *
+ * Every resource-backed tab counts, while a diff owns only its modified side.
+ * Visible editors add peek resources. VS Code exposes both sides of an active
+ * diff as visible editors, so each active diff consumes exactly one matching
+ * original-side occurrence before the remaining visible editors are added.
+ */
+export function collect_diagnostic_resource_uris(
+    tabs: readonly DiagnosticTabResource[],
+    visible_editor_uris: readonly string[]
+): string[] {
+    const resources = new Set<string>();
+    const excluded_visible_occurrences = new Map<string, number>();
+
+    for (const tab of tabs) {
+        if (tab.kind === 'resource') {
+            resources.add(tab.uri);
+            continue;
+        }
+
+        resources.add(tab.modified_uri);
+        if (tab.is_active && tab.original_uri !== undefined) {
+            excluded_visible_occurrences.set(
+                tab.original_uri,
+                (excluded_visible_occurrences.get(tab.original_uri) ?? 0) + 1
+            );
+        }
+    }
+
+    for (const uri of visible_editor_uris) {
+        const excluded_count = excluded_visible_occurrences.get(uri) ?? 0;
+        if (excluded_count > 0) {
+            if (excluded_count === 1) {
+                excluded_visible_occurrences.delete(uri);
+            } else {
+                excluded_visible_occurrences.set(uri, excluded_count - 1);
+            }
+            continue;
+        }
+        resources.add(uri);
+    }
+
+    return [...resources].sort();
+}
+
+/** Remove retained diagnostics for resources no longer owned by the editor. */
+export function clear_ineligible_diagnostics<TUri extends StringableUri>(
+    collection: DiagnosticCollectionLike<TUri> | undefined,
+    eligible_uris: ReadonlySet<string>
+): void {
+    if (!collection) {
+        return;
+    }
+
+    const stale_uris: TUri[] = [];
+    collection.forEach((uri) => {
+        if (!eligible_uris.has(uri.toString())) {
+            stale_uris.push(uri);
+        }
+    });
+    for (const uri of stale_uris) {
+        collection.delete(uri);
+    }
+}
+
+/** Client-side final gate for a server publication already in transit. */
+export function diagnostics_for_resource<TDiagnostic>(
+    uri: string,
+    diagnostics: TDiagnostic[],
+    eligible_uris: ReadonlySet<string>
+): TDiagnostic[] {
+    return eligible_uris.has(uri) ? diagnostics : [];
+}

--- a/client/src/diagnostic-resources.ts
+++ b/client/src/diagnostic-resources.ts
@@ -1,0 +1,56 @@
+import {
+    Uri,
+    window,
+    type Tab,
+} from 'vscode';
+import {
+    collect_diagnostic_resource_uris,
+    type DiagnosticTabResource,
+} from './diagnostic-resources-core.js';
+
+function tab_resource(tab: Tab): DiagnosticTabResource | undefined {
+    if (!tab.input || typeof tab.input !== 'object') {
+        return undefined;
+    }
+
+    const input = tab.input as {
+        uri?: unknown;
+        original?: unknown;
+        modified?: unknown;
+    };
+    // Structural inspection deliberately handles future resource-backed tab
+    // inputs without coupling ownership to today's concrete TabInput classes.
+    if (input.modified instanceof Uri) {
+        return {
+            kind: 'diff',
+            modified_uri: input.modified.toString(),
+            original_uri: input.original instanceof Uri
+                ? input.original.toString()
+                : undefined,
+            is_active: tab.isActive,
+        };
+    }
+    if (input.uri instanceof Uri) {
+        return { kind: 'resource', uri: input.uri.toString() };
+    }
+    return undefined;
+}
+
+export function current_diagnostic_resource_uris(): string[] {
+    const tabs: DiagnosticTabResource[] = [];
+    for (const group of window.tabGroups.all) {
+        for (const tab of group.tabs) {
+            const resource = tab_resource(tab);
+            if (resource) {
+                tabs.push(resource);
+            }
+        }
+    }
+
+    return collect_diagnostic_resource_uris(
+        tabs,
+        window.visibleTextEditors.map(
+            editor => editor.document.uri.toString()
+        )
+    );
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -10,6 +10,7 @@ import {
     LanguageClient,
     LanguageClientOptions,
     ServerOptions,
+    State,
     TransportKind
 } from 'vscode-languageclient/node.js';
 import {
@@ -25,7 +26,18 @@ import { ConflictDetector } from './conflict-detector.js';
 import { register_send_to_stata_commands, initialize_cd_context, register_cd_commands, set_language_client, register_open_in_stata, register_stata_terminal } from './send-to-stata/index.js';
 import { register_smcl_preview } from './smcl-preview/index.js';
 import { register_data_browser } from './data-browser/index.js';
-import { LanguageClientLifecycle } from './language-client-lifecycle.js';
+import {
+    LanguageClientLifecycle,
+    register_running_state_reconciliation,
+} from './language-client-lifecycle.js';
+import {
+    current_diagnostic_resource_uris,
+} from './diagnostic-resources.js';
+import {
+    clear_ineligible_diagnostics,
+    diagnostics_for_resource,
+    same_diagnostic_resource_uris,
+} from './diagnostic-resources-core.js';
 import {
     apply_language_configuration,
     read_line_comment_style,
@@ -40,6 +52,8 @@ let output_channel: OutputChannel | null = window.createOutputChannel(
     'Sight Extension'
 );
 const DEACTIVATE_TIMEOUT_MS = 200;
+const DIAGNOSTIC_RESOURCES_CHANGED =
+    'sight/diagnosticResourcesChanged';
 
 function sleep(my_timeout_ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, my_timeout_ms));
@@ -206,11 +220,33 @@ export function activate(context: ExtensionContext): void {
             // Synchronize the 'sight' configuration section with the server
             configurationSection: 'sight'
         },
+        // A function is required: vscode-languageclient reevaluates it on
+        // automatic restart, before replaying already-open didOpen messages.
+        initializationOptions: () => ({
+            // Keep protocol metadata separate from the server's settings
+            // mapper. An empty object survives JSON serialization; undefined
+            // would be dropped and expose diagnosticUris as a config key.
+            sight: {},
+            diagnosticUris: current_diagnostic_resource_uris(),
+        }),
         // Trust the `sight.openHelpTopic` command link that the server
         // emits in hover and completion markdown. VS Code strips
         // command URIs from LSP-provided markdown by default; this
         // middleware narrowly re-enables the single Sight command.
         middleware: {
+            handleDiagnostics: (uri, diagnostics, next) => {
+                const eligible = new Set(
+                    current_diagnostic_resource_uris()
+                );
+                // Client-side final gate for a publication already in transit
+                // when its tab disappeared.
+                next(
+                    uri,
+                    diagnostics_for_resource(
+                        uri.toString(), diagnostics, eligible
+                    )
+                );
+            },
             provideHover: async (document, position, token, next) => {
                 const my_hover = await next(document, position, token);
                 if (!my_hover) {
@@ -254,6 +290,83 @@ export function activate(context: ExtensionContext): void {
         'Sight Language Server',
         serverOptions,
         clientOptions
+    );
+
+    const the_client = client;
+    let last_notified_diagnostic_uris: string[] | undefined;
+    const synchronize_diagnostic_resources = async (
+        force_notification = false
+    ): Promise<void> => {
+        const diagnostic_uris = current_diagnostic_resource_uris();
+        clear_ineligible_diagnostics(
+            the_client.diagnostics,
+            new Set(diagnostic_uris)
+        );
+        // Clearing retained client diagnostics is useful even while stopped;
+        // only the wire notification requires a live connection.
+        if (the_client.state !== State.Running) {
+            return;
+        }
+        if (!force_notification && same_diagnostic_resource_uris(
+            last_notified_diagnostic_uris,
+            diagnostic_uris
+        )) {
+            return;
+        }
+
+        // Claim this snapshot before awaiting the transport so overlapping
+        // editor events cannot enqueue duplicate full-set notifications.
+        last_notified_diagnostic_uris = diagnostic_uris;
+        try {
+            await the_client.sendNotification(
+                DIAGNOSTIC_RESOURCES_CHANGED,
+                { diagnosticUris: diagnostic_uris }
+            );
+        } catch (error) {
+            if (same_diagnostic_resource_uris(
+                last_notified_diagnostic_uris,
+                diagnostic_uris
+            )) {
+                last_notified_diagnostic_uris = undefined;
+            }
+            throw error;
+        }
+    };
+
+    let activity_sync_scheduled = false;
+    const schedule_diagnostic_resource_sync = (): void => {
+        if (activity_sync_scheduled) {
+            return;
+        }
+        activity_sync_scheduled = true;
+        queueMicrotask(() => {
+            activity_sync_scheduled = false;
+            void synchronize_diagnostic_resources().catch((error) => {
+                output_channel?.appendLine(
+                    `Failed to synchronize diagnostic resources: ${error}`
+                );
+            });
+        });
+    };
+
+    context.subscriptions.push(
+        window.tabGroups.onDidChangeTabs(
+            schedule_diagnostic_resource_sync
+        ),
+        window.onDidChangeVisibleTextEditors(
+            schedule_diagnostic_resource_sync
+        ),
+        window.onDidChangeActiveTextEditor(
+            schedule_diagnostic_resource_sync
+        ),
+        register_running_state_reconciliation(
+            the_client,
+            State.Running,
+            () => synchronize_diagnostic_resources(true),
+            (error) => output_channel?.appendLine(
+                `Diagnostic restart reconciliation failed: ${error}`
+            )
+        )
     );
 
     // Start the client. This will also launch the server.

--- a/client/src/language-client-lifecycle.ts
+++ b/client/src/language-client-lifecycle.ts
@@ -3,6 +3,14 @@ export interface ManagedLanguageClient {
     stop(): Promise<void>;
 }
 
+export interface StateAwareManagedLanguageClient
+    extends ManagedLanguageClient {
+    readonly state: number;
+    onDidChangeState(
+        listener: (event: { newState: number }) => void
+    ): { dispose(): void };
+}
+
 export interface LifecycleLogger {
     appendLine(message: string): void;
 }
@@ -29,6 +37,48 @@ const DEFAULT_STOP_TIMEOUT_MS = 1000;
 
 function sleep(my_timeout_ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, my_timeout_ms));
+}
+
+/**
+ * Reconcile client-owned state after every initial start or automatic restart.
+ * The Running event can precede completion of start(), so reconciliation waits
+ * for that in-flight promise and verifies the transition is still current.
+ */
+export function register_running_state_reconciliation(
+    the_client: StateAwareManagedLanguageClient,
+    running_state: number,
+    reconcile: () => void | Promise<void>,
+    on_error: (error: unknown) => void = () => undefined
+): { dispose(): void } {
+    let transition_epoch = 0;
+    let disposed = false;
+    const state_subscription = the_client.onDidChangeState((event) => {
+        if (disposed) {
+            return;
+        }
+        const my_epoch = ++transition_epoch;
+        if (event.newState !== running_state) {
+            return;
+        }
+
+        void the_client.start().then(async () => {
+            if (my_epoch !== transition_epoch ||
+                the_client.state !== running_state) {
+                return;
+            }
+            await reconcile();
+        }).catch(on_error);
+    });
+    return {
+        dispose: () => {
+            if (disposed) {
+                return;
+            }
+            disposed = true;
+            transition_epoch++;
+            state_subscription.dispose();
+        },
+    };
 }
 
 export class LanguageClientLifecycle<TClient extends ManagedLanguageClient> {

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -5,6 +5,15 @@ unresolved macros, suspicious operators, and style issues. This page
 lists every diagnostic, shows how to silence individual reports, and
 documents the configuration keys that control severity.
 
+In VS Code, Sight keeps Problems entries only for files represented by real
+editor tabs or visible peek editors. A diff tab owns its modified side, not the
+original side. Text models opened invisibly by another extension remain
+synchronized and participate in cross-file analysis, but do not add background
+Problems entries. Closing and re-adding a tab starts a fresh diagnostic
+lifecycle, so an older in-flight result cannot reappear after the clear. Other
+LSP clients that do not send editor ownership metadata retain standard
+`didOpen`-scoped diagnostics.
+
 Diagnostics are deferred until the workspace scan completes, so
 cross-file warnings reflect the full project rather than just the open
 buffer. Each diagnostic carries a symbolic `code` (the rule IDs below)

--- a/src/diagnostic-resources.ts
+++ b/src/diagnostic-resources.ts
@@ -1,0 +1,99 @@
+import { URI } from 'vscode-uri';
+
+export const DIAGNOSTIC_RESOURCES_CHANGED_NOTIFICATION =
+    'sight/diagnosticResourcesChanged';
+
+function as_record(value: unknown): Record<string, unknown> | undefined {
+    return value !== null && typeof value === 'object' &&
+        !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : undefined;
+}
+
+/** Parse an explicit URI array. Undefined means "use normal LSP didOpen". */
+export function parse_diagnostic_uri_set(
+    value: unknown
+): Set<string> | undefined {
+    if (!Array.isArray(value)) {
+        return undefined;
+    }
+
+    const uris = new Set<string>();
+    for (const candidate of value) {
+        if (typeof candidate !== 'string') {
+            continue;
+        }
+        try {
+            const parsed = URI.parse(candidate, true);
+            if (parsed.scheme !== '') {
+                uris.add(parsed.toString());
+            }
+        } catch {
+            // Ignore malformed feature metadata without affecting settings.
+        }
+    }
+    return uris;
+}
+
+export function diagnostic_uris_from_initialization_options(
+    options: unknown
+): Set<string> | undefined {
+    return parse_diagnostic_uri_set(
+        as_record(options)?.['diagnosticUris']
+    );
+}
+
+export function diagnostic_uris_from_notification(
+    params: unknown
+): Set<string> | undefined {
+    return parse_diagnostic_uri_set(
+        as_record(params)?.['diagnosticUris']
+    );
+}
+
+/** Explicit policy sets compare unequal to the undefined LSP fallback. */
+export function same_diagnostic_uri_set(
+    current: ReadonlySet<string> | undefined,
+    next: ReadonlySet<string>
+): boolean {
+    if (current === undefined || current.size !== next.size) {
+        return false;
+    }
+    for (const uri of current) {
+        if (!next.has(uri)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+export interface DiagnosticUriSetChanges {
+    added: string[];
+    removed: string[];
+}
+
+/** Return the symmetric difference between two explicit ownership policies. */
+export function diagnostic_uri_set_changes(
+    current: ReadonlySet<string>,
+    next: ReadonlySet<string>
+): DiagnosticUriSetChanges {
+    const removed = [...current].filter(uri => !next.has(uri));
+    const added = [...next].filter(uri => !current.has(uri));
+    return { added, removed };
+}
+
+/**
+ * Remove feature metadata before bare initialization options reach the public
+ * settings mapper. A `{ sight: ... }` wrapper is already safely unwrapped by
+ * the existing configuration path and is left intact.
+ */
+export function settings_initialization_options(options: unknown): unknown {
+    const record = as_record(options);
+    if (!record || !('diagnosticUris' in record) || ('sight' in record)) {
+        return options;
+    }
+
+    const settings = { ...record };
+    delete settings['diagnosticUris'];
+    return settings;
+}

--- a/src/providers/diagnostics.ts
+++ b/src/providers/diagnostics.ts
@@ -919,13 +919,16 @@ export class DiagnosticsProvider {
         this.cache_generation++;
     }
 
-    /**
-     * Remove tracking for a closed document.
-     */
-    on_document_closed(uri: string): void {
+    /** Retire push diagnostics while retaining the document for analysis. */
+    on_document_hidden(uri: string): void {
         this.publish_gate.retire_lifecycle(uri);
         this.clear_cache_for_document(uri);
         this.clear_diagnostics(uri);
+    }
+
+    /** Remove diagnostic tracking for a closed document. */
+    on_document_closed(uri: string): void {
+        this.on_document_hidden(uri);
     }
 
     /** Retire every lifecycle so no work can publish after shutdown. */

--- a/src/server-factory.ts
+++ b/src/server-factory.ts
@@ -48,6 +48,14 @@ import { DependencyGraph } from './dependency-graph';
 import { URI } from 'vscode-uri';
 import * as fs from 'fs';
 import { discover_stata_ado_paths } from './utils/stata-install-paths';
+import {
+    DIAGNOSTIC_RESOURCES_CHANGED_NOTIFICATION,
+    diagnostic_uri_set_changes,
+    diagnostic_uris_from_initialization_options,
+    diagnostic_uris_from_notification,
+    same_diagnostic_uri_set,
+    settings_initialization_options,
+} from './diagnostic-resources';
 
 // Import cache directly so it gets bundled into the binary
 import embedded_cache_raw from './command-database/caches/v18.json' with { type: 'json' };
@@ -317,6 +325,10 @@ export async function create_server(options: ServerOptions): Promise<void> {
 
     // Initialization options config
     let init_options_config: unknown = undefined;
+    // Undefined preserves ordinary LSP didOpen behavior for non-Sight clients;
+    // an explicit empty set means no editor resource currently owns Problems.
+    let editor_diagnostic_uris: Set<string> | undefined = undefined;
+    let shutdown_requested = false;
 
     // Most recent client-pushed `sight` settings from didChangeConfiguration,
     // for clients without `workspace/configuration` capability. Retained so the
@@ -331,6 +343,58 @@ export async function create_server(options: ServerOptions): Promise<void> {
     const log_config_warning = (message: string): void => {
         connection.console.log(`Configuration warning: ${message}`);
     };
+
+    function diagnostics_publish_allowed(uri: string): boolean {
+        return editor_diagnostic_uris?.has(uri) ?? true;
+    }
+
+    function update_editor_diagnostic_uris(next: Set<string>): void {
+        // Focus and visibility events commonly repeat the same full snapshot.
+        // Avoid walking every LSP-open model when policy did not change.
+        if (same_diagnostic_uri_set(editor_diagnostic_uris, next)) {
+            return;
+        }
+        // Replace policy before lifecycle transitions: every concurrently
+        // resumed validation observes the new eligibility synchronously.
+        const previous = editor_diagnostic_uris;
+        editor_diagnostic_uris = next;
+        if (!diagnostics_provider) {
+            return;
+        }
+
+        if (previous === undefined) {
+            // The fallback policy allowed every didOpen document. This one-time
+            // transition is the only case that requires an all-documents scan.
+            for (const document of documents.all()) {
+                if (!next.has(document.uri)) {
+                    diagnostics_provider.on_document_hidden(document.uri);
+                }
+            }
+            return;
+        }
+
+        const changes = diagnostic_uri_set_changes(previous, next);
+        for (const uri of changes.removed) {
+            const document = documents.get(uri);
+            if (document) {
+                diagnostics_provider.on_document_hidden(
+                    document.uri
+                );
+            }
+        }
+        for (const uri of changes.added) {
+            const document = documents.get(uri);
+            if (document) {
+                diagnostics_provider.on_document_opened(
+                    document.uri,
+                    document.version
+                );
+                // A background-open model does not emit another didOpen when
+                // its tab appears, so explicitly run the normal pipeline.
+                void validate_text_document(document);
+            }
+        }
+    }
 
     function log_project_config_warnings(loaded: LoadedProjectConfig): void {
         for (const my_warning of loaded.warnings) {
@@ -1061,10 +1125,16 @@ export async function create_server(options: ServerOptions): Promise<void> {
             documents.get(snapshot_uri) === text_document &&
             text_document.version === snapshot_version;
         const validation_work_is_current = (): boolean => {
-            if (!snapshot_is_current()) {
+            if (shutdown_requested || !snapshot_is_current()) {
                 return false;
             }
             if (!diagnostics_provider) {
+                return true;
+            }
+            // Hidden LSP-open documents remain parse/index inputs. If the
+            // resource is re-added before old work finishes, this becomes
+            // false again and the new lifecycle's validation owns the commit.
+            if (!diagnostics_publish_allowed(snapshot_uri)) {
                 return true;
             }
             return diagnostics_trigger !== undefined &&
@@ -1212,7 +1282,8 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 }
 
                 // --- Diagnostic publication (Req 2.3) ---
-                if (!snapshot_is_current()) {
+                if (!snapshot_is_current() ||
+                    !diagnostics_publish_allowed(snapshot_uri)) {
                     return;
                 }
                 const document_state = document_store.get(snapshot_uri);
@@ -1265,7 +1336,9 @@ export async function create_server(options: ServerOptions): Promise<void> {
                 server_capabilities = caps;
             },
             (options: unknown) => {
-                init_options_config = options;
+                editor_diagnostic_uris =
+                    diagnostic_uris_from_initialization_options(options);
+                init_options_config = settings_initialization_options(options);
             },
             (root_uri: string | null) => {
                 init_root_uri = root_uri;
@@ -1559,10 +1632,12 @@ export async function create_server(options: ServerOptions): Promise<void> {
 
     // Document open handler - validate when a document is first opened
     documents.onDidOpen((e) => {
-        diagnostics_provider?.on_document_opened(
-            e.document.uri,
-            e.document.version
-        );
+        if (diagnostics_publish_allowed(e.document.uri)) {
+            diagnostics_provider?.on_document_opened(
+                e.document.uri,
+                e.document.version
+            );
+        }
         validate_text_document(e.document);
     });
 
@@ -1733,6 +1808,16 @@ export async function create_server(options: ServerOptions): Promise<void> {
         )
     );
 
+    connection.onNotification(
+        DIAGNOSTIC_RESOURCES_CHANGED_NOTIFICATION,
+        (params: unknown) => {
+            const next = diagnostic_uris_from_notification(params);
+            if (next !== undefined) {
+                update_editor_diagnostic_uris(next);
+            }
+        }
+    );
+
     // Request handlers — created once, registered once (Req 4.1, 4.2)
     const completion_handler = create_completion_handler(handler_deps);
     const hover_handler = create_hover_handler(handler_deps);
@@ -1761,7 +1846,12 @@ export async function create_server(options: ServerOptions): Promise<void> {
     connection.onExecuteCommand((params) => {
         return execute_command_handler(params.command, params.arguments || []);
     });
-    connection.onShutdown(shutdown_handler);
+    connection.onShutdown(() => {
+        // Hidden documents intentionally have no diagnostic lifecycle, so
+        // shutdown needs its own cancellation signal for in-flight analysis.
+        shutdown_requested = true;
+        return shutdown_handler();
+    });
     connection.onExit(create_exit_handler());
 
     // Custom request handlers

--- a/tests/integration/server-close-resync-wiring.test.ts
+++ b/tests/integration/server-close-resync-wiring.test.ts
@@ -1,6 +1,6 @@
 /**
- * Handler-level integration test for the onDidClose disk re-sync wiring
- * (issue #287, deferred from #184's review).
+ * Handler-level integration tests for document lifecycle wiring: onDidClose
+ * disk re-sync (#287) and editor diagnostic ownership (#602).
  *
  * All prior coverage of `resync_backward_directive_dependencies_from_disk`
  * is at the ScopeResolver unit level; nothing drove the REAL
@@ -32,7 +32,9 @@
  *      with TextDocuments still empty), and a vetoed re-sync does NOT
  *      revalidate open dependents. (The resolver-internal contract that
  *      the guard is consulted AFTER the disk read is unit-tested in
- *      tests/unit/document-store-commit-time-cross-file-effects.test.ts.)
+ *      tests/unit/document-store-commit-time-cross-file-effects.test.ts.);
+ *   5. hidden LSP-open models remain in DocumentStore while tab removal clears
+ *      their diagnostics and re-addition republishes without another didOpen.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
@@ -46,6 +48,7 @@ import type {
     DidOpenTextDocumentParams,
     DidCloseTextDocumentParams,
     PublishDiagnosticsParams,
+    CancellationToken,
 } from 'vscode-languageserver/node';
 import { create_server } from '../../src/server-factory';
 import { ScopeResolver } from '../../src/scope-resolver';
@@ -71,6 +74,9 @@ let captured_resolver: ScopeResolver | undefined;
 let captured_document_store: DocumentStore | undefined;
 let the_resync_calls: ResyncCall[] = [];
 let workspace_roots_seen: string[] = [];
+let scope_resolution_gate: Promise<void> | undefined;
+let scope_resolution_started: (() => void) | undefined;
+let captured_scope_cancellation_token: CancellationToken | undefined;
 // When set, the spied re-sync records its call, then holds before running
 // the real method until this promise resolves — letting a test create
 // race conditions deterministically (test 4). Undefined = no hold.
@@ -82,6 +88,7 @@ const original_set_workspace_roots =
     ScopeResolver.prototype.set_workspace_roots;
 const original_resync =
     ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk;
+const original_resolve = ScopeResolver.prototype.resolve;
 const original_set_scope_resolver =
     DocumentStore.prototype.set_scope_resolver;
 
@@ -91,6 +98,9 @@ function install_resolver_spies(): void {
     the_resync_calls = [];
     workspace_roots_seen = [];
     resync_gate = undefined;
+    scope_resolution_gate = undefined;
+    scope_resolution_started = undefined;
+    captured_scope_cancellation_token = undefined;
     ScopeResolver.prototype.set_dependency_graph = function (
         ...args: Parameters<typeof original_set_dependency_graph>
     ) {
@@ -119,6 +129,17 @@ function install_resolver_spies(): void {
             });
             return result;
         };
+    ScopeResolver.prototype.resolve = async function (
+        ...args: Parameters<typeof original_resolve>
+    ) {
+        const gate = scope_resolution_gate;
+        if (gate) {
+            captured_scope_cancellation_token = args[3];
+            scope_resolution_started?.();
+            await gate;
+        }
+        return original_resolve.apply(this, args);
+    };
     DocumentStore.prototype.set_scope_resolver = function (
         ...args: Parameters<typeof original_set_scope_resolver>
     ) {
@@ -134,6 +155,7 @@ function restore_resolver_spies(): void {
         original_set_workspace_roots;
     ScopeResolver.prototype.resync_backward_directive_dependencies_from_disk =
         original_resync;
+    ScopeResolver.prototype.resolve = original_resolve;
     DocumentStore.prototype.set_scope_resolver =
         original_set_scope_resolver;
 }
@@ -148,6 +170,7 @@ interface CapturedHandlers {
     initialized?: () => void;
     did_open?: (params: DidOpenTextDocumentParams) => void;
     did_close?: (params: DidCloseTextDocumentParams) => void;
+    diagnostic_resources?: (params: unknown) => void;
     shutdown?: () => unknown;
 }
 
@@ -183,6 +206,15 @@ function make_stub_connection(options: StubConnectionOptions): {
         },
         onDidChangeConfiguration: capture_nothing,
         onDidChangeWatchedFiles: capture_nothing,
+        onNotification: (
+            method: string,
+            handler: CapturedHandlers['diagnostic_resources']
+        ) => {
+            if (method === 'sight/diagnosticResourcesChanged') {
+                handlers.diagnostic_resources = handler;
+            }
+            return noop_disposable();
+        },
         onCompletion: capture_nothing,
         onCompletionResolve: capture_nothing,
         onHover: capture_nothing,
@@ -200,6 +232,7 @@ function make_stub_connection(options: StubConnectionOptions): {
         onRequest: capture_nothing,
         sendDiagnostics: (params: PublishDiagnosticsParams) => {
             options.published_uris.push(params.uri);
+            published_diagnostics.push(params);
         },
         // Surface used by TextDocuments.listen(connection):
         onDidOpenTextDocument: (
@@ -250,6 +283,7 @@ const WAIT_TIMEOUT_MS = 10000;
 
 let tmp_dir: string;
 let published_uris: string[] = [];
+let published_diagnostics: PublishDiagnosticsParams[] = [];
 let active_handlers: CapturedHandlers | undefined;
 
 // Disable workspace indexing so no scan-time dependency-graph edges or
@@ -257,7 +291,8 @@ let active_handlers: CapturedHandlers | undefined;
 const GLOBAL_PUBLIC_CONFIG = { crossFile: { indexWorkspace: false } };
 
 async function start_test_server(
-    get_scoped_config: (scope_uri: string | undefined) => unknown
+    get_scoped_config: (scope_uri: string | undefined) => unknown,
+    initialization_options?: unknown
 ): Promise<CapturedHandlers> {
     const workspace_folder_uri = URI.file(tmp_dir).toString();
     const { connection, handlers } = make_stub_connection({
@@ -278,6 +313,7 @@ async function start_test_server(
         rootUri: workspace_folder_uri,
         capabilities: { workspace: { configuration: true } },
         workspaceFolders: null,
+        initializationOptions: initialization_options,
     } as InitializeParams);
     handlers.initialized!();
     // onInitialized creates the providers synchronously, then finishes
@@ -354,10 +390,11 @@ async function wait_for_publish_quiescence(): Promise<void> {
     }, 'diagnostic publishes to go quiescent', WAIT_TIMEOUT_MS, 150);
 }
 
-describe('server onDidClose disk re-sync wiring (#287)', () => {
+describe('server document lifecycle wiring', () => {
     beforeEach(() => {
         install_resolver_spies();
         published_uris = [];
+        published_diagnostics = [];
         active_handlers = undefined;
         tmp_dir = fs.realpathSync(
             fs.mkdtempSync(path.join(os.tmpdir(), 'close-resync-wiring-'))
@@ -710,5 +747,87 @@ describe('server onDidClose disk re-sync wiring (#287)', () => {
             published_uris
                 .filter((my_uri) => my_uri === grandchild_uri).length
         ).toBe(grandchild_publishes_before);
+    }, TEST_TIMEOUT_MS);
+
+    it('retains hidden LSP models while tab ownership clears and ' +
+        'restores diagnostics without another didOpen (#602)', async () => {
+        const child_uri = file_uri('child.do');
+        const source = 'display "unterminated\n';
+        const handlers = await start_test_server(
+            () => GLOBAL_PUBLIC_CONFIG,
+            { sight: {}, diagnosticUris: [] }
+        );
+        expect(handlers.diagnostic_resources).toBeDefined();
+
+        open_document(handlers, child_uri, source);
+        await wait_until(
+            () => captured_document_store?.get(child_uri)?.version === 1,
+            'hidden document to commit into DocumentStore',
+            WAIT_TIMEOUT_MS
+        );
+        await wait_for_publish_quiescence();
+        expect(
+            published_diagnostics.filter(
+                params => params.uri === child_uri
+            )
+        ).toHaveLength(0);
+
+        // Adding a tab starts a lifecycle and explicitly validates the
+        // already-open model; vscode-languageclient sends no second didOpen.
+        handlers.diagnostic_resources!({ diagnosticUris: [child_uri] });
+        await wait_until(
+            () => published_diagnostics.some(
+                params => params.uri === child_uri &&
+                    params.diagnostics.length > 0
+            ),
+            'newly owned document to publish diagnostics',
+            WAIT_TIMEOUT_MS
+        );
+
+        handlers.diagnostic_resources!({ diagnosticUris: [] });
+        const child_publications_after_remove = published_diagnostics
+            .filter(params => params.uri === child_uri);
+        expect(child_publications_after_remove.at(-1)?.diagnostics)
+            .toEqual([]);
+        // Removal is a diagnostic lifecycle transition, not didClose.
+        expect(captured_document_store?.get(child_uri)).toBeDefined();
+
+        const nonempty_before_readd = child_publications_after_remove
+            .filter(params => params.diagnostics.length > 0).length;
+        handlers.diagnostic_resources!({ diagnosticUris: [child_uri] });
+        await wait_until(
+            () => published_diagnostics.filter(
+                params => params.uri === child_uri &&
+                    params.diagnostics.length > 0
+            ).length > nonempty_before_readd,
+            're-added document to republish at the same version',
+            WAIT_TIMEOUT_MS
+        );
+        expect(captured_document_store?.get(child_uri)?.version).toBe(1);
+    }, TEST_TIMEOUT_MS);
+
+    it('cancels hidden analysis that is in flight during shutdown', async () => {
+        const child_uri = file_uri('child.do');
+        const handlers = await start_test_server(
+            () => GLOBAL_PUBLIC_CONFIG,
+            { sight: {}, diagnosticUris: [] }
+        );
+        let release_scope: (() => void) | undefined;
+        const scope_started = new Promise<void>(resolve => {
+            scope_resolution_started = resolve;
+        });
+        scope_resolution_gate = new Promise<void>(resolve => {
+            release_scope = resolve;
+        });
+
+        open_document(handlers, child_uri, 'display 1\n');
+        await scope_started;
+
+        const shutdown = Promise.resolve(handlers.shutdown?.());
+        expect(captured_scope_cancellation_token?.isCancellationRequested)
+            .toBe(true);
+        release_scope?.();
+        await shutdown;
+        active_handlers = undefined;
     }, TEST_TIMEOUT_MS);
 });

--- a/tests/unit/diagnostic-resources-core.test.ts
+++ b/tests/unit/diagnostic-resources-core.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    clear_ineligible_diagnostics,
+    collect_diagnostic_resource_uris,
+    diagnostics_for_resource,
+    same_diagnostic_resource_uris,
+    type DiagnosticTabResource,
+} from '../../client/src/diagnostic-resources-core';
+
+function collect(
+    tabs: DiagnosticTabResource[],
+    visible: string[] = []
+): string[] {
+    return collect_diagnostic_resource_uris(tabs, visible);
+}
+
+describe('diagnostic editor resources', () => {
+    it('compares canonical snapshots for notification deduplication', () => {
+        expect(same_diagnostic_resource_uris(
+            ['file:///a.do', 'file:///b.do'],
+            ['file:///a.do', 'file:///b.do']
+        )).toBe(true);
+        expect(same_diagnostic_resource_uris(
+            ['file:///b.do', 'file:///a.do'],
+            ['file:///a.do', 'file:///b.do']
+        )).toBe(false);
+        expect(same_diagnostic_resource_uris(
+            undefined,
+            []
+        )).toBe(false);
+    });
+
+    it('includes active and inactive resource tabs deterministically', () => {
+        expect(collect([
+            { kind: 'resource', uri: 'file:///b.do' },
+            { kind: 'resource', uri: 'file:///a.do' },
+            { kind: 'resource', uri: 'file:///a.do' },
+        ])).toEqual(['file:///a.do', 'file:///b.do']);
+    });
+
+    it('owns only the modified side of a diff tab', () => {
+        expect(collect([{
+            kind: 'diff',
+            original_uri: 'file:///original.do',
+            modified_uri: 'file:///modified.do',
+            is_active: false,
+        }])).toEqual(['file:///modified.do']);
+    });
+
+    it('unions visible peek editors', () => {
+        expect(collect([], ['file:///peek.do']))
+            .toEqual(['file:///peek.do']);
+    });
+
+    it('subtracts the visible original side of an active diff', () => {
+        expect(collect([{
+            kind: 'diff',
+            original_uri: 'file:///original.do',
+            modified_uri: 'file:///modified.do',
+            is_active: true,
+        }], [
+            'file:///original.do',
+            'file:///modified.do',
+        ])).toEqual(['file:///modified.do']);
+    });
+
+    it('keeps a diff original that also has its own resource tab', () => {
+        expect(collect([
+            {
+                kind: 'diff',
+                original_uri: 'file:///shared.do',
+                modified_uri: 'file:///modified.do',
+                is_active: true,
+            },
+            { kind: 'resource', uri: 'file:///shared.do' },
+        ], ['file:///shared.do'])).toEqual([
+            'file:///modified.do',
+            'file:///shared.do',
+        ]);
+    });
+
+    it('keeps an independent peek matching an active diff original', () => {
+        expect(collect([{
+            kind: 'diff',
+            original_uri: 'file:///shared.do',
+            modified_uri: 'file:///modified.do',
+            is_active: true,
+        }], [
+            'file:///shared.do',
+            'file:///shared.do',
+        ])).toEqual([
+            'file:///modified.do',
+            'file:///shared.do',
+        ]);
+    });
+
+    it('consumes one occurrence for each active diff original', () => {
+        expect(collect([
+            {
+                kind: 'diff',
+                original_uri: 'file:///shared.do',
+                modified_uri: 'file:///modified-a.do',
+                is_active: true,
+            },
+            {
+                kind: 'diff',
+                original_uri: 'file:///shared.do',
+                modified_uri: 'file:///modified-b.do',
+                is_active: true,
+            },
+        ], [
+            'file:///shared.do',
+            'file:///shared.do',
+            'file:///shared.do',
+        ])).toEqual([
+            'file:///modified-a.do',
+            'file:///modified-b.do',
+            'file:///shared.do',
+        ]);
+    });
+
+    it('does not exclude a visible URI for an inactive diff', () => {
+        expect(collect([{
+            kind: 'diff',
+            original_uri: 'file:///peek.do',
+            modified_uri: 'file:///modified.do',
+            is_active: false,
+        }], ['file:///peek.do'])).toEqual([
+            'file:///modified.do',
+            'file:///peek.do',
+        ]);
+    });
+
+    it('prunes only retained diagnostics for ineligible resources', () => {
+        const deleted: string[] = [];
+        const uris = [
+            { toString: () => 'file:///visible.do' },
+            { toString: () => 'file:///hidden.do' },
+        ];
+        const collection = {
+            forEach: (callback: (uri: typeof uris[number]) => void) => {
+                uris.forEach(callback);
+            },
+            delete: (uri: typeof uris[number]) => {
+                deleted.push(uri.toString());
+            },
+        };
+
+        clear_ineligible_diagnostics(
+            collection,
+            new Set(['file:///visible.do'])
+        );
+        expect(deleted).toEqual(['file:///hidden.do']);
+    });
+
+    it('turns a late ineligible publication into an empty clear', () => {
+        const diagnostics = [{ message: 'stale' }];
+        const eligible = new Set(['file:///visible.do']);
+
+        expect(diagnostics_for_resource(
+            'file:///visible.do', diagnostics, eligible
+        )).toBe(diagnostics);
+        expect(diagnostics_for_resource(
+            'file:///hidden.do', diagnostics, eligible
+        )).toEqual([]);
+    });
+});

--- a/tests/unit/diagnostic-resources.test.ts
+++ b/tests/unit/diagnostic-resources.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    diagnostic_uri_set_changes,
+    diagnostic_uris_from_initialization_options,
+    diagnostic_uris_from_notification,
+    parse_diagnostic_uri_set,
+    same_diagnostic_uri_set,
+    settings_initialization_options,
+} from '../../src/diagnostic-resources';
+
+describe('diagnostic resource protocol metadata', () => {
+    it('diffs explicit policies without involving unrelated URIs', () => {
+        expect(diagnostic_uri_set_changes(
+            new Set(['file:///kept.do', 'file:///removed.do']),
+            new Set(['file:///kept.do', 'file:///added.do'])
+        )).toEqual({
+            added: ['file:///added.do'],
+            removed: ['file:///removed.do'],
+        });
+    });
+
+    it('deduplicates only identical explicit policy sets', () => {
+        expect(same_diagnostic_uri_set(
+            new Set(['file:///a.do', 'file:///b.do']),
+            new Set(['file:///b.do', 'file:///a.do'])
+        )).toBe(true);
+        expect(same_diagnostic_uri_set(
+            new Set(['file:///a.do']),
+            new Set(['file:///b.do'])
+        )).toBe(false);
+        expect(same_diagnostic_uri_set(undefined, new Set())).toBe(false);
+    });
+
+    it('preserves fallback behavior when the URI array is absent', () => {
+        expect(diagnostic_uris_from_initialization_options(undefined))
+            .toBeUndefined();
+        expect(diagnostic_uris_from_initialization_options({ sight: {} }))
+            .toBeUndefined();
+        expect(diagnostic_uris_from_notification({}))
+            .toBeUndefined();
+    });
+
+    it('distinguishes an explicit empty set from fallback behavior', () => {
+        expect(diagnostic_uris_from_initialization_options({
+            diagnosticUris: [],
+        })).toEqual(new Set());
+        expect(diagnostic_uris_from_notification({
+            diagnosticUris: [],
+        })).toEqual(new Set());
+    });
+
+    it('normalizes valid URI strings and filters malformed entries', () => {
+        expect(parse_diagnostic_uri_set([
+            'file:///workspace/a.do',
+            'file:///workspace/a.do',
+            'https://example.test/b.do',
+            'not-a-uri',
+            42,
+            null,
+        ])).toEqual(new Set([
+            'file:///workspace/a.do',
+            'https://example.test/b.do',
+        ]));
+    });
+
+    it('ignores malformed notification fields instead of clearing policy', () => {
+        expect(diagnostic_uris_from_notification({
+            diagnosticUris: 'file:///workspace/a.do',
+        })).toBeUndefined();
+    });
+
+    it('strips feature metadata from bare initialization settings', () => {
+        expect(settings_initialization_options({
+            diagnosticUris: ['file:///workspace/a.do'],
+            diagnostics: { enabled: false },
+        })).toEqual({ diagnostics: { enabled: false } });
+    });
+
+    it('keeps a sight wrapper for the existing settings unwrap path', () => {
+        const options = {
+            sight: { diagnostics: { enabled: false } },
+            diagnosticUris: ['file:///workspace/a.do'],
+        };
+        expect(settings_initialization_options(options)).toBe(options);
+    });
+});

--- a/tests/unit/diagnostics-provider.test.ts
+++ b/tests/unit/diagnostics-provider.test.ts
@@ -889,6 +889,59 @@ describe('DiagnosticsProvider', () => {
         });
     });
 
+    describe('on_document_hidden', () => {
+        it(
+            'retire/re-add rejects stale work at the identical version',
+            async () => {
+                const document = create_document_state(
+                    'display `undefined\'\n',
+                    1
+                );
+                const delayed_scope_resolver = new ScopeResolver();
+                let resolve_scope: (() => void) | undefined;
+                let resolve_started: (() => void) | undefined;
+                const scope_started = new Promise<void>(resolve => {
+                    resolve_started = resolve;
+                });
+                const scope_delay = new Promise<void>(resolve => {
+                    resolve_scope = resolve;
+                });
+
+                delayed_scope_resolver.resolve = async () => {
+                    resolve_started?.();
+                    await scope_delay;
+                    return create_empty_resolved_scope();
+                };
+
+                const stale_publish = publish_current(
+                    provider,
+                    document,
+                    DEFAULT_CONFIG,
+                    undefined,
+                    delayed_scope_resolver
+                );
+                await scope_started;
+
+                provider.on_document_hidden(document.uri);
+                provider.on_document_opened(
+                    document.uri,
+                    document.version
+                );
+                resolve_scope?.();
+                await stale_publish;
+
+                const sent_after_stale =
+                    mock_connection.get_sent_diagnostics();
+                expect(sent_after_stale).toHaveLength(1);
+                expect(sent_after_stale[0].diagnostics).toEqual([]);
+
+                await publish_current(provider, document, DEFAULT_CONFIG);
+                expect(mock_connection.get_sent_diagnostics())
+                    .toHaveLength(2);
+            }
+        );
+    });
+
     describe('on_shutdown', () => {
         it('drops an in-flight publish that resumes after shutdown', async () => {
             const document = create_document_state(

--- a/tests/unit/language-client-lifecycle.test.ts
+++ b/tests/unit/language-client-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import {
     LanguageClientLifecycle,
     ManagedLanguageClient,
+    register_running_state_reconciliation,
 } from '../../client/src/language-client-lifecycle';
 
 interface Deferred<T> {
@@ -244,5 +245,125 @@ describe('LanguageClientLifecycle', () => {
         await my_lifecycle.start_client(the_client);
 
         expect(started_hook_calls).toBe(1);
+    });
+});
+
+describe('running-state reconciliation', () => {
+    it('waits for every Running transition to finish starting', async () => {
+        const start_a = create_deferred<void>();
+        const start_b = create_deferred<void>();
+        const starts = [start_a.promise, start_b.promise];
+        const listeners = new Set<(event: { newState: number }) => void>();
+        let state = 1;
+        let start_calls = 0;
+        let reconcile_calls = 0;
+        const running_state = 2;
+        const the_client = {
+            get state(): number {
+                return state;
+            },
+            start: () => starts[start_calls++],
+            stop: async () => undefined,
+            onDidChangeState: (
+                listener: (event: { newState: number }) => void
+            ) => {
+                listeners.add(listener);
+                return { dispose: () => listeners.delete(listener) };
+            },
+        };
+        const emit = (new_state: number): void => {
+            state = new_state;
+            for (const listener of listeners) {
+                listener({ newState: new_state });
+            }
+        };
+
+        const disposable = register_running_state_reconciliation(
+            the_client,
+            running_state,
+            () => { reconcile_calls++; }
+        );
+
+        emit(running_state);
+        expect(reconcile_calls).toBe(0);
+        start_a.resolve();
+        await next_tick();
+        expect(reconcile_calls).toBe(1);
+
+        emit(1);
+        emit(running_state);
+        expect(reconcile_calls).toBe(1);
+        start_b.resolve();
+        await next_tick();
+        expect(reconcile_calls).toBe(2);
+        disposable.dispose();
+    });
+
+    it('drops reconciliation if Running is superseded during startup', async () => {
+        const start_deferred = create_deferred<void>();
+        let listener: ((event: { newState: number }) => void) | undefined;
+        let state = 1;
+        let reconcile_calls = 0;
+        const the_client = {
+            get state(): number {
+                return state;
+            },
+            start: () => start_deferred.promise,
+            stop: async () => undefined,
+            onDidChangeState: (
+                the_listener: (event: { newState: number }) => void
+            ) => {
+                listener = the_listener;
+                return { dispose: () => { listener = undefined; } };
+            },
+        };
+
+        register_running_state_reconciliation(
+            the_client,
+            2,
+            () => { reconcile_calls++; }
+        );
+        state = 2;
+        listener?.({ newState: 2 });
+        state = 1;
+        listener?.({ newState: 1 });
+        start_deferred.resolve();
+        await next_tick();
+
+        expect(reconcile_calls).toBe(0);
+    });
+
+    it('drops reconciliation pending when its subscription is disposed', async () => {
+        const start_deferred = create_deferred<void>();
+        let listener: ((event: { newState: number }) => void) | undefined;
+        let state = 1;
+        let reconcile_calls = 0;
+        const the_client = {
+            get state(): number {
+                return state;
+            },
+            start: () => start_deferred.promise,
+            stop: async () => undefined,
+            onDidChangeState: (
+                the_listener: (event: { newState: number }) => void
+            ) => {
+                listener = the_listener;
+                return { dispose: () => { listener = undefined; } };
+            },
+        };
+        const subscription = register_running_state_reconciliation(
+            the_client,
+            2,
+            () => { reconcile_calls++; }
+        );
+
+        state = 2;
+        listener?.({ newState: 2 });
+        subscription.dispose();
+        start_deferred.resolve();
+        await next_tick();
+
+        expect(reconcile_calls).toBe(0);
+        expect(listener).toBeUndefined();
     });
 });


### PR DESCRIPTION
## Summary
- mirror Raven #602 by treating real tabs and visible peek editors as diagnostic owners
- keep hidden LSP-open documents parsed and indexed while suppressing their own Problems entries
- make diff tabs own only the modified side and preserve independent peeks of an original URI
- synchronize ownership at initialization, tab/editor changes, and automatic client restarts
- retire and restart diagnostic publication epochs across tab removal and re-addition
- retain normal didOpen behavior for LSP clients that do not send ownership metadata
- deduplicate unchanged snapshots and process genuine changes in O(added + removed URIs)
- cancel hidden analysis during shutdown and invalidate pending restart reconciliation on disposal

## Verification
- bun run test: 7,577 passed, 5 skipped, 0 failed
- bun run lint
- client: bun run bundle
- focused protocol, client ownership, lifecycle-race, shutdown-cancellation, disposal-race, and handler integration tests

Reference: https://github.com/jbearak/raven/pull/602