### PR TITLE
Memoize mixed-effects separator classification

### DIFF
--- a/src/providers/operator-sequence-diagnostics.ts
+++ b/src/providers/operator-sequence-diagnostics.ts
@@ -558,13 +558,54 @@ function mark_mixed_effects_separators_in_statement(
 }
 
 /**
+ * Memo shared by the sibling analyzers, keyed by token-array identity.
+ * Each lex produces a fresh token array, so identity is a sound cache key
+ * and stale entries are collected with their arrays.
+ */
+const mixed_effects_separator_starts_memo =
+    new WeakMap<Token[], Set<Token>>();
+
+function file_mentions_mixed_effects_command(tokens: Token[]): boolean {
+    for (const my_token of tokens) {
+        if (
+            my_token.type === 'WORD' &&
+            MIXED_EFFECTS_SEPARATOR_COMMANDS.has(my_token.value)
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
  * Return the first bar token of each recognized mixed-effects separator.
  * Sibling token-stream analyzers use this shared classification so the
- * command-specific grammar remains single-sourced.
+ * command-specific grammar remains single-sourced. Results are memoized
+ * per token array because both analyzers run on every diagnostics pass.
  */
 export function collect_mixed_effects_separator_starts(
     tokens: Token[]
 ): Set<Token> {
+    const my_memoized = mixed_effects_separator_starts_memo.get(tokens);
+    if (my_memoized !== undefined) {
+        return my_memoized;
+    }
+
+    const the_separator_starts =
+        compute_mixed_effects_separator_starts(tokens);
+    mixed_effects_separator_starts_memo.set(tokens, the_separator_starts);
+    return the_separator_starts;
+}
+
+function compute_mixed_effects_separator_starts(
+    tokens: Token[]
+): Set<Token> {
+    // Most files contain no mixed-effects command; skip the significant-
+    // token rebuild and statement walk entirely for them.
+    if (!file_mentions_mixed_effects_command(tokens)) {
+        return new Set<Token>();
+    }
+
     const the_significant = collect_significant_tokens(tokens);
     const the_separator_starts = new Set<Token>();
     let statement_start = 0;

--- a/tests/unit/operator-sequence-diagnostics.test.ts
+++ b/tests/unit/operator-sequence-diagnostics.test.ts
@@ -17,7 +17,10 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { StataLexer } from '../../src/lexer';
-import { OperatorSequenceAnalyzer } from '../../src/providers/operator-sequence-diagnostics';
+import {
+    OperatorSequenceAnalyzer,
+    collect_mixed_effects_separator_starts,
+} from '../../src/providers/operator-sequence-diagnostics';
 import { StataDiagnosticCode, StataLSPConfig } from '../../src/types';
 import { DEFAULT_SETTINGS } from '../../src/server-handlers';
 import { create_document_state } from '../property/helpers/document-utils';
@@ -1197,6 +1200,59 @@ describe('OperatorSequenceAnalyzer Unit Tests', () => {
             const diagnostics = analyzer.analyze(doc, default_config);
             expect(diagnostics).toHaveLength(1);
             expect(diagnostics[0].source).toBe('sight');
+        });
+    });
+
+    describe('Separator-start memoization', () => {
+        it('returns the same Set instance for the same token array', () => {
+            const doc = create_document_state('mixed y x || id:');
+            const first_result =
+                collect_mixed_effects_separator_starts(doc.tokens);
+            const second_result =
+                collect_mixed_effects_separator_starts(doc.tokens);
+            expect(second_result).toBe(first_result);
+            expect(first_result.size).toBe(1);
+        });
+
+        it('computes independently for distinct token arrays of equal source', () => {
+            const doc_a = create_document_state('mixed y x || id:');
+            const doc_b = create_document_state('mixed y x || id:');
+            const result_a =
+                collect_mixed_effects_separator_starts(doc_a.tokens);
+            const result_b =
+                collect_mixed_effects_separator_starts(doc_b.tokens);
+            expect(result_a).not.toBe(result_b);
+            expect(result_a.size).toBe(1);
+            expect(result_b.size).toBe(1);
+        });
+
+        it('returns an empty set for files without mixed-effects commands', () => {
+            const doc = create_document_state(
+                'display x || y\nregress y x || id:'
+            );
+            const result =
+                collect_mixed_effects_separator_starts(doc.tokens);
+            expect(result.size).toBe(0);
+        });
+
+        it('early exit does not suppress diagnostics for plain double bars', () => {
+            const doc = create_document_state('display x || y');
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const invalid = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+            );
+            expect(invalid).toHaveLength(1);
+        });
+
+        it('still recognizes separators when another statement mentions the command', () => {
+            const doc = create_document_state(
+                'display "mixed models"\nmixed y x || id:'
+            );
+            const diagnostics = analyzer.analyze(doc, default_config);
+            const invalid = diagnostics.filter(
+                d => d.code === StataDiagnosticCode.INVALID_OPERATOR_SEQUENCE
+            );
+            expect(invalid).toHaveLength(0);
         });
     });
 });


### PR DESCRIPTION
## Summary

Follow-up to #321. Both `OperatorSequenceAnalyzer` and `MixedLogicalOperatorAnalyzer` call `collect_mixed_effects_separator_starts` on every diagnostics pass, each independently rebuilding the significant-token stream and walking every statement — two extra O(n) passes per debounced recompute for every file, including files with no mixed-effects commands.

- memoize the separator-start set per token array (`WeakMap` keyed by array identity; each lex produces a fresh token array, so identity is a sound cache key and entries are collected with their arrays)
- return early with an empty set, without building the significant-token stream, when no token in the file names a supported mixed-effects command (sound because `mark_mixed_effects_separators_in_statement` only marks separators in statements headed by an allowlisted `WORD`)

No behavioral change: same classification results, now computed at most once per token array.

## Testing

- `bun run typecheck`
- `bun test` — 7,671 passed, 5 skipped, 0 failed
- `bun run lint`
- new unit tests pin memo identity (same array → same `Set` instance, distinct arrays → independent results), the empty-set early exit, that the early exit does not suppress `INVALID_OPERATOR_SEQUENCE` for plain `||`, and that a command name appearing anywhere in the file (even in a string) keeps the full walk active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved operator-sequence diagnostics by avoiding repeated analysis of the same content.
  * Added a faster path when mixed-effects separator commands are not present.

* **Bug Fixes**
  * Preserved detection of invalid operator sequences and mixed-effects separators in edge cases.

* **Tests**
  * Added coverage for caching behavior, empty results, and distinct documents with identical content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->