### PR TITLE
Fix polynomial ReDoS in file-command completion detection

### DIFF
--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -660,13 +660,21 @@ function detect_command_path_context(text_before_cursor: string): CompletionCont
         return null;
     }
     
-    // Look for file command followed by space
-    const command_pattern = /^\s*(\w+)\s+(.*)$/;
-    const command_match = text_before_cursor.match(command_pattern);
-    
+    // Parse the command and separator independently. Keeping `\s+` next to a
+    // catch-all capture in one expression allows quadratic backtracking on a
+    // long whitespace-only path (CodeQL js/polynomial-redos).
+    const command_match = text_before_cursor.match(/^\s*(\w+)/);
+
     if (command_match) {
         const command = command_match[1];
-        const path_part = command_match[2];
+        const remainder = text_before_cursor.slice(command_match[0].length);
+        const separator_match = remainder.match(/^\s+/);
+
+        if (!separator_match) {
+            return null;
+        }
+
+        const path_part = remainder.slice(separator_match[0].length);
         
         // Check if this is a file command
         if (isFileCommand(command)) {

--- a/tests/property/malformed-expression-errors.prop.test.ts
+++ b/tests/property/malformed-expression-errors.prop.test.ts
@@ -3,6 +3,7 @@ import * as fc from 'fast-check';
 import { StataParser } from '../../src/parser';
 import { StataLexer } from '../../src/lexer';
 import { ParseErrorCode } from '../../src/types';
+import { arbitrary_non_reserved_identifier } from './generators';
 
 /**
  * Property-based tests for Malformed Expression Error Handling
@@ -27,7 +28,7 @@ describe('Malformed Expression Error Handling Property Tests', () => {
      * Generator for variable names
      */
     function arbitrary_variable_name(): fc.Arbitrary<string> {
-        return fc.stringMatching(/^[a-zA-Z][a-zA-Z0-9_]{0,8}$/);
+        return arbitrary_non_reserved_identifier();
     }
 
     /**

--- a/tests/unit/completion.test.ts
+++ b/tests/unit/completion.test.ts
@@ -195,6 +195,32 @@ describe('Completion Context Detection', () => {
             expect(context.type).toBe('variable');
         });
     });
+
+    describe('Command Path Context', () => {
+        it('should detect a file command path after separator whitespace', () => {
+            const source = 'do   scripts/setup.do';
+            const doc = create_test_document(source);
+            const context = detect_completion_context(doc, { line: 0, character: source.length });
+
+            expect(context).toEqual({
+                type: 'command_path',
+                command: 'do',
+                partial_path: 'scripts/setup.do',
+            });
+        });
+
+        it('should handle a long whitespace-only path without backtracking', () => {
+            const source = `do ${' '.repeat(100_000)}`;
+            const doc = create_test_document(source);
+            const context = detect_completion_context(doc, { line: 0, character: source.length });
+
+            expect(context).toEqual({
+                type: 'command_path',
+                command: 'do',
+                partial_path: '',
+            });
+        });
+    });
 });
 
 describe('Completion Provider', () => {


### PR DESCRIPTION
## Summary
- Split command parsing from separator parsing in `detect_command_path_context` to avoid quadratic backtracking on whitespace-heavy inputs.
- Preserve command-path completion behavior for file commands with normal separator spacing.
- Add unit coverage for both standard command-path detection and the long whitespace-only case.

## Testing
- Unit tests added for `detect_completion_context` command-path handling.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command and path detection when completing file paths after the `do` command.
  * Prevented incorrect partial-path suggestions when input contains extensive whitespace.

* **Tests**
  * Added coverage for command-and-path completion scenarios, including long whitespace-only input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->