### PR TITLE
Fix mixed-effects double-bar false positive

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -156,7 +156,10 @@ documented minimum through the full command: `cap`–`capture`, `qui`–`quietly
 and `noi`–`noisily`. The exact-case, colon-required `xi:` prefix is also
 supported; bare `xi` is not. Mixed-command abbreviations, wrong-case commands,
 argument-bearing prefixes, user programs, and commands such as `menl`, `gsem`,
-`twoway`, and `svyset` fail closed. The bars themselves must be adjacent;
+`twoway`, and `svyset` fail closed. The exception also fails closed when any
+top-level comma appears before the first `||`, including a comma that introduces
+valid fixed-equation options. Sight deliberately does not parse command-specific
+`fe_options` for this exception. The bars themselves must be adjacent;
 whitespace, comments, or `///` between them preserve
 `INVALID_OPERATOR_SEQUENCE`.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -147,14 +147,18 @@ Compact, top-level `|| levelvar:` random-equation separators are not treated as
 logical operators for these exact-case commands: `mixed`, `mecloglog`, `meglm`,
 `meintreg`, `melogit`, `menbreg`, `meologit`, `meoprobit`, `mepoisson`,
 `meprobit`, `meqrlogit`, `meqrpoisson`, `mestreg`, `metobit`, `xtmixed`,
-`xtmelogit`, and `xtmepoisson`. The same exception applies after exact-case
-simple prefix abbreviations from their documented minimum through the full
-command: `cap`–`capture`, `qui`–`quietly`, and `noi`–`noisily`. The exact-case,
-colon-required `xi:` prefix is also supported; bare `xi` is not.
-Mixed-command abbreviations, wrong-case commands, argument-bearing prefixes,
-user programs, and commands such as `menl`, `gsem`, `twoway`, and `svyset` fail
-closed. The bars themselves must be adjacent; whitespace, comments, or `///`
-between them preserve `INVALID_OPERATOR_SEQUENCE`.
+`xtmelogit`, and `xtmepoisson`. A plausible `levelvar:` must be the next
+significant content immediately after the compact bars. Fixed-effects model
+content must precede the first separator; only `mestreg` may omit it. Thus
+`mixed || id:` is flagged, while `mestreg || id:` is accepted. The same
+exception applies after exact-case simple prefix abbreviations from their
+documented minimum through the full command: `cap`–`capture`, `qui`–`quietly`,
+and `noi`–`noisily`. The exact-case, colon-required `xi:` prefix is also
+supported; bare `xi` is not. Mixed-command abbreviations, wrong-case commands,
+argument-bearing prefixes, user programs, and commands such as `menl`, `gsem`,
+`twoway`, and `svyset` fail closed. The bars themselves must be adjacent;
+whitespace, comments, or `///` between them preserve
+`INVALID_OPERATOR_SEQUENCE`.
 
 These operator/expression rules are heuristic token-stream checks. Apart from
 the narrow mixed-effects separator exception, they do not parse per-command

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -159,9 +159,11 @@ argument-bearing prefixes, user programs, and commands such as `menl`, `gsem`,
 `twoway`, and `svyset` fail closed. The exception also fails closed when any
 top-level comma appears before the first `||`, including a comma that introduces
 valid fixed-equation options. Sight deliberately does not parse command-specific
-`fe_options` for this exception. The bars themselves must be adjacent;
-whitespace, comments, or `///` between them preserve
-`INVALID_OPERATOR_SEQUENCE`.
+`fe_options` for this exception. Within one logical statement, whitespace,
+block comments, line comments under `#delimit ;`, and `///`-swallowed newlines
+preserve adjacency between the bars and therefore preserve
+`INVALID_OPERATOR_SEQUENCE`. A real statement terminator, including a newline
+under `#delimit cr`, breaks adjacency.
 
 These operator/expression rules are heuristic token-stream checks. Apart from
 the narrow mixed-effects separator exception, they do not parse per-command

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -143,8 +143,22 @@ turned off independently.
 | <a id="chained-comparison"></a>`CHAINED_COMPARISON` | warning | `chainedComparison` | Two or more comparisons chained without a logical connector (e.g., `a != b != c`, `a < b < c`). Stata evaluates these left-to-right — `a < b < c` is `(a < b) < c` — so a chain is usually a missing `&` / `\|` or missing parentheses. |
 | <a id="literal-macro-adjacency"></a>`LITERAL_MACRO_ADJACENCY` | hint | `literalMacroAdjacency` | A number or complete string literal placed directly against a following macro reference where the pair is an operand of a comparison/logical operator (e.g., `a == 1\`b'`, or `1\`b' == a`). Stata concatenates them during macro expansion — if `` `b' `` is `0`, `1\`b'` becomes `10`. Only flagged when a comparison/logical operator sits immediately before the literal or immediately after the macro, so intentional adjacency (`gen x\`i'`, function arguments, string interpolation) is left alone. |
 
-These operator/expression rules are heuristic token-stream checks: they do not
-parse per-command semantics, so they can fire inside text-storing commands
+Compact, top-level `|| levelvar:` random-equation separators are not treated as
+logical operators for these exact-case commands: `mixed`, `mecloglog`, `meglm`,
+`meintreg`, `melogit`, `menbreg`, `meologit`, `meoprobit`, `mepoisson`,
+`meprobit`, `meqrlogit`, `meqrpoisson`, `mestreg`, `metobit`, `xtmixed`,
+`xtmelogit`, and `xtmepoisson`. The same exception applies after exact-case
+simple prefix abbreviations from their documented minimum through the full
+command: `cap`–`capture`, `qui`–`quietly`, and `noi`–`noisily`. The exact-case,
+colon-required `xi:` prefix is also supported; bare `xi` is not.
+Mixed-command abbreviations, wrong-case commands, argument-bearing prefixes,
+user programs, and commands such as `menl`, `gsem`, `twoway`, and `svyset` fail
+closed. The bars themselves must be adjacent; whitespace, comments, or `///`
+between them preserve `INVALID_OPERATOR_SEQUENCE`.
+
+These operator/expression rules are heuristic token-stream checks. Apart from
+the narrow mixed-effects separator exception, they do not parse per-command
+semantics, so they can fire inside text-storing commands
 (e.g. `notes`, `char`, `local x <text>`) and do not cover every
 bare-expression command. `LITERAL_MACRO_ADJACENCY` additionally recognizes
 `assert` as a bare-boolean-expression command when it appears in command

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -590,8 +590,8 @@ function extract_command_name(text: string): string | null {
         // If the text before colon starts with "by" or "bysort", then it's "by varlist:" syntax
         const words_before = text_before_colon.split(/\s+/);
         
-        if (words_before.length >= 2 && 
-            ['by', 'bysort'].includes(words_before[0].toLowerCase()) &&
+        if (words_before.length >= 2 &&
+            ['by', 'bysort'].includes(words_before[0]) &&
             text_after_colon.length > 0) {
             working_text = text_after_colon;
         }
@@ -610,8 +610,7 @@ function extract_command_name(text: string): string | null {
         if (my_word === ':') {
             continue;
         }
-        const lower_word = my_word.toLowerCase();
-        if (!PREFIX_COMMANDS.includes(lower_word)) {
+        if (!PREFIX_COMMANDS.includes(my_word)) {
             return my_word;
         }
     }
@@ -699,68 +698,90 @@ function detect_subcommand_context(text_before_cursor: string, command_db?: Comm
     if (text_before_cursor.includes(',')) {
         return null;
     }
-    
+
     const trimmed = text_before_cursor.trim();
-    const the_words = trimmed.split(/\s+/).filter(w => w.length > 0);
-    
-    if (the_words.length === 0) {
+    // Colons are separate parts because logical-statement flattening inserts
+    // whitespace around them, while single-line source commonly does not.
+    const the_parts: string[] = trimmed.match(/:|[^\s:]+/g) ?? [];
+
+    if (the_parts.length === 0) {
         return null;
     }
-    
-    // Skip standard prefix commands (by, quietly, capture, etc.)
-    const STANDARD_PREFIXES = ['by', 'bysort', 'quietly', 'qui', 'capture', 'cap', 'noisily', 'noi'];
+
+    // Stata prefix syntax is case-sensitive. Walk it left-to-right instead of
+    // discarding everything before the last colon: a colon only exposes the
+    // following command when every preceding part is a supported prefix.
+    const STANDARD_PREFIXES = [
+        'by', 'bysort', 'quietly', 'qui',
+        'capture', 'cap', 'noisily', 'noi',
+    ];
+    const BY_PREFIXES = ['by', 'bysort'];
     let command_index = 0;
-    while (command_index < the_words.length && 
-           STANDARD_PREFIXES.includes(the_words[command_index].toLowerCase())) {
+    while (
+        command_index < the_parts.length &&
+        STANDARD_PREFIXES.includes(the_parts[command_index])
+    ) {
+        const my_prefix = the_parts[command_index];
         command_index++;
-    }
-    
-    // Handle "by varlist:" pattern - skip to after colon
-    if (trimmed.includes(':')) {
-        const after_colon = trimmed.split(':').pop()?.trim() || '';
-        const words_after_colon = after_colon.split(/\s+/).filter(w => w.length > 0);
-        if (words_after_colon.length > 0) {
-            const potential_prefix = words_after_colon[0].toLowerCase();
-            // Check if this command has subcommands using the database
-            if (command_db && command_db.has_subcommands(potential_prefix)) {
-                const words_after_prefix = words_after_colon.length - 1;
-                if (words_after_prefix === 0 && text_before_cursor.endsWith(' ')) {
-                    return { type: 'subcommand', prefix_command: potential_prefix };
-                }
-                if (words_after_prefix === 1 && !text_before_cursor.endsWith(' ')) {
-                    return { type: 'subcommand', prefix_command: potential_prefix };
-                }
+
+        if (BY_PREFIXES.includes(my_prefix)) {
+            const varlist_start = command_index;
+            while (
+                command_index < the_parts.length &&
+                the_parts[command_index] !== ':'
+            ) {
+                command_index++;
             }
+            if (
+                command_index === varlist_start ||
+                command_index >= the_parts.length
+            ) {
+                return null;
+            }
+            command_index++;
+            continue;
         }
+
+        // capture/quietly/noisily prefixes accept an optional colon.
+        if (the_parts[command_index] === ':') {
+            command_index++;
+        }
+    }
+
+    if (command_index >= the_parts.length) {
         return null;
     }
-    
-    if (command_index >= the_words.length) {
-        return null;
-    }
-    
-    const potential_prefix = the_words[command_index].toLowerCase();
-    
-    // Check if this command has subcommands using the database
+
+    // Command-database lookup is intentionally case-insensitive, unlike the
+    // hardcoded Stata prefix syntax above.
+    const potential_prefix = the_parts[command_index].toLowerCase();
+
     if (!command_db || !command_db.has_subcommands(potential_prefix)) {
         return null;
     }
-    
+
+    // Any colon left after the candidate belongs to command arguments or
+    // arbitrary syntax, not to the validated leading prefix chain.
+    const the_remaining_parts = the_parts.slice(command_index + 1);
+    if (the_remaining_parts.includes(':')) {
+        return null;
+    }
+
     // We're in subcommand context if:
     // 1. We're right after the prefix command with a space (e.g., "frame ")
     // 2. We're typing the subcommand (e.g., "frame cr")
-    const words_after_prefix = the_words.length - command_index - 1;
-    
+    const words_after_prefix = the_remaining_parts.length;
+
     if (words_after_prefix === 0 && text_before_cursor.endsWith(' ')) {
         // Right after "frame " - suggest subcommands
         return { type: 'subcommand', prefix_command: potential_prefix };
     }
-    
+
     if (words_after_prefix === 1 && !text_before_cursor.endsWith(' ')) {
         // Typing the subcommand (e.g., "frame cr") - suggest subcommands
         return { type: 'subcommand', prefix_command: potential_prefix };
     }
-    
+
     return null;
 }
 
@@ -791,7 +812,7 @@ function is_command_context(
         const after_colon = parts.slice(1).join(':').trim();
         
         // Check if before colon starts with a prefix command
-        const first_word = before_colon.split(/\s+/)[0].toLowerCase();
+        const first_word = before_colon.split(/\s+/)[0];
         if (PREFIX_COMMANDS.includes(first_word)) {
             // We're after "by varlist:" - check what's after the colon
             if (after_colon === '' || !after_colon.includes(' ')) {
@@ -804,8 +825,8 @@ function is_command_context(
     // If all words so far are prefix commands (without colon), we're still in command context
     let all_prefixes = true;
     for (const my_word of the_words) {
-        const lower_word = my_word.toLowerCase().replace(/:$/, ''); // Remove trailing colon
-        if (!PREFIX_COMMANDS.includes(lower_word)) {
+        const prefix_word = my_word.replace(/:$/, '');
+        if (!PREFIX_COMMANDS.includes(prefix_word)) {
             all_prefixes = false;
             break;
         }
@@ -819,9 +840,9 @@ function is_command_context(
     // This is true if there's only one word and no space after it
     if (the_words.length === 1 && !text_before_cursor.endsWith(' ')) {
         // Check if the word could be a prefix
-        const lower_word = the_words[0].toLowerCase();
+        const prefix_fragment = the_words[0];
         for (const prefix of PREFIX_COMMANDS) {
-            if (prefix.startsWith(lower_word)) {
+            if (prefix.startsWith(prefix_fragment)) {
                 return true;
             }
         }

--- a/src/providers/mixed-logical-diagnostics.ts
+++ b/src/providers/mixed-logical-diagnostics.ts
@@ -31,6 +31,17 @@ const EXPRESSION_BREAKERS: Set<string> = new Set([
 ]);
 
 /**
+ * Trivia skipped when checking whether a logical operator begins `||` or
+ * `&&`. Real statement terminators still stop the lookahead.
+ */
+const COMPOUND_LOGICAL_TRIVIA_TYPES: Set<string> = new Set([
+    'WHITESPACE',
+    'CONTINUATION',
+    'COMMENT_BLOCK',
+    'COMMENT_LINE',
+]);
+
+/**
  * State tracked for a single parenthesis group.
  */
 interface GroupState {
@@ -248,11 +259,10 @@ export class MixedLogicalOperatorAnalyzer {
         let my_in_continuation = false;
         for (let my_i = start_index + 1; my_i < the_tokens.length; my_i++) {
             const my_next_token = the_tokens[my_i];
-            if (my_next_token.type === 'WHITESPACE') {
-                continue;
-            }
-            if (my_next_token.type === 'CONTINUATION') {
-                my_in_continuation = true;
+            if (COMPOUND_LOGICAL_TRIVIA_TYPES.has(my_next_token.type)) {
+                if (my_next_token.type === 'CONTINUATION') {
+                    my_in_continuation = true;
+                }
                 continue;
             }
             if (

--- a/src/providers/mixed-logical-diagnostics.ts
+++ b/src/providers/mixed-logical-diagnostics.ts
@@ -25,7 +25,6 @@ const QUALIFIER_BREAKERS: Set<string> = new Set(['if', 'in']);
  */
 const EXPRESSION_BREAKERS: Set<string> = new Set([
     'STATEMENT_TERMINATOR',
-    'COMMENT_LINE',
     'LBRACE',
     'RBRACE',
 ]);
@@ -175,7 +174,12 @@ export class MixedLogicalOperatorAnalyzer {
                 continue;
             }
 
-            if (my_token.type === 'WHITESPACE') {
+            // A line comment is trivia, not a statement boundary. In CR
+            // mode, its following newline is the real terminator.
+            if (
+                my_token.type === 'WHITESPACE'
+                || my_token.type === 'COMMENT_LINE'
+            ) {
                 continue;
             }
 

--- a/src/providers/mixed-logical-diagnostics.ts
+++ b/src/providers/mixed-logical-diagnostics.ts
@@ -5,6 +5,9 @@ import { diagnostic_code_description_fields } from '../utils/diagnostic-code-des
 import { resolve_diagnostic_severity } from '../utils/diagnostic-severity';
 import { is_swallowed_continuation_terminator } from '../utils/continuation';
 import { is_diagnostic_range_ignored } from './diagnostic-token-stream';
+import {
+    collect_mixed_effects_separator_starts,
+} from './operator-sequence-diagnostics';
 
 /**
  * Logical operator values tracked for mixed-operator detection.
@@ -99,6 +102,8 @@ export class MixedLogicalOperatorAnalyzer {
 
         const my_ignored_lines = document.ignored_lines ?? new Set<number>();
         const my_severity = resolve_diagnostic_severity(my_config_severity);
+        const the_mixed_effects_separator_starts =
+            collect_mixed_effects_separator_starts(the_tokens);
 
         const my_diagnostics: Diagnostic[] = [];
         let my_state = this.fresh_state();
@@ -114,6 +119,21 @@ export class MixedLogicalOperatorAnalyzer {
                 )
             ) {
                 my_in_continuation = false;
+                continue;
+            }
+
+            if (the_mixed_effects_separator_starts.has(my_token)) {
+                // A random-equation separator is an expression boundary,
+                // not a logical operator in either adjacent clause.
+                my_in_continuation = false;
+                this.flush(
+                    my_state,
+                    my_diagnostics,
+                    my_severity,
+                    my_ignored_lines
+                );
+                my_state = this.fresh_state();
+                i++;
                 continue;
             }
 

--- a/src/providers/operator-sequence-diagnostics.ts
+++ b/src/providers/operator-sequence-diagnostics.ts
@@ -4,7 +4,12 @@ import { StataDiagnosticCode, StataLSPConfig, Token, StataAST, StataNode } from 
 import { diagnostic_code_description_fields } from '../utils/diagnostic-code-description';
 import { resolve_diagnostic_severity } from '../utils/diagnostic-severity';
 import { is_swallowed_continuation_terminator } from '../utils/continuation';
-import { is_diagnostic_range_ignored } from './diagnostic-token-stream';
+import { is_logical_statement_boundary } from '../utils/statement-span';
+import {
+    collect_significant_tokens,
+    is_adjacent,
+    is_diagnostic_range_ignored,
+} from './diagnostic-token-stream';
 
 /**
  * Spaced compound operators that Stata accepts as their compact form.
@@ -124,6 +129,462 @@ const ADJACENCY_BREAKERS: Set<string> = new Set([
 type OperatorContext = 'control_flow' | 'qualifier' | 'other';
 
 /**
+ * Commands whose documented grammar uses top-level compact
+ * `|| levelvar:` random-equation separators. Full names only: command
+ * abbreviations are not accepted without verified metadata.
+ */
+const MIXED_EFFECTS_SEPARATOR_COMMANDS: ReadonlySet<string> = new Set([
+    'mixed',
+    'mecloglog',
+    'meglm',
+    'meintreg',
+    'melogit',
+    'menbreg',
+    'meologit',
+    'meoprobit',
+    'mepoisson',
+    'meprobit',
+    'meqrlogit',
+    'meqrpoisson',
+    'mestreg',
+    'metobit',
+    'xtmixed',
+    'xtmelogit',
+    'xtmepoisson',
+]);
+
+const MIXED_COLON_OPTIONAL_PREFIX_COMMANDS: ReadonlySet<string> = new Set([
+    'cap', 'capt', 'captu', 'captur', 'capture',
+    'qui', 'quie', 'quiet', 'quietl', 'quietly',
+    'noi', 'nois', 'noisi', 'noisil', 'noisily',
+]);
+
+const MIXED_COLON_REQUIRED_PREFIX_COMMANDS: ReadonlySet<string> = new Set([
+    'xi',
+]);
+
+const NAME_FRAGMENT_TOKEN_TYPES: ReadonlySet<string> = new Set([
+    'WORD',
+    'MACRO_REF_LOCAL',
+    'MACRO_REF_GLOBAL',
+]);
+
+// Mirrors loop-expander/name-expander.ts: a numeric token may continue a
+// source-adjacent constructed name, but it cannot begin one.
+const NAME_CONTINUATION_TOKEN_TYPES: ReadonlySet<string> = new Set([
+    ...NAME_FRAGMENT_TOKEN_TYPES,
+    'NUMBER',
+]);
+
+/**
+ * Resolve the command used only by mixed-effects separator diagnostics.
+ * Capture/quietly/noisily prefixes accept all exact documented spellings and
+ * an optional colon; exact-case `xi` requires its colon. Argument-bearing and
+ * multiword prefixes remain unsupported. Source-constructed command names fail
+ * closed so they cannot inherit a built-in command's separator exception.
+ */
+function resolve_mixed_effects_command_head(
+    the_significant: Token[],
+    statement_start: number,
+    statement_end: number
+): { token: Token; index: number } | undefined {
+    let my_i = statement_start;
+    while (my_i < statement_end) {
+        const my_prefix = the_significant[my_i];
+        if (my_prefix.type !== 'WORD') {
+            break;
+        }
+
+        if (MIXED_COLON_OPTIONAL_PREFIX_COMMANDS.has(my_prefix.value)) {
+            my_i++;
+            if (
+                my_i < statement_end &&
+                the_significant[my_i].type === 'COLON'
+            ) {
+                my_i++;
+            }
+            continue;
+        }
+
+        if (
+            MIXED_COLON_REQUIRED_PREFIX_COMMANDS.has(my_prefix.value) &&
+            my_i + 1 < statement_end &&
+            the_significant[my_i + 1].type === 'COLON'
+        ) {
+            my_i += 2;
+            continue;
+        }
+        break;
+    }
+
+    const my_command = the_significant[my_i];
+    if (my_i >= statement_end || my_command?.type !== 'WORD') {
+        return undefined;
+    }
+
+    const my_continuation = the_significant[my_i + 1];
+    if (
+        my_i + 1 < statement_end &&
+        is_name_continuation_fragment(my_continuation) &&
+        is_adjacent(my_command, my_continuation)
+    ) {
+        return undefined;
+    }
+    return { token: my_command, index: my_i };
+}
+
+const OMITTED_MODEL_HEAD_COMMANDS: ReadonlySet<string> = new Set([
+    'mestreg',
+]);
+
+type GroupOpener = 'LPAREN' | 'LBRACKET';
+
+function is_matching_group_close(
+    my_opener: GroupOpener | undefined,
+    close_type: string
+): boolean {
+    return (
+        (my_opener === 'LPAREN' && close_type === 'RPAREN') ||
+        (my_opener === 'LBRACKET' && close_type === 'RBRACKET')
+    );
+}
+
+function is_name_fragment(
+    my_token: Token | undefined
+): my_token is Token {
+    return (
+        my_token !== undefined &&
+        NAME_FRAGMENT_TOKEN_TYPES.has(my_token.type)
+    );
+}
+
+function is_name_continuation_fragment(
+    my_token: Token | undefined
+): my_token is Token {
+    return (
+        my_token !== undefined &&
+        NAME_CONTINUATION_TOKEN_TYPES.has(my_token.type)
+    );
+}
+
+function is_plausible_model_head(
+    the_significant: Token[],
+    model_head_index: number,
+    statement_end: number
+): boolean {
+    const my_head = the_significant[model_head_index];
+    if (is_mixed_varlist_wildcard(my_head)) {
+        return true;
+    }
+    if (!is_name_fragment(my_head)) {
+        return false;
+    }
+    if (
+        my_head.type !== 'WORD' ||
+        (my_head.value !== 'if' && my_head.value !== 'in')
+    ) {
+        return true;
+    }
+
+    const my_continuation = the_significant[model_head_index + 1];
+    return (
+        model_head_index + 1 < statement_end &&
+        is_name_continuation_fragment(my_continuation) &&
+        is_adjacent(my_head, my_continuation)
+    );
+}
+
+function is_mixed_varlist_wildcard(
+    my_token: Token | undefined
+): boolean {
+    return (
+        (my_token?.type === 'OPERATOR' && my_token.value === '*') ||
+        ((my_token?.type === 'OPERATOR' || my_token?.type === 'WORD') &&
+            my_token.value === '?')
+    );
+}
+
+function is_mixed_constructed_name_fragment(
+    my_token: Token | undefined
+): boolean {
+    return (
+        is_name_continuation_fragment(my_token) ||
+        is_mixed_varlist_wildcard(my_token)
+    );
+}
+
+function is_standalone_mixed_qualifier(
+    the_significant: Token[],
+    token_index: number
+): boolean {
+    const my_token = the_significant[token_index];
+    if (
+        my_token.type !== 'WORD' ||
+        (my_token.value !== 'if' && my_token.value !== 'in')
+    ) {
+        return false;
+    }
+
+    const my_previous = the_significant[token_index - 1];
+    const my_next = the_significant[token_index + 1];
+    return !(
+        (is_mixed_constructed_name_fragment(my_previous) &&
+            is_adjacent(my_previous, my_token)) ||
+        (is_mixed_constructed_name_fragment(my_next) &&
+            is_adjacent(my_token, my_next))
+    );
+}
+
+function is_plausible_mixed_varlist_range_dash(
+    the_significant: Token[],
+    dash_index: number
+): boolean {
+    const my_dash = the_significant[dash_index];
+    const my_right_fragment = the_significant[dash_index + 1];
+    if (
+        my_dash.type !== 'OPERATOR' ||
+        my_dash.value !== '-' ||
+        !is_name_fragment(my_right_fragment) ||
+        !is_adjacent(my_dash, my_right_fragment)
+    ) {
+        return false;
+    }
+
+    let my_right_boundary = my_dash;
+    for (let my_i = dash_index - 1; my_i >= 0; my_i--) {
+        const my_left_fragment = the_significant[my_i];
+        if (
+            !is_name_continuation_fragment(my_left_fragment) ||
+            !is_adjacent(my_left_fragment, my_right_boundary)
+        ) {
+            return false;
+        }
+        if (is_name_fragment(my_left_fragment)) {
+            return true;
+        }
+        my_right_boundary = my_left_fragment;
+    }
+    return false;
+}
+
+function has_dangling_operator_before_mixed_separator(
+    the_significant: Token[],
+    first_bar_index: number,
+    mixed_varlist_is_open: boolean
+): boolean {
+    const my_previous = the_significant[first_bar_index - 1];
+    if (!is_mixed_varlist_wildcard(my_previous)) {
+        return my_previous?.type === 'OPERATOR';
+    }
+    if (!mixed_varlist_is_open) {
+        return true;
+    }
+
+    let my_i = first_bar_index - 2;
+    while (is_mixed_varlist_wildcard(the_significant[my_i])) {
+        my_i--;
+    }
+    return the_significant[my_i]?.type === 'OPERATOR';
+}
+
+function plausible_levelvar_colon_index(
+    the_significant: Token[],
+    first_bar_index: number,
+    statement_end: number
+): number | undefined {
+    const first_fragment_index = first_bar_index + 2;
+    const my_first_fragment = the_significant[first_fragment_index];
+    if (!is_name_fragment(my_first_fragment)) {
+        return undefined;
+    }
+
+    let fragment_count = 1;
+    let last_fragment_index = first_fragment_index;
+    while (last_fragment_index + 1 < statement_end) {
+        const my_last_fragment = the_significant[last_fragment_index];
+        const my_next_fragment = the_significant[last_fragment_index + 1];
+        if (
+            !is_name_continuation_fragment(my_next_fragment) ||
+            !is_adjacent(my_last_fragment, my_next_fragment)
+        ) {
+            break;
+        }
+        fragment_count++;
+        last_fragment_index++;
+    }
+
+    const my_colon_index = last_fragment_index + 1;
+    const my_colon = the_significant[my_colon_index];
+    if (my_colon?.type !== 'COLON') {
+        return undefined;
+    }
+    if (
+        fragment_count === 1 &&
+        my_first_fragment.type === 'WORD' &&
+        (my_first_fragment.value === 'if' ||
+            my_first_fragment.value === 'in')
+    ) {
+        return undefined;
+    }
+    return my_colon_index;
+}
+
+function mark_mixed_effects_separators_in_statement(
+    the_significant: Token[],
+    statement_start: number,
+    statement_end: number,
+    the_separator_starts: Set<Token>
+): void {
+    const my_command_head = resolve_mixed_effects_command_head(
+        the_significant,
+        statement_start,
+        statement_end
+    );
+    if (
+        my_command_head === undefined ||
+        !MIXED_EFFECTS_SEPARATOR_COMMANDS.has(my_command_head.token.value)
+    ) {
+        return;
+    }
+
+    const the_group_stack: GroupOpener[] = [];
+    const has_required_model_content =
+        OMITTED_MODEL_HEAD_COMMANDS.has(my_command_head.token.value) ||
+        is_plausible_model_head(
+            the_significant,
+            my_command_head.index + 1,
+            statement_end
+        );
+    let saw_top_level_options_comma = false;
+    let saw_top_level_double_bar = false;
+    let has_marked_separator = false;
+    let separators_are_valid = true;
+    let my_mixed_varlist_is_open = true;
+
+    for (
+        let my_i = my_command_head.index + 1;
+        my_i < statement_end;
+        my_i++
+    ) {
+        const my_token = the_significant[my_i];
+        if (my_token.type === 'LPAREN' || my_token.type === 'LBRACKET') {
+            the_group_stack.push(my_token.type);
+            continue;
+        }
+        if (my_token.type === 'RPAREN' || my_token.type === 'RBRACKET') {
+            if (
+                !is_matching_group_close(
+                    the_group_stack[the_group_stack.length - 1],
+                    my_token.type
+                )
+            ) {
+                break;
+            }
+            the_group_stack.pop();
+            continue;
+        }
+
+        if (the_group_stack.length !== 0) {
+            continue;
+        }
+        if (my_token.type === 'COMMA') {
+            if (!has_marked_separator) {
+                saw_top_level_options_comma = true;
+            }
+            my_mixed_varlist_is_open = false;
+            continue;
+        }
+        if (is_standalone_mixed_qualifier(the_significant, my_i)) {
+            my_mixed_varlist_is_open = false;
+        }
+
+        const my_second_bar = the_significant[my_i + 1];
+        if (
+            my_token.type !== 'OPERATOR' ||
+            my_token.value !== '|' ||
+            my_second_bar?.type !== 'OPERATOR' ||
+            my_second_bar.value !== '|' ||
+            !is_adjacent(my_token, my_second_bar)
+        ) {
+            if (
+                my_token.type === 'OPERATOR' &&
+                !is_mixed_varlist_wildcard(my_token) &&
+                !(
+                    my_mixed_varlist_is_open &&
+                    is_plausible_mixed_varlist_range_dash(
+                        the_significant,
+                        my_i
+                    )
+                )
+            ) {
+                my_mixed_varlist_is_open = false;
+            }
+            continue;
+        }
+
+        if (!saw_top_level_double_bar) {
+            saw_top_level_double_bar = true;
+            if (!has_required_model_content) {
+                separators_are_valid = false;
+            }
+        }
+
+        const my_levelvar_colon_index = plausible_levelvar_colon_index(
+            the_significant,
+            my_i,
+            statement_end
+        );
+        if (
+            !separators_are_valid ||
+            (!has_marked_separator && saw_top_level_options_comma) ||
+            has_dangling_operator_before_mixed_separator(
+                the_significant,
+                my_i,
+                my_mixed_varlist_is_open
+            ) ||
+            my_levelvar_colon_index === undefined
+        ) {
+            my_mixed_varlist_is_open = false;
+            continue;
+        }
+
+        the_separator_starts.add(my_token);
+        has_marked_separator = true;
+        my_mixed_varlist_is_open = true;
+        my_i = my_levelvar_colon_index;
+    }
+}
+
+function collect_mixed_effects_separator_starts(tokens: Token[]): Set<Token> {
+    const the_significant = collect_significant_tokens(tokens);
+    const the_separator_starts = new Set<Token>();
+    let statement_start = 0;
+
+    for (let my_i = 0; my_i <= the_significant.length; my_i++) {
+        const my_token = the_significant[my_i];
+        const at_end = my_token === undefined || my_token.type === 'EOF';
+        if (!at_end && !is_logical_statement_boundary(my_token)) {
+            continue;
+        }
+
+        if (statement_start < my_i) {
+            mark_mixed_effects_separators_in_statement(
+                the_significant,
+                statement_start,
+                my_i,
+                the_separator_starts
+            );
+        }
+        if (at_end) {
+            break;
+        }
+        statement_start = my_i + 1;
+    }
+
+    return the_separator_starts;
+}
+
+/**
  * Internal classification result for an operator pair.
  */
 interface OperatorPairResult {
@@ -187,6 +648,8 @@ export class OperatorSequenceAnalyzer {
         // Get AST for context detection (may be undefined)
         const ast = document.ast;
 
+        const the_mixed_effects_separator_starts =
+            collect_mixed_effects_separator_starts(the_tokens);
         const the_diagnostics: Diagnostic[] = [];
         let i = 0;
 
@@ -210,8 +673,17 @@ export class OperatorSequenceAnalyzer {
 
             const { second_token, next_index } = adjacency_result;
 
+            if (the_mixed_effects_separator_starts.has(first_token)) {
+                i = next_index;
+                continue;
+            }
+
             // Classify the pair
-            const pair_result = this.classify_pair(first_token, second_token, ast ?? undefined);
+            const pair_result = this.classify_pair(
+                first_token,
+                second_token,
+                ast ?? undefined
+            );
 
             if (!pair_result) {
                 // Pair is allowed or unrecognized, skip

--- a/src/providers/operator-sequence-diagnostics.ts
+++ b/src/providers/operator-sequence-diagnostics.ts
@@ -153,6 +153,10 @@ const MIXED_EFFECTS_SEPARATOR_COMMANDS: ReadonlySet<string> = new Set([
     'xtmepoisson',
 ]);
 
+const OMITTED_MODEL_HEAD_COMMANDS: ReadonlySet<string> = new Set([
+    'mestreg',
+]);
+
 const MIXED_COLON_OPTIONAL_PREFIX_COMMANDS: ReadonlySet<string> = new Set([
     'cap', 'capt', 'captu', 'captur', 'capture',
     'qui', 'quie', 'quiet', 'quietl', 'quietly',
@@ -232,10 +236,6 @@ function resolve_mixed_effects_command_head(
     }
     return { token: my_command, index: my_i };
 }
-
-const OMITTED_MODEL_HEAD_COMMANDS: ReadonlySet<string> = new Set([
-    'mestreg',
-]);
 
 type GroupOpener = 'LPAREN' | 'LBRACKET';
 
@@ -392,34 +392,35 @@ function plausible_levelvar_colon_index(
     first_bar_index: number,
     statement_end: number
 ): number | undefined {
-    const first_fragment_index = first_bar_index + 2;
-    const my_first_fragment = the_significant[first_fragment_index];
+    const my_first_fragment_index = first_bar_index + 2;
+    const my_first_fragment = the_significant[my_first_fragment_index];
     if (!is_name_fragment(my_first_fragment)) {
         return undefined;
     }
 
-    let fragment_count = 1;
-    let last_fragment_index = first_fragment_index;
-    while (last_fragment_index + 1 < statement_end) {
-        const my_last_fragment = the_significant[last_fragment_index];
-        const my_next_fragment = the_significant[last_fragment_index + 1];
+    let my_fragment_count = 1;
+    let my_last_fragment_index = my_first_fragment_index;
+    while (my_last_fragment_index + 1 < statement_end) {
+        const my_last_fragment = the_significant[my_last_fragment_index];
+        const my_next_fragment =
+            the_significant[my_last_fragment_index + 1];
         if (
             !is_name_continuation_fragment(my_next_fragment) ||
             !is_adjacent(my_last_fragment, my_next_fragment)
         ) {
             break;
         }
-        fragment_count++;
-        last_fragment_index++;
+        my_fragment_count++;
+        my_last_fragment_index++;
     }
 
-    const my_colon_index = last_fragment_index + 1;
+    const my_colon_index = my_last_fragment_index + 1;
     const my_colon = the_significant[my_colon_index];
     if (my_colon?.type !== 'COLON') {
         return undefined;
     }
     if (
-        fragment_count === 1 &&
+        my_fragment_count === 1 &&
         my_first_fragment.type === 'WORD' &&
         (my_first_fragment.value === 'if' ||
             my_first_fragment.value === 'in')
@@ -447,18 +448,18 @@ function mark_mixed_effects_separators_in_statement(
         return;
     }
 
-    const the_group_stack: GroupOpener[] = [];
-    const has_required_model_content =
+    const my_group_stack: GroupOpener[] = [];
+    const my_has_required_model_content =
         OMITTED_MODEL_HEAD_COMMANDS.has(my_command_head.token.value) ||
         is_plausible_model_head(
             the_significant,
             my_command_head.index + 1,
             statement_end
         );
-    let saw_top_level_options_comma = false;
-    let saw_top_level_double_bar = false;
-    let has_marked_separator = false;
-    let separators_are_valid = true;
+    let my_saw_top_level_options_comma = false;
+    let my_saw_top_level_double_bar = false;
+    let my_has_marked_separator = false;
+    let my_separators_are_valid = true;
     let my_mixed_varlist_is_open = true;
 
     for (
@@ -468,28 +469,28 @@ function mark_mixed_effects_separators_in_statement(
     ) {
         const my_token = the_significant[my_i];
         if (my_token.type === 'LPAREN' || my_token.type === 'LBRACKET') {
-            the_group_stack.push(my_token.type);
+            my_group_stack.push(my_token.type);
             continue;
         }
         if (my_token.type === 'RPAREN' || my_token.type === 'RBRACKET') {
             if (
                 !is_matching_group_close(
-                    the_group_stack[the_group_stack.length - 1],
+                    my_group_stack[my_group_stack.length - 1],
                     my_token.type
                 )
             ) {
                 break;
             }
-            the_group_stack.pop();
+            my_group_stack.pop();
             continue;
         }
 
-        if (the_group_stack.length !== 0) {
+        if (my_group_stack.length !== 0) {
             continue;
         }
         if (my_token.type === 'COMMA') {
-            if (!has_marked_separator) {
-                saw_top_level_options_comma = true;
+            if (!my_has_marked_separator) {
+                my_saw_top_level_options_comma = true;
             }
             my_mixed_varlist_is_open = false;
             continue;
@@ -522,10 +523,10 @@ function mark_mixed_effects_separators_in_statement(
             continue;
         }
 
-        if (!saw_top_level_double_bar) {
-            saw_top_level_double_bar = true;
-            if (!has_required_model_content) {
-                separators_are_valid = false;
+        if (!my_saw_top_level_double_bar) {
+            my_saw_top_level_double_bar = true;
+            if (!my_has_required_model_content) {
+                my_separators_are_valid = false;
             }
         }
 
@@ -535,8 +536,9 @@ function mark_mixed_effects_separators_in_statement(
             statement_end
         );
         if (
-            !separators_are_valid ||
-            (!has_marked_separator && saw_top_level_options_comma) ||
+            !my_separators_are_valid ||
+            (!my_has_marked_separator &&
+                my_saw_top_level_options_comma) ||
             has_dangling_operator_before_mixed_separator(
                 the_significant,
                 my_i,
@@ -549,13 +551,20 @@ function mark_mixed_effects_separators_in_statement(
         }
 
         the_separator_starts.add(my_token);
-        has_marked_separator = true;
+        my_has_marked_separator = true;
         my_mixed_varlist_is_open = true;
         my_i = my_levelvar_colon_index;
     }
 }
 
-function collect_mixed_effects_separator_starts(tokens: Token[]): Set<Token> {
+/**
+ * Return the first bar token of each recognized mixed-effects separator.
+ * Sibling token-stream analyzers use this shared classification so the
+ * command-specific grammar remains single-sourced.
+ */
+export function collect_mixed_effects_separator_starts(
+    tokens: Token[]
+): Set<Token> {
     const the_significant = collect_significant_tokens(tokens);
     const the_separator_starts = new Set<Token>();
     let statement_start = 0;

--- a/src/utils/statement-span.ts
+++ b/src/utils/statement-span.ts
@@ -242,6 +242,14 @@ const LOGICAL_BOUNDARY_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Whether a token bounds logical Stata statements. Continuation-swallowed
+ * terminators must be removed or checked separately by the caller.
+ */
+export function is_logical_statement_boundary(my_token: Token): boolean {
+    return LOGICAL_BOUNDARY_TYPES.has(my_token.type);
+}
+
+/**
  * Trivia skipped when locating the first real token of a statement
  * (after a boundary). Same membership as LEADING_TRIVIA_TYPES minus the
  * `#delimit` switch, which is itself a boundary and never leads a
@@ -361,7 +369,7 @@ export function logical_statement_start(
             // Swallowed `///` newline: trivia, keep walking.
             continue;
         }
-        if (LOGICAL_BOUNDARY_TYPES.has(my_token.type)) {
+        if (is_logical_statement_boundary(my_token)) {
             boundary_index = my_i;
             break;
         }

--- a/tests/integration/operator-sequence-diagnostics.test.ts
+++ b/tests/integration/operator-sequence-diagnostics.test.ts
@@ -273,6 +273,78 @@ describe('Operator Sequence Diagnostics Integration', () => {
             ]);
         });
 
+        it('reports a mix across a line comment in ; mode', async () => {
+            const my_content = [
+                '#delimit ;',
+                'keep if x & y // explanation',
+                '    | z ;',
+            ].join('\n');
+            const my_uri = 'file:///test_mixed_line_comment_semicolon.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            const the_diagnostics =
+                await diagnostics_provider.get_diagnostics(
+                    my_document,
+                    default_config
+                );
+            const the_mixed = the_diagnostics.filter(
+                (my_diagnostic) =>
+                    my_diagnostic.code ===
+                    StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+
+            expect(the_mixed).toHaveLength(1);
+        });
+
+        it('reports a mix across a full-line * comment in ; mode', async () => {
+            const my_content = [
+                '#delimit ;',
+                'keep if x & y',
+                '* explanation',
+                '    | z ;',
+            ].join('\n');
+            const my_uri = 'file:///test_mixed_star_comment_semicolon.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            const the_diagnostics =
+                await diagnostics_provider.get_diagnostics(
+                    my_document,
+                    default_config
+                );
+            const the_mixed = the_diagnostics.filter(
+                (my_diagnostic) =>
+                    my_diagnostic.code ===
+                    StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+
+            expect(the_mixed).toHaveLength(1);
+        });
+
+        it('does not mix operators across a line-comment CR terminator', async () => {
+            const my_content = [
+                'display x & y // explanation',
+                'display z | q',
+            ].join('\n');
+            const my_uri = 'file:///test_mixed_line_comment_cr_boundary.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            const the_diagnostics =
+                await diagnostics_provider.get_diagnostics(
+                    my_document,
+                    default_config
+                );
+            const the_mixed = the_diagnostics.filter(
+                (my_diagnostic) =>
+                    my_diagnostic.code ===
+                    StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+
+            expect(the_mixed).toHaveLength(0);
+        });
+
         it('should emit spaced compound operator diagnostics alongside semantic diagnostics', async () => {
             // Code with both undefined macro and a spaced compound operator
             const my_content = `display \`undefined_macro'

--- a/tests/integration/operator-sequence-diagnostics.test.ts
+++ b/tests/integration/operator-sequence-diagnostics.test.ts
@@ -43,6 +43,35 @@ describe('Operator Sequence Diagnostics Integration', () => {
     });
 
     describe('Full Pipeline Integration', () => {
+        it('does not flag a mixed random-equation separator', async () => {
+            const my_content = [
+                'local rhs price',
+                "mixed log_supply `rhs' if esample || state_num:",
+            ].join('\n');
+            const my_uri = 'file:///test_mixed_double_bar.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            const the_diagnostics =
+                await diagnostics_provider.get_diagnostics(
+                    my_document,
+                    default_config
+                );
+            const the_operator_sequence = the_diagnostics.filter(
+                (my_diagnostic) =>
+                    my_diagnostic.code ===
+                        StataDiagnosticCode.MALFORMED_OPERATOR ||
+                    my_diagnostic.code ===
+                        StataDiagnosticCode.SPACED_COMPOUND_OPERATOR ||
+                    my_diagnostic.code ===
+                        StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE ||
+                    my_diagnostic.code ===
+                        StataDiagnosticCode.CSTYLE_LOGICAL_IN_CONTROL_FLOW
+            );
+
+            expect(the_operator_sequence).toHaveLength(0);
+        });
+
         it('should emit spaced compound operator diagnostics alongside semantic diagnostics', async () => {
             // Code with both undefined macro and a spaced compound operator
             const my_content = `display \`undefined_macro'

--- a/tests/integration/operator-sequence-diagnostics.test.ts
+++ b/tests/integration/operator-sequence-diagnostics.test.ts
@@ -72,6 +72,116 @@ describe('Operator Sequence Diagnostics Integration', () => {
             expect(the_operator_sequence).toHaveLength(0);
         });
 
+        it('preserves a mixed warning before a separator', async () => {
+            const my_content = 'mixed y x if a & b | c || id:';
+            const my_uri = 'file:///test_mixed_logical_before_separator.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            const the_diagnostics =
+                await diagnostics_provider.get_diagnostics(
+                    my_document,
+                    default_config
+                );
+            const the_invalid = the_diagnostics.filter(
+                (my_diagnostic) =>
+                    my_diagnostic.code ===
+                    StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+            );
+            const the_mixed = the_diagnostics.filter(
+                (my_diagnostic) =>
+                    my_diagnostic.code ===
+                    StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+
+            expect(the_invalid).toHaveLength(0);
+            expect(
+                the_mixed.map((my_diagnostic) => ({
+                    code: my_diagnostic.code,
+                    range: my_diagnostic.range,
+                }))
+            ).toEqual([
+                {
+                    code: StataDiagnosticCode.MIXED_LOGICAL_OPERATORS,
+                    range: {
+                        start: { line: 0, character: 15 },
+                        end: { line: 0, character: 20 },
+                    },
+                },
+            ]);
+        });
+
+        it('keeps unsupported-command double bars invalid', async () => {
+            const my_content =
+                'my_mixed_program y x if a & b | c || id:';
+            const my_uri = 'file:///test_unsupported_mixed_separator.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            const the_diagnostics =
+                await diagnostics_provider.get_diagnostics(
+                    my_document,
+                    default_config
+                );
+            const the_relevant = the_diagnostics.filter(
+                (my_diagnostic) =>
+                    my_diagnostic.code ===
+                        StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE ||
+                    my_diagnostic.code ===
+                        StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+
+            expect(
+                the_relevant.map((my_diagnostic) => ({
+                    code: my_diagnostic.code,
+                    range: my_diagnostic.range,
+                }))
+            ).toEqual([
+                {
+                    code: StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE,
+                    range: {
+                        start: { line: 0, character: 34 },
+                        end: { line: 0, character: 36 },
+                    },
+                },
+            ]);
+        });
+
+        it('keeps ordinary expression double bars invalid', async () => {
+            const my_content = 'display a & b | c || d';
+            const my_uri = 'file:///test_ordinary_expression_double_bar.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            const the_diagnostics =
+                await diagnostics_provider.get_diagnostics(
+                    my_document,
+                    default_config
+                );
+            const the_relevant = the_diagnostics.filter(
+                (my_diagnostic) =>
+                    my_diagnostic.code ===
+                        StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE ||
+                    my_diagnostic.code ===
+                        StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+
+            expect(
+                the_relevant.map((my_diagnostic) => ({
+                    code: my_diagnostic.code,
+                    range: my_diagnostic.range,
+                }))
+            ).toEqual([
+                {
+                    code: StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE,
+                    range: {
+                        start: { line: 0, character: 18 },
+                        end: { line: 0, character: 20 },
+                    },
+                },
+            ]);
+        });
+
         it('should emit spaced compound operator diagnostics alongside semantic diagnostics', async () => {
             // Code with both undefined macro and a spaced compound operator
             const my_content = `display \`undefined_macro'

--- a/tests/integration/operator-sequence-diagnostics.test.ts
+++ b/tests/integration/operator-sequence-diagnostics.test.ts
@@ -182,6 +182,97 @@ describe('Operator Sequence Diagnostics Integration', () => {
             ]);
         });
 
+        it('reports only invalid bars separated by a block comment', async () => {
+            const my_content = 'display a & b |/* comment */| c';
+            const my_uri = 'file:///test_comment_separated_double_bar.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            const the_diagnostics =
+                await diagnostics_provider.get_diagnostics(
+                    my_document,
+                    default_config
+                );
+
+            expect(
+                the_diagnostics.map((my_diagnostic) => ({
+                    code: my_diagnostic.code,
+                    range: my_diagnostic.range,
+                }))
+            ).toEqual([
+                {
+                    code: StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE,
+                    range: {
+                        start: { line: 0, character: 14 },
+                        end: { line: 0, character: 29 },
+                    },
+                },
+            ]);
+        });
+
+        it('keeps line-comment-separated bars adjacent in ; mode', async () => {
+            const my_content = [
+                '#delimit ;',
+                'display a & b |// comment',
+                '| c ;',
+            ].join('\n');
+            const my_uri = 'file:///test_line_comment_double_bar_semicolon.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            const the_diagnostics =
+                await diagnostics_provider.get_diagnostics(
+                    my_document,
+                    default_config
+                );
+
+            expect(
+                the_diagnostics.map((my_diagnostic) => ({
+                    code: my_diagnostic.code,
+                    range: my_diagnostic.range,
+                }))
+            ).toEqual([
+                {
+                    code: StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE,
+                    range: {
+                        start: { line: 1, character: 14 },
+                        end: { line: 2, character: 1 },
+                    },
+                },
+            ]);
+        });
+
+        it('stops line-comment adjacency at a CR terminator', async () => {
+            const my_content = [
+                'display a & b |// comment',
+                '| c',
+            ].join('\n');
+            const my_uri = 'file:///test_line_comment_double_bar_cr.do';
+            await document_store.open(my_uri, my_content, 1);
+            const my_document = document_store.get(my_uri)!;
+
+            const the_diagnostics =
+                await diagnostics_provider.get_diagnostics(
+                    my_document,
+                    default_config
+                );
+
+            expect(
+                the_diagnostics.map((my_diagnostic) => ({
+                    code: my_diagnostic.code,
+                    range: my_diagnostic.range,
+                }))
+            ).toEqual([
+                {
+                    code: StataDiagnosticCode.MIXED_LOGICAL_OPERATORS,
+                    range: {
+                        start: { line: 0, character: 10 },
+                        end: { line: 0, character: 15 },
+                    },
+                },
+            ]);
+        });
+
         it('should emit spaced compound operator diagnostics alongside semantic diagnostics', async () => {
             // Code with both undefined macro and a spaced compound operator
             const my_content = `display \`undefined_macro'

--- a/tests/integration/send-to-stata-app-temp-file-lifecycle.test.ts
+++ b/tests/integration/send-to-stata-app-temp-file-lifecycle.test.ts
@@ -13,6 +13,8 @@ import * as crypto from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
+import * as real_applescript_module from
+    '../../client/src/send-to-stata/applescript';
 
 const SEND_TO_STATA_DIR = path.resolve(
     import.meta.dir,
@@ -28,6 +30,9 @@ const CD_CONTEXT_MODULE_URL = pathToFileURL(
 const APPLESCRIPT_MODULE_URL = pathToFileURL(
     path.join(SEND_TO_STATA_DIR, 'applescript.ts')
 ).href;
+// Bun updates cached module bindings when mock.module() runs. Snapshot the real
+// export shape first so unrelated tests keep the real helper implementations.
+const REAL_APPLESCRIPT_EXPORTS = { ...real_applescript_module };
 const STATA_DETECTOR_MODULE_URL = pathToFileURL(
     path.join(SEND_TO_STATA_DIR, 'stata-detector.ts')
 ).href;
@@ -406,11 +411,7 @@ describe.serial('Feature: send-to-stata app temp file lifecycle', () => {
         }));
 
         mock.module(APPLESCRIPT_MODULE_URL, () => ({
-            escape_for_applescript: (my_path: string) => {
-                return my_path
-                    .replace(/\\/g, '\\\\')
-                    .replace(/"/g, '\\"');
-            },
+            ...REAL_APPLESCRIPT_EXPORTS,
             send_to_stata_app: async (
                 _stata_app: string,
                 _command: string,

--- a/tests/property/no-duplicate-completions.prop.test.ts
+++ b/tests/property/no-duplicate-completions.prop.test.ts
@@ -12,7 +12,7 @@
 import * as fc from 'fast-check';
 import { CompletionProvider } from '../../src/providers/completion';
 import { DocumentState, SymbolTable } from '../../src/types';
-import { command_database } from '../../src/command-database';
+import { CommandDatabase } from '../../src/command-database';
 import { BUILTIN_COMMANDS } from '../../src/commands/builtin-commands';
 import { ContextTracker } from '../../src/context-tracker';
 import { Position } from 'vscode-languageserver/node';
@@ -29,8 +29,9 @@ describe('Property 1: No Duplicate Commands in Completions', () => {
     };
 
     beforeAll(() => {
-        command_database.register_all(BUILTIN_COMMANDS);
-        completion_provider = new CompletionProvider(command_database);
+        const command_db = new CommandDatabase();
+        command_db.register_all(BUILTIN_COMMANDS);
+        completion_provider = new CompletionProvider(command_db);
     });
 
     function create_document(content: string): DocumentState {

--- a/tests/property/operator-sequence-diagnostics.prop.test.ts
+++ b/tests/property/operator-sequence-diagnostics.prop.test.ts
@@ -1509,15 +1509,7 @@ describe('Mixed-effects separator properties (issue #320)', () => {
         arbitrary_numeric_macro_name_head
     );
     const my_analyzer = new OperatorSequenceAnalyzer();
-    const my_config: StataLSPConfig = {
-        ...DEFAULT_SETTINGS,
-        diagnostics: {
-            ...DEFAULT_SETTINGS.diagnostics,
-            severity: {
-                ...DEFAULT_SETTINGS.diagnostics.severity,
-            },
-        },
-    };
+    const my_config: StataLSPConfig = { ...DEFAULT_SETTINGS };
 
     const operator_sequence_diagnostics = (source: string) =>
         my_analyzer.analyze(

--- a/tests/property/operator-sequence-diagnostics.prop.test.ts
+++ b/tests/property/operator-sequence-diagnostics.prop.test.ts
@@ -3,7 +3,9 @@ import * as fc from 'fast-check';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { StataLexer } from '../../src/lexer';
 import { OperatorSequenceAnalyzer } from '../../src/providers/operator-sequence-diagnostics';
+import { DEFAULT_SETTINGS } from '../../src/server-handlers';
 import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
+import { arbitrary_non_reserved_identifier } from './generators';
 import { arbitrary_identifier } from './generators/primitives';
 import { create_document_state } from './helpers/document-utils';
 
@@ -1451,6 +1453,429 @@ describe('Operator Sequence Diagnostics Property Tests', () => {
     });
 });
 
+describe('Mixed-effects separator properties (issue #320)', () => {
+    const the_mixed_effects_commands = [
+        'mixed',
+        'mecloglog',
+        'meglm',
+        'meintreg',
+        'melogit',
+        'menbreg',
+        'meologit',
+        'meoprobit',
+        'mepoisson',
+        'meprobit',
+        'meqrlogit',
+        'meqrpoisson',
+        'mestreg',
+        'metobit',
+        'xtmixed',
+        'xtmelogit',
+        'xtmepoisson',
+    ];
+    const arbitrary_macro_name_head =
+        arbitrary_non_reserved_identifier().chain((my_name) =>
+            fc.constantFrom(`\`${my_name}'`, `$${my_name}`)
+        );
+    const arbitrary_name_head = fc.oneof(
+        arbitrary_non_reserved_identifier(),
+        arbitrary_macro_name_head
+    );
+    const arbitrary_concatenated_name_head = fc.tuple(
+        arbitrary_non_reserved_identifier(),
+        arbitrary_non_reserved_identifier()
+    ).chain(([my_first, my_second]) =>
+        fc.constantFrom(
+            `${my_first}\`${my_second}'`,
+            '${' + my_first + '}' + my_second,
+            `\`${my_first}'\`${my_second}'`,
+            '${' + my_first + '}${' + my_second + '}'
+        )
+    );
+    const arbitrary_numeric_macro_base =
+        arbitrary_non_reserved_identifier().chain((my_name) =>
+            fc.constantFrom(
+                `\`${my_name}'`,
+                '${' + my_name + '}'
+            )
+        );
+    const arbitrary_numeric_macro_name_head = fc.tuple(
+        arbitrary_numeric_macro_base,
+        fc.integer({ min: 0, max: 999 })
+    ).map(([my_macro, my_suffix]) => `${my_macro}${my_suffix}`);
+    const arbitrary_levelvar_head = fc.oneof(
+        arbitrary_name_head,
+        arbitrary_concatenated_name_head,
+        arbitrary_numeric_macro_name_head
+    );
+    const my_analyzer = new OperatorSequenceAnalyzer();
+    const my_config: StataLSPConfig = {
+        ...DEFAULT_SETTINGS,
+        diagnostics: {
+            ...DEFAULT_SETTINGS.diagnostics,
+            severity: {
+                ...DEFAULT_SETTINGS.diagnostics.severity,
+            },
+        },
+    };
+
+    const operator_sequence_diagnostics = (source: string) =>
+        my_analyzer.analyze(
+            create_document_state(source),
+            my_config
+        );
+
+    test('compact levelvar separators are accepted for the family', () => {
+        fc.assert(
+            fc.property(
+                fc.constantFrom(...the_mixed_effects_commands),
+                arbitrary_name_head,
+                arbitrary_non_reserved_identifier(),
+                arbitrary_levelvar_head,
+                (my_command, my_depvar, my_predictor, my_levelvar) => {
+                    const my_source =
+                        `${my_command} ${my_depvar} ${my_predictor} ` +
+                        `|| ${my_levelvar}:`;
+                    expect(
+                        operator_sequence_diagnostics(my_source)
+                    ).toHaveLength(0);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    test('numeric fragments only continue macro levelvar heads', () => {
+        fc.assert(
+            fc.property(
+                arbitrary_numeric_macro_base,
+                fc.integer({ min: 0, max: 999 }),
+                (my_macro, my_number) => {
+                    const my_valid =
+                        `mixed y x || ${my_macro}${my_number}:`;
+                    expect(
+                        operator_sequence_diagnostics(my_valid)
+                    ).toHaveLength(0);
+
+                    const my_invalid =
+                        `mixed y x || ${my_number}${my_macro}:`;
+                    expect(
+                        operator_sequence_diagnostics(my_invalid)
+                    ).toHaveLength(1);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    test('mestreg accepts an omitted fixed-effects varlist', () => {
+        fc.assert(
+            fc.property(
+                fc.constantFrom('none', 'if', 'in', 'weight'),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_levelvar_head,
+                (my_form, my_sample, my_levelvar) => {
+                    let my_qualifier = '';
+                    if (my_form === 'if') {
+                        my_qualifier = ` if ${my_sample}`;
+                    } else if (my_form === 'in') {
+                        my_qualifier = ' in 1/10';
+                    } else if (my_form === 'weight') {
+                        my_qualifier = ' [pw=weight]';
+                    }
+                    const my_source =
+                        `mestreg${my_qualifier} || ${my_levelvar}:, ` +
+                        'distribution(weibull)';
+                    expect(
+                        operator_sequence_diagnostics(my_source)
+                    ).toHaveLength(0);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    test('noncompact bars remain diagnostics', () => {
+        fc.assert(
+            fc.property(
+                fc.constantFrom(' | | ', ' |/* comment */| ', ' | ///\n| '),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                (my_bars, my_depvar, my_predictor, my_levelvar) => {
+                    const my_source =
+                        `mixed ${my_depvar} ${my_predictor}` +
+                        `${my_bars}${my_levelvar}:`;
+                    expect(
+                        operator_sequence_diagnostics(my_source)
+                    ).toHaveLength(1);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    test('levelvar fragments must be source-adjacent', () => {
+        fc.assert(
+            fc.property(
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                (my_first, my_second) => {
+                    const my_source =
+                        `mixed y x || ${my_first} ${my_second}:`;
+                    const the_diagnostics =
+                        operator_sequence_diagnostics(my_source);
+                    expect(the_diagnostics).toHaveLength(1);
+                    expect(the_diagnostics[0].range.start.character).toBe(
+                        my_source.indexOf('||')
+                    );
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    test('logical pairs stay diagnostic before a valid separator', () => {
+        fc.assert(
+            fc.property(
+                fc.boolean(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                (
+                    use_parentheses,
+                    my_depvar,
+                    my_predictor,
+                    my_lhs,
+                    my_rhs,
+                    my_levelvar
+                ) => {
+                    const my_condition = use_parentheses
+                        ? `(${my_lhs} || ${my_rhs})`
+                        : `${my_lhs} || ${my_rhs}`;
+                    const my_source =
+                        `mixed ${my_depvar} ${my_predictor} if ` +
+                        `${my_condition} || ${my_levelvar}:`;
+                    const the_diagnostics =
+                        operator_sequence_diagnostics(my_source);
+                    const my_invalid_start = my_source.indexOf('||');
+                    const my_valid_start = my_source.lastIndexOf('||');
+                    expect(the_diagnostics).toHaveLength(1);
+                    expect(the_diagnostics[0].code).toBe(
+                        StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+                    );
+                    expect(the_diagnostics[0].range).toEqual({
+                        start: {
+                            line: 0,
+                            character: my_invalid_start,
+                        },
+                        end: {
+                            line: 0,
+                            character: my_invalid_start + 2,
+                        },
+                    });
+                    expect(my_invalid_start).not.toBe(my_valid_start);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    test('leading mixed wildcard patterns stay valid', () => {
+        fc.assert(
+            fc.property(
+                fc.constantFrom('*', '?'),
+                fc.boolean(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                (my_wildcard, is_bare, my_suffix, my_levelvar) => {
+                    const my_model_head = is_bare
+                        ? my_wildcard
+                        : `${my_wildcard}${my_suffix}`;
+                    const my_source =
+                        `mixed ${my_model_head} || ${my_levelvar}:`;
+                    expect(
+                        operator_sequence_diagnostics(my_source)
+                    ).toHaveLength(0);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    test('mixed varlist wildcard tails stay valid before separators', () => {
+        fc.assert(
+            fc.property(
+                fc.constantFrom('*', '?'),
+                fc.boolean(),
+                fc.boolean(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                (
+                    my_wildcard,
+                    is_attached,
+                    use_later_equation,
+                    my_depvar,
+                    my_predictor,
+                    my_levelvar,
+                    my_random_predictor,
+                    my_school_levelvar
+                ) => {
+                    const my_fixed_tail = is_attached
+                        ? `${my_predictor}${my_wildcard}`
+                        : my_wildcard;
+                    const my_random_tail = is_attached
+                        ? `${my_random_predictor}${my_wildcard}`
+                        : my_wildcard;
+                    const my_source = use_later_equation
+                        ? `mixed ${my_depvar} if sample || ` +
+                            `${my_levelvar}: ${my_random_tail} || ` +
+                            `${my_school_levelvar}:`
+                        : `mixed ${my_depvar} ${my_fixed_tail} || ` +
+                            `${my_levelvar}:`;
+                    expect(
+                        operator_sequence_diagnostics(my_source)
+                    ).toHaveLength(0);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    test('source-adjacent ranges preserve mixed wildcard tails', () => {
+        fc.assert(
+            fc.property(
+                fc.constantFrom('*', '?'),
+                fc.boolean(),
+                fc.boolean(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                (
+                    my_wildcard,
+                    is_attached,
+                    use_later_equation,
+                    my_depvar,
+                    my_range_start,
+                    my_range_end,
+                    my_predictor,
+                    my_levelvar,
+                    my_school_levelvar
+                ) => {
+                    const my_wildcard_tail = is_attached
+                        ? `${my_predictor}${my_wildcard}`
+                        : my_wildcard;
+                    const my_equation =
+                        `${my_range_start}-${my_range_end} ` +
+                        my_wildcard_tail;
+                    const my_source = use_later_equation
+                        ? `mixed ${my_depvar} if sample || ` +
+                            `${my_levelvar}: ${my_equation} || ` +
+                            `${my_school_levelvar}:`
+                        : `mixed ${my_depvar} ${my_equation} || ` +
+                            `${my_levelvar}:`;
+                    expect(
+                        operator_sequence_diagnostics(my_source)
+                    ).toHaveLength(0);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    test('dangling operators keep compact bars diagnostic', () => {
+        fc.assert(
+            fc.property(
+                fc.constantFrom('=', '+', '-', '^', '!', '~'),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                (my_operator, my_depvar, my_predictor, my_levelvar) => {
+                    const my_source =
+                        `mixed ${my_depvar} ${my_predictor} ` +
+                        `${my_operator}|| ${my_levelvar}:`;
+                    const my_bar_start = my_source.indexOf('||');
+                    const the_diagnostics =
+                        operator_sequence_diagnostics(my_source);
+                    expect(the_diagnostics).toHaveLength(1);
+                    expect(the_diagnostics[0].code).toBe(
+                        StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+                    );
+                    expect(the_diagnostics[0].range).toEqual({
+                        start: { line: 0, character: my_bar_start },
+                        end: { line: 0, character: my_bar_start + 2 },
+                    });
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+
+    test('constructed supported command heads fail closed', () => {
+        const arbitrary_command_suffix = fc.oneof(
+            arbitrary_non_reserved_identifier().chain((my_name) =>
+                fc.constantFrom(
+                    `\`${my_name}'`,
+                    '${' + my_name + '}'
+                )
+            ),
+            arbitrary_non_reserved_identifier(),
+            fc.integer({ min: 0, max: 999 }).map(String)
+        );
+        fc.assert(
+            fc.property(arbitrary_command_suffix, (my_suffix) => {
+                const my_source =
+                    `mixed${my_suffix} y x || id:`;
+                const the_diagnostics =
+                    operator_sequence_diagnostics(my_source);
+                expect(the_diagnostics).toHaveLength(1);
+                expect(the_diagnostics[0].range.start.character).toBe(
+                    my_source.indexOf('||')
+                );
+            }),
+            { numRuns: 100 }
+        );
+    });
+
+    test('excluded and user commands remain diagnostics', () => {
+        const the_family = new Set(the_mixed_effects_commands);
+        const arbitrary_user_command =
+            arbitrary_non_reserved_identifier().filter(
+                (my_command) => !the_family.has(my_command)
+            );
+        fc.assert(
+            fc.property(
+                fc.oneof(
+                    fc.constantFrom(
+                        'menl',
+                        'gsem',
+                        'twoway',
+                        'svyset'
+                    ),
+                    arbitrary_user_command
+                ),
+                arbitrary_non_reserved_identifier(),
+                arbitrary_non_reserved_identifier(),
+                (my_command, my_depvar, my_levelvar) => {
+                    const my_source =
+                        `${my_command} ${my_depvar} || ${my_levelvar}:`;
+                    expect(
+                        operator_sequence_diagnostics(my_source)
+                    ).toHaveLength(1);
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+});
 
 /**
  * Feature: malformed-operator-diagnostics, Property 3: Embedded context suppression

--- a/tests/property/wrapped-option-context.prop.test.ts
+++ b/tests/property/wrapped-option-context.prop.test.ts
@@ -22,7 +22,56 @@ function option_context(source: string, position: Position) {
     return detect_completion_context(doc, position, doc.tokens);
 }
 
+function expect_command_in_all_wrappings(
+    statement_before_comma: string,
+    expected_command: string
+): void {
+    const single = `${statement_before_comma}, `;
+    const semi =
+        `#delimit ;\n${statement_before_comma},\n` +
+        '    ;\ndisplay 1 ;';
+    const cr = `${statement_before_comma}, ///\n    \ndisplay 1`;
+    const the_contexts = [
+        option_context(single, { line: 0, character: single.length }),
+        option_context(semi, { line: 2, character: 4 }),
+        option_context(cr, { line: 1, character: 4 }),
+    ];
+
+    for (const my_context of the_contexts) {
+        expect(my_context.type).toBe('option');
+        if (my_context.type === 'option') {
+            expect(my_context.command).toBe(expected_command);
+        }
+    }
+}
+
 describe('wrapped option context is stable (property, #310)', () => {
+    it('keeps wrong-case prefix spellings as command names in every rendering', () => {
+        const the_wrong_case_prefixes = [
+            'bY',
+            'By',
+            'BY',
+            'bySort',
+            'Quietly',
+            'qUi',
+            'Capture',
+            'cAp',
+            'Noisily',
+            'nOi',
+        ];
+
+        for (const my_prefix of the_wrong_case_prefixes) {
+            expect_command_in_all_wrappings(`${my_prefix} _`, my_prefix);
+        }
+    });
+
+    it('still unwraps an exact lowercase by prefix in every rendering', () => {
+        expect_command_in_all_wrappings(
+            'by group: regress y',
+            'regress'
+        );
+    });
+
     it('detects option context for the same command in single-line, ;-wrap, and ///-wrap renderings', () => {
         fc.assert(
             fc.property(

--- a/tests/unit/completion-wrapped-context.test.ts
+++ b/tests/unit/completion-wrapped-context.test.ts
@@ -343,6 +343,52 @@ describe('detect_completion_context — statement-scoped detectors over logical 
         }
     });
 
+    it('validates a lowercase prefix chain wrapped under #delimit ;', () => {
+        const source = '#delimit ;\nby group:\nquietly:\nframe ';
+        const context = context_of(
+            source,
+            { line: 3, character: 6 },
+            frame_command_db()
+        );
+        expect(context).toEqual({
+            type: 'subcommand',
+            prefix_command: 'frame',
+        });
+    });
+
+    it('validates a lowercase colon prefix across a true /// wrap', () => {
+        const source = 'capture: ///\n    frame ';
+        const context = context_of(
+            source,
+            { line: 1, character: 10 },
+            frame_command_db()
+        );
+        expect(context).toEqual({
+            type: 'subcommand',
+            prefix_command: 'frame',
+        });
+    });
+
+    it('rejects a wrong-case by prefix wrapped under #delimit ;', () => {
+        const source = '#delimit ;\nBY group:\nframe ';
+        const context = context_of(
+            source,
+            { line: 2, character: 6 },
+            frame_command_db()
+        );
+        expect(context.type).not.toBe('subcommand');
+    });
+
+    it('rejects a wrong-case colon prefix across a true /// wrap', () => {
+        const source = 'CAPTURE: ///\n    frame ';
+        const context = context_of(
+            source,
+            { line: 1, character: 10 },
+            frame_command_db()
+        );
+        expect(context.type).not.toBe('subcommand');
+    });
+
     it('still returns command_path for a genuine single-line file command', () => {
         const context = context_of('do myfile.do', { line: 0, character: 4 });
         expect(context.type).toBe('command_path');

--- a/tests/unit/frame-subcommand.test.ts
+++ b/tests/unit/frame-subcommand.test.ts
@@ -88,6 +88,19 @@ function create_test_command_db(): CommandDatabase {
     return db;
 }
 
+function detect_test_context(
+    source: string,
+    command_db: CommandDatabase
+) {
+    const doc = create_test_document(source);
+    return detect_completion_context(
+        doc,
+        { line: 0, character: source.length },
+        undefined,
+        command_db
+    );
+}
+
 describe('Frame Subcommand Completion', () => {
     let completion_provider: CompletionProvider;
     let command_db: CommandDatabase;
@@ -123,6 +136,101 @@ describe('Frame Subcommand Completion', () => {
             if (context.type === 'subcommand') {
                 expect(context.prefix_command).toBe('frame');
             }
+        });
+
+        it('accepts exact-case by and colon-suffixed execution prefixes', () => {
+            const the_sources = [
+                'by group: frame ',
+                'bysort group: frame ',
+                'capture: frame ',
+                'cap: frame ',
+                'quietly: frame ',
+                'qui: frame ',
+                'noisily: frame ',
+                'noi: frame ',
+            ];
+
+            for (const my_source of the_sources) {
+                const context = detect_test_context(my_source, command_db);
+                expect(context).toEqual({
+                    type: 'subcommand',
+                    prefix_command: 'frame',
+                });
+            }
+        });
+
+        it('accepts supported lowercase prefix chains', () => {
+            const the_sources = [
+                'quietly capture frame ',
+                'capture quietly: frame ',
+                'quietly: capture: frame ',
+                'by group: quietly frame ',
+                'quietly: by group: capture: frame ',
+            ];
+
+            for (const my_source of the_sources) {
+                const context = detect_test_context(my_source, command_db);
+                expect(context).toEqual({
+                    type: 'subcommand',
+                    prefix_command: 'frame',
+                });
+            }
+        });
+
+        it('requires a by varlist and colon before the command', () => {
+            const the_sources = [
+                'by frame ',
+                'bysort frame ',
+                'by: frame ',
+                'by group frame ',
+                'quietly by frame ',
+            ];
+
+            for (const my_source of the_sources) {
+                const context = detect_test_context(my_source, command_db);
+                expect(context.type).not.toBe('subcommand');
+            }
+        });
+
+        it('rejects wrong-case spellings in every hardcoded prefix branch', () => {
+            const the_sources = [
+                'BY group: frame ',
+                'BYSORT group: frame ',
+                'Quietly: frame ',
+                'QUI: frame ',
+                'Capture: frame ',
+                'CAP: frame ',
+                'Noisily: frame ',
+                'NOI: frame ',
+                'quietly: CAPTURE: frame ',
+            ];
+
+            for (const my_source of the_sources) {
+                const context = detect_test_context(my_source, command_db);
+                expect(context.type).not.toBe('subcommand');
+            }
+        });
+
+        it('rejects arbitrary and malformed colon syntax', () => {
+            const the_sources = [
+                'merge 1:m frame ',
+                'not_a_prefix: frame ',
+                'mi: frame ',
+                'quietly:: frame ',
+            ];
+
+            for (const my_source of the_sources) {
+                const context = detect_test_context(my_source, command_db);
+                expect(context.type).not.toBe('subcommand');
+            }
+        });
+
+        it('keeps the database candidate lookup case-insensitive', () => {
+            const context = detect_test_context('FRAME ', command_db);
+            expect(context).toEqual({
+                type: 'subcommand',
+                prefix_command: 'frame',
+            });
         });
 
         it('should NOT detect subcommand context after "frame create " (past subcommand)', () => {
@@ -171,6 +279,39 @@ describe('Frame Subcommand Completion', () => {
             const labels = completions.map(c => c.label);
             expect(labels).toContain('create');
             expect(labels).toContain('change');
+        });
+
+        it('suggests subcommands for an uppercase database candidate', async () => {
+            const source = 'FRAME ';
+            const doc = create_test_document(source);
+            const completions = await completion_provider.get_completions(
+                doc,
+                { line: 0, character: source.length }
+            );
+
+            const labels = completions.map(c => c.label);
+            expect(labels).toContain('create');
+            expect(labels).toContain('change');
+        });
+
+        it('does not leak subcommands past invalid source prefixes', async () => {
+            const the_sources = [
+                'BY group: frame ',
+                'CAPTURE: frame ',
+                'by frame ',
+                'quietly by frame ',
+            ];
+            for (const my_source of the_sources) {
+                const doc = create_test_document(my_source);
+                const completions = await completion_provider.get_completions(
+                    doc,
+                    { line: 0, character: my_source.length }
+                );
+
+                const labels = completions.map(c => c.label);
+                expect(labels).not.toContain('create');
+                expect(labels).not.toContain('change');
+            }
         });
     });
 });

--- a/tests/unit/mixed-logical-diagnostics.test.ts
+++ b/tests/unit/mixed-logical-diagnostics.test.ts
@@ -544,6 +544,39 @@ describe('MixedLogicalOperatorAnalyzer Unit Tests', () => {
             );
             expect(mixed).toHaveLength(1);
         });
+
+        it('detects mixed operators across a line comment in ; mode', () => {
+            const doc = create_document_state(
+                '#delimit ;\nkeep if x & y // explanation\n    | z ;'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const mixed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+            expect(mixed).toHaveLength(1);
+        });
+
+        it('detects mixed operators across a full-line * comment in ; mode', () => {
+            const doc = create_document_state(
+                '#delimit ;\nkeep if x & y\n* explanation\n    | z ;'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const mixed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+            expect(mixed).toHaveLength(1);
+        });
+
+        it('does not mix operators across a line-comment CR terminator', () => {
+            const doc = create_document_state(
+                'display x & y // explanation\ndisplay z | q'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const mixed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+            expect(mixed).toHaveLength(0);
+        });
     });
 
     describe('Multiple Logical Operators', () => {

--- a/tests/unit/mixed-logical-diagnostics.test.ts
+++ b/tests/unit/mixed-logical-diagnostics.test.ts
@@ -179,6 +179,22 @@ describe('MixedLogicalOperatorAnalyzer Unit Tests', () => {
             );
             expect(mixed).toHaveLength(0);
         });
+
+        it('flushes and resets at a mixed-effects separator', () => {
+            const doc = create_document_state(
+                'mixed y x if a & b | c || id: z & q'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const mixed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+
+            expect(mixed).toHaveLength(1);
+            expect(mixed[0].range).toEqual({
+                start: { line: 0, character: 15 },
+                end: { line: 0, character: 20 },
+            });
+        });
     });
 
     describe('Explicit Grouping Suppresses Warning', () => {

--- a/tests/unit/mixed-logical-diagnostics.test.ts
+++ b/tests/unit/mixed-logical-diagnostics.test.ts
@@ -171,6 +171,17 @@ describe('MixedLogicalOperatorAnalyzer Unit Tests', () => {
             expect(mixed).toHaveLength(0);
         });
 
+        it('does not add a mixed warning for comment-separated || sequences', () => {
+            const doc = create_document_state(
+                'display a & b |/* comment */| c'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const mixed = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.MIXED_LOGICAL_OPERATORS
+            );
+            expect(mixed).toHaveLength(0);
+        });
+
         it('does not add a mixed warning for invalid && sequences', () => {
             const doc = create_document_state('keep if x && y | z');
             const diagnostics = analyzer.analyze(doc, default_config);

--- a/tests/unit/operator-sequence-diagnostics.test.ts
+++ b/tests/unit/operator-sequence-diagnostics.test.ts
@@ -505,6 +505,636 @@ describe('OperatorSequenceAnalyzer Unit Tests', () => {
         });
     });
 
+    describe('Mixed-effects random-equation separators (issue #320)', () => {
+        const operator_sequence_diagnostics = (source: string) =>
+            analyzer.analyze(
+                create_document_state(source),
+                default_config
+            );
+
+        const expect_only_operator_diagnostic_at = (
+            source: string,
+            pair_start_line: number,
+            pair_start_character: number,
+            pair_length: number
+        ) => {
+            const the_diagnostics = operator_sequence_diagnostics(source);
+            expect(the_diagnostics).toHaveLength(1);
+            expect(the_diagnostics[0].range).toEqual({
+                start: {
+                    line: pair_start_line,
+                    character: pair_start_character,
+                },
+                end: {
+                    line: pair_start_line,
+                    character: pair_start_character + pair_length,
+                },
+            });
+            return the_diagnostics[0];
+        };
+
+        it('accepts the exact issue reproduction', () => {
+            const source =
+                "mixed log_supply `rhs' if esample || state_num:";
+            expect(operator_sequence_diagnostics(source)).toHaveLength(0);
+        });
+
+        it('allows mestreg to omit the fixed-effects varlist', () => {
+            expect(
+                operator_sequence_diagnostics(
+                    'mestreg || id:, distribution(weibull)'
+                )
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics(
+                    'mestreg if sample || id:, distribution(weibull)'
+                )
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics(
+                    'mestreg in 1/10 || id:, distribution(weibull)'
+                )
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics(
+                    'mestreg [pw=weight] || id:, distribution(weibull)'
+                )
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics('mixed || id:')
+            ).toHaveLength(1);
+            expect(
+                operator_sequence_diagnostics('mixed in 1/10 || id:')
+            ).toHaveLength(1);
+            expect(
+                operator_sequence_diagnostics(
+                    'mixed [pw=weight] || id:'
+                )
+            ).toHaveLength(1);
+        });
+
+        it('accepts macro-expanded model and level-variable heads', () => {
+            expect(
+                operator_sequence_diagnostics("mixed `outcome' x || id:")
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics('mixed $outcome x || id:')
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics("mixed y x || `panel':")
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics('mixed y x || $panel:')
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics(
+                    "mixed y x || state_`suffix':"
+                )
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics(
+                    'mixed y x || ${prefix}id:'
+                )
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics(
+                    "mixed y x || `prefix'`suffix':"
+                )
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics(
+                    "mixed y x || `panel'1:"
+                )
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics(
+                    'mixed y x || ${panel}2:'
+                )
+            ).toHaveLength(0);
+        });
+
+        it('accepts constructed model heads beginning with if or in', () => {
+            const the_valid_sources = [
+                "mixed if`suffix' x || id:",
+                'mixed in${suffix} x || id:',
+            ];
+            for (const my_source of the_valid_sources) {
+                expect(
+                    operator_sequence_diagnostics(my_source)
+                ).toHaveLength(0);
+            }
+
+            const the_invalid_sources = [
+                "mixed if `suffix' x || id:",
+                'mixed in ${suffix} x || id:',
+            ];
+            for (const my_source of the_invalid_sources) {
+                const my_bar_start = my_source.indexOf('||');
+                const my_diagnostic = expect_only_operator_diagnostic_at(
+                    my_source,
+                    0,
+                    my_bar_start,
+                    2
+                );
+                expect(my_diagnostic.code).toBe(
+                    StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+                );
+            }
+        });
+
+        it('accepts the explicit mixed-effects command family', () => {
+            const the_commands = [
+                'mixed',
+                'mecloglog',
+                'meglm',
+                'meintreg',
+                'melogit',
+                'menbreg',
+                'meologit',
+                'meoprobit',
+                'mepoisson',
+                'meprobit',
+                'meqrlogit',
+                'meqrpoisson',
+                'mestreg',
+                'metobit',
+                'xtmixed',
+                'xtmelogit',
+                'xtmepoisson',
+            ];
+            for (const my_command of the_commands) {
+                expect(
+                    operator_sequence_diagnostics(`${my_command} y x || id:`)
+                ).toHaveLength(0);
+            }
+        });
+
+        it('accepts exact-case simple prefixes and their colons', () => {
+            const the_prefixes = [
+                'cap', 'capt:', 'captu', 'captur:', 'capture',
+                'qui', 'quie:', 'quiet', 'quietl:', 'quietly',
+                'noi', 'nois:', 'noisi', 'noisil:', 'noisily',
+                'capt nois:',
+                'capture: quietly: noisily:',
+            ];
+            for (const my_prefix of the_prefixes) {
+                expect(
+                    operator_sequence_diagnostics(
+                        `${my_prefix} mixed y x || id:`
+                    )
+                ).toHaveLength(0);
+            }
+        });
+
+        it('accepts exact-case colon-required xi prefixes', () => {
+            const the_valid_sources = [
+                'xi: mixed y i.group || id:',
+                'xi: xtmixed y i.group || id:',
+                'capture xi: xtmixed y i.group || id:',
+            ];
+            for (const my_source of the_valid_sources) {
+                expect(
+                    operator_sequence_diagnostics(my_source)
+                ).toHaveLength(0);
+            }
+
+            const the_invalid_sources = [
+                'Xi: mixed y i.group || id:',
+                'xi mixed y i.group || id:',
+            ];
+            for (const my_source of the_invalid_sources) {
+                const my_bar_start = my_source.indexOf('||');
+                const my_diagnostic = expect_only_operator_diagnostic_at(
+                    my_source,
+                    0,
+                    my_bar_start,
+                    2
+                );
+                expect(my_diagnostic.code).toBe(
+                    StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+                );
+            }
+        });
+
+        it('rejects wrong case and unverified command abbreviations', () => {
+            const the_sources = [
+                'Mixed y x || id:',
+                'capture Mixed y x || id:',
+                'Capture mixed y x || id:',
+                'mix y x || id:',
+                'xtmix y x || id:',
+            ];
+            for (const my_source of the_sources) {
+                expect(
+                    operator_sequence_diagnostics(my_source)
+                ).toHaveLength(1);
+            }
+        });
+
+        it('keeps constructed command-head separators diagnostic', () => {
+            const the_sources = [
+                "mixed`suffix' y x || id:",
+                'mixed${suffix} y x || id:',
+                'mixedmore y x || id:',
+                'mixed1 y x || id:',
+            ];
+            for (const my_source of the_sources) {
+                const my_bar_start = my_source.indexOf('||');
+                const my_diagnostic = expect_only_operator_diagnostic_at(
+                    my_source,
+                    0,
+                    my_bar_start,
+                    2
+                );
+                expect(my_diagnostic.code).toBe(
+                    StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+                );
+            }
+        });
+
+        it('fails closed for argument-bearing prefixes and exclusions', () => {
+            const the_commands = [
+                'menl',
+                'gsem',
+                'twoway',
+                'svyset',
+                'my_mixed_program',
+            ];
+            for (const my_command of the_commands) {
+                expect(
+                    operator_sequence_diagnostics(`${my_command} y x || id:`)
+                ).toHaveLength(1);
+            }
+            expect(
+                operator_sequence_diagnostics('by group: mixed y x || id:')
+            ).toHaveLength(1);
+        });
+
+        it('accepts leading model wildcard patterns', () => {
+            const the_sources = [
+                'mixed * || id:',
+                'mixed *outcome || id:',
+                'mixed ?outcome || id:',
+                'quietly: mixed *outcome || id:',
+            ];
+            for (const my_source of the_sources) {
+                expect(
+                    operator_sequence_diagnostics(my_source)
+                ).toHaveLength(0);
+            }
+        });
+
+        it('accepts varlist wildcard tails before separators', () => {
+            const the_sources = [
+                'mixed y x* || id:',
+                'mixed y x? || id:',
+                'mixed y * || id:',
+                'mixed y ? || id:',
+                'mixed y || id: z* || school:',
+                'mixed y || id: z? || school:',
+                'mixed y if sample || id: z* || school:',
+            ];
+            for (const my_source of the_sources) {
+                expect(
+                    operator_sequence_diagnostics(my_source)
+                ).toHaveLength(0);
+            }
+        });
+
+        it('accepts wildcard tails after source-adjacent ranges', () => {
+            const the_sources = [
+                'mixed y x1-x5 z* || id:',
+                'mixed y x1-x5 * || id:',
+                'mixed y || id: x1-x5 z? || school:',
+                'mixed y || id: x1-x5 ? || school:',
+                'mixed y if sample || id: x1-x5 z* || school:',
+                "mixed y `lo'1-`hi'5 z* || id:",
+                'mixed y || id: ${lo}1-${hi}5 ? || school:',
+            ];
+            for (const my_source of the_sources) {
+                expect(
+                    operator_sequence_diagnostics(my_source)
+                ).toHaveLength(0);
+            }
+        });
+
+        it('accepts constructed if and in wildcard names', () => {
+            const the_sources = [
+                'mixed y x1if* || id:',
+                "mixed y `p'1if* || id:",
+                'mixed y in? || id:',
+                'mixed y ${prefix}1in? || id:',
+                "mixed y || id: `p'1if* || school:",
+            ];
+            for (const my_source of the_sources) {
+                expect(
+                    operator_sequence_diagnostics(my_source)
+                ).toHaveLength(0);
+            }
+        });
+
+        it('supports multiple equations and random-equation options', () => {
+            const source =
+                'mixed y x || id: z, covariance(unstructured) ' +
+                '|| school: age || classroom:';
+            expect(operator_sequence_diagnostics(source)).toHaveLength(0);
+        });
+
+        it('distinguishes grouped commas from command options', () => {
+            expect(
+                operator_sequence_diagnostics(
+                    'mixed y x if inlist(group, 1, 2) || id:'
+                )
+            ).toHaveLength(0);
+
+            const my_top_level = 'mixed y x, mle || id:';
+            const my_bar_start = my_top_level.indexOf('||');
+            const my_diagnostic = expect_only_operator_diagnostic_at(
+                my_top_level,
+                0,
+                my_bar_start,
+                2
+            );
+            expect(my_diagnostic.code).toBe(
+                StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+            );
+        });
+
+        it('requires model content and a plausible levelvar colon', () => {
+            const the_sources = [
+                'mixed || id:',
+                'mixed if esample || id:',
+                'mixed in 1/10 || id:',
+                'mixed 1 || id:',
+                'mixed "outcome" || id:',
+                'mixed [pw=weight] || id:',
+                'mixed y x || id',
+                'mixed y x || :',
+                'mixed y x || if:',
+                'mixed y x || in:',
+                'mixed y x || 1:',
+                "mixed y x || 1`suffix':",
+                'mixed y x || first second:',
+                "mixed y x || state_ `suffix':",
+                'mixed y x || ${prefix} id:',
+            ];
+            for (const my_source of the_sources) {
+                expect(
+                    operator_sequence_diagnostics(my_source)
+                ).toHaveLength(1);
+            }
+        });
+
+        it('keeps every noncompact double bar diagnostic', () => {
+            const the_sources = [
+                'mixed y x | | id:',
+                'mixed y x |/* comment */| id:',
+                'mixed y x | ///\n| id:',
+                '#delimit ;\nmixed y x | // comment\n| id: ;',
+            ];
+            for (const my_source of the_sources) {
+                expect(
+                    operator_sequence_diagnostics(my_source)
+                ).toHaveLength(1);
+            }
+        });
+
+        it('allows a valid separator after a logical double bar', () => {
+            const the_sources = [
+                'mixed y x if (a || b) || id:',
+                'mixed y x if a[1 || 2] || id:',
+                'mixed y x if a || b || id:',
+            ];
+            for (const my_source of the_sources) {
+                const my_invalid_start = my_source.indexOf('||');
+                const my_valid_start = my_source.lastIndexOf('||');
+                expect(my_invalid_start).not.toBe(my_valid_start);
+                const my_diagnostic = expect_only_operator_diagnostic_at(
+                    my_source,
+                    0,
+                    my_invalid_start,
+                    2
+                );
+                expect(my_diagnostic.code).toBe(
+                    StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+                );
+                expect(my_diagnostic.range.start.character).not.toBe(
+                    my_valid_start
+                );
+            }
+        });
+
+        it('preserves each operator diagnostic beside a separator', () => {
+            const the_cases = [
+                {
+                    source: 'mixed y x if a && b || id:',
+                    pair: '&&',
+                    code: StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE,
+                },
+                {
+                    source: 'mixed y x if a < | b || id:',
+                    pair: '< |',
+                    code: StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE,
+                },
+                {
+                    source: 'mixed y x if a = = b || id:',
+                    pair: '= =',
+                    code: StataDiagnosticCode.MALFORMED_OPERATOR,
+                },
+                {
+                    source: 'mixed y x if a < = b || id:',
+                    pair: '< =',
+                    code: StataDiagnosticCode.SPACED_COMPOUND_OPERATOR,
+                },
+            ];
+            for (const my_case of the_cases) {
+                const my_invalid_start = my_case.source.indexOf(
+                    my_case.pair
+                );
+                const my_valid_start = my_case.source.lastIndexOf('||');
+                const my_diagnostic = expect_only_operator_diagnostic_at(
+                    my_case.source,
+                    0,
+                    my_invalid_start,
+                    my_case.pair.length
+                );
+                expect(my_diagnostic.code).toBe(my_case.code);
+                expect(my_diagnostic.range.start.character).not.toBe(
+                    my_valid_start
+                );
+            }
+        });
+
+        it('keeps dangling = before bars diagnostic at the bars', () => {
+            const my_source = 'mixed y x =|| id:';
+            const my_bar_start = my_source.indexOf('||');
+            const my_diagnostic = expect_only_operator_diagnostic_at(
+                my_source,
+                0,
+                my_bar_start,
+                2
+            );
+            expect(my_diagnostic.code).toBe(
+                StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+            );
+        });
+
+        it('rejects wildcard-like tails outside mixed varlists', () => {
+            const the_sources = [
+                'mixed y +* || id:',
+                'mixed y =? || id:',
+                'mixed y x if a* || id:',
+                'mixed y if * || id:',
+                'mixed y in ? || id:',
+                'mixed y x1 - x5 z* || id:',
+                'mixed y x1- z* || id:',
+                'mixed y +x1-x5 z* || id:',
+                'mixed y if sample x1-x5 z* || id:',
+            ];
+            for (const my_source of the_sources) {
+                const my_bar_start = my_source.indexOf('||');
+                const my_diagnostic = expect_only_operator_diagnostic_at(
+                    my_source,
+                    0,
+                    my_bar_start,
+                    2
+                );
+                expect(my_diagnostic.code).toBe(
+                    StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+                );
+            }
+        });
+
+        it('preserves an outer control-flow style diagnostic', () => {
+            const source = [
+                'if a || b {',
+                '    mixed y x || id:',
+                '}',
+            ].join('\n');
+            const my_diagnostic = expect_only_operator_diagnostic_at(
+                source,
+                0,
+                source.split('\n')[0].indexOf('||'),
+                2
+            );
+            expect(my_diagnostic.code).toBe(
+                StataDiagnosticCode.CSTYLE_LOGICAL_IN_CONTROL_FLOW
+            );
+            expect(my_diagnostic.range.start.line).not.toBe(1);
+        });
+
+        it('fails closed after malformed grouping', () => {
+            const my_unclosed = 'mixed y x if (a || b || id:';
+            const the_unclosed_diagnostics =
+                operator_sequence_diagnostics(my_unclosed);
+            const my_first_bar = my_unclosed.indexOf('||');
+            const my_second_bar = my_unclosed.lastIndexOf('||');
+            expect(the_unclosed_diagnostics).toHaveLength(2);
+            expect(
+                the_unclosed_diagnostics.map((my_diagnostic) => ({
+                    code: my_diagnostic.code,
+                    range: my_diagnostic.range,
+                }))
+            ).toEqual([
+                {
+                    code: StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE,
+                    range: {
+                        start: { line: 0, character: my_first_bar },
+                        end: { line: 0, character: my_first_bar + 2 },
+                    },
+                },
+                {
+                    code: StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE,
+                    range: {
+                        start: { line: 0, character: my_second_bar },
+                        end: { line: 0, character: my_second_bar + 2 },
+                    },
+                },
+            ]);
+
+            const my_mismatched =
+                'mixed y x || id: (z] || school:';
+            const my_valid_start = my_mismatched.indexOf('||');
+            const my_invalid_start = my_mismatched.lastIndexOf('||');
+            const my_diagnostic = expect_only_operator_diagnostic_at(
+                my_mismatched,
+                0,
+                my_invalid_start,
+                2
+            );
+            expect(my_diagnostic.code).toBe(
+                StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+            );
+            expect(my_diagnostic.range.start.character).not.toBe(
+                my_valid_start
+            );
+        });
+
+        it('supports #delimit ; and /// statement wrapping', () => {
+            expect(
+                operator_sequence_diagnostics('mixed y x ///\n    || id:')
+            ).toHaveLength(0);
+            expect(
+                operator_sequence_diagnostics(
+                    '#delimit ;\nmixed y x\n|| id:\n' +
+                    '|| school:\n;'
+                )
+            ).toHaveLength(0);
+        });
+
+        it('does not leak separator state across statements', () => {
+            const the_lines = [
+                'mixed y x || id:',
+                'display a || b',
+                'mixed z, mle || school:',
+                'mixed q || firm:',
+            ];
+            const the_diagnostics = operator_sequence_diagnostics(
+                the_lines.join('\n')
+            );
+            expect(
+                the_diagnostics.map((my_diagnostic) => ({
+                    code: my_diagnostic.code,
+                    range: my_diagnostic.range,
+                }))
+            ).toEqual([
+                {
+                    code: StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE,
+                    range: {
+                        start: {
+                            line: 1,
+                            character: the_lines[1].indexOf('||'),
+                        },
+                        end: {
+                            line: 1,
+                            character: the_lines[1].indexOf('||') + 2,
+                        },
+                    },
+                },
+                {
+                    code: StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE,
+                    range: {
+                        start: {
+                            line: 2,
+                            character: the_lines[2].indexOf('||'),
+                        },
+                        end: {
+                            line: 2,
+                            character: the_lines[2].indexOf('||') + 2,
+                        },
+                    },
+                },
+            ]);
+            expect(
+                the_diagnostics.some(
+                    (my_diagnostic) =>
+                        my_diagnostic.range.start.line === 0 ||
+                        my_diagnostic.range.start.line === 3
+                )
+            ).toBe(false);
+        });
+    });
+
     describe('Diagnostic Severity', () => {
         it('spaced compound pairs emit Information severity by default', () => {
             const doc = create_document_state('display x < = y');

--- a/tests/unit/operator-sequence-diagnostics.test.ts
+++ b/tests/unit/operator-sequence-diagnostics.test.ts
@@ -560,16 +560,14 @@ describe('OperatorSequenceAnalyzer Unit Tests', () => {
                     'mestreg [pw=weight] || id:, distribution(weibull)'
                 )
             ).toHaveLength(0);
+        });
+
+        it('requires fixed-effects model content for mixed', () => {
             expect(
                 operator_sequence_diagnostics('mixed || id:')
             ).toHaveLength(1);
             expect(
                 operator_sequence_diagnostics('mixed in 1/10 || id:')
-            ).toHaveLength(1);
-            expect(
-                operator_sequence_diagnostics(
-                    'mixed [pw=weight] || id:'
-                )
             ).toHaveLength(1);
         });
 


### PR DESCRIPTION
## Summary

- recognize compact `|| levelvar:` random-equation separators for the supported mixed-effects command family
- keep suppression pair-local, exact-case, and fail-closed for malformed syntax, unsupported prefixes, and command-wide option placement
- preserve sibling mixed-logical diagnostics across valid separators and align comment/statement-boundary behavior in both delimiter modes
- make hardcoded completion-prefix parsing exact-case and isolate order-sensitive completion and AppleScript tests uncovered by CI
- document the narrow mixed-effects diagnostic exception and its intentional limitations

## Testing

- `bun run typecheck`
- `bun test ./tests` — 7,647 passed, 5 skipped, 0 failed
- `bun run lint`
- `git diff --check`
- three final independent review passes returned clean on commit `6939fa26`

Closes #320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator-sequence diagnostics for mixed-effects model syntax using `|| levelvar:` separators.
  * Reduced false-positive warnings for valid command forms, prefixes, grouping, and wildcard patterns.
  * Preserved diagnostics for malformed, non-adjacent, unsupported, or otherwise invalid separator expressions.
  * Improved handling across statement boundaries and delimiter styles.

* **Documentation**
  * Clarified supported exceptions, prefix rules, adjacency requirements, and heuristic behavior for these diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

